### PR TITLE
fix(ci): the ffmpeg fetch trusts nothing but a real archive, and the prerender retries

### DIFF
--- a/.github/workflows/synology.yml
+++ b/.github/workflows/synology.yml
@@ -219,9 +219,15 @@ jobs:
             echo "using the cached ffmpeg-arm64"
             exit 0
           fi
+          # `xz -t` is part of the fetch, not a separate step: the primary has
+          # served an HTML error page WITH HTTP 200 (2026-07-31, coming back
+          # from an outage), which -f waves through and tar then dies on -
+          # before the fallback was ever consulted. A fetch only counts when
+          # what arrived is actually an xz archive.
           fetch() {
             curl -fSL --connect-timeout 20 --retry 3 --retry-delay 4 --retry-all-errors \
-              --proto '=https' --proto-redir '=https' "$1" -o ff.tar.xz
+              --proto '=https' --proto-redir '=https' "$1" -o ff.tar.xz \
+              && xz -t ff.tar.xz 2>/dev/null
           }
           if ! fetch "$FFMPEG_URL"; then
             echo "primary ffmpeg source unreachable, trying the fallback"

--- a/clients/site/vite.config.ts
+++ b/clients/site/vite.config.ts
@@ -38,6 +38,12 @@ export default defineConfig({
       prerender: {
         enabled: true,
         crawlLinks: true,
+        // The prerenderer fetches pages from its own just-started local
+        // server, and CI has lost that race twice in one day (connect
+        // ETIMEDOUT/ECONNREFUSED on the first page). A failed page gets
+        // retried instead of failing the build.
+        retryCount: 3,
+        retryDelay: 1000,
         // Two kinds of crawled href are not a page: in-page anchors and the
         // trailing-slash twin of a path already queued. The FIRST spelling of
         // a twin wins, not the slashless one: the route tree spells a


### PR DESCRIPTION
Two follow-ups to today's pipeline reds, both now with the actual root cause:

- **Synology arm64**: johnvansickle.com came back from its outage serving a 7 KB HTML error page **with HTTP 200** — `curl -f` accepts it and `tar` dies before the BtbN fallback is ever consulted. `xz -t` is now part of the fetch itself, so a fetch only "succeeds" when what arrived is a real xz archive; garbage falls through to the fallback exactly like a connection failure.
- **Client / site**: the TanStack prerenderer fetches pages from its own just-started local server and lost that race twice today (`ETIMEDOUT ::1:<port>` on the first page). `retryCount: 3, retryDelay: 1000` retries the page instead of failing the build. Verified locally: full site build + prerender passes with the config.