### PR TITLE
fix(ci): stop two release jobs failing for reasons nobody changed

### DIFF
--- a/.github/scripts/asc-mint-profiles.py
+++ b/.github/scripts/asc-mint-profiles.py
@@ -26,6 +26,7 @@ Then:
 
 import argparse
 import datetime
+import os
 import sys
 
 import asc_api as asc
@@ -47,11 +48,67 @@ WANTED = [
     (f"{BUNDLE}.TopShelf", "TVOS_APP_STORE", "tvos-topshelf"),
 ]
 
+# Capabilities the App ID must carry for a minted profile to be usable.
+#
+# A profile only ever contains what the App ID had AT MINT TIME, so this is the
+# other half of the job: minting against an App ID that is missing a capability
+# produces a profile that installs cleanly and then fails the archive with
+# "doesn't include the ... entitlement". That is exactly how push shipped - the
+# app declared `aps-environment`, the App ID did not have Push Notifications,
+# and the stored profile predated both.
+#
+# Listed here rather than read from the entitlements because enabling one is a
+# change to the Apple ACCOUNT: it should be a deliberate line in a diff, not
+# something a build infers and does silently.
+#
+# Only ones that need no configuration of their own. APP_GROUPS is deliberately
+# absent: it has to be pointed at a specific group, so it stays a manual step.
+REQUIRED_CAPABILITIES = {
+    BUNDLE: ["PUSH_NOTIFICATIONS"],
+}
+
+
+def ensure_capabilities(bundle: str, bundle_id: str, jwt: str) -> bool:
+    """Turn on anything the App ID is missing. True when something changed."""
+    wanted = REQUIRED_CAPABILITIES.get(bundle, [])
+    if not wanted:
+        return False
+    have = {
+        c["attributes"]["capabilityType"]
+        for c in asc.get(f"bundleIds/{bundle_id}/bundleIdCapabilities?limit=200", jwt).get(
+            "data", []
+        )
+        if c.get("attributes", {}).get("capabilityType")
+    }
+    changed = False
+    for capability in wanted:
+        if capability in have:
+            continue
+        asc.post(
+            "bundleIdCapabilities",
+            jwt,
+            {
+                "data": {
+                    "type": "bundleIdCapabilities",
+                    "attributes": {"capabilityType": capability},
+                    "relationships": {
+                        "bundleId": {"data": {"type": "bundleIds", "id": bundle_id}}
+                    },
+                }
+            },
+        )
+        print(f"  enabled {capability} on {bundle}")
+        changed = True
+    return changed
+
 
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--out", default=".", help="where to write the .b64 files")
     args = ap.parse_args()
+    # The workflow points --out at a fresh path under RUNNER_TEMP, so this has to
+    # create it; writing was previously only ever done into an existing cwd.
+    os.makedirs(args.out, exist_ok=True)
 
     jwt = asc.token()
 
@@ -80,6 +137,15 @@ def main() -> int:
     certs.sort(key=lambda c: c["attributes"].get("expirationDate", ""), reverse=True)
     cert_id = certs[0]["id"]
     print(f"using certificate {certs[0]['attributes'].get('displayName','?')}")
+
+    # Capabilities FIRST, for every App ID, before a single profile is minted.
+    # Enabling one invalidates every existing profile for that App ID - including
+    # any this loop had already created - so doing it per-bundle inside the mint
+    # loop would invalidate the profiles minted on earlier iterations.
+    for bundle in {b for b, _, _ in WANTED}:
+        bundle_id = found.get(bundle)
+        if bundle_id:
+            ensure_capabilities(bundle, bundle_id, jwt)
 
     stamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d")
     for bundle, profile_type, basename in WANTED:

--- a/.github/scripts/ios-import-signing-assets.sh
+++ b/.github/scripts/ios-import-signing-assets.sh
@@ -7,6 +7,12 @@
 # extension. The Apple TV app builds two targets (KROMA and KromaTopShelf) whose
 # bundle ids differ, and Apple issues a profile per bundle id, so one profile can
 # never cover both.
+#
+# IOS_PROFILE_FILE / IOS_PROFILE_EXTRA_FILE name a base64 file minted earlier in
+# the job and TAKE PRECEDENCE over the matching secret. A stored profile is a
+# derived artifact that goes stale whenever the App ID's capabilities change, so
+# the freshly minted one is the answer whenever there is one; the secret remains
+# the fallback for a run with no App Store Connect key.
 set -euo pipefail
 
 kc="$RUNNER_TEMP/kroma-ios.keychain-db"
