### PR TITLE
chore(ci): runs learn to skip what a change cannot touch

### DIFF
--- a/.github/scripts/upload-to-testflight.sh
+++ b/.github/scripts/upload-to-testflight.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Upload one .ipa to TestFlight.
+# Upload one .ipa to TestFlight - or only prove that it could be.
 #
 # Inputs (step env):
 #   IPA            path to the .ipa
@@ -7,6 +7,12 @@
 #                  carries iOS and tvOS as two platforms of one listing, and the
 #                  flag is what tells it which half a build belongs to; a tvOS
 #                  .ipa sent as `-t ios` is rejected outright.
+#   MODE           upload (default) | validate. `validate` runs the same App
+#                  Store checks an upload does - the class of rejection that
+#                  appears AFTER a perfect archive/sign/export (a missing plist
+#                  key, a bad entitlement) - without claiming a build number or
+#                  notifying a single tester, so every candidate can carry the
+#                  verdict instead of the promote step being first to learn it.
 #   ASC_KEY_ID / ASC_ISSUER_ID / ASC_PRIVATE_KEY   preferred
 #   APPLE_ID / APPLE_PASSWORD                      fallback (app-specific password)
 #
@@ -15,6 +21,13 @@
 # that has otherwise gone out.
 set -euo pipefail
 
+MODE="${MODE:-upload}"
+case "$MODE" in
+  upload) action=--upload-app ;;
+  validate) action=--validate-app ;;
+  *) echo "::error::MODE must be upload or validate, not '$MODE'"; exit 1 ;;
+esac
+
 [[ -f "$IPA" ]] || { echo "::error::no .ipa at $IPA"; exit 1; }
 
 if [[ -n "${ASC_KEY_ID:-}" && -n "${ASC_ISSUER_ID:-}" && -n "${ASC_PRIVATE_KEY:-}" ]]; then
