### PR TITLE
The deployed workbench gets a history to read

### DIFF
--- a/.github/workflows/kit.yml
+++ b/.github/workflows/kit.yml
@@ -49,7 +49,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      # Whole history, not the default depth of one: the workbench reads each
+      # component's first and last commit out of the log at build time, and a
+      # shallow clone's earliest commit is the day of the fetch rather than the
+      # day the file was written. The reader refuses to guess, so a shallow
+      # build ships with no dates at all.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
 
       # Push only: PRs always build (that is the gate), a dispatch always
       # ships. `changed` stays empty when skipped, and every later step treats


### PR DESCRIPTION
`ui.kroma.tv/what-changed` lists nothing, and says why: the build was made from
a shallow clone.

It was. `actions/checkout` fetches depth 1 unless told otherwise, and
`readGitHistory` returns `NO_HISTORY` the moment
`git rev-parse --is-shallow-repository` reports true. That refusal is right and
stays: the earliest commit such a clone holds is the day of the fetch rather
than the day a file was written, and a wrong creation date is worse than none.

So the fix is at the clone, not the reader: `fetch-depth: 0` on the kit
deploy's checkout. One step, one job, no other workflow builds the workbench.

https://claude.ai/code/session_01AUBr58cBBeqvhmHgLAck8B