### PR TITLE
fix(cast): casting is scoped to the signed-in account

### DIFF
--- a/server/crates/kroma-domain/src/cast.rs
+++ b/server/crates/kroma-domain/src/cast.rs
@@ -84,8 +84,9 @@ pub struct CastReceiver {
     pub id: String,
     pub name: String,
     pub platform: String,
-    // Deliberately the only identity here: no account id and no per-reader
-    // "mine" flag, so one row can be pushed unchanged to every viewer.
+    // Deliberately the only identity here: the roster is scoped to the account
+    // the receiver is signed into, so a reader needs no account id or "mine"
+    // flag — everything it is shown is its own.
     pub username: String,
     pub network: String,
     #[serde(rename = "nowPlaying", skip_serializing_if = "Option::is_none")]

--- a/server/crates/kroma-engine/src/services/cast/mod.rs
+++ b/server/crates/kroma-engine/src/services/cast/mod.rs
@@ -4,8 +4,10 @@
 //!
 //! Security invariants: a receiver id is bound to the account that first announced
 //! it, so nobody can impersonate the living-room TV to intercept its commands;
-//! a command leaves the inbox only once acked, so a lost push is applied exactly
-//! once; roster and inboxes are bounded; nothing served is privileged.
+//! everything is scoped to that account — only its own sessions see, pick up, or
+//! drive the set, so a stranger signed into the same server cannot touch it; a
+//! command leaves the inbox only once acked, so a lost push is applied exactly
+//! once; roster and inboxes are bounded.
 
 mod registry;
 

--- a/server/crates/kroma-engine/src/services/cast/registry.rs
+++ b/server/crates/kroma-engine/src/services/cast/registry.rs
@@ -57,7 +57,8 @@ pub enum Announced {
     Full,
 }
 
-// The account is kept off the wire type: the roster is readable by every viewer.
+// The account id is kept off the wire type: rows leave the server, and the
+// username already names the profile.
 struct ControllerEntry {
     view: CastController,
     user_id: String,
@@ -67,11 +68,12 @@ struct Receiver {
     id: String,
     name: String,
     platform: String,
-    // Sticky for the receiver's lifetime; gates re-announce and unregister,
-    // never who may command it.
+    // Sticky for the receiver's lifetime; scopes everything — who sees this set,
+    // who may command it, who may re-announce or unregister it.
     user_id: String,
     username: String,
-    // `LAN` | `WAN`, never the IP: the roster is readable by every viewer.
+    // `LAN` | `WAN`, never the IP: the row still travels to every device of the
+    // account.
     network: String,
     playback: Option<CastPlayback>,
     // Resolved server-side, so senders render a title they cannot spoof.
@@ -256,7 +258,8 @@ impl Registry {
     }
 
     /// `controller_id` is minted by the caller per socket, never by the client,
-    /// so the identity a television shows cannot be forged.
+    /// so the identity a television shows cannot be forged. Owner-scoped like
+    /// commanding: another account's set cannot be picked up at all.
     pub fn attach_controller(
         &self,
         receiver_id: &str,
@@ -267,7 +270,7 @@ impl Registry {
         avatar_url: Option<&str>,
     ) -> Option<CastReceiver> {
         let mut map = self.inner.write().unwrap();
-        let entry = map.get_mut(receiver_id).filter(|r| r.live())?;
+        let entry = map.get_mut(receiver_id).filter(|r| r.live() && r.user_id == user_id)?;
         // Picking a set up again is deliberate, so it clears an earlier kick.
         entry.kicked.remove(user_id);
         let view = CastController {
@@ -306,20 +309,22 @@ impl Registry {
         Some(entry.view())
     }
 
-    pub fn detach_controller(&self, controller_id: &str) -> Vec<CastReceiver> {
+    /// Returns each changed row with the account it belongs to, so the caller can
+    /// address the update to that account's sockets and no others.
+    pub fn detach_controller(&self, controller_id: &str) -> Vec<(String, CastReceiver)> {
         let mut map = self.inner.write().unwrap();
         let mut changed = Vec::new();
         for receiver in map.values_mut() {
             if receiver.controllers.remove(controller_id).is_some() {
-                changed.push(receiver.view());
+                changed.push((receiver.user_id.clone(), receiver.view()));
             }
         }
         changed
     }
 
-    /// Scoped to `receiver_id` on purpose: the roster is readable by every viewer
-    /// and carries controller ids, so removing by controller id alone would let
-    /// any set evict somebody else's remote.
+    /// Scoped to `receiver_id` on purpose: rows carry controller ids to every
+    /// device of the account, so removing by controller id alone would let one
+    /// set evict a remote attached to another.
     pub fn kick_controller(
         &self,
         receiver_id: &str,
@@ -332,11 +337,13 @@ impl Registry {
         Some((entry.view(), gone.user_id))
     }
 
-    /// Whether `user_id` may send this set an order. `None` when there is no such
-    /// live receiver: the caller answers 404, so this cannot probe the roster.
+    /// Whether `user_id` may send this set an order: only the account the receiver
+    /// is signed into. `None` for a receiver that is absent, dead, *or* another
+    /// account's — the caller answers all three with a 404, so somebody else's
+    /// TV is indistinguishable from no TV at all.
     pub fn may_command(&self, receiver_id: &str, user_id: &str) -> Option<bool> {
         let map = self.inner.read().unwrap();
-        let entry = map.get(receiver_id).filter(|r| r.live())?;
+        let entry = map.get(receiver_id).filter(|r| r.live() && r.user_id == user_id)?;
         Some(!entry.kicked.contains(user_id))
     }
 
@@ -366,11 +373,18 @@ impl Registry {
             .is_none_or(|item| item.id != item_id)
     }
 
-    /// Queue a command and hand back its seq. `None` when the receiver is gone;
-    /// the caller answers 404.
-    pub fn enqueue(&self, receiver_id: &str, command: CastCommand) -> Option<CastCommandEnvelope> {
+    /// Queue a command and hand back its seq. `None` when the receiver is gone or
+    /// not `user_id`'s; the caller answers 404. The owner check is repeated here,
+    /// under the same lock as the write, so a set that changes hands between an
+    /// authorization check and the enqueue can never receive the order.
+    pub fn enqueue(
+        &self,
+        receiver_id: &str,
+        user_id: &str,
+        command: CastCommand,
+    ) -> Option<CastCommandEnvelope> {
         let mut map = self.inner.write().unwrap();
-        let entry = map.get_mut(receiver_id).filter(|r| r.live())?;
+        let entry = map.get_mut(receiver_id).filter(|r| r.live() && r.user_id == user_id)?;
         let seq = entry.next_seq;
         entry.next_seq += 1;
         while entry.inbox.len() >= MAX_INBOX {
@@ -384,13 +398,15 @@ impl Registry {
         Some(envelope)
     }
 
-    pub fn list(&self) -> Vec<CastReceiver> {
+    /// The live receivers signed into `user_id`'s account — the only ones that
+    /// account may see or drive. Another household's TV never appears here.
+    pub fn list(&self, user_id: &str) -> Vec<CastReceiver> {
         let mut v: Vec<CastReceiver> = self
             .inner
             .read()
             .unwrap()
             .values()
-            .filter(|r| r.live())
+            .filter(|r| r.live() && r.user_id == user_id)
             .map(Receiver::view)
             .collect();
         v.sort_by(|a, b| a.name.cmp(&b.name));
@@ -422,11 +438,14 @@ impl Registry {
         }
     }
 
-    fn reap(&self) -> Vec<String> {
+    fn reap(&self) -> Vec<(String, String)> {
         let mut map = self.inner.write().unwrap();
-        let gone: Vec<String> =
-            map.iter().filter(|(_, r)| !r.live()).map(|(id, _)| id.clone()).collect();
-        for id in &gone {
+        let gone: Vec<(String, String)> = map
+            .iter()
+            .filter(|(_, r)| !r.live())
+            .map(|(id, r)| (id.clone(), r.user_id.clone()))
+            .collect();
+        for (id, _) in &gone {
             map.remove(id);
         }
         gone
@@ -439,8 +458,8 @@ impl Registry {
         tokio::spawn(async move {
             loop {
                 tokio::time::sleep(REAP_INTERVAL).await;
-                for receiver_id in reg.reap() {
-                    events.publish(ServerEvent::CastReceiverGone { receiver_id });
+                for (receiver_id, owner) in reg.reap() {
+                    events.publish_to(&owner, ServerEvent::CastReceiverGone { receiver_id });
                 }
             }
         });
@@ -562,7 +581,7 @@ mod tests {
         assert!(!reg.wants_item("tv-salon-01", "it1"));
         assert!(reg.wants_item("tv-salon-01", "it2"));
 
-        let list = reg.list();
+        let list = reg.list("u1");
         assert_eq!(list.len(), 1);
         assert_eq!(list[0].name, "Salon");
         let np = list[0].now_playing.as_ref().expect("now playing");
@@ -572,11 +591,24 @@ mod tests {
     }
 
     #[test]
+    fn another_account_never_sees_nor_drives_a_receiver() {
+        let reg = Registry::new();
+        announce_ok(&reg, beat("tv-salon-01", 0, None), "u1", None);
+
+        assert!(reg.list("u2").is_empty(), "the roster is scoped to the signed-in account");
+        // `None`, not `Some(false)`: the caller answers 404, so a stranger cannot
+        // even learn the id exists.
+        assert_eq!(reg.may_command("tv-salon-01", "u2"), None);
+        assert!(reg.attach_controller("tv-salon-01", "sock-x", "iPhone", "u2", "bob", None).is_none());
+        assert_eq!(reg.may_command("tv-salon-01", "u1"), Some(true));
+    }
+
+    #[test]
     fn going_idle_clears_the_title() {
         let reg = Registry::new();
         announce_ok(&reg, beat("tv-salon-01", 0, Some(playing("it1", 10))), "u1", Some(item("it1")));
         announce_ok(&reg, beat("tv-salon-01", 0, None), "u1", None);
-        assert!(reg.list()[0].now_playing.is_none());
+        assert!(reg.list("u1")[0].now_playing.is_none());
         assert!(reg.wants_item("tv-salon-01", "it1"));
     }
 
@@ -601,16 +633,16 @@ mod tests {
             reg.announce(beat("tv-9999-xxxx", 0, None), "u1", "Alice", "LAN".into(), None),
             Announced::Full
         ));
-        assert_eq!(reg.list().len(), MAX_RECEIVERS);
+        assert_eq!(reg.list("u1").len(), MAX_RECEIVERS);
     }
 
     #[test]
     fn commands_replay_until_they_are_acked() {
         let reg = Registry::new();
         announce_ok(&reg, beat("tv-salon-01", 0, None), "u1", None);
-        let first = reg.enqueue("tv-salon-01", CastCommand::Pause).expect("queued");
+        let first = reg.enqueue("tv-salon-01", "u1", CastCommand::Pause).expect("queued");
         let second = reg
-            .enqueue("tv-salon-01", CastCommand::Seek { position_ms: 5000 })
+            .enqueue("tv-salon-01", "u1", CastCommand::Seek { position_ms: 5000 })
             .expect("queued");
         assert_eq!((first.seq, second.seq), (1, 2));
 
@@ -620,7 +652,7 @@ mod tests {
         assert_eq!(pending.len(), 1);
         assert_eq!(pending[0].seq, 2);
         assert!(announce_ok(&reg, beat("tv-salon-01", 2, None), "u1", None).is_empty());
-        assert_eq!(reg.enqueue("tv-salon-01", CastCommand::Stop).unwrap().seq, 3);
+        assert_eq!(reg.enqueue("tv-salon-01", "u1", CastCommand::Stop).unwrap().seq, 3);
     }
 
     #[test]
@@ -628,7 +660,7 @@ mod tests {
         let reg = Registry::new();
         announce_ok(&reg, beat("tv-salon-01", 0, None), "u1", None);
         for _ in 0..(MAX_INBOX + 5) {
-            reg.enqueue("tv-salon-01", CastCommand::Pause);
+            reg.enqueue("tv-salon-01", "u1", CastCommand::Pause);
         }
         let pending = announce_ok(&reg, beat("tv-salon-01", 0, None), "u1", None);
         assert_eq!(pending.len(), MAX_INBOX);
@@ -638,7 +670,7 @@ mod tests {
     #[test]
     fn commands_for_an_unknown_or_dead_receiver_are_refused() {
         let reg = Registry::new();
-        assert!(reg.enqueue("tv-ghost-01", CastCommand::Pause).is_none());
+        assert!(reg.enqueue("tv-ghost-01", "u1", CastCommand::Pause).is_none());
         assert!(reg.owner_of("tv-ghost-01").is_none());
 
         announce_ok(&reg, beat("tv-salon-01", 0, None), "u1", None);
@@ -646,9 +678,9 @@ mod tests {
             let mut map = reg.inner.write().unwrap();
             map.get_mut("tv-salon-01").unwrap().last_seen = Instant::now() - Duration::from_secs(120);
         }
-        assert!(reg.enqueue("tv-salon-01", CastCommand::Pause).is_none());
-        assert!(reg.list().is_empty());
-        assert_eq!(reg.reap(), vec!["tv-salon-01".to_string()]);
+        assert!(reg.enqueue("tv-salon-01", "u1", CastCommand::Pause).is_none());
+        assert!(reg.list("u1").is_empty());
+        assert_eq!(reg.reap(), vec![("tv-salon-01".to_string(), "u1".to_string())]);
         assert!(reg.reap().is_empty());
     }
 
@@ -657,9 +689,9 @@ mod tests {
         let reg = Registry::new();
         announce_ok(&reg, beat("tv-salon-01", 0, None), "u1", None);
         assert!(!reg.remove_owned("tv-salon-01", "u2"));
-        assert_eq!(reg.list().len(), 1);
+        assert_eq!(reg.list("u1").len(), 1);
         assert!(reg.remove_owned("tv-salon-01", "u1"));
-        assert!(reg.list().is_empty());
+        assert!(reg.list("u1").is_empty());
         assert!(!reg.remove_owned("tv-salon-01", "u1"));
     }
 
@@ -686,7 +718,7 @@ mod tests {
         ann.name = format!("  Sa\u{7}lon{}  ", "x".repeat(200));
         ann.platform = "tv\nOS".into();
         announce_ok(&reg, ann, "u1", None);
-        let row = &reg.list()[0];
+        let row = &reg.list("u1")[0];
         assert!(!row.name.contains('\u{7}'), "control chars are stripped: {:?}", row.name);
         assert!(row.name.len() <= MAX_NAME);
         assert_eq!(row.platform, "tvOS");
@@ -715,7 +747,7 @@ mod tests {
             reg.attach(hello(), "u1", "Alice", "LAN".into()),
             Announced::Ok { .. }
         ));
-        assert_eq!(reg.list().len(), 1);
+        assert_eq!(reg.list("u1").len(), 1);
 
         let change = reg.set_state("tv-salon-01", Some(playing("it1", 0)), Some(item("it1")));
         assert!(matches!(change, Some(StateChange::Row(_))));
@@ -740,7 +772,7 @@ mod tests {
             reg.set_state("tv-salon-01", None, None),
             Some(StateChange::Row(_))
         ));
-        assert!(reg.list()[0].now_playing.is_none());
+        assert!(reg.list("u1")[0].now_playing.is_none());
 
         assert!(matches!(reg.set_state("tv-salon-01", None, None), Some(StateChange::Nothing)));
         assert!(reg.set_state("tv-ghost-01", None, None).is_none());
@@ -755,8 +787,8 @@ mod tests {
             "Alice",
             "LAN".into(),
         );
-        reg.enqueue("tv-salon-01", CastCommand::Pause);
-        reg.enqueue("tv-salon-01", CastCommand::Stop);
+        reg.enqueue("tv-salon-01", "u1", CastCommand::Pause);
+        reg.enqueue("tv-salon-01", "u1", CastCommand::Stop);
         reg.ack("tv-salon-01", 1);
         let pending = announce_ok(&reg, beat("tv-salon-01", 0, None), "u1", None);
         assert_eq!(pending.len(), 1);
@@ -768,26 +800,25 @@ mod tests {
         }
         reg.touch("tv-salon-01");
         assert!(reg.reap().is_empty());
-        assert_eq!(reg.list().len(), 1);
+        assert_eq!(reg.list("u1").len(), 1);
     }
 
     #[test]
     fn a_kicked_remote_stops_being_obeyed_until_it_picks_the_set_up_again() {
         let reg = Registry::new();
         announce_ok(&reg, beat("tv-salon-01", 0, None), "u1", None);
-        reg.attach_controller("tv-salon-01", "sock-b", "iPad", "u2", "bob", None).expect("attached");
+        reg.attach_controller("tv-salon-01", "sock-b", "iPad", "u1", "alice", None).expect("attached");
 
-        assert_eq!(reg.may_command("tv-salon-01", "u2"), Some(true));
+        assert_eq!(reg.may_command("tv-salon-01", "u1"), Some(true));
         reg.kick_controller("tv-salon-01", "sock-b").expect("kicked");
 
-        assert_eq!(reg.may_command("tv-salon-01", "u2"), Some(false));
+        assert_eq!(reg.may_command("tv-salon-01", "u1"), Some(false));
+
+        reg.attach_controller("tv-salon-01", "sock-c", "iPad", "u1", "alice", None).expect("attached");
         assert_eq!(reg.may_command("tv-salon-01", "u1"), Some(true));
 
-        reg.attach_controller("tv-salon-01", "sock-c", "iPad", "u2", "bob", None).expect("attached");
-        assert_eq!(reg.may_command("tv-salon-01", "u2"), Some(true));
-
         // Not a 403: the caller answers 404, so this cannot probe which ids exist.
-        assert_eq!(reg.may_command("tv-ghost-01", "u2"), None);
+        assert_eq!(reg.may_command("tv-ghost-01", "u1"), None);
     }
 
     #[test]
@@ -800,26 +831,27 @@ mod tests {
             .expect("attached");
         assert_eq!(row.controllers.len(), 1);
         let row = reg
-            .attach_controller("tv-salon-01", "sock-b", "Chrome", "u2", "bob", None)
+            .attach_controller("tv-salon-01", "sock-b", "Chrome", "u1", "alice", None)
             .expect("attached");
         assert_eq!(
             row.controllers.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(),
             vec!["Chrome", "iPhone"],
             "listed in a stable order, so the TV's list does not reshuffle"
         );
-        assert!(row.controllers.iter().any(|c| c.username == "bob"));
 
         assert!(reg.attach_controller("tv-salon-01", "sock-a", "iPhone", "u1", "alice", None).is_none());
 
         let (row, owner) = reg.kick_controller("tv-salon-01", "sock-b").expect("kicked");
-        assert_eq!(owner, "u2");
+        assert_eq!(owner, "u1");
         assert_eq!(row.controllers.len(), 1);
         assert_eq!(row.controllers[0].name, "iPhone");
         assert!(reg.kick_controller("tv-salon-01", "sock-b").is_none());
 
         let rows = reg.detach_controller("sock-a");
         assert_eq!(rows.len(), 1);
-        assert!(rows[0].controllers.is_empty());
+        let (owner, row) = &rows[0];
+        assert_eq!(owner, "u1");
+        assert!(row.controllers.is_empty());
         assert!(reg.detach_controller("sock-a").is_empty());
     }
 
@@ -831,7 +863,7 @@ mod tests {
         reg.attach_controller("tv-salon-01", "sock-a", "iPhone", "u1", "alice", None).expect("attached");
 
         assert!(reg.kick_controller("tv-chambre-02", "sock-a").is_none());
-        assert_eq!(reg.list().iter().flat_map(|r| &r.controllers).count(), 1);
+        assert_eq!(reg.list("u1").iter().flat_map(|r| &r.controllers).count(), 1);
     }
 
     #[test]
@@ -846,8 +878,9 @@ mod tests {
         assert_eq!(row.controllers.len(), 1, "one device, one row");
         assert_eq!(row.controllers[0].id, "sock-new");
 
+        // A different device of the same account is a second remote, not a replay.
         let row = reg
-            .attach_controller("tv-salon-01", "sock-bob", "iPhone", "u2", "bob", None)
+            .attach_controller("tv-salon-01", "sock-ipad", "iPad", "u1", "alice", None)
             .expect("attached");
         assert_eq!(row.controllers.len(), 2);
     }
@@ -874,7 +907,7 @@ mod tests {
             reg.attach_controller("tv-salon-01", "sock-flood", "Phone flood", "u1", "alice", None)
                 .is_none()
         );
-        assert_eq!(reg.list()[0].controllers.len(), MAX_CONTROLLERS);
+        assert_eq!(reg.list("u1")[0].controllers.len(), MAX_CONTROLLERS);
     }
 
     #[test]
@@ -889,16 +922,17 @@ mod tests {
         let reg = Registry::new();
         announce_ok(&reg, beat("tv-salon-01", 0, None), "u1", None);
         let seek = reg
-            .enqueue("tv-salon-01", CastCommand::Seek { position_ms: -5 })
+            .enqueue("tv-salon-01", "u1", CastCommand::Seek { position_ms: -5 })
             .unwrap();
         assert_eq!(seek.command, CastCommand::Seek { position_ms: 0 });
         let skip = reg
-            .enqueue("tv-salon-01", CastCommand::Skip { delta_ms: i64::MIN })
+            .enqueue("tv-salon-01", "u1", CastCommand::Skip { delta_ms: i64::MIN })
             .unwrap();
         assert_eq!(skip.command, CastCommand::Skip { delta_ms: -MAX_SKIP_MS });
         let play = reg
             .enqueue(
                 "tv-salon-01",
+                "u1",
                 CastCommand::Play { item_id: "it1".into(), position_ms: i64::MAX },
             )
             .unwrap();

--- a/server/src/api/cast.rs
+++ b/server/src/api/cast.rs
@@ -115,19 +115,23 @@ pub async fn announce(
         Announced::Ok { commands, changed } => {
             if changed {
                 if let Some(row) = state.cast.row(&body.receiver_id) {
-                    state.events.publish(ServerEvent::CastReceiverChanged {
-                        receiver: Box::new(row),
-                    });
+                    state.events.publish_to(
+                        &user.id,
+                        ServerEvent::CastReceiverChanged { receiver: Box::new(row) },
+                    );
                 }
             }
             if let Some((position_ms, duration_ms, cast_state)) = position {
                 if !changed && cast_state != CastState::Idle {
-                    state.events.publish(ServerEvent::CastPosition {
-                        receiver_id: body.receiver_id.clone(),
-                        position_ms,
-                        duration_ms,
-                        state: cast_state,
-                    });
+                    state.events.publish_to(
+                        &user.id,
+                        ServerEvent::CastPosition {
+                            receiver_id: body.receiver_id.clone(),
+                            position_ms,
+                            duration_ms,
+                            state: cast_state,
+                        },
+                    );
                 }
             }
             commands
@@ -153,12 +157,12 @@ pub async fn announce(
     .into_response())
 }
 
-/// `GET /api/cast/receivers` (Bearer) → `CastReceiver[]`. Every live receiver on
-/// the server, not just the caller's own: the TV runs its own profile. The rows
-/// carry no address and no account id.
+/// `GET /api/cast/receivers` (Bearer) → `CastReceiver[]`. Only the receivers
+/// signed into the caller's own account: casting is scoped to where you are
+/// connected, so nobody browses — let alone drives — another household's TVs.
 pub async fn list(State(state): State<SharedState>, AuthUser(user): AuthUser) -> Result<Response, Response> {
     require_playback(&user)?;
-    Ok(Json(state.cast.list()).into_response())
+    Ok(Json(state.cast.list(&user.id)).into_response())
 }
 
 /// `DELETE /api/cast/receivers/:id` (Bearer) → 204. Owner-scoped: naming somebody
@@ -171,7 +175,7 @@ pub async fn unregister(
 ) -> Result<Response, Response> {
     require_playback(&user)?;
     if state.cast.remove_owned(&id, &user.id) {
-        state.events.publish(ServerEvent::CastReceiverGone { receiver_id: id });
+        state.events.publish_to(&user.id, ServerEvent::CastReceiverGone { receiver_id: id });
     }
     Ok(StatusCode::NO_CONTENT.into_response())
 }
@@ -188,8 +192,10 @@ pub struct CommandReply {
 }
 
 /// `POST /api/cast/receivers/:id/command` (Bearer) `{ type, ... }` → `{ seq }`.
-/// A `play` is checked against the catalog first, so the TV is never handed an id
-/// the server did not recognize.
+/// Owner-scoped: only the account the receiver is signed into may drive it, and
+/// anybody else's receiver answers exactly like a missing one. A `play` is
+/// checked against the catalog first, so the TV is never handed an id the server
+/// did not recognize.
 pub async fn command(
     State(state): State<SharedState>,
     AuthUser(user): AuthUser,
@@ -200,10 +206,13 @@ pub async fn command(
     if !valid_receiver_id(&id) {
         return Err(bad_id(&user));
     }
-    // `None` means "no such receiver" and must stay distinct from a refusal: the
-    // enqueue below answers it with a 404, so this cannot probe the roster.
-    if state.cast.may_command(&id, &user.id) == Some(false) {
-        return Err(lerr(locale(&user), StatusCode::FORBIDDEN, "error.forbidden"));
+    // `None` covers absent, dead and foreign alike; answering all three with the
+    // same 404 keeps the roster unprobable. Only a kick — which already implies
+    // the set is the caller's own — is a refusal.
+    match state.cast.may_command(&id, &user.id) {
+        Some(true) => {}
+        Some(false) => return Err(lerr(locale(&user), StatusCode::FORBIDDEN, "error.forbidden")),
+        None => return Err(lerr(locale(&user), StatusCode::NOT_FOUND, "error.castReceiverGone")),
     }
     if let CastCommand::Play { item_id, .. } = &body.command {
         let wanted = item_id.clone();
@@ -216,17 +225,14 @@ pub async fn command(
         }
     }
 
-    let Some(owner) = state.cast.owner_of(&id) else {
-        return Err(lerr(locale(&user), StatusCode::NOT_FOUND, "error.castReceiverGone"));
-    };
-    let Some(envelope) = state.cast.enqueue(&id, body.command) else {
+    let Some(envelope) = state.cast.enqueue(&id, &user.id, body.command) else {
         return Err(lerr(locale(&user), StatusCode::NOT_FOUND, "error.castReceiverGone"));
     };
 
-    // Addressed to the account the receiver is signed into, so no other
-    // household's clients ever see it.
+    // Addressed to the caller's own account — the only one the receiver can
+    // belong to here — so no other household's clients ever see it.
     state.events.publish_to(
-        &owner,
+        &user.id,
         ServerEvent::CastCommandIssued {
             receiver_id: id,
             seq: envelope.seq,

--- a/server/src/api/it_cast.rs
+++ b/server/src/api/it_cast.rs
@@ -1,6 +1,6 @@
 //! Integration tests for the cast surface (`src/api/cast.rs`): a receiver
 //! announcing itself, a sender listing + driving it, and the refusals that keep
-//! the feature honest (no capability, no such receiver, someone else's id, an
+//! the feature honest (no capability, no such receiver, someone else's TV, an
 //! item that doesn't exist).
 
 use axum::http::StatusCode;
@@ -38,7 +38,7 @@ async fn a_receiver_announces_and_a_sender_drives_it() {
     assert_eq!(list[0]["username"], "owner");
     assert!(list[0]["nowPlaying"].is_null());
     // The roster carries nothing privileged - no address, no account id, and no
-    // per-reader flag (which is what lets one row be broadcast to everyone).
+    // per-reader flag (everything a caller is shown is its own).
     assert!(list[0].get("ip").is_none());
     assert!(list[0].get("userId").is_none());
     assert!(list[0].get("mine").is_none());
@@ -93,7 +93,7 @@ async fn a_receiver_leaves_the_roster_when_it_says_so() {
 }
 
 #[tokio::test]
-async fn another_account_cannot_take_over_a_receiver_id() {
+async fn another_account_cannot_see_take_over_or_drive_a_receiver() {
     let t = test_app();
     let (_, bob) = seed_session(&t.state, "bob@test.dev", "bob", &[Permission::Playback]);
     send(&t.app, "POST", "/api/cast/announce", Some(&t.token), Some(beat("tv-salon-01", None))).await;
@@ -109,15 +109,29 @@ async fn another_account_cannot_take_over_a_receiver_id() {
     let (_, list) = get(&t.app, "/api/cast/receivers", Some(&t.token)).await;
     assert_eq!(list.as_array().map(Vec::len), Some(1));
 
-    // He CAN see it and drive it: any TV on the server is castable, whichever
-    // profile it runs. The row names the profile it belongs to.
+    // He cannot even see it: casting is scoped to the account a receiver is
+    // signed into, so a stranger's session on the same server offers nothing.
     let (_, list) = get(&t.app, "/api/cast/receivers", Some(&bob)).await;
-    assert_eq!(list[0]["username"], "owner");
+    assert_eq!(list.as_array().map(Vec::len), Some(0));
+
+    // And driving it answers exactly like a receiver that does not exist, so the
+    // roster cannot be probed by id.
     let (status, _) = send(
         &t.app,
         "POST",
         "/api/cast/receivers/tv-salon-01/command",
         Some(&bob),
+        Some(json!({ "type": "pause" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    // The owner still drives it.
+    let (status, _) = send(
+        &t.app,
+        "POST",
+        "/api/cast/receivers/tv-salon-01/command",
+        Some(&t.token),
         Some(json!({ "type": "pause" })),
     )
     .await;

--- a/server/src/api/ws.rs
+++ b/server/src/api/ws.rs
@@ -193,7 +193,7 @@ async fn pump(mut socket: WebSocket, state: SharedState, who: Viewer) {
     // immediately, rather than leaving a dead set offerable until its TTL expires.
     if let Some(id) = receiver {
         if state.cast.remove_owned(&id, &who.id) {
-            state.events.publish(ServerEvent::CastReceiverGone { receiver_id: id });
+            state.events.publish_to(&who.id, ServerEvent::CastReceiverGone { receiver_id: id });
         }
     }
     if controlling {
@@ -225,11 +225,13 @@ fn cast_hello(
     }
     *receiver = Some(receiver_id.clone());
     if let Some(row) = state.cast.row(&receiver_id) {
-        state.events.publish(ServerEvent::CastReceiverChanged { receiver: Box::new(row) });
+        state
+            .events
+            .publish_to(&who.id, ServerEvent::CastReceiverChanged { receiver: Box::new(row) });
     }
 }
 
-async fn cast_state(state: &SharedState, id: String, playback: Option<CastPlayback>) {
+async fn cast_state(state: &SharedState, owner: &str, id: String, playback: Option<CastPlayback>) {
     let item = match playback.as_ref() {
         Some(pb) if state.cast.wants_item(&id, &pb.item_id) => {
             let pool = state.db.clone();
@@ -244,23 +246,30 @@ async fn cast_state(state: &SharedState, id: String, playback: Option<CastPlayba
     };
     match state.cast.set_state(&id, playback, item) {
         Some(StateChange::Row(row)) => {
-            state.events.publish(ServerEvent::CastReceiverChanged { receiver: Box::new(row) });
+            state
+                .events
+                .publish_to(owner, ServerEvent::CastReceiverChanged { receiver: Box::new(row) });
         }
         Some(StateChange::Position { position_ms, duration_ms, state: transport }) => {
-            state.events.publish(ServerEvent::CastPosition {
-                receiver_id: id,
-                position_ms,
-                duration_ms,
-                state: transport,
-            });
+            state.events.publish_to(
+                owner,
+                ServerEvent::CastPosition {
+                    receiver_id: id,
+                    position_ms,
+                    duration_ms,
+                    state: transport,
+                },
+            );
         }
         Some(StateChange::Nothing) | None => {}
     }
 }
 
 fn release_controller(state: &SharedState, controller_id: &str) {
-    for row in state.cast.detach_controller(controller_id) {
-        state.events.publish(ServerEvent::CastReceiverChanged { receiver: Box::new(row) });
+    for (owner, row) in state.cast.detach_controller(controller_id) {
+        state
+            .events
+            .publish_to(&owner, ServerEvent::CastReceiverChanged { receiver: Box::new(row) });
     }
 }
 
@@ -278,7 +287,7 @@ async fn handle_client(
         }
         ClientMessage::CastState { playback } => {
             let Some(id) = receiver.clone() else { return };
-            cast_state(state, id, playback).await;
+            cast_state(state, &who.id, id, playback).await;
         }
         ClientMessage::CastAck { seq } => {
             if let Some(id) = receiver.as_deref() {
@@ -292,6 +301,8 @@ async fn handle_client(
             // One socket drives one set: picking another releases the first.
             release_controller(state, controller_id);
             *controlling = true;
+            // Refused silently for another account's set: only the account a
+            // receiver is signed into may pick it up.
             if let Some(row) =
                 state.cast.attach_controller(
                     &receiver_id,
@@ -302,7 +313,9 @@ async fn handle_client(
                     who.avatar_url.as_deref(),
                 )
             {
-                state.events.publish(ServerEvent::CastReceiverChanged { receiver: Box::new(row) });
+                state
+                    .events
+                    .publish_to(&who.id, ServerEvent::CastReceiverChanged { receiver: Box::new(row) });
             }
         }
         ClientMessage::CastRelease => {
@@ -315,7 +328,9 @@ async fn handle_client(
             let Some((row, user_id)) = state.cast.kick_controller(&id, &controller_id) else {
                 return;
             };
-            state.events.publish(ServerEvent::CastReceiverChanged { receiver: Box::new(row) });
+            state
+                .events
+                .publish_to(&who.id, ServerEvent::CastReceiverChanged { receiver: Box::new(row) });
             state
                 .events
                 .publish_to(&user_id, ServerEvent::CastKicked { receiver_id: id });


### PR DESCRIPTION
## Problem

The cast roster was deliberately open: any account with the Playback permission could `GET /cast/receivers` and see **every** live receiver on the server, and command any of them unless that TV had kicked it. On a server with several households connected, anybody could control anybody else's TV.

## Change

A receiver now belongs to the account it is signed into, end to end:

- **`GET /cast/receivers`** returns only the caller's own receivers (`Registry::list(user_id)`).
- **`POST /cast/receivers/:id/command`** answers a foreign receiver exactly like a missing one — the same 404 — so the roster cannot be probed by id. Only a kick (which already implies the set is the caller's own) is a 403.
- **`enqueue` repeats the owner check under the write lock**, so a receiver id that expires and is re-registered by another account between the authorization check and the enqueue can never receive the order.
- **`cast.control`** (attaching as a remote over WS) is refused for another account's set.
- **All roster events** — `cast.receiver`, `cast.position`, `cast.receiver.gone`, including the TTL reaper's — are now addressed to the owner (`publish_to`) instead of broadcast. Without this, other accounts would still overhear what a household is watching on the event socket even with the list filtered.

No client changes: clients render whatever the server sends, and commands were already addressed to the owner's sockets.

## Behavioral notes

- Multiple remotes per TV are unchanged (up to 8, all listed in the TV top bar); same-account devices with **different** names (Chrome + iPhone) show as two.
- The TV-side "kick a remote" now blocks by account, and since all remotes are the same account, kicking one refuses all of them until any remote picks the set up again.
- A TV signed into a *different* profile than the phone can no longer be cast to — that cross-profile openness is exactly what this PR removes.

## Tests

- Registry: new `another_account_never_sees_nor_drives_a_receiver`; controller tests rewritten to the same-account model (21 pass).
- Integration: `another_account_cannot_take_over_a_receiver_id` became `another_account_cannot_see_take_over_or_drive_a_receiver` — bob's list is empty, his command is a 404, the owner still drives (7 pass).
- Full suites green: 693 (kroma-engine) + 228 (kroma-server); clippy clean apart from pre-existing warnings.