@@ -22,12 +35,12 @@ if [[ -n "${ASC_KEY_ID:-}" && -n "${ASC_ISSUER_ID:-}" && -n "${ASC_PRIVATE_KEY:-
   printf '%s' "$ASC_PRIVATE_KEY" \
     > "$HOME/.appstoreconnect/private_keys/AuthKey_${ASC_KEY_ID}.p8"
   trap 'rm -rf "$HOME/.appstoreconnect"' EXIT
-  xcrun altool --upload-app -f "$IPA" -t "$PLATFORM" \
+  xcrun altool "$action" -f "$IPA" -t "$PLATFORM" \
     --apiKey "$ASC_KEY_ID" --apiIssuer "$ASC_ISSUER_ID"
 elif [[ -n "${APPLE_ID:-}" && -n "${APPLE_PASSWORD:-}" ]]; then
-  xcrun altool --upload-app -f "$IPA" -t "$PLATFORM" -u "$APPLE_ID" -p "$APPLE_PASSWORD"
+  xcrun altool "$action" -f "$IPA" -t "$PLATFORM" -u "$APPLE_ID" -p "$APPLE_PASSWORD"
 else
-  echo "No App Store Connect credentials; $IPA is built and attached but not uploaded."
+  echo "No App Store Connect credentials; $IPA is built and attached, $MODE skipped."
   exit 0
 fi
-echo "uploaded $(basename "$IPA") to TestFlight ($PLATFORM)"
+echo "altool $action ok: $(basename "$IPA") ($PLATFORM)"

--- a/.github/workflows/_release-appletv.yml
+++ b/.github/workflows/_release-appletv.yml
@@ -315,6 +315,25 @@ jobs:
           path: .derived/tvnative
           key: dd-tvnative-v1-${{ env.XCODE_VERSION }}-${{ github.run_id }}
 
+      - name: Validate for the App Store
+        # Runs on every candidate, upload or not: v0.1.35's .ipa archived,
+        # signed and exported perfectly and was then rejected AT UPLOAD (90502,
+        # a plist key only App Store validation checks) - with the promote step
+        # first to learn it. --validate-app runs those same checks without
+        # claiming a build number or notifying a tester, so a green candidate
+        # now means "TestFlight would take this".
+        if: steps.signing.outputs.ready == 'true'
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_PRIVATE_KEY: ${{ secrets.ASC_PRIVATE_KEY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          IPA: out/KROMA-appletv-${{ inputs.version }}.ipa
+          PLATFORM: tvos
+          MODE: validate
+        run: .github/scripts/upload-to-testflight.sh
+
       - name: Upload to TestFlight
         # A CANDIDATE build compiles the .ipa and stops there - that is what the
         # gate needs to know. Distribution is a deploy-time act, not a

--- a/.github/workflows/_release-mobile.yml
+++ b/.github/workflows/_release-mobile.yml
@@ -415,6 +415,22 @@ jobs:
           path: .derived/mobile
           key: dd-mobile-v1-${{ env.XCODE_VERSION }}-${{ github.run_id }}
 
+      - name: Validate for the App Store
+        # See the Apple TV job: every candidate proves it would be accepted,
+        # without claiming a build number - the 90502 class of rejection only
+        # ever surfaced at promote time before.
+        if: steps.signing.outputs.ready == 'true'
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_PRIVATE_KEY: ${{ secrets.ASC_PRIVATE_KEY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          IPA: out/KROMA-mobile-${{ inputs.version }}.ipa
+          PLATFORM: ios
+          MODE: validate
+        run: .github/scripts/upload-to-testflight.sh
+
       - name: Upload to TestFlight
         # See the Apple TV job: candidates build, they do not distribute.
         # `targets` says what to BUILD; it must not also mean "ship it".

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
-# Every push/PR proves the WHOLE client fleet builds in PRODUCTION mode:
+# Every push/PR proves the client fleet it can affect builds in PRODUCTION
+# mode (the `changes` job skips the halves a change cannot touch):
 #  - web SPA
 #  - Samsung Tizen bundle
 #  - LG webOS bundle - BOTH tiers: modern (Chrome 99+) AND legacy (Chromium
@@ -15,10 +16,22 @@ name: CI
 # shell factory (clients/tv-build/shell.ts) strips console/debugger on build,
 # and KROMA_TV_DEVICE (on-device dev HMR) is never set in CI.
 
+# Docs-only changes build nothing and check nothing; skip the run entirely.
+# (No branch protection requires these checks, so a skipped run blocks nobody.)
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.claude/**'
+      - 'LICENSE'
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.claude/**'
+      - 'LICENSE'
 
 # Cancel superseded runs on the same ref (e.g. rapid pushes to a PR).
 concurrency:
@@ -32,6 +45,44 @@ env:
   BUN_VERSION: '1.3.14'
 
 jobs:
+  # Which half of the fleet the change can actually touch. `rust` gates the
+  # server job (a JS-only PR pays no clippy+test), `fleet` gates the client
+  # builds (a server-only PR pays no vite/gradle/tauri). `quality` stays
+  # unconditional: it is the cheap always-green check, and its inputs (biome,
+  # vitest, tokens) span too much of the tree to be worth a filter.
+  changes:
+    name: Detect relevant changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 5
+    outputs:
+      rust: ${{ steps.f.outputs.rust }}
+      fleet: ${{ steps.f.outputs.fleet }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: f
+        with:
+          filters: |
+            rust:
+              - 'server/**'
+              # kroma-engine include_str!s these catalogs at compile time.
+              - 'packages/core/src/locales/**'
+              - 'rust-toolchain.toml'
+              - '.github/workflows/ci.yml'
+            fleet:
+              - 'clients/**'
+              - 'packages/**'
+              # bun patches change what an install produces.
+              - 'patches/**'
+              - 'bun.lock'
+              - 'package.json'
+              - 'tsconfig.base.json'
+              # desktop-shell compiles Rust under the repo toolchain pin.
+              - 'rust-toolchain.toml'
+              - '.github/workflows/ci.yml'
+
   quality:
     name: Typecheck + unit tests + lint
     runs-on: ubuntu-latest
@@ -67,6 +118,8 @@ jobs:
 
   clients:
     name: Client / ${{ matrix.name }}
+    needs: changes
+    if: needs.changes.outputs.fleet == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
@@ -117,6 +170,8 @@ jobs:
   # first. The Apple TV half needs a macOS runner and is not built here.
   tv-native:
     name: Native TV app (Android compile)
+    needs: changes
+    if: needs.changes.outputs.fleet == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -150,6 +205,8 @@ jobs:
 
   desktop-shell:
     name: Desktop shell (cargo check, Linux/mpv path)
+    needs: changes
+    if: needs.changes.outputs.fleet == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 45
     steps:
@@ -205,6 +262,8 @@ jobs:
 
   server:
     name: Server (Rust) clippy + test
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,11 +3,23 @@ name: Security scan
 # Static analysis (CodeQL) for the JS/TS surface + a RustSec advisory audit of the
 # Cargo dependency graph. Runs on pushes/PRs to main and weekly (catches new CVEs
 # on unchanged code).
+# Docs-only changes reach neither analyzer (CodeQL scans JS/TS, cargo-audit
+# reads Cargo.lock); the weekly schedule keeps full coverage of unchanged code.
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.claude/**'
+      - 'LICENSE'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.claude/**'
+      - 'LICENSE'
   schedule:
     - cron: '0 6 * * 1' # Monday 06:00 UTC
 

--- a/.github/workflows/desktop-autoupdate.yml
+++ b/.github/workflows/desktop-autoupdate.yml
@@ -17,6 +17,8 @@ on:
       - 'packages/tv/**'
       - 'packages/core/**'
       - 'packages/ui/**'
+      # The desktop frontend builds through @kroma/bundler.
+      - 'packages/bundler/**'
       - '.github/workflows/desktop-autoupdate.yml'
   workflow_dispatch:
 
@@ -30,7 +32,7 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 5
     outputs:
       version: ${{ steps.v.outputs.version }}
     steps:
@@ -48,7 +50,7 @@ jobs:
     permissions:
       contents: write # delete + recreate the rolling desktop-latest release
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 5
     outputs:
       release_id: ${{ steps.mk.outputs.result }}
     steps:
@@ -245,7 +247,7 @@ jobs:
     permissions:
       contents: write # flip the draft pre-release to published
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 5
     steps:
       - name: Publish the pre-release (serve latest.json)
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/kit.yml
+++ b/.github/workflows/kit.yml
@@ -22,6 +22,8 @@ on:
       - 'clients/kit/**'
       - 'packages/ui/**'
       - 'packages/core/**'
+      # vite.config.ts imports @kroma/bundler/props-docs.
+      - 'packages/bundler/**'
       - 'clients/tv-build/rnw.ts'
       - '.github/workflows/kit.yml'
   pull_request:
@@ -29,6 +31,7 @@ on:
       - 'clients/kit/**'
       - 'packages/ui/**'
       - 'packages/core/**'
+      - 'packages/bundler/**'
       - 'clients/tv-build/rnw.ts'
       - '.github/workflows/kit.yml'
   workflow_dispatch:
@@ -65,7 +68,7 @@ jobs:
           fi
           git fetch --no-tags --depth=1 origin "$last" 2>/dev/null || true
           # An unfetchable sha (force-push, expired) errors the diff -> deploy.
-          if git diff --quiet "$last" HEAD -- clients/kit packages/ui packages/core clients/tv-build/rnw.ts .github/workflows/kit.yml 2>/dev/null; then
+          if git diff --quiet "$last" HEAD -- clients/kit packages/ui packages/core packages/bundler clients/tv-build/rnw.ts .github/workflows/kit.yml 2>/dev/null; then
             echo "::notice::ui.kroma.tv is already serving this tree (last deployed $last); skipping."
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,30 @@ name: Build & Release
 on:
   push:
     branches: [main]
+    # A candidate build only matters when it can change a promoted artifact.
+    # Docs, the Cloudflare-hosted showcases (kit + site are in no release
+    # artifact) and sibling workflows that build none of the fleet skip the
+    # whole run. Promotion stays correct: deploy.yml takes an explicit run id,
+    # and these paths change no promoted bytes. synology.yml is deliberately
+    # NOT ignored - the .spk on a Release comes from the synology run at the
+    # SAME sha as the candidate, so an .spk-pipeline change still needs a
+    # candidate here to be promotable.
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.claude/**'
+      - 'LICENSE'
+      - 'clients/kit/**'
+      - 'clients/site/**'
+      - '.github/workflows/ci.yml'
+      - '.github/workflows/sonar.yml'
+      - '.github/workflows/codeql.yml'
+      - '.github/workflows/kit.yml'
+      - '.github/workflows/tv-web.yml'
+      - '.github/workflows/repo-worker.yml'
+      - '.github/workflows/desktop-autoupdate.yml'
+      - '.github/workflows/apple-signing-doctor.yml'
+      - '.github/workflows/deploy.yml'
   schedule:
     - cron: '0 3 * * *' # nightly, 03:00 UTC
   workflow_dispatch:
@@ -110,7 +134,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # only reads the repo and uploads run artifacts
-    timeout-minutes: 45
+    timeout-minutes: 5
     env:
       GH_TOKEN: ${{ github.token }}
       GH_REPO: ${{ github.repository }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -9,10 +9,22 @@ name: Sonar
 # SonarCloud (Administration > Analysis Method) - SonarCloud rejects a CI scan
 # while Automatic Analysis owns the branch.
 
+# Docs-only changes carry no analyzable code and no coverage delta; skip the
+# scan (SonarCloud's gate is not a required check, so nothing blocks).
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.claude/**'
+      - 'LICENSE'
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.claude/**'
+      - 'LICENSE'
 
 concurrency:
   group: sonar-${{ github.ref }}

--- a/.github/workflows/synology.yml
+++ b/.github/workflows/synology.yml
@@ -60,12 +60,14 @@ jobs:
     needs: changes
     permissions:
       contents: read
-    # `always()` so a SKIPPED changes job (tag / dispatch) still lets the tag
-    # and dispatch legs run; a main push only builds when relevant files changed.
+    # `always()` so the SKIPPED changes job (dispatch) still lets the dispatch
+    # leg run; a main push only builds when relevant files changed. The old
+    # `github.ref == 'refs/heads/main'` clause is gone: it was true on EVERY
+    # main push, which made the changes gate dead code and cold-built the .spk
+    # for TV-only and docs commits.
     if: >-
       always() && !cancelled()
-      && (github.ref == 'refs/heads/main'
-          || github.event_name == 'workflow_dispatch'
+      && (github.event_name == 'workflow_dispatch'
           || needs.changes.outputs.relevant == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -152,10 +154,11 @@ jobs:
     needs: changes
     permissions:
       contents: read
+    # Same gate as `build` above: dispatch always, main pushes only on
+    # relevant changes.
     if: >-
       always() && !cancelled()
-      && (github.ref == 'refs/heads/main'
-          || github.event_name == 'workflow_dispatch'
+      && (github.event_name == 'workflow_dispatch'
           || needs.changes.outputs.relevant == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 45


### PR DESCRIPTION
CI hygiene batch:

- **ci.yml**: docs-only changes (`**.md`, `docs/`, `.claude/`, LICENSE) skip the run; a new `changes` job gates the halves — a JS-only PR pays no clippy+test (`rust` filter), a server-only PR builds no clients (`fleet` filter). `quality` stays unconditional as the cheap always-green check.
- **sonar.yml / codeql.yml**: same docs-only skip (neither is a required check; CodeQL's weekly schedule keeps full coverage of unchanged code).
- **release.yml**: docs, Cloudflare-hosted showcases (kit/site) and sibling workflows that build none of the fleet no longer produce a candidate. synology.yml is deliberately NOT ignored — the .spk on a Release must come from the synology run at the same sha.
- **kit.yml / desktop-autoupdate.yml**: also trigger on `packages/bundler/**`, which both build through (kit's vite config imports `@kroma/bundler/props-docs`).
- **synology.yml**: the `github.ref == 'refs/heads/main'` clause was true on every main push, making the `changes` gate dead code — TV-only and docs commits cold-built the .spk. The gate now actually gates; dispatch still always runs.
- Bookkeeping jobs (version calc, release create/publish) drop from 45-minute to 5-minute timeouts.