@@ -40,6 +46,16 @@ install_profile() {
   rm -f "$tmp" "$tmp.plist"
 }
 
-install_profile "${IOS_PROFILE:-}"
-install_profile "${IOS_PROFILE_EXTRA:-}"
+# A minted file wins over the secret of the same name.
+profile_or_secret() {
+  local file="$1" secret="$2"
+  if [[ -n "$file" && -s "$file" ]]; then
+    printf '%s' "$(cat "$file")"
+  else
+    printf '%s' "$secret"
+  fi
+}
+
+install_profile "$(profile_or_secret "${IOS_PROFILE_FILE:-}" "${IOS_PROFILE:-}")"
+install_profile "$(profile_or_secret "${IOS_PROFILE_EXTRA_FILE:-}" "${IOS_PROFILE_EXTRA:-}")"
 rm -f "$RUNNER_TEMP/ios-cert.p12"

--- a/.github/workflows/_release-appletv.yml
+++ b/.github/workflows/_release-appletv.yml
@@ -195,15 +195,43 @@ jobs:
           cd clients/tv-native/ios
           REACT_NATIVE_NODE_MODULES_DIR="$PWD/../node_modules" pod install
 
+      # Same reasoning as the phone job: a profile is derived from the App ID's
+      # current capabilities, so it is minted per run rather than stored. One
+      # call covers both bundle ids - the app and its Top Shelf extension.
+      - name: Mint provisioning profiles
+        id: profiles
+        if: steps.signing.outputs.ready == 'true'
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_PRIVATE_KEY: ${{ secrets.ASC_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${ASC_KEY_ID:-}" || -z "${ASC_ISSUER_ID:-}" || -z "${ASC_PRIVATE_KEY:-}" ]]; then
+            echo "No App Store Connect key; falling back to the stored profile secrets."
+            exit 0
+          fi
+          mkdir -p "$RUNNER_TEMP/asc"
+          printf '%s' "$ASC_PRIVATE_KEY" > "$RUNNER_TEMP/asc/AuthKey_${ASC_KEY_ID}.p8"
+          if ASC_PRIVATE_KEY_PATH="$RUNNER_TEMP/asc/AuthKey_${ASC_KEY_ID}.p8" \
+             python3 .github/scripts/asc-mint-profiles.py --out "$RUNNER_TEMP/profiles"; then
+            echo "minted=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::minting failed; falling back to the stored profile secrets"
+          fi
+          rm -f "$RUNNER_TEMP/asc/AuthKey_${ASC_KEY_ID}.p8"
+
       - name: Import certificate + provisioning profile
         if: steps.signing.outputs.ready == 'true'
         env:
           IOS_CERTIFICATE: ${{ secrets.MOBILE_IOS_CERTIFICATE }}
           IOS_CERTIFICATE_PASSWORD: ${{ secrets.MOBILE_IOS_CERTIFICATE_PASSWORD }}
+          IOS_PROFILE_FILE: ${{ steps.profiles.outputs.minted == 'true' && format('{0}/profiles/tvos.b64', runner.temp) || '' }}
           IOS_PROFILE: ${{ secrets.TVOS_PROVISIONING_PROFILE }}
           # The Top Shelf extension is a separate bundle id and so a separate
           # profile; without it that target goes unsigned and the export fails
           # with "No profiles for 'tv.kroma.mobile.TopShelf' were found".
+          IOS_PROFILE_EXTRA_FILE: ${{ steps.profiles.outputs.minted == 'true' && format('{0}/profiles/tvos-topshelf.b64', runner.temp) || '' }}
           IOS_PROFILE_EXTRA: ${{ secrets.TVOS_TOPSHELF_PROVISIONING_PROFILE }}
         run: .github/scripts/ios-import-signing-assets.sh
 

--- a/.github/workflows/_release-mobile.yml
+++ b/.github/workflows/_release-mobile.yml
@@ -293,11 +293,51 @@ jobs:
           /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $build" "$plist"
           echo "re-stamped $plist -> $ver ($build)"
 
+      # Mint the profile HERE rather than read a stored one.
+      #
+      # A provisioning profile is a DERIVED artifact - App ID, plus that App ID's
+      # capabilities, plus the distribution certificate - so freezing one into a
+      # secret guarantees it goes stale the moment any of those changes, and the
+      # staleness surfaces days later as an archive error blaming the profile.
+      # That is exactly what adding push did: the app declared `aps-environment`,
+      # and the stored profile had been minted before push existed.
+      #
+      # Minting per run also enables any capability the App ID is missing, so the
+      # two halves can never disagree. The stored secret stays as the fallback
+      # for a run without API credentials (a fork, a key rotation) - it is no
+      # longer the normal path.
+      - name: Mint provisioning profiles
+        id: profiles
+        if: steps.signing.outputs.ready == 'true'
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_PRIVATE_KEY: ${{ secrets.ASC_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${ASC_KEY_ID:-}" || -z "${ASC_ISSUER_ID:-}" || -z "${ASC_PRIVATE_KEY:-}" ]]; then
+            echo "No App Store Connect key; falling back to the stored profile secret."
+            exit 0
+          fi
+          mkdir -p "$RUNNER_TEMP/asc"
+          printf '%s' "$ASC_PRIVATE_KEY" > "$RUNNER_TEMP/asc/AuthKey_${ASC_KEY_ID}.p8"
+          # Not fatal: a mint failure should fall back to the stored secret
+          # rather than fail a release outright.
+          if ASC_PRIVATE_KEY_PATH="$RUNNER_TEMP/asc/AuthKey_${ASC_KEY_ID}.p8" \
+             python3 .github/scripts/asc-mint-profiles.py --out "$RUNNER_TEMP/profiles"; then
+            echo "minted=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::minting failed; falling back to the stored profile secret"
+          fi
+          rm -f "$RUNNER_TEMP/asc/AuthKey_${ASC_KEY_ID}.p8"
+
       - name: Import certificate + provisioning profile
         if: steps.signing.outputs.ready == 'true'
         env:
           IOS_CERTIFICATE: ${{ secrets.MOBILE_IOS_CERTIFICATE }}
           IOS_CERTIFICATE_PASSWORD: ${{ secrets.MOBILE_IOS_CERTIFICATE_PASSWORD }}
+          # The freshly minted profile when there is one, else the stored secret.
+          IOS_PROFILE_FILE: ${{ steps.profiles.outputs.minted == 'true' && format('{0}/profiles/ios.b64', runner.temp) || '' }}
           IOS_PROFILE: ${{ secrets.MOBILE_IOS_PROVISIONING_PROFILE }}
         run: .github/scripts/ios-import-signing-assets.sh
 

--- a/clients/synology/build.sh
+++ b/clients/synology/build.sh
@@ -77,7 +77,18 @@ TARGET="x86_64-unknown-linux-musl"
 # cached build artifact (CI caches server/target across runs). Bump the digest
 # deliberately when a newer toolchain is wanted.
 RUST_IMAGE="${RUST_IMAGE:-messense/rust-musl-cross:x86_64-musl@sha256:ce75e9174325d4fbb3de85c309e2d7ca29f7500169bc4b5d2c611ff7e86d549a}"
-FFMPEG_URL="https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz"
+# Static ffmpeg/ffprobe. Two sources, tried in order.
+#
+# The primary is what has always shipped. It is one person's web server with no
+# CDN behind it, and when it is down - which it has been, for the whole of a
+# 24-minute build - there is nothing to fall back to and the package cannot be
+# built at all. The secondary is BtbN's, hosted on GitHub releases: same GPL
+# static build, a different machine and a different network.
+#
+# Order matters: the primary stays first so a normal build ships exactly what it
+# always has, and the fallback only decides whether an OUTAGE costs a release.
+FFMPEG_URL="${FFMPEG_URL:-https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz}"
+FFMPEG_FALLBACK_URL="${FFMPEG_FALLBACK_URL:-https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz}"
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 SKEL="$ROOT/clients/synology/spk"
@@ -134,13 +145,46 @@ fi
 
 # 3) Static ffmpeg + ffprobe (x86_64) ----------------------------------------
 FF="$CACHE/ffmpeg-amd64-static"
+
+# Download `$1` to `$2`, or return non-zero.
+#
+# `--connect-timeout` is the point of this. Without it a host that accepts no
+# connections is retried five times at ~135 s each, so an outage cost 24 minutes
+# and then failed anyway - the worst of both. A dead host should be established
+# in seconds so the fallback gets its turn while the build still has a chance.
+#
+# --retry-all-errors is kept: the primary intermittently answers a spurious 4xx
+# that a plain retry would not cover.
+fetch_ffmpeg() {
+  curl -fSL --connect-timeout 20 --retry 3 --retry-delay 4 --retry-all-errors \
+    --proto '=https' --proto-redir '=https' "$1" -o "$2"
+}
+
 if [ ! -x "$FF/ffmpeg" ]; then
   say "Fetching static ffmpeg/ffprobe"
-  # --retry-all-errors: johnvansickle.com intermittently 4xx/5xxs, so retry even
-  # an HTTP error (e.g. a spurious 415), not just connection failures.
-  curl -fSL --retry 5 --retry-delay 4 --retry-all-errors \
-    --proto '=https' --proto-redir '=https' "$FFMPEG_URL" -o "$WORK/ff.tar.xz"
-  mkdir -p "$FF" && tar xJf "$WORK/ff.tar.xz" -C "$FF" --strip-components=1
+  if ! fetch_ffmpeg "$FFMPEG_URL" "$WORK/ff.tar.xz"; then
+    say "Primary ffmpeg source unreachable, trying the fallback"
+    fetch_ffmpeg "$FFMPEG_FALLBACK_URL" "$WORK/ff.tar.xz" \
+      || { echo "both ffmpeg sources failed"; exit 1; }
+  fi
+
+  # Extracted whole rather than with --strip-components, because the two sources
+  # do not agree on the layout: the primary puts the binaries at the root of its
+  # directory, BtbN puts them under `bin/`. Find them instead of assuming.
+  mkdir -p "$WORK/ffx" && tar xJf "$WORK/ff.tar.xz" -C "$WORK/ffx"
+  mkdir -p "$FF"
+  for tool in ffmpeg ffprobe; do
+    found="$(find "$WORK/ffx" -type f -name "$tool" -perm -u+x -print -quit)"
+    [ -n "$found" ] || { echo "$tool missing from the ffmpeg archive"; exit 1; }
+    install -m755 "$found" "$FF/$tool"
+  done
+
+  # The tarball URL is a MOVING "latest release" pointer, so there is no checksum
+  # to pin against. Running the thing is the check that is actually available: it
+  # catches a truncated download, an HTML error page saved as a tarball, and an
+  # archive for the wrong architecture.
+  "$FF/ffmpeg" -version >/dev/null 2>&1 \
+    || { echo "downloaded ffmpeg does not run"; exit 1; }
 fi
 
 # 4) Stage the payload (→ /var/packages/kroma/target) -------------------------


### PR DESCRIPTION
Two unrelated `main` failures, both structural rather than caused by any commit.

## 1. Synology `.spk` — the ffmpeg host went down

The build failed after **24 minutes**, all of it spent on `johnvansickle.com`
refusing connections: six retries at ~135 s each, then a failure anyway.

- **A second source** — BtbN's static builds on GitHub releases. The primary
  stays *first*, so a normal build ships exactly what it always has; the fallback
  only decides whether an outage costs a release.
- **Fail fast** — `--connect-timeout 20`. Without it a dead host burns ~11
  minutes before the fallback could even get its turn.
- **Check what arrived** — the URL is a moving "latest release" pointer so there
  is no checksum to pin, but `ffmpeg -version` catches a truncated download, an
  HTML error page saved as a tarball, and a wrong-architecture archive.

The archive is extracted whole and the binaries located with `find`, because the
sources disagree on layout — johnvansickle puts them at the root, BtbN under
`bin/`. Verified by fetching from both.

## 2. Apple `.ipa` — the stored profile was a frozen derived value

A provisioning profile is derived from (App ID + its capabilities + distribution
certificate). Storing one in a secret guarantees it goes stale whenever any input
changes, and the staleness surfaces later as an archive error blaming the
profile. That is how push broke the release: the app began declaring
`aps-environment`, the App ID lacked Push Notifications, and the stored profile
predated both.

**Not** fixed by returning to automatic signing — `ios-archive-export-ipa.sh`
records why that was abandoned: `-allowProvisioningUpdates` invents certificates,
and ten piled up in a week until the account hit Apple's ceiling. Manual signing
is unchanged.

Instead, both Apple jobs mint profiles per run and the import prefers the fresh
file over the secret. `asc-mint-profiles.py` also now enables any capability the
App ID is missing *before* minting, since a profile only ever carries what the
App ID had at mint time. Capabilities are listed explicitly, not inferred from
entitlements — enabling one changes the Apple account and belongs in a diff.

The stored secrets remain as a fallback for a run without an ASC key, and a mint
failure warns rather than failing the release, so this is strictly additive.

### Not verified end to end
These jobs only run on `main` and need signing secrets, so this PR's checks
cannot exercise them. The logic is reviewed and the scripts syntax-check, but the
first real proof is the next release run.