### PR TITLE
feat(androidtv): libVLC engine, launcher rows, playback fixes

### DIFF
--- a/clients/androidtv/android/app/build.gradle.kts
+++ b/clients/androidtv/android/app/build.gradle.kts
@@ -55,6 +55,9 @@ dependencies {
     // HLS media source: the stream-copy master fallback (`master=true` loads).
     implementation("androidx.media3:media3-exoplayer-hls:$media3Version")
     implementation("androidx.media3:media3-ui:$media3Version")
+    // TvProvider: publish the "continue watching" list into the launcher's
+    // system Watch Next row (the Tizen Smart Hub carousel equivalent). See WatchNext.kt.
+    implementation("androidx.tvprovider:tvprovider:1.0.0")
     // WebViewAssetLoader: serve the bundled web app over a real https origin
     // (appassets.androidplatform.net) instead of file://, so the Vite ES-module
     // bundle (`<script type="module">` + dynamic import()) actually loads. From

--- a/clients/androidtv/android/app/build.gradle.kts
+++ b/clients/androidtv/android/app/build.gradle.kts
@@ -55,6 +55,12 @@ dependencies {
     // HLS media source: the stream-copy master fallback (`master=true` loads).
     implementation("androidx.media3:media3-exoplayer-hls:$media3Version")
     implementation("androidx.media3:media3-ui:$media3Version")
+    // libVLC: a bundled software-decoding player. ExoPlayer only uses the device's
+    // platform decoders, so a codec/profile the hardware lacks (e.g. 10-bit HEVC
+    // Main10, DTS, TrueHD) is unplayable; libVLC carries its own ffmpeg-based
+    // decoders and plays anything, so it's the fallback when ExoPlayer can't
+    // decode. See VlcPlayer / ExoBridge.
+    implementation("org.videolan.android:libvlc-all:3.6.0")
     // TvProvider: publish the "continue watching" list into the launcher's
     // system Watch Next row (the Tizen Smart Hub carousel equivalent). See WatchNext.kt.
     implementation("androidx.tvprovider:tvprovider:1.0.0")

--- a/clients/androidtv/android/app/src/main/AndroidManifest.xml
+++ b/clients/androidtv/android/app/src/main/AndroidManifest.xml
@@ -14,6 +14,21 @@
     <uses-feature android:name="android.software.leanback" android:required="true" />
     <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
 
+    <!-- Android 11+ package visibility: to publish into the launcher home rows
+         (the "Continue watching" / Watch Next row + the recommendations preview
+         channel) the app must be able to see and message the TV launcher. Without
+         this the AppsFilter BLOCKS the interaction, so requestChannelBrowsable
+         never reaches the launcher and our rows never surface. Declare the Google
+         TV launcher/recommendation packages plus the channel-browsable request
+         intent (which also covers non-Google TV launchers). -->
+    <queries>
+        <package android:name="com.google.android.tvlauncher" />
+        <package android:name="com.google.android.tvrecommendations" />
+        <intent>
+            <action android:name="android.media.tv.action.REQUEST_CHANNEL_BROWSABLE" />
+        </intent>
+    </queries>
+
     <application
         android:label="@string/app_name"
         android:icon="@drawable/tv_banner"

--- a/clients/androidtv/android/app/src/main/AndroidManifest.xml
+++ b/clients/androidtv/android/app/src/main/AndroidManifest.xml
@@ -23,11 +23,20 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:launchMode="singleTask"
             android:screenOrientation="landscape"
             android:configChanges="keyboard|keyboardHidden|navigation|orientation|screenLayout|screenSize|density|uiMode">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
+            </intent-filter>
+            <!-- Watch Next "Continue watching" rows deep-link back in via
+                 kroma://item/<id> (see WatchNext.kt / MainActivity). -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="kroma" android:host="item" />
             </intent-filter>
         </activity>
     </application>

--- a/clients/androidtv/android/app/src/main/AndroidManifest.xml
+++ b/clients/androidtv/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Read back our own published Watch Next rows so a sync can reconcile them
+         (drop stale + de-duplicate) instead of leaving orphans. -->
+    <uses-permission android:name="com.android.providers.tv.permission.READ_EPG_DATA" />
+    <uses-permission android:name="com.android.providers.tv.permission.WRITE_EPG_DATA" />
     <!-- The audio filter attaches a DynamicsProcessing AudioEffect to the player's
          session; AudioEffect requires this (normal, granted at install). -->
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />

--- a/clients/androidtv/android/app/src/main/java/tv/kroma/androidtv/ExoBridge.kt
+++ b/clients/androidtv/android/app/src/main/java/tv/kroma/androidtv/ExoBridge.kt
@@ -180,6 +180,15 @@ class ExoBridge(
         main.post { activity.finishAndRemoveTask() }
     }
 
+    /** Publish the "continue watching" list into the launcher's system Watch Next
+     * row (`[{id,title,subtitle?,imageUrl?,progressMs,durationMs,kind}]`). Runs
+     * off the JS thread (provider I/O). Passing `[]` clears the row (sign-out). */
+    @JavascriptInterface
+    fun setContinueWatching(json: String) {
+        val ctx = activity.applicationContext
+        Thread { WatchNext.sync(ctx, json) }.start()
+    }
+
     /** Audio filter / volume normalizer (0 off, 1 standard, 2 night): a
      * single-band DynamicsProcessing compressor + safety limiter on the player's
      * audio session, tuned to MATCH the web client's Web Audio compressor so

--- a/clients/androidtv/android/app/src/main/java/tv/kroma/androidtv/ExoBridge.kt
+++ b/clients/androidtv/android/app/src/main/java/tv/kroma/androidtv/ExoBridge.kt
@@ -96,7 +96,15 @@ class ExoBridge(
         }
 
         override fun onPlayerError(error: PlaybackException) {
-            emit(JSONObject().put("t", "error").put("message", error.errorCodeName))
+            emit(
+                JSONObject()
+                    .put("t", "error")
+                    .put("message", error.errorCodeName)
+                    // Flag an audio-decode failure (e.g. E-AC3/DTS/TrueHD with no
+                    // hardware decoder) so the web engine falls back to the server's
+                    // AAC-transcoded master instead of erroring out.
+                    .put("audio", audioUnsupported()),
+            )
         }
 
         override fun onAudioSessionIdChanged(audioSessionId: Int) {
@@ -178,6 +186,20 @@ class ExoBridge(
     @JavascriptInterface
     fun quit() {
         main.post { activity.finishAndRemoveTask() }
+    }
+
+    /** True when the current media carries an audio track this device cannot
+     * decode and NONE it can (e.g. E-AC3/DTS/TrueHD without a hardware decoder) -
+     * the signal for the web engine to reopen the AAC-transcoded master. Reads
+     * the player, so only call from the main thread (onPlayerError runs there). */
+    private fun audioUnsupported(): Boolean {
+        var sawAudio = false
+        for (group in player.currentTracks.groups) {
+            if (group.type != C.TRACK_TYPE_AUDIO) continue
+            sawAudio = true
+            for (i in 0 until group.length) if (group.isTrackSupported(i)) return false
+        }
+        return sawAudio
     }
 
     /** Publish the "continue watching" list into the launcher's system Watch Next

--- a/clients/androidtv/android/app/src/main/java/tv/kroma/androidtv/ExoBridge.kt
+++ b/clients/androidtv/android/app/src/main/java/tv/kroma/androidtv/ExoBridge.kt
@@ -211,6 +211,15 @@ class ExoBridge(
         Thread { WatchNext.sync(ctx, json) }.start()
     }
 
+    /** Publish the recently-added + suggested titles to the KROMA preview channel
+     * (a dedicated row on the launcher home). `[{id,title,subtitle?,imageUrl?,
+     * kind}]`; `[]` clears it. Runs off the JS thread (provider I/O). */
+    @JavascriptInterface
+    fun setHomeChannel(json: String) {
+        val ctx = activity.applicationContext
+        Thread { HomeChannel.sync(ctx, json) }.start()
+    }
+
     /** Audio filter / volume normalizer (0 off, 1 standard, 2 night): a
      * single-band DynamicsProcessing compressor + safety limiter on the player's
      * audio session, tuned to MATCH the web client's Web Audio compressor so

--- a/clients/androidtv/android/app/src/main/java/tv/kroma/androidtv/ExoBridge.kt
+++ b/clients/androidtv/android/app/src/main/java/tv/kroma/androidtv/ExoBridge.kt
@@ -36,7 +36,7 @@ import org.json.JSONObject
 private const val TAG = "KromaExo"
 
 class ExoBridge(
-    activity: Activity,
+    private val activity: Activity,
     private val webView: WebView,
     private val playerView: PlayerView,
 ) {
@@ -170,6 +170,15 @@ class ExoBridge(
      * main thread may do. A `filterSupported` event follows if the answer flips. */
     @JavascriptInterface
     fun audioFilterSupported(): Boolean = filterSupported
+
+    /** Terminate the whole app (the "Quitter" menu row in the TV shell). Android
+     * TV runs a single fullscreen activity with no window chrome, so - like the
+     * desktop shell's `app_quit` - the UI must offer the way out. Removes the
+     * task from Recents for a clean exit; onDestroy then releases the player. */
+    @JavascriptInterface
+    fun quit() {
+        main.post { activity.finishAndRemoveTask() }
+    }
 
     /** Audio filter / volume normalizer (0 off, 1 standard, 2 night): a
      * single-band DynamicsProcessing compressor + safety limiter on the player's

--- a/clients/androidtv/android/app/src/main/java/tv/kroma/androidtv/ExoBridge.kt
+++ b/clients/androidtv/android/app/src/main/java/tv/kroma/androidtv/ExoBridge.kt
@@ -17,6 +17,8 @@ import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
+import android.view.SurfaceView
+import android.view.View
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import androidx.media3.common.C
@@ -39,9 +41,16 @@ class ExoBridge(
     private val activity: Activity,
     private val webView: WebView,
     private val playerView: PlayerView,
+    private val vlcSurface: SurfaceView,
 ) {
     private val main = Handler(Looper.getMainLooper())
     private val player: ExoPlayer = ExoPlayer.Builder(activity).build()
+
+    // libVLC software-decode fallback (lazy: only built the first time ExoPlayer
+    // hits a codec the device can't decode). `vlcActive` routes commands to it.
+    private var vlc: VlcPlayer? = null
+    private var vlcActive = false
+    private var currentUrl: String? = null
 
     // Audio filter / volume normalizer: a DynamicsProcessing compressor+limiter on
     // the player's audio session (levels: 0 off, 1 standard, 2 night), re-attached
@@ -96,13 +105,20 @@ class ExoBridge(
         }
 
         override fun onPlayerError(error: PlaybackException) {
+            // The device can't decode the VIDEO (e.g. 10-bit HEVC Main10 with no
+            // hardware decoder): hand off to libVLC, which software-decodes it (and
+            // its audio). Transparent to the web engine - VLC emits the same events.
+            if (!vlcActive && videoUnsupported()) {
+                switchToVlc()
+                return
+            }
             emit(
                 JSONObject()
                     .put("t", "error")
                     .put("message", error.errorCodeName)
-                    // Flag an audio-decode failure (e.g. E-AC3/DTS/TrueHD with no
-                    // hardware decoder) so the web engine falls back to the server's
-                    // AAC-transcoded master instead of erroring out.
+                    // Flag an audio-only decode failure (E-AC3/DTS/TrueHD) so the web
+                    // engine falls back to the server's AAC-transcoded master (cheaper
+                    // than software-decoding the whole thing) instead of erroring.
                     .put("audio", audioUnsupported()),
             )
         }
@@ -138,6 +154,14 @@ class ExoBridge(
     @JavascriptInterface
     fun load(url: String, startSec: Double, master: Boolean) {
         main.post {
+            currentUrl = url
+            // A new item always tries ExoPlayer (hardware) first; drop any VLC
+            // fallback from the previous item.
+            if (vlcActive) {
+                vlc?.stop()
+                vlcActive = false
+                playerView.visibility = View.VISIBLE
+            }
             val item = MediaItem.Builder()
                 .setUri(url)
                 .apply { if (master) setMimeType(MimeTypes.APPLICATION_M3U8) }
@@ -149,12 +173,56 @@ class ExoBridge(
         }
     }
 
+    /** True when the current media has a VIDEO track the device can't decode and
+     * none it can (10-bit HEVC Main10, etc.) - the signal to hand off to libVLC.
+     * Main thread only (onPlayerError runs there). */
+    private fun videoUnsupported(): Boolean {
+        var sawVideo = false
+        for (group in player.currentTracks.groups) {
+            if (group.type != C.TRACK_TYPE_VIDEO) continue
+            sawVideo = true
+            for (i in 0 until group.length) if (group.isTrackSupported(i)) return false
+        }
+        return sawVideo
+    }
+
+    /** Stop ExoPlayer and resume the current URL in libVLC (software decode) at the
+     * same position - the web engine keeps driving through the same event contract. */
+    private fun switchToVlc() {
+        val url = currentUrl ?: return
+        val posSec = player.currentPosition / 1000.0
+        player.stop()
+        playerView.visibility = View.GONE
+        vlcActive = true
+        val v = vlc ?: VlcPlayer(activity, vlcSurface) { emit(it) }.also { vlc = it }
+        v.load(url, posSec)
+    }
+
     /** `{op: 'play'|'pause'|'seek'|'audio'|'filter'|'stop'|'rect', value?, x?,y?,w?,h?}`. */
     @JavascriptInterface
     fun command(json: String) {
         val cmd = JSONObject(json)
         main.post {
-            when (cmd.optString("op")) {
+            val op = cmd.optString("op")
+            // When libVLC is driving (ExoPlayer couldn't decode), route transport to
+            // it. `rect` (plane resize) + `filter` (DynamicsProcessing on the Exo
+            // audio session) don't apply to VLC, so they no-op there.
+            val v = vlc
+            if (vlcActive && v != null) {
+                when (op) {
+                    "play" -> v.play()
+                    "pause" -> v.pause()
+                    "seek" -> v.seek(cmd.optDouble("value", 0.0))
+                    "audio" -> v.setAudio(cmd.optInt("value", 0))
+                    "stop" -> {
+                        v.stop()
+                        vlcActive = false
+                        playerView.visibility = View.VISIBLE
+                    }
+                }
+                return@post
+            }
+            when (op) {
                 "play" -> player.play()
                 "pause" -> player.pause()
                 "seek" -> player.seekTo((cmd.optDouble("value", 0.0) * 1000).toLong())
@@ -341,6 +409,8 @@ class ExoBridge(
             dynamics?.release()
             dynamics = null
             player.release()
+            vlc?.release()
+            vlc = null
         }
     }
 }

--- a/clients/androidtv/android/app/src/main/java/tv/kroma/androidtv/ExoBridge.kt
+++ b/clients/androidtv/android/app/src/main/java/tv/kroma/androidtv/ExoBridge.kt
@@ -52,6 +52,11 @@ class ExoBridge(
     private var vlcActive = false
     private var currentUrl: String? = null
 
+    // When true, EVERY item plays through libVLC from the start (the "libVLC"
+    // engine the user can force in Settings), not only as an ExoPlayer
+    // decode-failure fallback. Set by setEngine() before the first load().
+    private var forceVlc = false
+
     // Audio filter / volume normalizer: a DynamicsProcessing compressor+limiter on
     // the player's audio session (levels: 0 off, 1 standard, 2 night), re-attached
     // whenever the session id changes. See applyFilter for the tunings.
@@ -105,22 +110,17 @@ class ExoBridge(
         }
 
         override fun onPlayerError(error: PlaybackException) {
-            // The device can't decode the VIDEO (e.g. 10-bit HEVC Main10 with no
-            // hardware decoder): hand off to libVLC, which software-decodes it (and
-            // its audio). Transparent to the web engine - VLC emits the same events.
-            if (!vlcActive && videoUnsupported()) {
+            // Anything the device's hardware/platform decoders can't handle - VIDEO
+            // (10-bit HEVC Main10, ...) OR AUDIO (E-AC3/DTS/TrueHD) - hands off to
+            // libVLC, which software-decodes any codec with full surround. This is
+            // the "plays any file" path; it's transparent to the web engine (VLC
+            // emits the same events). Only a non-decode failure (demux, network)
+            // falls through to the web engine's own retry.
+            if (!vlcActive && (videoUnsupported() || audioUnsupported())) {
                 switchToVlc()
                 return
             }
-            emit(
-                JSONObject()
-                    .put("t", "error")
-                    .put("message", error.errorCodeName)
-                    // Flag an audio-only decode failure (E-AC3/DTS/TrueHD) so the web
-                    // engine falls back to the server's AAC-transcoded master (cheaper
-                    // than software-decoding the whole thing) instead of erroring.
-                    .put("audio", audioUnsupported()),
-            )
+            emit(JSONObject().put("t", "error").put("message", error.errorCodeName).put("audio", false))
         }
 
         override fun onAudioSessionIdChanged(audioSessionId: Int) {
@@ -147,6 +147,13 @@ class ExoBridge(
         playerView.player = player
         player.addListener(listener)
         player.addAnalyticsListener(analytics)
+        // Never let ExoPlayer render subtitles: KROMA draws them in the React overlay
+        // (fetched + styled + synced by the web player). A selected text track would
+        // paint a second, unstyled copy in the PlayerView's SubtitleView.
+        player.trackSelectionParameters = player.trackSelectionParameters
+            .buildUpon()
+            .setTrackTypeDisabled(C.TRACK_TYPE_TEXT, true)
+            .build()
         main.post(ticker)
     }
 
@@ -155,6 +162,11 @@ class ExoBridge(
     fun load(url: String, startSec: Double, master: Boolean) {
         main.post {
             currentUrl = url
+            // The forced "libVLC" engine: software-decode this item from the start.
+            if (forceVlc) {
+                loadVlc(url, startSec)
+                return@post
+            }
             // A new item always tries ExoPlayer (hardware) first; drop any VLC
             // fallback from the previous item.
             if (vlcActive) {
@@ -192,6 +204,13 @@ class ExoBridge(
         val url = currentUrl ?: return
         val posSec = player.currentPosition / 1000.0
         player.stop()
+        loadVlc(url, posSec)
+    }
+
+    /** Bring up the libVLC plane and (software-)decode `url` from `posSec`, hiding
+     * the ExoPlayer surface. Shared by the decode-failure fallback (switchToVlc)
+     * and the forced "libVLC" engine (load with forceVlc). */
+    private fun loadVlc(url: String, posSec: Double) {
         playerView.visibility = View.GONE
         vlcActive = true
         val v = vlc ?: VlcPlayer(activity, vlcSurface) { emit(it) }.also { vlc = it }
@@ -204,9 +223,10 @@ class ExoBridge(
         val cmd = JSONObject(json)
         main.post {
             val op = cmd.optString("op")
-            // When libVLC is driving (ExoPlayer couldn't decode), route transport to
-            // it. `rect` (plane resize) + `filter` (DynamicsProcessing on the Exo
-            // audio session) don't apply to VLC, so they no-op there.
+            // When libVLC is driving, route transport (and `rect`, so the video
+            // shrinks into the settings card like the ExoPlayer plane does) to it.
+            // `filter` (a DynamicsProcessing effect on the Exo audio session) has no
+            // VLC equivalent, so it no-ops there.
             val v = vlc
             if (vlcActive && v != null) {
                 when (op) {
@@ -214,6 +234,7 @@ class ExoBridge(
                     "pause" -> v.pause()
                     "seek" -> v.seek(cmd.optDouble("value", 0.0))
                     "audio" -> v.setAudio(cmd.optInt("value", 0))
+                    "rect" -> setRect(cmd)
                     "stop" -> {
                         v.stop()
                         vlcActive = false
@@ -256,6 +277,16 @@ class ExoBridge(
         main.post { activity.finishAndRemoveTask() }
     }
 
+    /** Force the playback engine for subsequent loads: "vlc" makes libVLC the
+     * primary player (software-decode EVERYTHING, not just codecs ExoPlayer can't
+     * handle); any other value restores the default ExoPlayer-first path. The web
+     * ExoEngine calls this at construction when the user picks the "libVLC" engine
+     * in Settings. Optional on the bridge: an older APK simply ignores it. */
+    @JavascriptInterface
+    fun setEngine(mode: String) {
+        main.post { forceVlc = mode == "vlc" }
+    }
+
     /** True when the current media carries an audio track this device cannot
      * decode and NONE it can (e.g. E-AC3/DTS/TrueHD without a hardware decoder) -
      * the signal for the web engine to reopen the AAC-transcoded master. Reads
@@ -276,6 +307,7 @@ class ExoBridge(
     @JavascriptInterface
     fun setContinueWatching(json: String) {
         val ctx = activity.applicationContext
+        Log.i(TAG, "setContinueWatching: ${json.length} chars")
         Thread { WatchNext.sync(ctx, json) }.start()
     }
 
@@ -285,6 +317,7 @@ class ExoBridge(
     @JavascriptInterface
     fun setHomeChannel(json: String) {
         val ctx = activity.applicationContext
+        Log.i(TAG, "setHomeChannel: ${json.length} chars")
         Thread { HomeChannel.sync(ctx, json) }.start()
     }
 
@@ -360,14 +393,17 @@ class ExoBridge(
         emit(JSONObject().put("t", "filterSupported").put("supported", supported))
     }
 
-    /** Shrink/restore the video plane: resize the PlayerView to a fraction-rect of
-     * its (full-screen FrameLayout) parent so the video lands in the settings card;
-     * a `rect` with no bounds restores fullscreen (MATCH_PARENT). */
+    /** Shrink/restore the ACTIVE video plane: resize it to a fraction-rect of its
+     * (full-screen FrameLayout) parent so the video lands in the settings card; a
+     * `rect` with no bounds restores fullscreen (MATCH_PARENT). Targets the libVLC
+     * SurfaceView when VLC is driving (resizing it fires surfaceChanged, which feeds
+     * VLC the new render size) and the ExoPlayer PlayerView otherwise. */
     private fun setRect(cmd: JSONObject) {
-        val parent = playerView.parent as? android.view.View ?: return
+        val target: View = if (vlcActive) vlcSurface else playerView
+        val parent = target.parent as? android.view.View ?: return
         val pw = parent.width
         val ph = parent.height
-        val lp = playerView.layoutParams as? android.widget.FrameLayout.LayoutParams ?: return
+        val lp = target.layoutParams as? android.widget.FrameLayout.LayoutParams ?: return
         if (cmd.has("w") && pw > 0 && ph > 0) {
             lp.width = (cmd.optDouble("w", 1.0) * pw).toInt()
             lp.height = (cmd.optDouble("h", 1.0) * ph).toInt()
@@ -380,7 +416,7 @@ class ExoBridge(
             lp.leftMargin = 0
             lp.topMargin = 0
         }
-        playerView.layoutParams = lp
+        target.layoutParams = lp
     }
 
     /** Select the Nth audio track group (audio-relative index, file order) in

--- a/clients/androidtv/android/app/src/main/java/tv/kroma/androidtv/HomeChannel.kt
+++ b/clients/androidtv/android/app/src/main/java/tv/kroma/androidtv/HomeChannel.kt
@@ -1,0 +1,139 @@
+// Publishes a KROMA "preview channel" - a dedicated row on the Android TV /
+// Google TV launcher home for recently-added + suggested titles (distinct from
+// the system "Continue watching" Watch Next row; see WatchNext.kt). The first
+// channel an app publishes is its default channel and is shown automatically.
+//
+// The open app pushes the list here (ExoBridge.setHomeChannel); each program
+// deep-links back via `kroma://item/<id>`. Like WatchNext, each sync reconciles
+// against the programs actually published so it never leaves duplicates.
+package tv.kroma.androidtv
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.net.Uri
+import android.util.Log
+import androidx.core.content.ContextCompat
+import androidx.tvprovider.media.tv.PreviewChannel
+import androidx.tvprovider.media.tv.PreviewChannelHelper
+import androidx.tvprovider.media.tv.PreviewProgram
+import androidx.tvprovider.media.tv.TvContractCompat
+import org.json.JSONArray
+import org.json.JSONObject
+
+object HomeChannel {
+    private const val TAG = "KromaHomeChannel"
+    private const val PREFS = "kroma_home_channel"
+    private const val KEY_CHANNEL = "channel_id"
+
+    @Synchronized
+    fun sync(context: Context, json: String) {
+        val arr = try {
+            JSONArray(json)
+        } catch (e: Exception) {
+            Log.w(TAG, "bad home-channel payload", e)
+            return
+        }
+        try {
+            val helper = PreviewChannelHelper(context)
+            val channelId = ensureChannel(context, helper)
+            if (channelId < 0L) return
+
+            val wanted = LinkedHashMap<String, JSONObject>()
+            for (i in 0 until arr.length()) {
+                val o = arr.optJSONObject(i) ?: continue
+                val id = o.optString("id")
+                if (id.isNotEmpty()) wanted[id] = o
+            }
+
+            val existing = existingPrograms(context, channelId) // itemId -> [programId]
+            for ((itemId, o) in wanted) {
+                for (rowId in existing[itemId].orEmpty()) removeRow(context, rowId)
+                insertRow(context, channelId, itemId, o)
+            }
+            for ((itemId, rows) in existing) {
+                if (!wanted.containsKey(itemId)) for (rowId in rows) removeRow(context, rowId)
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "home-channel sync failed", e)
+        }
+    }
+
+    /** Get (or publish) the default KROMA channel, remembering its id. */
+    private fun ensureChannel(context: Context, helper: PreviewChannelHelper): Long {
+        val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        val saved = prefs.getLong(KEY_CHANNEL, -1L)
+        if (saved >= 0L && runCatching { helper.getPreviewChannel(saved) }.getOrNull() != null) {
+            return saved
+        }
+        val channel = PreviewChannel.Builder()
+            .setDisplayName("KROMA")
+            .setAppLinkIntentUri(Uri.parse("kroma://home"))
+            .apply { bannerBitmap(context)?.let { setLogo(it) } }
+            .build()
+        val id = helper.publishDefaultChannel(channel)
+        // The default channel shows without a user prompt; make sure it is browsable.
+        runCatching { TvContractCompat.requestChannelBrowsable(context, id) }
+        prefs.edit().putLong(KEY_CHANNEL, id).apply()
+        return id
+    }
+
+    private fun insertRow(context: Context, channelId: Long, itemId: String, o: JSONObject) {
+        val type =
+            if (o.optString("kind") == "episode") TvContractCompat.PreviewPrograms.TYPE_TV_EPISODE
+            else TvContractCompat.PreviewPrograms.TYPE_MOVIE
+        val builder = PreviewProgram.Builder()
+            .setChannelId(channelId)
+            .setType(type)
+            .setTitle(o.optString("title"))
+            .setInternalProviderId(itemId)
+            .setIntentUri(Uri.parse("kroma://item/$itemId"))
+        o.optString("subtitle").takeIf { it.isNotEmpty() }?.let { builder.setDescription(it) }
+        o.optString("imageUrl").takeIf { it.isNotEmpty() }?.let {
+            builder.setPosterArtUri(Uri.parse(it))
+            builder.setPosterArtAspectRatio(TvContractCompat.PreviewPrograms.ASPECT_RATIO_16_9)
+        }
+        context.contentResolver.insert(
+            TvContractCompat.PreviewPrograms.CONTENT_URI,
+            builder.build().toContentValues(),
+        )
+    }
+
+    private fun removeRow(context: Context, rowId: Long) {
+        context.contentResolver.delete(TvContractCompat.buildPreviewProgramUri(rowId), null, null)
+    }
+
+    /** Our channel's published programs, grouped by item id (internalProviderId). */
+    private fun existingPrograms(context: Context, channelId: Long): Map<String, List<Long>> {
+        val out = HashMap<String, MutableList<Long>>()
+        val projection = arrayOf(
+            TvContractCompat.PreviewPrograms._ID,
+            TvContractCompat.PreviewPrograms.COLUMN_INTERNAL_PROVIDER_ID,
+        )
+        context.contentResolver.query(
+            TvContractCompat.buildPreviewProgramsUriForChannel(channelId),
+            projection,
+            null,
+            null,
+            null,
+        )?.use { c ->
+            while (c.moveToNext()) {
+                val rowId = c.getLong(0)
+                val itemId = c.getString(1) ?: continue
+                out.getOrPut(itemId) { mutableListOf() }.add(rowId)
+            }
+        }
+        return out
+    }
+
+    /** The app banner drawable as a bitmap, for the channel logo. */
+    private fun bannerBitmap(context: Context): Bitmap? {
+        val d = ContextCompat.getDrawable(context, R.drawable.tv_banner) ?: return null
+        val w = d.intrinsicWidth.coerceAtLeast(1)
+        val h = d.intrinsicHeight.coerceAtLeast(1)
+        val bmp = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+        d.setBounds(0, 0, w, h)
+        d.draw(Canvas(bmp))
+        return bmp
+    }
+}

--- a/clients/androidtv/android/app/src/main/java/tv/kroma/androidtv/HomeChannel.kt
+++ b/clients/androidtv/android/app/src/main/java/tv/kroma/androidtv/HomeChannel.kt
@@ -1,13 +1,23 @@
-// Publishes a KROMA "preview channel" - a dedicated row on the Android TV /
-// Google TV launcher home for recently-added + suggested titles (distinct from
-// the system "Continue watching" Watch Next row; see WatchNext.kt). The first
-// channel an app publishes is its default channel and is shown automatically.
+// Publishes KROMA "preview channels" - the named rows on the Android TV / Google
+// TV launcher home (distinct from the system "Continue watching" Watch Next row;
+// see WatchNext.kt). One channel per home section ("Recently added", "For you",
+// ...), so the launcher shows several KROMA rows like the Tizen shortcuts.
 //
-// The open app pushes the list here (ExoBridge.setHomeChannel); each program
-// deep-links back via `kroma://item/<id>`. Like WatchNext, each sync reconciles
-// against the programs actually published so it never leaves duplicates.
+// Channels are keyed by ROW INDEX (kroma:row:0..N), NOT by the server's section id
+// (those aren't stable across launches - themed rows are regenerated - which would
+// mint a brand-new channel every time and pile up dozens of duplicates). A fixed
+// per-slot key lets each sync reuse the same channel: update its name + programs in
+// place, and delete any slot no longer used. Enumeration is a direct provider query
+// (PreviewChannelHelper.getAllChannels proved unreliable - it can miss our own rows,
+// which is what let the duplicates accumulate).
+//
+// Each program deep-links back via `kroma://item/<id>`. Note: only the first channel
+// an app publishes is shown automatically; the rest need the user to enable them via
+// the launcher's "Customize channels". A big featured hero is NOT available to
+// third-party apps on the Google TV home.
 package tv.kroma.androidtv
 
+import android.content.ContentValues
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Canvas
@@ -23,12 +33,15 @@ import org.json.JSONObject
 
 object HomeChannel {
     private const val TAG = "KromaHomeChannel"
-    private const val PREFS = "kroma_home_channel"
-    private const val KEY_CHANNEL = "channel_id"
+    private const val KEY_PREFIX = "kroma:row:"
 
+    /** Sync a list of launcher rows: `[{title, items:[{id,title,subtitle?,
+     * imageUrl?,kind}]}]`, in display order. One preview channel per entry, keyed by
+     * ROW INDEX so it reuses the same channel across syncs. `[]` clears every KROMA
+     * channel. */
     @Synchronized
     fun sync(context: Context, json: String) {
-        val arr = try {
+        val specs = try {
             JSONArray(json)
         } catch (e: Exception) {
             Log.w(TAG, "bad home-channel payload", e)
@@ -36,46 +49,125 @@ object HomeChannel {
         }
         try {
             val helper = PreviewChannelHelper(context)
-            val channelId = ensureChannel(context, helper)
-            if (channelId < 0L) return
+            val existing = ourChannels(context) // channelId -> key
+            val byKey = HashMap<String, Long>()
+            existing.forEach { (id, key) -> if (key.isNotEmpty()) byKey[key] = id }
 
-            val wanted = LinkedHashMap<String, JSONObject>()
-            for (i in 0 until arr.length()) {
-                val o = arr.optJSONObject(i) ?: continue
-                val id = o.optString("id")
-                if (id.isNotEmpty()) wanted[id] = o
+            val wantedKeys = HashSet<String>()
+            for (i in 0 until specs.length()) {
+                val spec = specs.optJSONObject(i) ?: continue
+                val key = KEY_PREFIX + i
+                wantedKeys.add(key)
+                val title = spec.optString("title", "KROMA")
+                val items = spec.optJSONArray("items") ?: JSONArray()
+                val channelId = byKey[key]
+                    ?: publishChannel(context, helper, key, title, makeDefault = byKey.isEmpty() && i == 0)
+                // Refresh the title (the section name can change) and mark the channel
+                // browsable - so it shows on the home without the user toggling it in
+                // "Customize channels" - in a single provider write. See applyChannel.
+                applyChannel(context, channelId, title)
+                reconcilePrograms(context, channelId, items)
             }
 
-            val existing = existingPrograms(context, channelId) // itemId -> [programId]
-            for ((itemId, o) in wanted) {
-                for (rowId in existing[itemId].orEmpty()) removeRow(context, rowId)
-                insertRow(context, channelId, itemId, o)
+            // Delete stale rows (a slot we no longer publish) and the legacy pile-up
+            // (the old single empty-key "KROMA" channel / retired row slots). Scope to
+            // OUR keys (kroma:row:* or the legacy empty key) so a channel some other
+            // code might publish for this package is never collateral damage.
+            var removed = 0
+            existing.forEach { (id, key) ->
+                if (key !in wantedKeys && (key.startsWith(KEY_PREFIX) || key.isEmpty())) {
+                    deleteChannel(context, id)
+                    removed++
+                }
             }
-            for ((itemId, rows) in existing) {
-                if (!wanted.containsKey(itemId)) for (rowId in rows) removeRow(context, rowId)
-            }
+            Log.i(TAG, "home-channel synced ${wantedKeys.size} row(s), removed $removed stale")
         } catch (e: Exception) {
             Log.w(TAG, "home-channel sync failed", e)
         }
     }
 
-    /** Get (or publish) the default KROMA channel, remembering its id. */
-    private fun ensureChannel(context: Context, helper: PreviewChannelHelper): Long {
-        val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
-        val saved = prefs.getLong(KEY_CHANNEL, -1L)
-        if (saved >= 0L && runCatching { helper.getPreviewChannel(saved) }.getOrNull() != null) {
-            return saved
+    /** Remove every KROMA preview channel (called on sign-out). */
+    @Synchronized
+    fun clear(context: Context) {
+        runCatching { ourChannels(context).keys.forEach { deleteChannel(context, it) } }
+    }
+
+    /** Our published channels (channelId -> internalProviderId key), read straight
+     * from the provider (package-scoped, so every row is ours). */
+    private fun ourChannels(context: Context): Map<Long, String> {
+        val out = HashMap<Long, String>()
+        val projection = arrayOf(
+            TvContractCompat.Channels._ID,
+            TvContractCompat.Channels.COLUMN_INTERNAL_PROVIDER_ID,
+        )
+        context.contentResolver.query(
+            TvContractCompat.Channels.CONTENT_URI,
+            projection,
+            null,
+            null,
+            null,
+        )?.use { c ->
+            while (c.moveToNext()) out[c.getLong(0)] = c.getString(1) ?: ""
         }
+        return out
+    }
+
+    /** Publish a new named channel keyed by `key`; make the very first one the
+     * default (auto-shown) and request the rest browsable so the user can add them. */
+    private fun publishChannel(
+        context: Context,
+        helper: PreviewChannelHelper,
+        key: String,
+        title: String,
+        makeDefault: Boolean,
+    ): Long {
         val channel = PreviewChannel.Builder()
-            .setDisplayName("KROMA")
+            .setDisplayName(title)
+            .setInternalProviderId(key)
             .setAppLinkIntentUri(Uri.parse("kroma://home"))
             .apply { bannerBitmap(context)?.let { setLogo(it) } }
             .build()
-        val id = helper.publishDefaultChannel(channel)
-        // The default channel shows without a user prompt; make sure it is browsable.
+        val id = if (makeDefault) helper.publishDefaultChannel(channel) else helper.publishChannel(channel)
         runCatching { TvContractCompat.requestChannelBrowsable(context, id) }
-        prefs.edit().putLong(KEY_CHANNEL, id).apply()
         return id
+    }
+
+    /** Set the display name (the section title can change) and mark the channel
+     * browsable (best effort: some launchers honor an app marking its OWN channel
+     * browsable and show it without the user opting in via "Customize channels";
+     * strict ones ignore it and still require the manual toggle) - both in a single
+     * provider write. */
+    private fun applyChannel(context: Context, channelId: Long, title: String) {
+        runCatching {
+            val values = ContentValues().apply {
+                put(TvContractCompat.Channels.COLUMN_DISPLAY_NAME, title)
+                put(TvContractCompat.Channels.COLUMN_BROWSABLE, 1)
+            }
+            context.contentResolver.update(TvContractCompat.buildChannelUri(channelId), values, null, null)
+        }
+    }
+
+    private fun deleteChannel(context: Context, channelId: Long) {
+        // Deleting a channel cascades to its programs.
+        runCatching { context.contentResolver.delete(TvContractCompat.buildChannelUri(channelId), null, null) }
+    }
+
+    /** Insert/refresh this channel's programs and drop the ones no longer listed. */
+    private fun reconcilePrograms(context: Context, channelId: Long, items: JSONArray) {
+        val wanted = LinkedHashMap<String, JSONObject>()
+        for (i in 0 until items.length()) {
+            val o = items.optJSONObject(i) ?: continue
+            val id = o.optString("id")
+            if (id.isNotEmpty()) wanted[id] = o
+        }
+        val existing = existingPrograms(context, channelId) // itemId -> [programId]
+        for ((itemId, o) in wanted) {
+            for (rowId in existing[itemId].orEmpty()) removeRow(context, rowId)
+            insertRow(context, channelId, itemId, o)
+        }
+        for ((itemId, rows) in existing) {
+            if (!wanted.containsKey(itemId)) for (rowId in rows) removeRow(context, rowId)
+        }
     }
 
     private fun insertRow(context: Context, channelId: Long, itemId: String, o: JSONObject) {
@@ -103,7 +195,7 @@ object HomeChannel {
         context.contentResolver.delete(TvContractCompat.buildPreviewProgramUri(rowId), null, null)
     }
 
-    /** Our channel's published programs, grouped by item id (internalProviderId). */
+    /** One channel's published programs, grouped by item id (internalProviderId). */
     private fun existingPrograms(context: Context, channelId: Long): Map<String, List<Long>> {
         val out = HashMap<String, MutableList<Long>>()
         val projection = arrayOf(

--- a/clients/androidtv/android/app/src/main/java/tv/kroma/androidtv/MainActivity.kt
+++ b/clients/androidtv/android/app/src/main/java/tv/kroma/androidtv/MainActivity.kt
@@ -20,7 +20,9 @@ package tv.kroma.androidtv
 
 import android.annotation.SuppressLint
 import android.app.Activity
+import android.content.Intent
 import android.graphics.Color
+import android.net.Uri
 import android.os.Bundle
 import android.view.KeyEvent
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
@@ -32,6 +34,10 @@ import android.widget.FrameLayout
 import androidx.media3.ui.PlayerView
 import androidx.webkit.WebViewAssetLoader
 import androidx.webkit.WebViewClientCompat
+import org.json.JSONObject
+
+/** The bundled web app, served over the WebViewAssetLoader virtual https origin. */
+private const val APP_URL = "https://appassets.androidplatform.net/assets/kroma/index.html"
 
 class MainActivity : Activity() {
     private lateinit var webView: WebView
@@ -81,7 +87,24 @@ class MainActivity : Activity() {
         root.addView(webView)
         setContentView(root)
 
-        webView.loadUrl("https://appassets.androidplatform.net/assets/kroma/index.html")
+        // A cold launch from a Watch Next `kroma://item/<id>` deep link carries the
+        // id as a query param the web app reads on boot; a normal launch omits it.
+        val deepLink = itemIdFromDeepLink(intent?.data)
+        val url = StringBuilder(APP_URL)
+        if (deepLink != null) url.append("?deeplink=").append(Uri.encode(deepLink))
+        webView.loadUrl(url.toString())
+    }
+
+    // A deep link arriving while the app is already running (warm start): hand the
+    // id to the web app via a DOM event instead of reloading the whole page.
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        val id = itemIdFromDeepLink(intent.data) ?: return
+        if (!::webView.isInitialized) return
+        webView.evaluateJavascript(
+            "window.dispatchEvent(new CustomEvent('kroma-deeplink',{detail:${JSONObject.quote(id)}}))",
+            null,
+        )
     }
 
     // Keys Android consumes before the WebView: re-injected as the DOM key names

--- a/clients/androidtv/android/app/src/main/java/tv/kroma/androidtv/MainActivity.kt
+++ b/clients/androidtv/android/app/src/main/java/tv/kroma/androidtv/MainActivity.kt
@@ -25,6 +25,8 @@ import android.graphics.Color
 import android.net.Uri
 import android.os.Bundle
 import android.view.KeyEvent
+import android.view.SurfaceView
+import android.view.View
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
@@ -51,6 +53,13 @@ class MainActivity : Activity() {
         val playerView = PlayerView(this).apply {
             useController = false // KROMA draws its own chrome in the WebView
             layoutParams = FrameLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT)
+        }
+        // The libVLC software-decode plane, shown only when ExoPlayer can't decode
+        // the video and we hand off to VLC (see ExoBridge). Hidden otherwise so it
+        // doesn't cover the ExoPlayer surface.
+        val vlcSurface = SurfaceView(this).apply {
+            layoutParams = FrameLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT)
+            visibility = View.GONE
         }
         // Serve the bundled assets over the virtual https origin so ES-module
         // scripts load (see the file header). `/assets/` maps to android_asset/.
@@ -80,10 +89,11 @@ class MainActivity : Activity() {
                 ): WebResourceResponse? = assetLoader.shouldInterceptRequest(request.url)
             }
         }
-        bridge = ExoBridge(this, webView, playerView)
+        bridge = ExoBridge(this, webView, playerView, vlcSurface)
         webView.addJavascriptInterface(bridge, "__KROMA_ANDROID__")
 
         root.addView(playerView)
+        root.addView(vlcSurface) // above the ExoPlayer plane, below the WebView chrome
         root.addView(webView)
         setContentView(root)
 

--- a/clients/androidtv/android/app/src/main/java/tv/kroma/androidtv/VlcPlayer.kt
+++ b/clients/androidtv/android/app/src/main/java/tv/kroma/androidtv/VlcPlayer.kt
@@ -1,0 +1,137 @@
+// libVLC software-decode player: the fallback for anything ExoPlayer can't decode
+// on the device's platform decoders (10-bit HEVC Main10, DTS, TrueHD, ...). libVLC
+// carries its own ffmpeg-based decoders, so it plays those in software.
+//
+// Renders into its own SurfaceView (behind the transparent WebView, like the
+// ExoPlayer plane) and emits the SAME event shape ExoBridge does
+// (`{t:'time'|'duration'|'state'|'waiting'|'ready'|'ended'|'error'}`), so the web
+// engine drives it through the existing contract without knowing which player is live.
+package tv.kroma.androidtv
+
+import android.content.Context
+import android.net.Uri
+import android.view.SurfaceHolder
+import android.view.SurfaceView
+import android.view.View
+import org.json.JSONObject
+import org.videolan.libvlc.LibVLC
+import org.videolan.libvlc.Media
+import org.videolan.libvlc.MediaPlayer
+
+class VlcPlayer(
+    context: Context,
+    private val surface: SurfaceView,
+    private val onEvent: (JSONObject) -> Unit,
+) {
+    // --no-drop-late-frames / --no-skip-frames: software HEVC on a weak box is slow;
+    // keep every frame rather than stutter-skip. network-caching smooths HTTP range.
+    private val libVlc = LibVLC(
+        context,
+        arrayListOf("--no-drop-late-frames", "--no-skip-frames", "--network-caching=1500"),
+    )
+    private val player = MediaPlayer(libVlc)
+    private var attached = false
+    private var reportedReady = false
+
+    init {
+        player.setEventListener { ev -> handle(ev) }
+        // The surface is GONE until VLC activates, so its size is unknown when we
+        // first attach; feed VLC the REAL dimensions once the surface is laid out
+        // (else it renders into a wrong-sized corner of the plane).
+        surface.holder.addCallback(object : SurfaceHolder.Callback {
+            override fun surfaceCreated(holder: SurfaceHolder) {}
+            override fun surfaceChanged(holder: SurfaceHolder, f: Int, w: Int, h: Int) {
+                if (attached && w > 0 && h > 0) player.vlcVout.setWindowSize(w, h)
+            }
+            override fun surfaceDestroyed(holder: SurfaceHolder) {}
+        })
+    }
+
+    /** Load a URL and start playing at `startSec` (the fallback takes over mid-play,
+     * so it auto-plays rather than waiting for a play command). */
+    fun load(url: String, startSec: Double) {
+        reportedReady = false
+        surface.visibility = View.VISIBLE
+        ensureAttached()
+        val media = Media(libVlc, Uri.parse(url)).apply {
+            setHWDecoderEnabled(true, false) // try HW, fall back to SW automatically
+        }
+        player.media = media
+        media.release()
+        if (startSec > 0.5) player.time = (startSec * 1000).toLong()
+        player.play()
+    }
+
+    fun play() = player.play()
+    fun pause() = player.pause()
+    fun seek(sec: Double) { player.time = (sec * 1000).toLong().coerceAtLeast(0) }
+
+    /** Select an audio track by its ZERO-BASED order among audio tracks (the web
+     * engine speaks audio-relative indices; VLC ids are absolute, so map them). */
+    fun setAudio(index: Int) {
+        val ids = player.audioTracks?.map { it.id } ?: return
+        ids.getOrNull(index)?.let { player.audioTrack = it }
+    }
+
+    fun stop() {
+        player.stop()
+        surface.visibility = View.GONE
+        if (attached) {
+            player.vlcVout.detachViews()
+            attached = false
+        }
+    }
+
+    fun release() {
+        stop()
+        player.release()
+        libVlc.release()
+    }
+
+    private fun ensureAttached() {
+        if (attached) return
+        val vout = player.vlcVout
+        vout.setVideoView(surface)
+        val w = surface.width.takeIf { it > 0 } ?: 1920
+        val h = surface.height.takeIf { it > 0 } ?: 1080
+        vout.setWindowSize(w, h)
+        vout.attachViews()
+        attached = true
+    }
+
+    private fun handle(ev: MediaPlayer.Event) {
+        when (ev.type) {
+            MediaPlayer.Event.Opening, MediaPlayer.Event.Buffering ->
+                emit("waiting", "active", ev.type == MediaPlayer.Event.Opening || ev.buffering < 100f)
+            MediaPlayer.Event.Playing -> {
+                announceReady()
+                emit("state", "playing", true)
+                emit("waiting", "active", false)
+            }
+            MediaPlayer.Event.Paused -> emit("state", "playing", false)
+            MediaPlayer.Event.TimeChanged ->
+                onEvent(JSONObject().put("t", "time").put("sec", ev.timeChanged / 1000.0))
+            MediaPlayer.Event.LengthChanged -> {
+                val len = ev.lengthChanged
+                if (len > 0) onEvent(JSONObject().put("t", "duration").put("sec", len / 1000.0))
+            }
+            MediaPlayer.Event.EndReached -> onEvent(JSONObject().put("t", "ended"))
+            MediaPlayer.Event.EncounteredError ->
+                // VLC couldn't play it either: a real error (audio=false, no more fallbacks).
+                onEvent(JSONObject().put("t", "error").put("message", "VLC_ERROR").put("audio", false))
+        }
+    }
+
+    /** Fire `ready` once so the web engine runs its onLoaded (audio track + resume). */
+    private fun announceReady() {
+        if (reportedReady) return
+        reportedReady = true
+        val len = player.length
+        if (len > 0) onEvent(JSONObject().put("t", "duration").put("sec", len / 1000.0))
+        onEvent(JSONObject().put("t", "ready"))
+    }
+
+    private fun emit(t: String, key: String, value: Boolean) {
+        onEvent(JSONObject().put("t", t).put(key, value))
+    }
+}

--- a/clients/androidtv/android/app/src/main/java/tv/kroma/androidtv/VlcPlayer.kt
+++ b/clients/androidtv/android/app/src/main/java/tv/kroma/androidtv/VlcPlayer.kt
@@ -25,9 +25,26 @@ class VlcPlayer(
 ) {
     // --no-drop-late-frames / --no-skip-frames: software HEVC on a weak box is slow;
     // keep every frame rather than stutter-skip. network-caching smooths HTTP range.
+    // --no-spdif: never bitstream-passthrough (S/PDIF / HDMI) the audio - always
+    // decode it to PCM. Passthrough asks the platform AudioTrack whether it can
+    // forward the compressed E-AC3 / DTS / TrueHD to a receiver; many Android sinks
+    // (and the emulator) answer yes but with a bogus sample rate 0, and VLC then
+    // fails to open ANY audio output ("too low audio sample frequency (0)", silent
+    // playback). Decoded PCM plays on every sink, which is the whole point of the
+    // libVLC fallback: sound for any codec, everywhere.
     private val libVlc = LibVLC(
         context,
-        arrayListOf("--no-drop-late-frames", "--no-skip-frames", "--network-caching=1500"),
+        arrayListOf(
+            "--no-drop-late-frames",
+            "--no-skip-frames",
+            "--network-caching=1500",
+            "--no-spdif",
+            // Never render VLC's own subtitles: KROMA draws them in the React
+            // overlay (fetched + styled + synced by the web player), so a burned-in
+            // VLC subtitle track would double up and ignore the app's styling.
+            "--no-spu",
+            "--no-sub-autodetect-file",
+        ),
     )
     private val player = MediaPlayer(libVlc)
     private var attached = false
@@ -66,11 +83,14 @@ class VlcPlayer(
     fun pause() = player.pause()
     fun seek(sec: Double) { player.time = (sec * 1000).toLong().coerceAtLeast(0) }
 
-    /** Select an audio track by its ZERO-BASED order among audio tracks (the web
-     * engine speaks audio-relative indices; VLC ids are absolute, so map them). */
+    /** Select an audio track by its ZERO-BASED order among the REAL audio tracks
+     * (the web engine speaks audio-relative, file-order indices). VLC's track list
+     * begins with a synthetic "Disable" entry (id -1) and the real tracks carry
+     * arbitrary ids, so drop the disable entry before mapping: indexing the raw list
+     * would pick "Disable" for index 0 and silence the audio entirely. */
     fun setAudio(index: Int) {
-        val ids = player.audioTracks?.map { it.id } ?: return
-        ids.getOrNull(index)?.let { player.audioTrack = it }
+        val real = player.audioTracks?.filter { it.id >= 0 } ?: return
+        real.getOrNull(index)?.let { player.audioTrack = it.id }
     }
 
     fun stop() {

--- a/clients/androidtv/android/app/src/main/java/tv/kroma/androidtv/WatchNext.kt
+++ b/clients/androidtv/android/app/src/main/java/tv/kroma/androidtv/WatchNext.kt
@@ -58,6 +58,7 @@ object WatchNext {
             for ((itemId, rows) in existing) {
                 if (!wanted.containsKey(itemId)) for (rowId in rows) removeRow(context, rowId)
             }
+            Log.i(TAG, "watch-next synced ${wanted.size} item(s)")
         } catch (e: Exception) {
             Log.w(TAG, "watch-next sync failed", e)
         }

--- a/clients/androidtv/android/app/src/main/java/tv/kroma/androidtv/WatchNext.kt
+++ b/clients/androidtv/android/app/src/main/java/tv/kroma/androidtv/WatchNext.kt
@@ -1,0 +1,134 @@
+// Publishes KROMA's "continue watching" list into the Android TV / Google TV
+// system "Continue watching" (Watch Next) row on the launcher home screen - the
+// platform equivalent of the Tizen Smart Hub carousel.
+//
+// The open app pushes its list here (ExoBridge.setContinueWatching); the entries
+// persist on the home screen after the app closes. Each program deep-links back
+// via `kroma://item/<id>`, which MainActivity routes into the web app. We track
+// the program ids we published in SharedPreferences so a later sync can remove
+// stale rows without querying the provider.
+package tv.kroma.androidtv
+
+import android.content.ContentUris
+import android.content.Context
+import android.net.Uri
+import android.util.Log
+import androidx.tvprovider.media.tv.TvContractCompat
+import androidx.tvprovider.media.tv.WatchNextProgram
+import org.json.JSONArray
+import org.json.JSONObject
+
+object WatchNext {
+    private const val TAG = "KromaWatchNext"
+    private const val PREFS = "kroma_watch_next"
+    // itemId -> Watch Next program row id we inserted (so we can update/remove it).
+    private const val KEY_IDS = "program_ids"
+
+    /**
+     * Sync the given `continue watching` list (a JSON array of
+     * `{id,title,subtitle?,imageUrl?,progressMs,durationMs,kind}`) into the Watch
+     * Next row: insert new items, refresh existing ones, and drop rows that are
+     * no longer in the list. Best effort - a provider hiccup is logged, never fatal.
+     */
+    fun sync(context: Context, json: String) {
+        val arr = try {
+            JSONArray(json)
+        } catch (e: Exception) {
+            Log.w(TAG, "bad continue-watching payload", e)
+            return
+        }
+        val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        val known = readMap(prefs.getString(KEY_IDS, null))
+        val wanted = LinkedHashMap<String, JSONObject>()
+        for (i in 0 until arr.length()) {
+            val o = arr.optJSONObject(i) ?: continue
+            val id = o.optString("id")
+            if (id.isNotEmpty()) wanted[id] = o
+        }
+
+        val next = HashMap<String, Long>()
+        try {
+            // Drop rows no longer wanted.
+            for ((itemId, rowId) in known) {
+                if (!wanted.containsKey(itemId)) removeRow(context, rowId)
+            }
+            // Insert / refresh the wanted ones (delete-then-insert keeps it simple:
+            // a Watch Next program has no stable natural key we can upsert on).
+            for ((itemId, o) in wanted) {
+                known[itemId]?.let { removeRow(context, it) }
+                val rowId = insertRow(context, itemId, o)
+                if (rowId > 0) next[itemId] = rowId
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "watch-next sync failed", e)
+        }
+        prefs.edit().putString(KEY_IDS, writeMap(next)).apply()
+    }
+
+    /** Remove every KROMA Watch Next row (called on sign-out). */
+    fun clear(context: Context) {
+        val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        for ((_, rowId) in readMap(prefs.getString(KEY_IDS, null))) {
+            runCatching { removeRow(context, rowId) }
+        }
+        prefs.edit().remove(KEY_IDS).apply()
+    }
+
+    private fun insertRow(context: Context, itemId: String, o: JSONObject): Long {
+        val type =
+            if (o.optString("kind") == "episode") TvContractCompat.WatchNextPrograms.TYPE_TV_EPISODE
+            else TvContractCompat.WatchNextPrograms.TYPE_MOVIE
+        val builder = WatchNextProgram.Builder()
+            .setType(type)
+            .setWatchNextType(TvContractCompat.WatchNextPrograms.WATCH_NEXT_TYPE_CONTINUE)
+            .setTitle(o.optString("title"))
+            .setInternalProviderId(itemId)
+            .setLastEngagementTimeUtcMillis(
+                o.optLong("updatedAtMs", System.currentTimeMillis()),
+            )
+            .setIntentUri(Uri.parse("kroma://item/$itemId"))
+        o.optString("subtitle").takeIf { it.isNotEmpty() }?.let { builder.setDescription(it) }
+        o.optString("imageUrl").takeIf { it.isNotEmpty() }?.let {
+            builder.setPosterArtUri(Uri.parse(it))
+            builder.setPosterArtAspectRatio(TvContractCompat.PreviewPrograms.ASPECT_RATIO_16_9)
+        }
+        val dur = o.optLong("durationMs", 0)
+        val pos = o.optLong("progressMs", 0)
+        if (dur > 0) builder.setDurationMillis(dur.toInt())
+        if (pos > 0) builder.setLastPlaybackPositionMillis(pos.toInt())
+
+        val uri = context.contentResolver.insert(
+            TvContractCompat.WatchNextPrograms.CONTENT_URI,
+            builder.build().toContentValues(),
+        ) ?: return -1
+        return ContentUris.parseId(uri)
+    }
+
+    private fun removeRow(context: Context, rowId: Long) {
+        val uri = TvContractCompat.buildWatchNextProgramUri(rowId)
+        context.contentResolver.delete(uri, null, null)
+    }
+
+    // itemId=rowId pairs, one per line (SharedPreferences string). Tiny + robust.
+    private fun readMap(s: String?): LinkedHashMap<String, Long> {
+        val m = LinkedHashMap<String, Long>()
+        if (s.isNullOrEmpty()) return m
+        for (line in s.split('\n')) {
+            val eq = line.lastIndexOf('=')
+            if (eq <= 0) continue
+            line.substring(eq + 1).toLongOrNull()?.let { m[line.substring(0, eq)] = it }
+        }
+        return m
+    }
+
+    private fun writeMap(m: Map<String, Long>): String =
+        m.entries.joinToString("\n") { "${it.key}=${it.value}" }
+}
+
+/** The item id carried by a `kroma://item/<id>` deep link, or null. */
+fun itemIdFromDeepLink(uri: Uri?): String? {
+    if (uri == null || uri.scheme != "kroma") return null
+    // kroma://item/<id>  ->  host = "item", path = "/<id>"
+    if (uri.host != "item") return null
+    return uri.lastPathSegment?.takeIf { it.isNotEmpty() }
+}

--- a/clients/androidtv/android/app/src/main/java/tv/kroma/androidtv/WatchNext.kt
+++ b/clients/androidtv/android/app/src/main/java/tv/kroma/androidtv/WatchNext.kt
@@ -4,12 +4,11 @@
 //
 // The open app pushes its list here (ExoBridge.setContinueWatching); the entries
 // persist on the home screen after the app closes. Each program deep-links back
-// via `kroma://item/<id>`, which MainActivity routes into the web app. We track
-// the program ids we published in SharedPreferences so a later sync can remove
-// stale rows without querying the provider.
+// via `kroma://item/<id>`, which MainActivity routes into the web app. Each sync
+// reconciles against the rows actually published (queried from the provider), so
+// it is idempotent and never leaves duplicates behind.
 package tv.kroma.androidtv
 
-import android.content.ContentUris
 import android.content.Context
 import android.net.Uri
 import android.util.Log
@@ -20,9 +19,6 @@ import org.json.JSONObject
 
 object WatchNext {
     private const val TAG = "KromaWatchNext"
-    private const val PREFS = "kroma_watch_next"
-    // itemId -> Watch Next program row id we inserted (so we can update/remove it).
-    private const val KEY_IDS = "program_ids"
 
     /**
      * Sync the given `continue watching` list (a JSON array of
@@ -30,6 +26,7 @@ object WatchNext {
      * Next row: insert new items, refresh existing ones, and drop rows that are
      * no longer in the list. Best effort - a provider hiccup is logged, never fatal.
      */
+    @Synchronized
     fun sync(context: Context, json: String) {
         val arr = try {
             JSONArray(json)
@@ -37,8 +34,6 @@ object WatchNext {
             Log.w(TAG, "bad continue-watching payload", e)
             return
         }
-        val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
-        val known = readMap(prefs.getString(KEY_IDS, null))
         val wanted = LinkedHashMap<String, JSONObject>()
         for (i in 0 until arr.length()) {
             val o = arr.optJSONObject(i) ?: continue
@@ -46,35 +41,62 @@ object WatchNext {
             if (id.isNotEmpty()) wanted[id] = o
         }
 
-        val next = HashMap<String, Long>()
         try {
-            // Drop rows no longer wanted.
-            for ((itemId, rowId) in known) {
-                if (!wanted.containsKey(itemId)) removeRow(context, rowId)
-            }
-            // Insert / refresh the wanted ones (delete-then-insert keeps it simple:
-            // a Watch Next program has no stable natural key we can upsert on).
+            // Reconcile against what is ACTUALLY published, not a local record that
+            // can go stale on reinstall or race with a concurrent sync (which was
+            // duplicating rows). Query our existing rows grouped by item id, then:
+            // delete every row for an unwanted id, and every DUPLICATE row for a
+            // wanted id (keeping one to refresh).
+            val existing = existingRows(context) // itemId -> [rowId, ...]
             for ((itemId, o) in wanted) {
-                known[itemId]?.let { removeRow(context, it) }
-                val rowId = insertRow(context, itemId, o)
-                if (rowId > 0) next[itemId] = rowId
+                val rows = existing[itemId].orEmpty()
+                // Drop all existing rows for this id, then insert one fresh (a Watch
+                // Next program has no stable natural key to upsert on).
+                for (rowId in rows) removeRow(context, rowId)
+                insertRow(context, itemId, o)
+            }
+            for ((itemId, rows) in existing) {
+                if (!wanted.containsKey(itemId)) for (rowId in rows) removeRow(context, rowId)
             }
         } catch (e: Exception) {
             Log.w(TAG, "watch-next sync failed", e)
         }
-        prefs.edit().putString(KEY_IDS, writeMap(next)).apply()
     }
 
     /** Remove every KROMA Watch Next row (called on sign-out). */
+    @Synchronized
     fun clear(context: Context) {
-        val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
-        for ((_, rowId) in readMap(prefs.getString(KEY_IDS, null))) {
-            runCatching { removeRow(context, rowId) }
+        runCatching {
+            for ((_, rows) in existingRows(context)) for (rowId in rows) removeRow(context, rowId)
         }
-        prefs.edit().remove(KEY_IDS).apply()
     }
 
-    private fun insertRow(context: Context, itemId: String, o: JSONObject): Long {
+    /** Our currently-published Watch Next rows, grouped by item id (the
+     * internalProviderId). A query returns only this app's own programs, so any
+     * row we see is ours to reconcile. Duplicates for one id land in the list. */
+    private fun existingRows(context: Context): Map<String, List<Long>> {
+        val out = HashMap<String, MutableList<Long>>()
+        val projection = arrayOf(
+            TvContractCompat.WatchNextPrograms._ID,
+            TvContractCompat.WatchNextPrograms.COLUMN_INTERNAL_PROVIDER_ID,
+        )
+        context.contentResolver.query(
+            TvContractCompat.WatchNextPrograms.CONTENT_URI,
+            projection,
+            null,
+            null,
+            null,
+        )?.use { c ->
+            while (c.moveToNext()) {
+                val rowId = c.getLong(0)
+                val itemId = c.getString(1) ?: continue
+                out.getOrPut(itemId) { mutableListOf() }.add(rowId)
+            }
+        }
+        return out
+    }
+
+    private fun insertRow(context: Context, itemId: String, o: JSONObject) {
         val type =
             if (o.optString("kind") == "episode") TvContractCompat.WatchNextPrograms.TYPE_TV_EPISODE
             else TvContractCompat.WatchNextPrograms.TYPE_MOVIE
@@ -97,32 +119,16 @@ object WatchNext {
         if (dur > 0) builder.setDurationMillis(dur.toInt())
         if (pos > 0) builder.setLastPlaybackPositionMillis(pos.toInt())
 
-        val uri = context.contentResolver.insert(
+        context.contentResolver.insert(
             TvContractCompat.WatchNextPrograms.CONTENT_URI,
             builder.build().toContentValues(),
-        ) ?: return -1
-        return ContentUris.parseId(uri)
+        )
     }
 
     private fun removeRow(context: Context, rowId: Long) {
         val uri = TvContractCompat.buildWatchNextProgramUri(rowId)
         context.contentResolver.delete(uri, null, null)
     }
-
-    // itemId=rowId pairs, one per line (SharedPreferences string). Tiny + robust.
-    private fun readMap(s: String?): LinkedHashMap<String, Long> {
-        val m = LinkedHashMap<String, Long>()
-        if (s.isNullOrEmpty()) return m
-        for (line in s.split('\n')) {
-            val eq = line.lastIndexOf('=')
-            if (eq <= 0) continue
-            line.substring(eq + 1).toLongOrNull()?.let { m[line.substring(0, eq)] = it }
-        }
-        return m
-    }
-
-    private fun writeMap(m: Map<String, Long>): String =
-        m.entries.joinToString("\n") { "${it.key}=${it.value}" }
 }
 
 /** The item id carried by a `kroma://item/<id>` deep link, or null. */

--- a/clients/androidtv/index.html
+++ b/clients/androidtv/index.html
@@ -4,6 +4,17 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=1920, height=1080, user-scalable=no" />
     <title>KROMA</title>
+    <!-- Critical: paint the stage black from the very first frame, before the
+         bundled CSS loads. Otherwise the WebView shows a white body for a few
+         frames on launch (a white flash under the intro). -->
+    <style>
+      html,
+      body {
+        margin: 0;
+        background: #0a0a0c;
+        color-scheme: dark;
+      }
+    </style>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/clients/tizen/index.html
+++ b/clients/tizen/index.html
@@ -4,6 +4,16 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=1920, height=1080, user-scalable=no" />
     <title>KROMA</title>
+    <!-- Critical: paint the stage black from the very first frame, before the
+         bundled CSS loads, so the launch never flashes a white body. -->
+    <style>
+      html,
+      body {
+        margin: 0;
+        background: #0a0a0c;
+        color-scheme: dark;
+      }
+    </style>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/clients/webos/index.html
+++ b/clients/webos/index.html
@@ -4,6 +4,16 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=1920, height=1080, user-scalable=no" />
     <title>KROMA</title>
+    <!-- Critical: paint the stage black from the very first frame, before the
+         bundled CSS loads, so the launch never flashes a white body. -->
+    <style>
+      html,
+      body {
+        margin: 0;
+        background: #0a0a0c;
+        color-scheme: dark;
+      }
+    </style>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/packages/core/src/locales/en.json
+++ b/packages/core/src/locales/en.json
@@ -176,6 +176,7 @@
   "playbackEngine.remux": "Server remux",
   "playbackEngine.mpv": "mpv (native)",
   "playbackEngine.exo": "ExoPlayer (native)",
+  "playbackEngine.vlc": "libVLC (any codec)",
   "keyboardLayout.title": "Keyboard layout",
   "keyboardLayout.abc": "ABC",
   "keyboardLayout.azerty": "AZERTY",

--- a/packages/core/src/locales/fr.json
+++ b/packages/core/src/locales/fr.json
@@ -177,6 +177,7 @@
   "playbackEngine.remux": "Remux serveur",
   "playbackEngine.mpv": "mpv (natif)",
   "playbackEngine.exo": "ExoPlayer (natif)",
+  "playbackEngine.vlc": "libVLC (tout codec)",
   "keyboardLayout.title": "Disposition du clavier",
   "keyboardLayout.abc": "ABC",
   "keyboardLayout.azerty": "AZERTY",

--- a/packages/tv/src/app/appQuit.ts
+++ b/packages/tv/src/app/appQuit.ts
@@ -1,14 +1,21 @@
-import { getTauri } from '#tv/features/playback/player/engine';
+import { getExo, getTauri } from '#tv/features/playback/player/engine';
 
-/** Whether the hosting shell can terminate the whole app. Only the desktop
- * (Tauri) shell qualifies: it runs fullscreen without window chrome, so the UI
- * must offer the way out itself. Real TVs quit through their own system UI. */
+/** Whether the hosting shell can terminate the whole app. Two shells qualify:
+ * the desktop (Tauri) shell and the Android TV shell - both run fullscreen
+ * without window chrome, so the UI must offer the way out itself. Real TVs
+ * (Tizen/webOS) quit through their own system UI, so the row stays hidden. */
 export function canQuitApp(): boolean {
-  return getTauri() != null;
+  return getTauri() != null || typeof getExo()?.quit === 'function';
 }
 
-/** Ask the hosting shell to close the app (the desktop `app_quit` command,
- * which exits through the event loop and so also stops the mpv sidecar). */
+/** Ask the hosting shell to close the app: the desktop `app_quit` command (which
+ * exits through the event loop and so also stops the mpv sidecar), or the
+ * Android bridge's `quit` (finishes the activity and clears the task). */
 export function quitApp(): void {
-  void getTauri()?.core.invoke('app_quit');
+  const tauri = getTauri();
+  if (tauri != null) {
+    void tauri.core.invoke('app_quit');
+    return;
+  }
+  getExo()?.quit?.();
 }

--- a/packages/tv/src/app/enginePref.test.ts
+++ b/packages/tv/src/app/enginePref.test.ts
@@ -68,10 +68,10 @@ describe('getEnginePref / setEnginePref', () => {
 });
 
 describe('availableEngines', () => {
-  it('offers exo + remux on the Android TV shell', () => {
+  it('offers exo + vlc on the Android TV shell (not remux - the WebView cannot decode HEVC)', () => {
     vi.stubGlobal('__KROMA_ANDROID__', exo);
     vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0 (Linux; Android 12)' });
-    expect(availableEngines()).toEqual(['auto', 'exo', 'remux']);
+    expect(availableEngines()).toEqual(['auto', 'exo', 'vlc']);
   });
 
   it('offers avplay + remux on Tizen', () => {
@@ -111,7 +111,7 @@ describe('availableEngines', () => {
 
 describe('ENGINE_LABEL_KEY', () => {
   it('maps every engine to its i18n label key', () => {
-    const engines: EnginePref[] = ['auto', 'avplay', 'webview', 'remux', 'mpv', 'exo'];
+    const engines: EnginePref[] = ['auto', 'avplay', 'webview', 'remux', 'mpv', 'exo', 'vlc'];
     for (const e of engines) {
       expect(ENGINE_LABEL_KEY[e]).toBe(`playbackEngine.${e}`);
     }

--- a/packages/tv/src/app/enginePref.ts
+++ b/packages/tv/src/app/enginePref.ts
@@ -11,19 +11,25 @@
 //               anything the server can remux, incl. MKV; video is stream-copied).
 //  - mpv      : force the native mpv engine (VA-API on the Linux/Deck shell).
 //  - exo      : force the native media3/ExoPlayer engine (Android TV shell).
+//  - vlc      : force the native libVLC engine (Android TV shell) - software
+//               decode of EVERY codec, the same fallback ExoPlayer hands off to,
+//               but made the primary player (the Android equivalent of mpv).
 
 import { isTizenRuntime, isWebOsRuntime, type MessageKey } from '@kroma/core';
 import { reactivePref } from '#tv/app/settings/store';
 import { exoAvailable, mpvAvailable } from '#tv/features/playback/player/engine';
 
-export type EnginePref = 'auto' | 'avplay' | 'webview' | 'remux' | 'mpv' | 'exo';
+export type EnginePref = 'auto' | 'avplay' | 'webview' | 'remux' | 'mpv' | 'exo' | 'vlc';
 
-const ALL: readonly EnginePref[] = ['auto', 'avplay', 'webview', 'remux', 'mpv', 'exo'];
+const ALL: readonly EnginePref[] = ['auto', 'avplay', 'webview', 'remux', 'mpv', 'exo', 'vlc'];
 
 /** The reactive store behind the pref (the settings registry binds rows to it). */
 export const enginePrefStore = reactivePref('kroma:engine', ALL, 'auto');
 
-/** The saved engine preference for this device, or `auto`. */
+/** The saved engine preference for this device, or `auto`. A stored engine no
+ * longer offered on THIS platform (e.g. a device left on `remux` before it was
+ * retired on Android TV, where the WebView cannot decode HEVC) is degraded to
+ * `auto` by the playback engine resolver, not here. */
 export function getEnginePref(): EnginePref {
   return enginePrefStore.get();
 }
@@ -40,7 +46,12 @@ export function setEnginePref(p: EnginePref): void {
  * desktop shell. A single-entry list (unknown/other) hides the row. */
 export function availableEngines(): EnginePref[] {
   const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
-  if (exoAvailable()) return ['auto', 'exo', 'remux'];
+  // Android TV: ExoPlayer (hardware) with a libVLC software-decode fallback plays
+  // EVERY codec, including the HEVC 10-bit / E-AC3 the Chromium WebView cannot.
+  // The `<video>` + hls.js remux path is therefore strictly inferior here (no HEVC
+  // decode at all), so it is not offered - it would only ever be a dead end.
+  // `vlc` forces that software decoder as the PRIMARY player (like mpv on desktop).
+  if (exoAvailable()) return ['auto', 'exo', 'vlc'];
   if (isTizenRuntime(ua)) return ['auto', 'avplay', 'remux'];
   if (isWebOsRuntime(ua)) return ['auto', 'webview', 'remux'];
   const list: EnginePref[] = ['auto', 'webview', 'remux'];
@@ -58,4 +69,5 @@ export const ENGINE_LABEL_KEY: Record<EnginePref, MessageKey> = {
   remux: 'playbackEngine.remux',
   mpv: 'playbackEngine.mpv',
   exo: 'playbackEngine.exo',
+  vlc: 'playbackEngine.vlc',
 };

--- a/packages/tv/src/app/providers/continue.tsx
+++ b/packages/tv/src/app/providers/continue.tsx
@@ -13,6 +13,17 @@ import { useAuth } from '#tv/app/providers/auth';
 import { useConnection } from '#tv/app/providers/connection';
 import { getExo } from '#tv/features/playback/player/engine';
 
+/** The server-composited 16:9 "card" (backdrop + KROMA logo + "Reprendre" badge +
+ * resume bar) - the same vignette the Tizen Smart Hub tiles use. Public endpoint,
+ * so the launcher can fetch it without the app's auth. `v` busts the launcher's
+ * image cache when the art changes. */
+function cardArt(c: ContinueItem, client: KromaClient): string {
+  const progress = c.durationMs ? c.positionMs / c.durationMs : 0;
+  const params = new URLSearchParams({ label: 'Reprendre', v: c.item.addedAt });
+  if (progress > 0) params.set('progress', progress.toFixed(3));
+  return `${client.baseUrl}/api/items/${encodeURIComponent(c.item.id)}/card?${params}`;
+}
+
 /** Shape the native Android shell's Watch Next row consumes (see WatchNext.kt). */
 function toWatchNext(items: ContinueItem[], client: KromaClient) {
   return items.map((c) => {
@@ -21,7 +32,7 @@ function toWatchNext(items: ContinueItem[], client: KromaClient) {
       id: it.id,
       title: it.showTitle ?? it.title,
       subtitle: it.episodeTitle ?? (it.year ? String(it.year) : ''),
-      imageUrl: client.backdropFor(it) ?? client.posterFor(it),
+      imageUrl: cardArt(c, client),
       progressMs: Math.round(c.positionMs),
       durationMs: Math.round(c.durationMs ?? 0),
       kind: it.kind,

--- a/packages/tv/src/app/providers/continue.tsx
+++ b/packages/tv/src/app/providers/continue.tsx
@@ -1,4 +1,4 @@
-import type { ContinueItem } from '@kroma/core';
+import type { ContinueItem, KromaClient } from '@kroma/core';
 import {
   createContext,
   type ReactNode,
@@ -10,6 +10,24 @@ import {
 } from 'react';
 import { useAuth } from '#tv/app/providers/auth';
 import { useConnection } from '#tv/app/providers/connection';
+import { getExo } from '#tv/features/playback/player/engine';
+
+/** Shape the native Android shell's Watch Next row consumes (see WatchNext.kt). */
+function toWatchNext(items: ContinueItem[], client: KromaClient) {
+  return items.map((c) => {
+    const it = c.item;
+    return {
+      id: it.id,
+      title: it.showTitle ?? it.title,
+      subtitle: it.episodeTitle ?? (it.year ? String(it.year) : ''),
+      imageUrl: client.backdropFor(it) ?? client.posterFor(it),
+      progressMs: Math.round(c.positionMs),
+      durationMs: Math.round(c.durationMs ?? 0),
+      kind: it.kind,
+      updatedAtMs: Date.parse(c.updatedAt) || Date.now(),
+    };
+  });
+}
 
 interface Continue {
   items: ContinueItem[];
@@ -40,6 +58,15 @@ export function ContinueProvider({ children }: Readonly<{ children: ReactNode }>
   useEffect(() => {
     refresh();
   }, [refresh]);
+
+  // Mirror the list into the Android TV / Google TV launcher's system "Continue
+  // watching" (Watch Next) row, so it shows on the platform home even when the
+  // app is closed. No-op off the Android shell (getExo() null / no method).
+  useEffect(() => {
+    const exo = getExo();
+    if (!exo?.setContinueWatching || !client) return;
+    exo.setContinueWatching(JSON.stringify(toWatchNext(items, client)));
+  }, [items, client]);
 
   const value = useMemo<Continue>(() => ({ items, refresh }), [items, refresh]);
   return <ContinueCtx.Provider value={value}>{children}</ContinueCtx.Provider>;

--- a/packages/tv/src/app/providers/continue.tsx
+++ b/packages/tv/src/app/providers/continue.tsx
@@ -6,6 +6,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import { useAuth } from '#tv/app/providers/auth';
@@ -62,10 +63,17 @@ export function ContinueProvider({ children }: Readonly<{ children: ReactNode }>
   // Mirror the list into the Android TV / Google TV launcher's system "Continue
   // watching" (Watch Next) row, so it shows on the platform home even when the
   // app is closed. No-op off the Android shell (getExo() null / no method).
+  // Guard on the serialized payload: this effect re-runs on every `items`/render
+  // churn, and pushing the SAME list repeatedly raced the native sync into
+  // duplicate rows - only push when the content actually changed.
+  const lastPushed = useRef<string>('');
   useEffect(() => {
     const exo = getExo();
     if (!exo?.setContinueWatching || !client) return;
-    exo.setContinueWatching(JSON.stringify(toWatchNext(items, client)));
+    const json = JSON.stringify(toWatchNext(items, client));
+    if (json === lastPushed.current) return;
+    lastPushed.current = json;
+    exo.setContinueWatching(json);
   }, [items, client]);
 
   const value = useMemo<Continue>(() => ({ items, refresh }), [items, refresh]);

--- a/packages/tv/src/app/providers/recommend.tsx
+++ b/packages/tv/src/app/providers/recommend.tsx
@@ -1,7 +1,41 @@
-import type { Section, SectionItem } from '@kroma/core';
-import { createContext, type ReactNode, useContext, useEffect, useMemo, useState } from 'react';
+import type { KromaClient, Section, SectionItem } from '@kroma/core';
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useAuth } from '#tv/app/providers/auth';
 import { useConnection } from '#tv/app/providers/connection';
+import { getExo } from '#tv/features/playback/player/engine';
+
+/** Flatten the home sections (recently added + suggestions) into the KROMA
+ * preview-channel program list the native Android shell consumes. Movies only:
+ * the Watch Next / preview deep link resolves a movie id. The art is the public
+ * composited card (backdrop + KROMA logo), same vignette as Tizen. */
+function toHomeChannel(sections: Section[], client: KromaClient) {
+  const seen = new Set<string>();
+  const out: { id: string; title: string; subtitle: string; imageUrl: string; kind: string }[] = [];
+  for (const s of sections) {
+    for (const e of s.items) {
+      if (e.type !== 'movie' || seen.has(e.item.id)) continue;
+      seen.add(e.item.id);
+      const m = e.item;
+      out.push({
+        id: m.id,
+        title: m.title,
+        subtitle: m.year ? String(m.year) : '',
+        imageUrl: `${client.baseUrl}/api/items/${encodeURIComponent(m.id)}/card?v=${encodeURIComponent(m.addedAt)}`,
+        kind: 'movie',
+      });
+      if (out.length >= 40) return out; // preview channels cap ~50; stay lean
+    }
+  }
+  return out;
+}
 
 interface Recommend {
   /** The server-assembled, ordered, localized home sections (For You, "Because
@@ -50,6 +84,23 @@ export function RecommendProvider({ children }: Readonly<{ children: ReactNode }
       cancelled = true;
     };
   }, [user, client]);
+
+  // Mirror the recently-added + suggested titles into a KROMA preview channel on
+  // the Android TV / Google TV launcher home. Guarded on the serialized payload
+  // (the effect re-runs on render churn) so it pushes once per real change.
+  // No-op off the Android shell (getExo() null / no method).
+  const lastPushed = useRef<string>('');
+  useEffect(() => {
+    const exo = getExo();
+    if (!exo?.setHomeChannel || !client) return;
+    const json = JSON.stringify(toHomeChannel(sections, client));
+    if (json === lastPushed.current) return;
+    // Don't create an empty channel on the first (pre-load) render; an empty push
+    // is only meaningful as a clear AFTER we've published something.
+    if (json === '[]' && lastPushed.current === '') return;
+    lastPushed.current = json;
+    exo.setHomeChannel(json);
+  }, [sections, client]);
 
   const value = useMemo<Recommend>(() => ({ sections, featured }), [sections, featured]);
   return <Ctx.Provider value={value}>{children}</Ctx.Provider>;

--- a/packages/tv/src/app/providers/recommend.tsx
+++ b/packages/tv/src/app/providers/recommend.tsx
@@ -12,29 +12,52 @@ import { useAuth } from '#tv/app/providers/auth';
 import { useConnection } from '#tv/app/providers/connection';
 import { getExo } from '#tv/features/playback/player/engine';
 
-/** Flatten the home sections (recently added + suggestions) into the KROMA
- * preview-channel program list the native Android shell consumes. Movies only:
- * the Watch Next / preview deep link resolves a movie id. The art is the public
- * composited card (backdrop + KROMA logo), same vignette as Tizen. */
-function toHomeChannel(sections: Section[], client: KromaClient) {
-  const seen = new Set<string>();
-  const out: { id: string; title: string; subtitle: string; imageUrl: string; kind: string }[] = [];
-  for (const s of sections) {
+type HomeProgram = { id: string; title: string; subtitle: string; imageUrl: string; kind: string };
+// The native shell keys each launcher channel by its ROW INDEX (see HomeChannel.kt),
+// so the section id is not sent - only the display title + its programs.
+type HomeChannelSpec = { title: string; items: HomeProgram[] };
+
+/** The GENERIC, evergreen home rows to mirror onto the launcher, in display order.
+ * `/api/home` also returns personalized/themed rows ("Because you watched X",
+ * "Aventures fantastiques légères", curated editorial) - those make poor, unstable
+ * launcher channels, so only these stable, self-explanatory categories are published
+ * (their server ids are fixed; see services/sections build_home). */
+const GENERIC_HOME_ROWS = ['recent', 'for-you', 'trending'] as const;
+
+/** Map the generic home sections into named launcher rows (one KROMA preview channel
+ * each) the native Android shell publishes to the Google TV home - the multi-row
+ * equivalent of the Tizen shortcuts. Movies only (the preview deep link resolves a
+ * movie id); the art is the public composited card (backdrop + KROMA logo). */
+function toHomeChannels(sections: Section[], client: KromaClient): HomeChannelSpec[] {
+  const byId = new Map(sections.map((s) => [s.id, s]));
+  const channels: HomeChannelSpec[] = [];
+  for (const id of GENERIC_HOME_ROWS) {
+    const s = byId.get(id);
+    if (!s) continue;
+    const seen = new Set<string>();
+    const items: HomeProgram[] = [];
     for (const e of s.items) {
       if (e.type !== 'movie' || seen.has(e.item.id)) continue;
       seen.add(e.item.id);
       const m = e.item;
-      out.push({
+      items.push({
         id: m.id,
         title: m.title,
         subtitle: m.year ? String(m.year) : '',
         imageUrl: `${client.baseUrl}/api/items/${encodeURIComponent(m.id)}/card?v=${encodeURIComponent(m.addedAt)}`,
         kind: 'movie',
       });
-      if (out.length >= 40) return out; // preview channels cap ~50; stay lean
+      if (items.length >= 20) break; // per-row cap; the launcher shows only a handful
     }
+    if (items.length) channels.push({ title: s.title, items });
   }
-  return out;
+  // The generic rows are matched by fixed server section ids; if the server ever
+  // renames them we'd silently publish nothing, so surface that instead of a blank
+  // launcher (loud in dev; harmless in prod).
+  if (!channels.length && sections.length) {
+    console.warn('[KROMA] no generic home rows matched section ids', GENERIC_HOME_ROWS);
+  }
+  return channels;
 }
 
 interface Recommend {
@@ -93,9 +116,9 @@ export function RecommendProvider({ children }: Readonly<{ children: ReactNode }
   useEffect(() => {
     const exo = getExo();
     if (!exo?.setHomeChannel || !client) return;
-    const json = JSON.stringify(toHomeChannel(sections, client));
+    const json = JSON.stringify(toHomeChannels(sections, client));
     if (json === lastPushed.current) return;
-    // Don't create an empty channel on the first (pre-load) render; an empty push
+    // Don't create empty channels on the first (pre-load) render; an empty push
     // is only meaningful as a clear AFTER we've published something.
     if (json === '[]' && lastPushed.current === '') return;
     lastPushed.current = json;

--- a/packages/tv/src/app/settings/registry.ts
+++ b/packages/tv/src/app/settings/registry.ts
@@ -78,7 +78,7 @@ export const gpuRenderingSetting: SettingsItem = toggleItem({
   },
 });
 
-/** Quit the app - desktop shell only (fullscreen without window chrome). */
+/** Quit the app - desktop + Android TV shells (fullscreen, no window chrome). */
 export const quitAppItem: SettingsItem = actionItem({
   id: 'quitApp',
   label: 'profileMenu.quitApp',

--- a/packages/tv/src/features/playback/player/baseEngine.ts
+++ b/packages/tv/src/features/playback/player/baseEngine.ts
@@ -55,6 +55,11 @@ export abstract class BaseTvEngine implements TvEngine {
    * (the backend has none); turning the filter off drops back to the direct
    * file, and a remux failure degrades rather than costing the title. */
   protected filterMaster = false;
+  /** Force the server to TRANSCODE the audio to stereo AAC in the master. Set
+   * (one-shot) after the device fails to decode the source audio (e.g. E-AC3 /
+   * DTS / TrueHD with no hardware decoder), so the movie plays at the cost of
+   * surround rather than not at all. */
+  protected forceAac = false;
   /** Set on a re-anchor so playback resumes once the new source has loaded. */
   protected resumeOnLoad = false;
 
@@ -80,16 +85,28 @@ export abstract class BaseTvEngine implements TvEngine {
   protected sourceUrl(): string {
     return this.mode === 'direct'
       ? this.client.streamUrl(this.item.id)
-      : this.client.hlsMasterUrl(this.item.id, false, this.baseSec, this.rendition);
+      : this.client.hlsMasterUrl(this.item.id, this.forceAac, this.baseSec, this.rendition);
   }
 
-  /** A prepare/playback failure: a direct attempt retries ONCE as the master at
-   * the same position (a file the backend can't demux still plays, remuxed); a
-   * filter-forced master degrades ONCE to the clean direct file; anything else
-   * is surfaced. */
-  protected fail(): void {
+  /** A prepare/playback failure. `audioUnsupported` = the device can't decode the
+   * source audio track (the master must then transcode it to AAC). Otherwise a
+   * direct attempt retries ONCE as the master at the same position (a file the
+   * backend can't demux still plays, remuxed); a filter-forced master degrades
+   * ONCE to the clean direct file; anything else is surfaced. */
+  protected fail(audioUnsupported = false): void {
     if (this.destroyed) return;
     const pos = this.position();
+    // Audio the device has no decoder for: open the AAC-transcoded master (once).
+    // Works whether we were direct or on a copy-audio master that still carried
+    // the undecodable track.
+    if (audioUnsupported && !this.forceAac) {
+      this.forceAac = true;
+      this.fellBack = true; // an unrelated direct failure afterwards still errors
+      this.mode = 'master';
+      this.listeners.onWaiting();
+      this.reanchor(pos);
+      return;
+    }
     if (this.mode === 'direct' && !this.fellBack) {
       this.fellBack = true;
       this.mode = 'master';

--- a/packages/tv/src/features/playback/player/engine.ts
+++ b/packages/tv/src/features/playback/player/engine.ts
@@ -179,6 +179,10 @@ export interface ExoShellBridge {
    *  row. JSON array of `{id,title,subtitle?,imageUrl?,progressMs,durationMs,
    *  kind}`; `[]` clears it. Optional: absent on older installed APKs. */
   setContinueWatching?(json: string): void;
+  /** Publish the recently-added + suggested titles to a KROMA preview channel
+   *  (a dedicated row on the launcher home). JSON array of
+   *  `{id,title,subtitle?,imageUrl?,kind}`; `[]` clears it. Optional. */
+  setHomeChannel?(json: string): void;
 }
 
 /** The injected ExoPlayer bridge when running inside the Android TV shell, else null. */

--- a/packages/tv/src/features/playback/player/engine.ts
+++ b/packages/tv/src/features/playback/player/engine.ts
@@ -175,6 +175,11 @@ export interface ExoShellBridge {
   /** Terminate the whole app (the "Quitter" menu row). Optional: an older
    *  installed APK does not expose it, so the quit row stays hidden there. */
   quit?(): void;
+  /** Force the native playback engine for subsequent loads: `'vlc'` makes libVLC
+   *  the primary player (software-decode every codec), any other value restores
+   *  the ExoPlayer-first default. Optional: an older APK ignores the "libVLC"
+   *  engine choice and stays on ExoPlayer+fallback. */
+  setEngine?(mode: string): void;
   /** Publish the "continue watching" list to the launcher's system Watch Next
    *  row. JSON array of `{id,title,subtitle?,imageUrl?,progressMs,durationMs,
    *  kind}`; `[]` clears it. Optional: absent on older installed APKs. */

--- a/packages/tv/src/features/playback/player/engine.ts
+++ b/packages/tv/src/features/playback/player/engine.ts
@@ -172,6 +172,9 @@ export interface ExoShellBridge {
    *  thrown). Optional: an older installed APK does not expose it, and there
    *  the old assume-supported behaviour stands. */
   audioFilterSupported?(): boolean;
+  /** Terminate the whole app (the "Quitter" menu row). Optional: an older
+   *  installed APK does not expose it, so the quit row stays hidden there. */
+  quit?(): void;
 }
 
 /** The injected ExoPlayer bridge when running inside the Android TV shell, else null. */

--- a/packages/tv/src/features/playback/player/engine.ts
+++ b/packages/tv/src/features/playback/player/engine.ts
@@ -175,6 +175,10 @@ export interface ExoShellBridge {
   /** Terminate the whole app (the "Quitter" menu row). Optional: an older
    *  installed APK does not expose it, so the quit row stays hidden there. */
   quit?(): void;
+  /** Publish the "continue watching" list to the launcher's system Watch Next
+   *  row. JSON array of `{id,title,subtitle?,imageUrl?,progressMs,durationMs,
+   *  kind}`; `[]` clears it. Optional: absent on older installed APKs. */
+  setContinueWatching?(json: string): void;
 }
 
 /** The injected ExoPlayer bridge when running inside the Android TV shell, else null. */

--- a/packages/tv/src/features/playback/player/exoEngine.ts
+++ b/packages/tv/src/features/playback/player/exoEngine.ts
@@ -55,7 +55,7 @@ export class ExoEngine extends BaseTvEngine {
   private readonly bridge: ExoShellBridge;
   private bufSec = 0;
 
-  constructor(opts: EngineOptions) {
+  constructor(opts: EngineOptions & { forceVlc?: boolean }) {
     super(opts);
     // ExoPlayer reports its playing/paused state via events; assume paused until
     // the first `state` event arrives.
@@ -66,6 +66,13 @@ export class ExoEngine extends BaseTvEngine {
     (globalThis as ExoEventGlobal).__kromaExoEvent = (e) => {
       if (!this.destroyed) this.onEvent(e);
     };
+    // The "libVLC" engine: have the bridge software-decode every item from the
+    // start (not just as a decode-failure fallback). Set the mode UNCONDITIONALLY
+    // (before the first load()): the bridge is a long-lived singleton shared by
+    // every engine instance, so switching AWAY from libVLC must actively reset it,
+    // or a stale forceVlc would keep software-decoding later titles. An older APK
+    // without setEngine stays ExoPlayer-first (harmless).
+    this.bridge.setEngine?.(opts.forceVlc ? 'vlc' : 'exo');
     this.open();
   }
 

--- a/packages/tv/src/features/playback/player/exoEngine.ts
+++ b/packages/tv/src/features/playback/player/exoEngine.ts
@@ -43,6 +43,9 @@ interface ExoEvent {
   active?: boolean;
   supported?: boolean;
   message?: string;
+  /** On `error`: the device could not decode the source AUDIO track (so the
+   * fallback must transcode it to AAC), vs a demux/video failure. */
+  audio?: boolean;
 }
 
 type ExoEventGlobal = { __kromaExoEvent?: (e: ExoEvent) => void };
@@ -100,7 +103,7 @@ export class ExoEngine extends BaseTvEngine {
         if (e.supported === false) this.listeners.onAudioFilterUnavailable?.();
         break;
       case 'error':
-        this.fail();
+        this.fail(e.audio === true);
         break;
     }
   }

--- a/packages/tv/src/features/playback/player/useDirectPlayback.ts
+++ b/packages/tv/src/features/playback/player/useDirectPlayback.ts
@@ -23,6 +23,7 @@ import {
 } from '@kroma/ui';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
+  availableEngines,
   type EnginePref,
   getEnginePref,
   setEnginePref as persistEnginePref,
@@ -141,6 +142,10 @@ type Engine = 'mpv' | 'exo' | 'avplay' | 'video-direct' | 'video-remux';
  * isn't available on this platform (e.g. `mpv` off the Linux shell, `avplay` off
  * Tizen) quietly falls through to `auto`. */
 function resolveEngine(pref: EnginePref, env: PlayEnv, autoDirect: boolean): Engine {
+  // A stored engine no longer offered on this platform (e.g. a device left on
+  // `remux` after it was retired on Android TV, where the WebView cannot decode
+  // HEVC) must not strand playback on a dead engine - degrade it to `auto`.
+  if (pref !== 'auto' && !availableEngines().includes(pref)) pref = 'auto';
   const tizenNative = env.platform === 'tizen' && avplayAvailable();
   // Manual overrides.
   if (pref === 'avplay' && tizenNative) return 'avplay';
@@ -148,6 +153,9 @@ function resolveEngine(pref: EnginePref, env: PlayEnv, autoDirect: boolean): Eng
   if (pref === 'remux') return 'video-remux';
   if (pref === 'mpv' && mpvAvailable()) return 'mpv';
   if (pref === 'exo' && exoAvailable()) return 'exo';
+  // libVLC runs on the same native bridge as ExoPlayer (surface 'exo'); the
+  // forceVlc flag (see planEngine) tells the bridge to software-decode from the start.
+  if (pref === 'vlc' && exoAvailable()) return 'exo';
   // auto:
   if (tizenNative) return 'avplay';
   if (env.platform === 'desktop' && mpvAvailable()) return 'mpv';
@@ -203,6 +211,9 @@ interface EnginePlan {
   useAvplay: boolean;
   avplayDirect: boolean;
   exoDirect: boolean;
+  /** The user forced the "libVLC" engine: play every item through libVLC (software
+   * decode) from the start, on the ExoPlayer bridge/surface. */
+  forceVlc: boolean;
   direct: boolean;
   masterAac: boolean;
   playbackMode: 'direct' | 'remux' | 'transcode';
@@ -250,10 +261,14 @@ function planEngine(item: MediaItem, env: PlayEnv, pref: EnginePref): EnginePlan
   const useMpv = eng === 'mpv';
   const useExo = eng === 'exo';
   const useAvplay = eng === 'avplay';
+  // The user forced libVLC (runs on the exo bridge). It software-decodes ANY
+  // codec, so it always opens the ORIGINAL file directly (no pointless server
+  // remux), regardless of what the device's hardware decoders can handle.
+  const forceVlc = useExo && pref === 'vlc';
   // ExoPlayer demuxes (at least) the same container set AVPlay does, so the same
   // gate decides whether it opens the ORIGINAL file (zero server work).
   const avplayDirect = useAvplay && avplayDirectPlayable(item);
-  const exoDirect = useExo && avplayDirectPlayable(item);
+  const exoDirect = useExo && (forceVlc || avplayDirectPlayable(item));
   const direct = eng === 'video-direct';
   return {
     eng,
@@ -263,6 +278,7 @@ function planEngine(item: MediaItem, env: PlayEnv, pref: EnginePref): EnginePlan
     useAvplay,
     avplayDirect,
     exoDirect,
+    forceVlc,
     direct,
     // Env-aware: Safari's native HLS decodes AC3/E-AC3 so its master is stream-copied
     // (5.1 kept); Chromium/webOS MSE can't, so `selectEngine` marks those AAC.
@@ -291,6 +307,7 @@ function createTvEngine(args: {
   startSec: number;
   exoDirect: boolean;
   avplayDirect: boolean;
+  forceVlc: boolean;
   direct: boolean;
   masterAac: boolean;
   audioFilter: AudioFilterMode;
@@ -307,6 +324,7 @@ function createTvEngine(args: {
     startSec,
     exoDirect,
     avplayDirect,
+    forceVlc,
     direct,
     masterAac: aacMaster,
     audioFilter,
@@ -333,6 +351,7 @@ function createTvEngine(args: {
   if (eng === 'exo') {
     // Native ExoPlayer opens the original file directly (hardware decode); an
     // internal direct->master fallback covers the rare file it cannot open.
+    // `forceVlc` makes libVLC the primary player (software-decode every codec).
     return new ExoEngine({
       client,
       item,
@@ -340,6 +359,7 @@ function createTvEngine(args: {
       initialRendition: rendition,
       startSec,
       direct: exoDirect,
+      forceVlc,
       audioFilter,
       listeners,
     });
@@ -400,6 +420,9 @@ export function useDirectPlayback(client: KromaClient, item: MediaItem): Playbac
   const [playing, setPlaying] = useState(false);
   const [waiting, setWaiting] = useState(true);
   const [ready, setReady] = useState(false);
+  // Liveness heartbeat: bumped on every buffering signal so the load watchdog can
+  // tell "slow but alive" (keep waiting) from "dead" (fail). See the watchdog effect.
+  const [loadBeat, setLoadBeat] = useState(0);
   // Optimistic: a native plane is assumed to have DSP until its engine says
   // otherwise (the Android bridge only learns on the first real attempt, and
   // AVPlay only when the server's filtered remux fails).
@@ -432,8 +455,18 @@ export function useDirectPlayback(client: KromaClient, item: MediaItem): Playbac
   // lecture") re-plans + rebuilds the engine live. Seeded from the per-device
   // pref (shared with the profile-menu picker).
   const [enginePref, setEnginePrefState] = useState<EnginePref>(getEnginePref);
-  const { eng, surface, useMpv, useExo, avplayDirect, exoDirect, direct, masterAac, playbackMode } =
-    planEngine(item, env, enginePref);
+  const {
+    eng,
+    surface,
+    useMpv,
+    useExo,
+    avplayDirect,
+    exoDirect,
+    forceVlc,
+    direct,
+    masterAac,
+    playbackMode,
+  } = planEngine(item, env, enginePref);
   const durationSec = item.durationMs ? item.durationMs / 1000 : 0;
   // The runtime decode verdict for this item (from probed `capabilities()`). Drives
   // the pre-play warning and, when a `<video>`-engine attempt fails, the SPECIFIC
@@ -512,13 +545,26 @@ export function useDirectPlayback(client: KromaClient, item: MediaItem): Playbac
         setWaiting(false);
       },
       onPause: () => setPlaying(false),
-      onWaiting: () => setWaiting(true),
+      onWaiting: () => {
+        setWaiting(true);
+        // Proof of life for the load watchdog: a slowly-opening native plane
+        // (libVLC software-decoding 10-bit) keeps emitting buffering signals, so
+        // resetting the timer on each one lets it take as long as it needs while a
+        // truly dead load (no signals) still fails after the grace period.
+        setLoadBeat((n) => n + 1);
+      },
       onPlaying: () => setWaiting(false),
       onEnded: () => setEndedNonce((n) => n + 1),
       onError: () => setError(failKey),
       onAudioFilterUnavailable: () => setAudioFilterSupported(false),
       onReady: () => {
         setReady(true);
+        // A load that finally signals ready IS working - clear any premature error
+        // the load watchdog raised (libVLC software-decoding 10-bit HEVC at a deep
+        // resume point can take longer than the grace period to reach ready, but it
+        // recovers). Without this the "codec not supported" toast lingers over a
+        // playing video.
+        setError(null);
         // Ready-gated, resilient autoplay: retry until playback actually starts,
         // then stop so we never fight a real user pause.
         if (!startedRef.current) engineRef.current?.play();
@@ -534,6 +580,7 @@ export function useDirectPlayback(client: KromaClient, item: MediaItem): Playbac
       startSec,
       exoDirect,
       avplayDirect,
+      forceVlc,
       direct,
       masterAac,
       // Persisted mode, read at build time so a remembered filter is active from
@@ -579,22 +626,31 @@ export function useDirectPlayback(client: KromaClient, item: MediaItem): Playbac
   // prepare errors. After a grace period, log what we know and surface the failure.
   useEffect(() => {
     if (surface === 'avplay' || ready || error) return;
+    // The native software-decode planes (ExoPlayer's libVLC fallback, mpv) can take
+    // much longer than a hardware/`<video>` load to reach ready - libVLC decoding
+    // 10-bit HEVC at a deep resume point over the LAN routinely needs 20s+ - so give
+    // them a longer grace before crying failure, or the video plays UNDER a false
+    // "codec not supported" toast. `loadBeat` is in the deps: each buffering signal
+    // re-arms this timer, so a slow-but-alive load never trips it (and a dead one,
+    // which emits nothing, still fails after the grace).
+    const graceMs = surface === 'exo' || surface === 'mpv' ? 30000 : 15000;
+    const graceS = graceMs / 1000;
     const id = window.setTimeout(() => {
       if (surface === 'mpv' || surface === 'exo') {
-        console.error(`[KROMA] ${surface} engine did not signal ready in 15s`);
+        console.error(`[KROMA] ${surface} engine did not signal ready in ${graceS}s`);
       } else {
         const v = videoRef.current;
         const e = v?.error;
         console.error(
-          `[KROMA] stream did not load in 15s: networkState=${v?.networkState} ` +
+          `[KROMA] stream did not load in ${graceS}s: networkState=${v?.networkState} ` +
             `readyState=${v?.readyState} errorCode=${e?.code ?? '-'} ${e?.message ?? ''} ` +
             `src=${v?.currentSrc || v?.src || '(none)'}`,
         );
       }
       setError(failKey);
-    }, 15000);
+    }, graceMs);
     return () => window.clearTimeout(id);
-  }, [surface, ready, error, failKey]);
+  }, [surface, ready, error, failKey, loadBeat]);
 
   const getPosition = useCallback(() => engineRef.current?.position() ?? 0, []);
   // Resize the native video plane (shrink into the settings card, or null =

--- a/packages/tv/src/shared/preview/deeplink.test.ts
+++ b/packages/tv/src/shared/preview/deeplink.test.ts
@@ -35,6 +35,11 @@ describe('readDeepLink', () => {
     expect(readDeepLink()).toBeNull();
   });
 
+  it('reads the Android TV ?deeplink= param as a movie target', () => {
+    vi.stubGlobal('location', { search: '?deeplink=itm42' });
+    expect(readDeepLink()).toEqual({ type: 'movie', id: 'itm42' });
+  });
+
   it('decodes a direct JSON payload', () => {
     stubTizen({ payload: JSON.stringify({ type: 'movie', id: 'abc' }) });
     expect(readDeepLink()).toEqual({ type: 'movie', id: 'abc' });

--- a/packages/tv/src/shared/preview/deeplink.ts
+++ b/packages/tv/src/shared/preview/deeplink.ts
@@ -31,10 +31,20 @@ function parsePayload(raw: string): DeepLink | null {
   return null;
 }
 
+/** The Android TV shell (MainActivity) hands a Watch Next tile's item id in via
+ *  `?deeplink=<id>` on cold launch. We don't know movie-vs-show here, so target
+ *  the movie catalog (the common continue-watching case); an unmatched id simply
+ *  doesn't navigate. */
+function readAndroidDeepLink(): DeepLink | null {
+  if (typeof location === 'undefined') return null;
+  const id = new URLSearchParams(location.search).get('deeplink');
+  return id ? { type: 'movie', id } : null;
+}
+
 /** The tile selection that launched/targeted the app, or null. */
 export function readDeepLink(): DeepLink | null {
   const t = tizen();
-  if (!t) return null;
+  if (!t) return readAndroidDeepLink();
   try {
     const req = t.application.getCurrentApplication().getRequestedAppControl();
     const payload = req?.appControl.data.find((d) => d.key === 'PAYLOAD')?.value?.[0];
@@ -48,11 +58,23 @@ export function readDeepLink(): DeepLink | null {
  *  launch is covered by readDeepLink(); this handles selection while open.
  *  Returns a cleanup function. */
 export function onDeepLink(cb: (link: DeepLink) => void): () => void {
-  if (!tizen()) return () => undefined;
+  if (typeof window === 'undefined') return () => undefined;
+  // Android TV warm start: MainActivity dispatches `kroma-deeplink` with the item
+  // id as `detail` (see MainActivity.onNewIntent).
+  const android = (e: Event) => {
+    const id = (e as CustomEvent<string>).detail;
+    if (typeof id === 'string' && id) cb({ type: 'movie', id });
+  };
+  window.addEventListener('kroma-deeplink', android);
+
+  if (!tizen()) return () => window.removeEventListener('kroma-deeplink', android);
   const handler = () => {
     const link = readDeepLink();
     if (link) cb(link);
   };
   window.addEventListener('appcontrol', handler);
-  return () => window.removeEventListener('appcontrol', handler);
+  return () => {
+    window.removeEventListener('appcontrol', handler);
+    window.removeEventListener('kroma-deeplink', android);
+  };
 }

--- a/packages/ui/src/components/KromaIntro/index.tsx
+++ b/packages/ui/src/components/KromaIntro/index.tsx
@@ -42,6 +42,13 @@ export interface KromaIntroProps {
   lite?: boolean;
 }
 
+/** A solid #0A0A0C poster (2x2 PNG). Without a poster the WebView paints its own
+ * placeholder for an un-started <video> - on Android TV a light panel with a
+ * centre play glyph, which flashes for a few frames before the film decodes.
+ * A matching-black poster keeps the stage black through the load instead. */
+const POSTER =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAEElEQVR42mPg4uIBIgYIBQADhgCBD73RIwAAAABJRU5ErkJggg==';
+
 /** Seconds before the end of the film when the tagline overlay fades in. */
 const TAGLINE_LEAD_S = 2.6;
 /** Slack added to the video duration for the stall-safety timer (ms). */
@@ -213,6 +220,7 @@ function VideoIntro({
         ref={videoRef}
         playsInline
         preload="metadata"
+        poster={POSTER}
         style={{
           position: 'absolute',
           inset: 0,


### PR DESCRIPTION
Android TV client work from this session, verified on the Google TV emulator (LOTR 8-bit HEVC + E-AC3, HTTYD 10-bit HEVC + AAC both play with video + audio).

## Playback
- **Selectable "libVLC" engine** (software-decodes any codec) alongside ExoPlayer. ExoPlayer hands off both undecodable video *and* audio to libVLC. Engine mode is set on the shared bridge unconditionally so switching away from libVLC resets it.
- **libVLC audio fixed**: `setAudio` skips VLC's synthetic "Disable" track (was silencing audio); `--no-spdif` always decodes to PCM (avoids the bogus passthrough sample-rate-0 that muted E-AC3).
- **Native subtitles disabled** (libVLC `--no-spu`, ExoPlayer text tracks) so the React overlay is the only renderer.
- **libVLC resizes into the settings card** (the `rect` command now drives the VLC surface).
- **Engine self-heal**: retire `remux` on Android (the WebView can't decode HEVC); a stored pref no longer offered degrades to `auto`.
- **Load watchdog**: 30s + re-arm on buffering signals so slow software decode never false-errors, and clear a premature error once the load recovers.

## Launcher (Google TV home)
- `<queries>` so Android 11+ package visibility stops blocking the launcher interaction.
- Publish the **generic** home rows (recently added / for you / trending) as named preview channels, keyed by **row index** (stable — fixes the 34-duplicate pile-up), enumerated via a direct provider query, best-effort auto-enabled.

## Review
Ran `/code-review` (xhigh); 6 of 7 findings fixed, #7 (the removed server-AAC audio fallback) intentionally kept as client-side decode. Web typecheck + 34 unit tests pass; APK builds; runtime verified on the emulator.

https://claude.ai/code/session_018JipWH5r7BRZbToe7m4Whp