### PR TITLE
Review fixes for the lazy workbench: a live icon regression, and two loading faults

### DIFF
--- a/.github/workflows/kit.yml
+++ b/.github/workflows/kit.yml
@@ -73,7 +73,11 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          git fetch --no-tags --depth=1 origin "$last" 2>/dev/null || true
+          # No --depth here: a shallow fetch writes .git/shallow and marks the
+          # WHOLE repository shallow, which is what the checkout above asked for
+          # the opposite of. The workbench reads its dates out of the log, and
+          # refuses to read them from a truncated one.
+          git fetch --no-tags origin "$last" 2>/dev/null || true
           # An unfetchable sha (force-push, expired) errors the diff -> deploy.
           if git diff --quiet "$last" HEAD -- apps/kit packages/ui packages/core packages/bundler clients/tv-build/rnw.ts .github/workflows/kit.yml 2>/dev/null; then
             echo "::notice::ui.kroma.tv is already serving this tree (last deployed $last); skipping."

--- a/apps/kit/metro.config.cjs
+++ b/apps/kit/metro.config.cjs
@@ -4,5 +4,5 @@
 const { expoWorkspaceConfig } = require('../../clients/expo-build/metro-workspace.ts');
 
 // `icons: 'full'`: the kit IS the icon gallery, so the product clients' subset
-// would cut it to 243 of Tabler's 6167.
+// would cut it to 299 of Tabler's 6250.
 module.exports = expoWorkspaceConfig(__dirname, {}, { icons: 'full' });

--- a/clients/web/src/routeTree.gen.ts
+++ b/clients/web/src/routeTree.gen.ts
@@ -8,392 +8,392 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root'
-import { Route as AppRouteImport } from './routes/_app'
-import { Route as AdminRouteImport } from './routes/admin'
-import { Route as JoinRouteImport } from './routes/join'
-import { Route as LoginRouteImport } from './routes/login'
-import { Route as AppIndexRouteImport } from './routes/_app.index'
-import { Route as AppSplatRouteImport } from './routes/_app.$'
-import { Route as AppAccountRouteImport } from './routes/_app.account'
-import { Route as AppComingSoonRouteImport } from './routes/_app.coming-soon'
-import { Route as AppConnectRouteImport } from './routes/_app.connect'
-import { Route as AppFilmsRouteImport } from './routes/_app.films'
-import { Route as AppGenresRouteImport } from './routes/_app.genres'
-import { Route as AppInviteRouteImport } from './routes/_app.invite'
-import { Route as AppMissingRouteImport } from './routes/_app.missing'
-import { Route as AppMylistRouteImport } from './routes/_app.mylist'
-import { Route as AppRequestsRouteImport } from './routes/_app.requests'
-import { Route as AppSearchRouteImport } from './routes/_app.search'
-import { Route as AppSeriesRouteImport } from './routes/_app.series'
-import { Route as AdminIndexRouteImport } from './routes/admin.index'
-import { Route as AdminSplatRouteImport } from './routes/admin.$'
-import { Route as AdminAiRouteImport } from './routes/admin.ai'
-import { Route as AdminBackupRouteImport } from './routes/admin.backup'
-import { Route as AdminGeneralRouteImport } from './routes/admin.general'
-import { Route as AdminJobsRouteImport } from './routes/admin.jobs'
-import { Route as AdminLibrariesRouteImport } from './routes/admin.libraries'
-import { Route as AdminLogsRouteImport } from './routes/admin.logs'
-import { Route as AdminModulesRouteImport } from './routes/admin.modules'
-import { Route as AdminNetworkRouteImport } from './routes/admin.network'
-import { Route as AdminNotificationsRouteImport } from './routes/admin.notifications'
-import { Route as AdminPipelineRouteImport } from './routes/admin.pipeline'
-import { Route as AdminReportsRouteImport } from './routes/admin.reports'
-import { Route as AdminRequestsRouteImport } from './routes/admin.requests'
-import { Route as AdminStorageRouteImport } from './routes/admin.storage'
-import { Route as AdminStoreRouteImport } from './routes/admin.store'
-import { Route as AdminTranscoderRouteImport } from './routes/admin.transcoder'
-import { Route as AdminUsersRouteImport } from './routes/admin.users'
-import { Route as AppGenreGenreRouteImport } from './routes/_app.genre.$genre'
-import { Route as AppMovieIdRouteImport } from './routes/_app.movie.$id'
-import { Route as AppPersonNameRouteImport } from './routes/_app.person.$name'
-import { Route as AppShowIdRouteImport } from './routes/_app.show.$id'
-import { Route as AppTrendingTypeRouteImport } from './routes/_app.trending.$type'
-import { Route as AppWatchIdRouteImport } from './routes/_app.watch.$id'
-import { Route as AppDiscoverTypeTmdbIdRouteImport } from './routes/_app.discover.$type.$tmdbId'
+import { Route as rootRouteImport } from './routes/__root';
+import { Route as AppRouteImport } from './routes/_app';
+import { Route as AdminRouteImport } from './routes/admin';
+import { Route as JoinRouteImport } from './routes/join';
+import { Route as LoginRouteImport } from './routes/login';
+import { Route as AppIndexRouteImport } from './routes/_app.index';
+import { Route as AppSplatRouteImport } from './routes/_app.$';
+import { Route as AppAccountRouteImport } from './routes/_app.account';
+import { Route as AppComingSoonRouteImport } from './routes/_app.coming-soon';
+import { Route as AppConnectRouteImport } from './routes/_app.connect';
+import { Route as AppFilmsRouteImport } from './routes/_app.films';
+import { Route as AppGenresRouteImport } from './routes/_app.genres';
+import { Route as AppInviteRouteImport } from './routes/_app.invite';
+import { Route as AppMissingRouteImport } from './routes/_app.missing';
+import { Route as AppMylistRouteImport } from './routes/_app.mylist';
+import { Route as AppRequestsRouteImport } from './routes/_app.requests';
+import { Route as AppSearchRouteImport } from './routes/_app.search';
+import { Route as AppSeriesRouteImport } from './routes/_app.series';
+import { Route as AdminIndexRouteImport } from './routes/admin.index';
+import { Route as AdminSplatRouteImport } from './routes/admin.$';
+import { Route as AdminAiRouteImport } from './routes/admin.ai';
+import { Route as AdminBackupRouteImport } from './routes/admin.backup';
+import { Route as AdminGeneralRouteImport } from './routes/admin.general';
+import { Route as AdminJobsRouteImport } from './routes/admin.jobs';
+import { Route as AdminLibrariesRouteImport } from './routes/admin.libraries';
+import { Route as AdminLogsRouteImport } from './routes/admin.logs';
+import { Route as AdminModulesRouteImport } from './routes/admin.modules';
+import { Route as AdminNetworkRouteImport } from './routes/admin.network';
+import { Route as AdminNotificationsRouteImport } from './routes/admin.notifications';
+import { Route as AdminPipelineRouteImport } from './routes/admin.pipeline';
+import { Route as AdminReportsRouteImport } from './routes/admin.reports';
+import { Route as AdminRequestsRouteImport } from './routes/admin.requests';
+import { Route as AdminStorageRouteImport } from './routes/admin.storage';
+import { Route as AdminStoreRouteImport } from './routes/admin.store';
+import { Route as AdminTranscoderRouteImport } from './routes/admin.transcoder';
+import { Route as AdminUsersRouteImport } from './routes/admin.users';
+import { Route as AppGenreGenreRouteImport } from './routes/_app.genre.$genre';
+import { Route as AppMovieIdRouteImport } from './routes/_app.movie.$id';
+import { Route as AppPersonNameRouteImport } from './routes/_app.person.$name';
+import { Route as AppShowIdRouteImport } from './routes/_app.show.$id';
+import { Route as AppTrendingTypeRouteImport } from './routes/_app.trending.$type';
+import { Route as AppWatchIdRouteImport } from './routes/_app.watch.$id';
+import { Route as AppDiscoverTypeTmdbIdRouteImport } from './routes/_app.discover.$type.$tmdbId';
 
 const AppRoute = AppRouteImport.update({
   id: '/_app',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const AdminRoute = AdminRouteImport.update({
   id: '/admin',
   path: '/admin',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const JoinRoute = JoinRouteImport.update({
   id: '/join',
   path: '/join',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const LoginRoute = LoginRouteImport.update({
   id: '/login',
   path: '/login',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const AppIndexRoute = AppIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => AppRoute,
-} as any)
+} as any);
 const AppSplatRoute = AppSplatRouteImport.update({
   id: '/$',
   path: '/$',
   getParentRoute: () => AppRoute,
-} as any)
+} as any);
 const AppAccountRoute = AppAccountRouteImport.update({
   id: '/account',
   path: '/account',
   getParentRoute: () => AppRoute,
-} as any)
+} as any);
 const AppComingSoonRoute = AppComingSoonRouteImport.update({
   id: '/coming-soon',
   path: '/coming-soon',
   getParentRoute: () => AppRoute,
-} as any)
+} as any);
 const AppConnectRoute = AppConnectRouteImport.update({
   id: '/connect',
   path: '/connect',
   getParentRoute: () => AppRoute,
-} as any)
+} as any);
 const AppFilmsRoute = AppFilmsRouteImport.update({
   id: '/films',
   path: '/films',
   getParentRoute: () => AppRoute,
-} as any)
+} as any);
 const AppGenresRoute = AppGenresRouteImport.update({
   id: '/genres',
   path: '/genres',
   getParentRoute: () => AppRoute,
-} as any)
+} as any);
 const AppInviteRoute = AppInviteRouteImport.update({
   id: '/invite',
   path: '/invite',
   getParentRoute: () => AppRoute,
-} as any)
+} as any);
 const AppMissingRoute = AppMissingRouteImport.update({
   id: '/missing',
   path: '/missing',
   getParentRoute: () => AppRoute,
-} as any)
+} as any);
 const AppMylistRoute = AppMylistRouteImport.update({
   id: '/mylist',
   path: '/mylist',
   getParentRoute: () => AppRoute,
-} as any)
+} as any);
 const AppRequestsRoute = AppRequestsRouteImport.update({
   id: '/requests',
   path: '/requests',
   getParentRoute: () => AppRoute,
-} as any)
+} as any);
 const AppSearchRoute = AppSearchRouteImport.update({
   id: '/search',
   path: '/search',
   getParentRoute: () => AppRoute,
-} as any)
+} as any);
 const AppSeriesRoute = AppSeriesRouteImport.update({
   id: '/series',
   path: '/series',
   getParentRoute: () => AppRoute,
-} as any)
+} as any);
 const AdminIndexRoute = AdminIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => AdminRoute,
-} as any)
+} as any);
 const AdminSplatRoute = AdminSplatRouteImport.update({
   id: '/$',
   path: '/$',
   getParentRoute: () => AdminRoute,
-} as any)
+} as any);
 const AdminAiRoute = AdminAiRouteImport.update({
   id: '/ai',
   path: '/ai',
   getParentRoute: () => AdminRoute,
-} as any)
+} as any);
 const AdminBackupRoute = AdminBackupRouteImport.update({
   id: '/backup',
   path: '/backup',
   getParentRoute: () => AdminRoute,
-} as any)
+} as any);
 const AdminGeneralRoute = AdminGeneralRouteImport.update({
   id: '/general',
   path: '/general',
   getParentRoute: () => AdminRoute,
-} as any)
+} as any);
 const AdminJobsRoute = AdminJobsRouteImport.update({
   id: '/jobs',
   path: '/jobs',
   getParentRoute: () => AdminRoute,
-} as any)
+} as any);
 const AdminLibrariesRoute = AdminLibrariesRouteImport.update({
   id: '/libraries',
   path: '/libraries',
   getParentRoute: () => AdminRoute,
-} as any)
+} as any);
 const AdminLogsRoute = AdminLogsRouteImport.update({
   id: '/logs',
   path: '/logs',
   getParentRoute: () => AdminRoute,
-} as any)
+} as any);
 const AdminModulesRoute = AdminModulesRouteImport.update({
   id: '/modules',
   path: '/modules',
   getParentRoute: () => AdminRoute,
-} as any)
+} as any);
 const AdminNetworkRoute = AdminNetworkRouteImport.update({
   id: '/network',
   path: '/network',
   getParentRoute: () => AdminRoute,
-} as any)
+} as any);
 const AdminNotificationsRoute = AdminNotificationsRouteImport.update({
   id: '/notifications',
   path: '/notifications',
   getParentRoute: () => AdminRoute,
-} as any)
+} as any);
 const AdminPipelineRoute = AdminPipelineRouteImport.update({
   id: '/pipeline',
   path: '/pipeline',
   getParentRoute: () => AdminRoute,
-} as any)
+} as any);
 const AdminReportsRoute = AdminReportsRouteImport.update({
   id: '/reports',
   path: '/reports',
   getParentRoute: () => AdminRoute,
-} as any)
+} as any);
 const AdminRequestsRoute = AdminRequestsRouteImport.update({
   id: '/requests',
   path: '/requests',
   getParentRoute: () => AdminRoute,
-} as any)
+} as any);
 const AdminStorageRoute = AdminStorageRouteImport.update({
   id: '/storage',
   path: '/storage',
   getParentRoute: () => AdminRoute,
-} as any)
+} as any);
 const AdminStoreRoute = AdminStoreRouteImport.update({
   id: '/store',
   path: '/store',
   getParentRoute: () => AdminRoute,
-} as any)
+} as any);
 const AdminTranscoderRoute = AdminTranscoderRouteImport.update({
   id: '/transcoder',
   path: '/transcoder',
   getParentRoute: () => AdminRoute,
-} as any)
+} as any);
 const AdminUsersRoute = AdminUsersRouteImport.update({
   id: '/users',
   path: '/users',
   getParentRoute: () => AdminRoute,
-} as any)
+} as any);
 const AppGenreGenreRoute = AppGenreGenreRouteImport.update({
   id: '/genre/$genre',
   path: '/genre/$genre',
   getParentRoute: () => AppRoute,
-} as any)
+} as any);
 const AppMovieIdRoute = AppMovieIdRouteImport.update({
   id: '/movie/$id',
   path: '/movie/$id',
   getParentRoute: () => AppRoute,
-} as any)
+} as any);
 const AppPersonNameRoute = AppPersonNameRouteImport.update({
   id: '/person/$name',
   path: '/person/$name',
   getParentRoute: () => AppRoute,
-} as any)
+} as any);
 const AppShowIdRoute = AppShowIdRouteImport.update({
   id: '/show/$id',
   path: '/show/$id',
   getParentRoute: () => AppRoute,
-} as any)
+} as any);
 const AppTrendingTypeRoute = AppTrendingTypeRouteImport.update({
   id: '/trending/$type',
   path: '/trending/$type',
   getParentRoute: () => AppRoute,
-} as any)
+} as any);
 const AppWatchIdRoute = AppWatchIdRouteImport.update({
   id: '/watch/$id',
   path: '/watch/$id',
   getParentRoute: () => AppRoute,
-} as any)
+} as any);
 const AppDiscoverTypeTmdbIdRoute = AppDiscoverTypeTmdbIdRouteImport.update({
   id: '/discover/$type/$tmdbId',
   path: '/discover/$type/$tmdbId',
   getParentRoute: () => AppRoute,
-} as any)
+} as any);
 
 export interface FileRoutesByFullPath {
-  '/': typeof AppIndexRoute
-  '/admin': typeof AdminRouteWithChildren
-  '/join': typeof JoinRoute
-  '/login': typeof LoginRoute
-  '/$': typeof AppSplatRoute
-  '/account': typeof AppAccountRoute
-  '/coming-soon': typeof AppComingSoonRoute
-  '/connect': typeof AppConnectRoute
-  '/films': typeof AppFilmsRoute
-  '/genres': typeof AppGenresRoute
-  '/invite': typeof AppInviteRoute
-  '/missing': typeof AppMissingRoute
-  '/mylist': typeof AppMylistRoute
-  '/requests': typeof AppRequestsRoute
-  '/search': typeof AppSearchRoute
-  '/series': typeof AppSeriesRoute
-  '/admin/$': typeof AdminSplatRoute
-  '/admin/ai': typeof AdminAiRoute
-  '/admin/backup': typeof AdminBackupRoute
-  '/admin/general': typeof AdminGeneralRoute
-  '/admin/jobs': typeof AdminJobsRoute
-  '/admin/libraries': typeof AdminLibrariesRoute
-  '/admin/logs': typeof AdminLogsRoute
-  '/admin/modules': typeof AdminModulesRoute
-  '/admin/network': typeof AdminNetworkRoute
-  '/admin/notifications': typeof AdminNotificationsRoute
-  '/admin/pipeline': typeof AdminPipelineRoute
-  '/admin/reports': typeof AdminReportsRoute
-  '/admin/requests': typeof AdminRequestsRoute
-  '/admin/storage': typeof AdminStorageRoute
-  '/admin/store': typeof AdminStoreRoute
-  '/admin/transcoder': typeof AdminTranscoderRoute
-  '/admin/users': typeof AdminUsersRoute
-  '/admin/': typeof AdminIndexRoute
-  '/genre/$genre': typeof AppGenreGenreRoute
-  '/movie/$id': typeof AppMovieIdRoute
-  '/person/$name': typeof AppPersonNameRoute
-  '/show/$id': typeof AppShowIdRoute
-  '/trending/$type': typeof AppTrendingTypeRoute
-  '/watch/$id': typeof AppWatchIdRoute
-  '/discover/$type/$tmdbId': typeof AppDiscoverTypeTmdbIdRoute
+  '/': typeof AppIndexRoute;
+  '/admin': typeof AdminRouteWithChildren;
+  '/join': typeof JoinRoute;
+  '/login': typeof LoginRoute;
+  '/$': typeof AppSplatRoute;
+  '/account': typeof AppAccountRoute;
+  '/coming-soon': typeof AppComingSoonRoute;
+  '/connect': typeof AppConnectRoute;
+  '/films': typeof AppFilmsRoute;
+  '/genres': typeof AppGenresRoute;
+  '/invite': typeof AppInviteRoute;
+  '/missing': typeof AppMissingRoute;
+  '/mylist': typeof AppMylistRoute;
+  '/requests': typeof AppRequestsRoute;
+  '/search': typeof AppSearchRoute;
+  '/series': typeof AppSeriesRoute;
+  '/admin/$': typeof AdminSplatRoute;
+  '/admin/ai': typeof AdminAiRoute;
+  '/admin/backup': typeof AdminBackupRoute;
+  '/admin/general': typeof AdminGeneralRoute;
+  '/admin/jobs': typeof AdminJobsRoute;
+  '/admin/libraries': typeof AdminLibrariesRoute;
+  '/admin/logs': typeof AdminLogsRoute;
+  '/admin/modules': typeof AdminModulesRoute;
+  '/admin/network': typeof AdminNetworkRoute;
+  '/admin/notifications': typeof AdminNotificationsRoute;
+  '/admin/pipeline': typeof AdminPipelineRoute;
+  '/admin/reports': typeof AdminReportsRoute;
+  '/admin/requests': typeof AdminRequestsRoute;
+  '/admin/storage': typeof AdminStorageRoute;
+  '/admin/store': typeof AdminStoreRoute;
+  '/admin/transcoder': typeof AdminTranscoderRoute;
+  '/admin/users': typeof AdminUsersRoute;
+  '/admin/': typeof AdminIndexRoute;
+  '/genre/$genre': typeof AppGenreGenreRoute;
+  '/movie/$id': typeof AppMovieIdRoute;
+  '/person/$name': typeof AppPersonNameRoute;
+  '/show/$id': typeof AppShowIdRoute;
+  '/trending/$type': typeof AppTrendingTypeRoute;
+  '/watch/$id': typeof AppWatchIdRoute;
+  '/discover/$type/$tmdbId': typeof AppDiscoverTypeTmdbIdRoute;
 }
 export interface FileRoutesByTo {
-  '/join': typeof JoinRoute
-  '/login': typeof LoginRoute
-  '/$': typeof AppSplatRoute
-  '/account': typeof AppAccountRoute
-  '/coming-soon': typeof AppComingSoonRoute
-  '/connect': typeof AppConnectRoute
-  '/films': typeof AppFilmsRoute
-  '/genres': typeof AppGenresRoute
-  '/invite': typeof AppInviteRoute
-  '/missing': typeof AppMissingRoute
-  '/mylist': typeof AppMylistRoute
-  '/requests': typeof AppRequestsRoute
-  '/search': typeof AppSearchRoute
-  '/series': typeof AppSeriesRoute
-  '/admin/$': typeof AdminSplatRoute
-  '/admin/ai': typeof AdminAiRoute
-  '/admin/backup': typeof AdminBackupRoute
-  '/admin/general': typeof AdminGeneralRoute
-  '/admin/jobs': typeof AdminJobsRoute
-  '/admin/libraries': typeof AdminLibrariesRoute
-  '/admin/logs': typeof AdminLogsRoute
-  '/admin/modules': typeof AdminModulesRoute
-  '/admin/network': typeof AdminNetworkRoute
-  '/admin/notifications': typeof AdminNotificationsRoute
-  '/admin/pipeline': typeof AdminPipelineRoute
-  '/admin/reports': typeof AdminReportsRoute
-  '/admin/requests': typeof AdminRequestsRoute
-  '/admin/storage': typeof AdminStorageRoute
-  '/admin/store': typeof AdminStoreRoute
-  '/admin/transcoder': typeof AdminTranscoderRoute
-  '/admin/users': typeof AdminUsersRoute
-  '/': typeof AppIndexRoute
-  '/admin': typeof AdminIndexRoute
-  '/genre/$genre': typeof AppGenreGenreRoute
-  '/movie/$id': typeof AppMovieIdRoute
-  '/person/$name': typeof AppPersonNameRoute
-  '/show/$id': typeof AppShowIdRoute
-  '/trending/$type': typeof AppTrendingTypeRoute
-  '/watch/$id': typeof AppWatchIdRoute
-  '/discover/$type/$tmdbId': typeof AppDiscoverTypeTmdbIdRoute
+  '/join': typeof JoinRoute;
+  '/login': typeof LoginRoute;
+  '/$': typeof AppSplatRoute;
+  '/account': typeof AppAccountRoute;
+  '/coming-soon': typeof AppComingSoonRoute;
+  '/connect': typeof AppConnectRoute;
+  '/films': typeof AppFilmsRoute;
+  '/genres': typeof AppGenresRoute;
+  '/invite': typeof AppInviteRoute;
+  '/missing': typeof AppMissingRoute;
+  '/mylist': typeof AppMylistRoute;
+  '/requests': typeof AppRequestsRoute;
+  '/search': typeof AppSearchRoute;
+  '/series': typeof AppSeriesRoute;
+  '/admin/$': typeof AdminSplatRoute;
+  '/admin/ai': typeof AdminAiRoute;
+  '/admin/backup': typeof AdminBackupRoute;
+  '/admin/general': typeof AdminGeneralRoute;
+  '/admin/jobs': typeof AdminJobsRoute;
+  '/admin/libraries': typeof AdminLibrariesRoute;
+  '/admin/logs': typeof AdminLogsRoute;
+  '/admin/modules': typeof AdminModulesRoute;
+  '/admin/network': typeof AdminNetworkRoute;
+  '/admin/notifications': typeof AdminNotificationsRoute;
+  '/admin/pipeline': typeof AdminPipelineRoute;
+  '/admin/reports': typeof AdminReportsRoute;
+  '/admin/requests': typeof AdminRequestsRoute;
+  '/admin/storage': typeof AdminStorageRoute;
+  '/admin/store': typeof AdminStoreRoute;
+  '/admin/transcoder': typeof AdminTranscoderRoute;
+  '/admin/users': typeof AdminUsersRoute;
+  '/': typeof AppIndexRoute;
+  '/admin': typeof AdminIndexRoute;
+  '/genre/$genre': typeof AppGenreGenreRoute;
+  '/movie/$id': typeof AppMovieIdRoute;
+  '/person/$name': typeof AppPersonNameRoute;
+  '/show/$id': typeof AppShowIdRoute;
+  '/trending/$type': typeof AppTrendingTypeRoute;
+  '/watch/$id': typeof AppWatchIdRoute;
+  '/discover/$type/$tmdbId': typeof AppDiscoverTypeTmdbIdRoute;
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport
-  '/_app': typeof AppRouteWithChildren
-  '/admin': typeof AdminRouteWithChildren
-  '/join': typeof JoinRoute
-  '/login': typeof LoginRoute
-  '/_app/$': typeof AppSplatRoute
-  '/_app/account': typeof AppAccountRoute
-  '/_app/coming-soon': typeof AppComingSoonRoute
-  '/_app/connect': typeof AppConnectRoute
-  '/_app/films': typeof AppFilmsRoute
-  '/_app/genres': typeof AppGenresRoute
-  '/_app/invite': typeof AppInviteRoute
-  '/_app/missing': typeof AppMissingRoute
-  '/_app/mylist': typeof AppMylistRoute
-  '/_app/requests': typeof AppRequestsRoute
-  '/_app/search': typeof AppSearchRoute
-  '/_app/series': typeof AppSeriesRoute
-  '/admin/$': typeof AdminSplatRoute
-  '/admin/ai': typeof AdminAiRoute
-  '/admin/backup': typeof AdminBackupRoute
-  '/admin/general': typeof AdminGeneralRoute
-  '/admin/jobs': typeof AdminJobsRoute
-  '/admin/libraries': typeof AdminLibrariesRoute
-  '/admin/logs': typeof AdminLogsRoute
-  '/admin/modules': typeof AdminModulesRoute
-  '/admin/network': typeof AdminNetworkRoute
-  '/admin/notifications': typeof AdminNotificationsRoute
-  '/admin/pipeline': typeof AdminPipelineRoute
-  '/admin/reports': typeof AdminReportsRoute
-  '/admin/requests': typeof AdminRequestsRoute
-  '/admin/storage': typeof AdminStorageRoute
-  '/admin/store': typeof AdminStoreRoute
-  '/admin/transcoder': typeof AdminTranscoderRoute
-  '/admin/users': typeof AdminUsersRoute
-  '/_app/': typeof AppIndexRoute
-  '/admin/': typeof AdminIndexRoute
-  '/_app/genre/$genre': typeof AppGenreGenreRoute
-  '/_app/movie/$id': typeof AppMovieIdRoute
-  '/_app/person/$name': typeof AppPersonNameRoute
-  '/_app/show/$id': typeof AppShowIdRoute
-  '/_app/trending/$type': typeof AppTrendingTypeRoute
-  '/_app/watch/$id': typeof AppWatchIdRoute
-  '/_app/discover/$type/$tmdbId': typeof AppDiscoverTypeTmdbIdRoute
+  __root__: typeof rootRouteImport;
+  '/_app': typeof AppRouteWithChildren;
+  '/admin': typeof AdminRouteWithChildren;
+  '/join': typeof JoinRoute;
+  '/login': typeof LoginRoute;
+  '/_app/$': typeof AppSplatRoute;
+  '/_app/account': typeof AppAccountRoute;
+  '/_app/coming-soon': typeof AppComingSoonRoute;
+  '/_app/connect': typeof AppConnectRoute;
+  '/_app/films': typeof AppFilmsRoute;
+  '/_app/genres': typeof AppGenresRoute;
+  '/_app/invite': typeof AppInviteRoute;
+  '/_app/missing': typeof AppMissingRoute;
+  '/_app/mylist': typeof AppMylistRoute;
+  '/_app/requests': typeof AppRequestsRoute;
+  '/_app/search': typeof AppSearchRoute;
+  '/_app/series': typeof AppSeriesRoute;
+  '/admin/$': typeof AdminSplatRoute;
+  '/admin/ai': typeof AdminAiRoute;
+  '/admin/backup': typeof AdminBackupRoute;
+  '/admin/general': typeof AdminGeneralRoute;
+  '/admin/jobs': typeof AdminJobsRoute;
+  '/admin/libraries': typeof AdminLibrariesRoute;
+  '/admin/logs': typeof AdminLogsRoute;
+  '/admin/modules': typeof AdminModulesRoute;
+  '/admin/network': typeof AdminNetworkRoute;
+  '/admin/notifications': typeof AdminNotificationsRoute;
+  '/admin/pipeline': typeof AdminPipelineRoute;
+  '/admin/reports': typeof AdminReportsRoute;
+  '/admin/requests': typeof AdminRequestsRoute;
+  '/admin/storage': typeof AdminStorageRoute;
+  '/admin/store': typeof AdminStoreRoute;
+  '/admin/transcoder': typeof AdminTranscoderRoute;
+  '/admin/users': typeof AdminUsersRoute;
+  '/_app/': typeof AppIndexRoute;
+  '/admin/': typeof AdminIndexRoute;
+  '/_app/genre/$genre': typeof AppGenreGenreRoute;
+  '/_app/movie/$id': typeof AppMovieIdRoute;
+  '/_app/person/$name': typeof AppPersonNameRoute;
+  '/_app/show/$id': typeof AppShowIdRoute;
+  '/_app/trending/$type': typeof AppTrendingTypeRoute;
+  '/_app/watch/$id': typeof AppWatchIdRoute;
+  '/_app/discover/$type/$tmdbId': typeof AppDiscoverTypeTmdbIdRoute;
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath
+  fileRoutesByFullPath: FileRoutesByFullPath;
   fullPaths:
     | '/'
     | '/admin'
@@ -435,8 +435,8 @@ export interface FileRouteTypes {
     | '/show/$id'
     | '/trending/$type'
     | '/watch/$id'
-    | '/discover/$type/$tmdbId'
-  fileRoutesByTo: FileRoutesByTo
+    | '/discover/$type/$tmdbId';
+  fileRoutesByTo: FileRoutesByTo;
   to:
     | '/join'
     | '/login'
@@ -477,7 +477,7 @@ export interface FileRouteTypes {
     | '/show/$id'
     | '/trending/$type'
     | '/watch/$id'
-    | '/discover/$type/$tmdbId'
+    | '/discover/$type/$tmdbId';
   id:
     | '__root__'
     | '/_app'
@@ -521,336 +521,336 @@ export interface FileRouteTypes {
     | '/_app/show/$id'
     | '/_app/trending/$type'
     | '/_app/watch/$id'
-    | '/_app/discover/$type/$tmdbId'
-  fileRoutesById: FileRoutesById
+    | '/_app/discover/$type/$tmdbId';
+  fileRoutesById: FileRoutesById;
 }
 export interface RootRouteChildren {
-  AppRoute: typeof AppRouteWithChildren
-  AdminRoute: typeof AdminRouteWithChildren
-  JoinRoute: typeof JoinRoute
-  LoginRoute: typeof LoginRoute
+  AppRoute: typeof AppRouteWithChildren;
+  AdminRoute: typeof AdminRouteWithChildren;
+  JoinRoute: typeof JoinRoute;
+  LoginRoute: typeof LoginRoute;
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
     '/_app': {
-      id: '/_app'
-      path: ''
-      fullPath: '/'
-      preLoaderRoute: typeof AppRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/_app';
+      path: '';
+      fullPath: '/';
+      preLoaderRoute: typeof AppRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/admin': {
-      id: '/admin'
-      path: '/admin'
-      fullPath: '/admin'
-      preLoaderRoute: typeof AdminRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/admin';
+      path: '/admin';
+      fullPath: '/admin';
+      preLoaderRoute: typeof AdminRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/join': {
-      id: '/join'
-      path: '/join'
-      fullPath: '/join'
-      preLoaderRoute: typeof JoinRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/join';
+      path: '/join';
+      fullPath: '/join';
+      preLoaderRoute: typeof JoinRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/login': {
-      id: '/login'
-      path: '/login'
-      fullPath: '/login'
-      preLoaderRoute: typeof LoginRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/login';
+      path: '/login';
+      fullPath: '/login';
+      preLoaderRoute: typeof LoginRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/_app/': {
-      id: '/_app/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof AppIndexRouteImport
-      parentRoute: typeof AppRoute
-    }
+      id: '/_app/';
+      path: '/';
+      fullPath: '/';
+      preLoaderRoute: typeof AppIndexRouteImport;
+      parentRoute: typeof AppRoute;
+    };
     '/_app/$': {
-      id: '/_app/$'
-      path: '/$'
-      fullPath: '/$'
-      preLoaderRoute: typeof AppSplatRouteImport
-      parentRoute: typeof AppRoute
-    }
+      id: '/_app/$';
+      path: '/$';
+      fullPath: '/$';
+      preLoaderRoute: typeof AppSplatRouteImport;
+      parentRoute: typeof AppRoute;
+    };
     '/_app/account': {
-      id: '/_app/account'
-      path: '/account'
-      fullPath: '/account'
-      preLoaderRoute: typeof AppAccountRouteImport
-      parentRoute: typeof AppRoute
-    }
+      id: '/_app/account';
+      path: '/account';
+      fullPath: '/account';
+      preLoaderRoute: typeof AppAccountRouteImport;
+      parentRoute: typeof AppRoute;
+    };
     '/_app/coming-soon': {
-      id: '/_app/coming-soon'
-      path: '/coming-soon'
-      fullPath: '/coming-soon'
-      preLoaderRoute: typeof AppComingSoonRouteImport
-      parentRoute: typeof AppRoute
-    }
+      id: '/_app/coming-soon';
+      path: '/coming-soon';
+      fullPath: '/coming-soon';
+      preLoaderRoute: typeof AppComingSoonRouteImport;
+      parentRoute: typeof AppRoute;
+    };
     '/_app/connect': {
-      id: '/_app/connect'
-      path: '/connect'
-      fullPath: '/connect'
-      preLoaderRoute: typeof AppConnectRouteImport
-      parentRoute: typeof AppRoute
-    }
+      id: '/_app/connect';
+      path: '/connect';
+      fullPath: '/connect';
+      preLoaderRoute: typeof AppConnectRouteImport;
+      parentRoute: typeof AppRoute;
+    };
     '/_app/films': {
-      id: '/_app/films'
-      path: '/films'
-      fullPath: '/films'
-      preLoaderRoute: typeof AppFilmsRouteImport
-      parentRoute: typeof AppRoute
-    }
+      id: '/_app/films';
+      path: '/films';
+      fullPath: '/films';
+      preLoaderRoute: typeof AppFilmsRouteImport;
+      parentRoute: typeof AppRoute;
+    };
     '/_app/genres': {
-      id: '/_app/genres'
-      path: '/genres'
-      fullPath: '/genres'
-      preLoaderRoute: typeof AppGenresRouteImport
-      parentRoute: typeof AppRoute
-    }
+      id: '/_app/genres';
+      path: '/genres';
+      fullPath: '/genres';
+      preLoaderRoute: typeof AppGenresRouteImport;
+      parentRoute: typeof AppRoute;
+    };
     '/_app/invite': {
-      id: '/_app/invite'
-      path: '/invite'
-      fullPath: '/invite'
-      preLoaderRoute: typeof AppInviteRouteImport
-      parentRoute: typeof AppRoute
-    }
+      id: '/_app/invite';
+      path: '/invite';
+      fullPath: '/invite';
+      preLoaderRoute: typeof AppInviteRouteImport;
+      parentRoute: typeof AppRoute;
+    };
     '/_app/missing': {
-      id: '/_app/missing'
-      path: '/missing'
-      fullPath: '/missing'
-      preLoaderRoute: typeof AppMissingRouteImport
-      parentRoute: typeof AppRoute
-    }
+      id: '/_app/missing';
+      path: '/missing';
+      fullPath: '/missing';
+      preLoaderRoute: typeof AppMissingRouteImport;
+      parentRoute: typeof AppRoute;
+    };
     '/_app/mylist': {
-      id: '/_app/mylist'
-      path: '/mylist'
-      fullPath: '/mylist'
-      preLoaderRoute: typeof AppMylistRouteImport
-      parentRoute: typeof AppRoute
-    }
+      id: '/_app/mylist';
+      path: '/mylist';
+      fullPath: '/mylist';
+      preLoaderRoute: typeof AppMylistRouteImport;
+      parentRoute: typeof AppRoute;
+    };
     '/_app/requests': {
-      id: '/_app/requests'
-      path: '/requests'
-      fullPath: '/requests'
-      preLoaderRoute: typeof AppRequestsRouteImport
-      parentRoute: typeof AppRoute
-    }
+      id: '/_app/requests';
+      path: '/requests';
+      fullPath: '/requests';
+      preLoaderRoute: typeof AppRequestsRouteImport;
+      parentRoute: typeof AppRoute;
+    };
     '/_app/search': {
-      id: '/_app/search'
-      path: '/search'
-      fullPath: '/search'
-      preLoaderRoute: typeof AppSearchRouteImport
-      parentRoute: typeof AppRoute
-    }
+      id: '/_app/search';
+      path: '/search';
+      fullPath: '/search';
+      preLoaderRoute: typeof AppSearchRouteImport;
+      parentRoute: typeof AppRoute;
+    };
     '/_app/series': {
-      id: '/_app/series'
-      path: '/series'
-      fullPath: '/series'
-      preLoaderRoute: typeof AppSeriesRouteImport
-      parentRoute: typeof AppRoute
-    }
+      id: '/_app/series';
+      path: '/series';
+      fullPath: '/series';
+      preLoaderRoute: typeof AppSeriesRouteImport;
+      parentRoute: typeof AppRoute;
+    };
     '/admin/': {
-      id: '/admin/'
-      path: '/'
-      fullPath: '/admin/'
-      preLoaderRoute: typeof AdminIndexRouteImport
-      parentRoute: typeof AdminRoute
-    }
+      id: '/admin/';
+      path: '/';
+      fullPath: '/admin/';
+      preLoaderRoute: typeof AdminIndexRouteImport;
+      parentRoute: typeof AdminRoute;
+    };
     '/admin/$': {
-      id: '/admin/$'
-      path: '/$'
-      fullPath: '/admin/$'
-      preLoaderRoute: typeof AdminSplatRouteImport
-      parentRoute: typeof AdminRoute
-    }
+      id: '/admin/$';
+      path: '/$';
+      fullPath: '/admin/$';
+      preLoaderRoute: typeof AdminSplatRouteImport;
+      parentRoute: typeof AdminRoute;
+    };
     '/admin/ai': {
-      id: '/admin/ai'
-      path: '/ai'
-      fullPath: '/admin/ai'
-      preLoaderRoute: typeof AdminAiRouteImport
-      parentRoute: typeof AdminRoute
-    }
+      id: '/admin/ai';
+      path: '/ai';
+      fullPath: '/admin/ai';
+      preLoaderRoute: typeof AdminAiRouteImport;
+      parentRoute: typeof AdminRoute;
+    };
     '/admin/backup': {
-      id: '/admin/backup'
-      path: '/backup'
-      fullPath: '/admin/backup'
-      preLoaderRoute: typeof AdminBackupRouteImport
-      parentRoute: typeof AdminRoute
-    }
+      id: '/admin/backup';
+      path: '/backup';
+      fullPath: '/admin/backup';
+      preLoaderRoute: typeof AdminBackupRouteImport;
+      parentRoute: typeof AdminRoute;
+    };
     '/admin/general': {
-      id: '/admin/general'
-      path: '/general'
-      fullPath: '/admin/general'
-      preLoaderRoute: typeof AdminGeneralRouteImport
-      parentRoute: typeof AdminRoute
-    }
+      id: '/admin/general';
+      path: '/general';
+      fullPath: '/admin/general';
+      preLoaderRoute: typeof AdminGeneralRouteImport;
+      parentRoute: typeof AdminRoute;
+    };
     '/admin/jobs': {
-      id: '/admin/jobs'
-      path: '/jobs'
-      fullPath: '/admin/jobs'
-      preLoaderRoute: typeof AdminJobsRouteImport
-      parentRoute: typeof AdminRoute
-    }
+      id: '/admin/jobs';
+      path: '/jobs';
+      fullPath: '/admin/jobs';
+      preLoaderRoute: typeof AdminJobsRouteImport;
+      parentRoute: typeof AdminRoute;
+    };
     '/admin/libraries': {
-      id: '/admin/libraries'
-      path: '/libraries'
-      fullPath: '/admin/libraries'
-      preLoaderRoute: typeof AdminLibrariesRouteImport
-      parentRoute: typeof AdminRoute
-    }
+      id: '/admin/libraries';
+      path: '/libraries';
+      fullPath: '/admin/libraries';
+      preLoaderRoute: typeof AdminLibrariesRouteImport;
+      parentRoute: typeof AdminRoute;
+    };
     '/admin/logs': {
-      id: '/admin/logs'
-      path: '/logs'
-      fullPath: '/admin/logs'
-      preLoaderRoute: typeof AdminLogsRouteImport
-      parentRoute: typeof AdminRoute
-    }
+      id: '/admin/logs';
+      path: '/logs';
+      fullPath: '/admin/logs';
+      preLoaderRoute: typeof AdminLogsRouteImport;
+      parentRoute: typeof AdminRoute;
+    };
     '/admin/modules': {
-      id: '/admin/modules'
-      path: '/modules'
-      fullPath: '/admin/modules'
-      preLoaderRoute: typeof AdminModulesRouteImport
-      parentRoute: typeof AdminRoute
-    }
+      id: '/admin/modules';
+      path: '/modules';
+      fullPath: '/admin/modules';
+      preLoaderRoute: typeof AdminModulesRouteImport;
+      parentRoute: typeof AdminRoute;
+    };
     '/admin/network': {
-      id: '/admin/network'
-      path: '/network'
-      fullPath: '/admin/network'
-      preLoaderRoute: typeof AdminNetworkRouteImport
-      parentRoute: typeof AdminRoute
-    }
+      id: '/admin/network';
+      path: '/network';
+      fullPath: '/admin/network';
+      preLoaderRoute: typeof AdminNetworkRouteImport;
+      parentRoute: typeof AdminRoute;
+    };
     '/admin/notifications': {
-      id: '/admin/notifications'
-      path: '/notifications'
-      fullPath: '/admin/notifications'
-      preLoaderRoute: typeof AdminNotificationsRouteImport
-      parentRoute: typeof AdminRoute
-    }
+      id: '/admin/notifications';
+      path: '/notifications';
+      fullPath: '/admin/notifications';
+      preLoaderRoute: typeof AdminNotificationsRouteImport;
+      parentRoute: typeof AdminRoute;
+    };
     '/admin/pipeline': {
-      id: '/admin/pipeline'
-      path: '/pipeline'
-      fullPath: '/admin/pipeline'
-      preLoaderRoute: typeof AdminPipelineRouteImport
-      parentRoute: typeof AdminRoute
-    }
+      id: '/admin/pipeline';
+      path: '/pipeline';
+      fullPath: '/admin/pipeline';
+      preLoaderRoute: typeof AdminPipelineRouteImport;
+      parentRoute: typeof AdminRoute;
+    };
     '/admin/reports': {
-      id: '/admin/reports'
-      path: '/reports'
-      fullPath: '/admin/reports'
-      preLoaderRoute: typeof AdminReportsRouteImport
-      parentRoute: typeof AdminRoute
-    }
+      id: '/admin/reports';
+      path: '/reports';
+      fullPath: '/admin/reports';
+      preLoaderRoute: typeof AdminReportsRouteImport;
+      parentRoute: typeof AdminRoute;
+    };
     '/admin/requests': {
-      id: '/admin/requests'
-      path: '/requests'
-      fullPath: '/admin/requests'
-      preLoaderRoute: typeof AdminRequestsRouteImport
-      parentRoute: typeof AdminRoute
-    }
+      id: '/admin/requests';
+      path: '/requests';
+      fullPath: '/admin/requests';
+      preLoaderRoute: typeof AdminRequestsRouteImport;
+      parentRoute: typeof AdminRoute;
+    };
     '/admin/storage': {
-      id: '/admin/storage'
-      path: '/storage'
-      fullPath: '/admin/storage'
-      preLoaderRoute: typeof AdminStorageRouteImport
-      parentRoute: typeof AdminRoute
-    }
+      id: '/admin/storage';
+      path: '/storage';
+      fullPath: '/admin/storage';
+      preLoaderRoute: typeof AdminStorageRouteImport;
+      parentRoute: typeof AdminRoute;
+    };
     '/admin/store': {
-      id: '/admin/store'
-      path: '/store'
-      fullPath: '/admin/store'
-      preLoaderRoute: typeof AdminStoreRouteImport
-      parentRoute: typeof AdminRoute
-    }
+      id: '/admin/store';
+      path: '/store';
+      fullPath: '/admin/store';
+      preLoaderRoute: typeof AdminStoreRouteImport;
+      parentRoute: typeof AdminRoute;
+    };
     '/admin/transcoder': {
-      id: '/admin/transcoder'
-      path: '/transcoder'
-      fullPath: '/admin/transcoder'
-      preLoaderRoute: typeof AdminTranscoderRouteImport
-      parentRoute: typeof AdminRoute
-    }
+      id: '/admin/transcoder';
+      path: '/transcoder';
+      fullPath: '/admin/transcoder';
+      preLoaderRoute: typeof AdminTranscoderRouteImport;
+      parentRoute: typeof AdminRoute;
+    };
     '/admin/users': {
-      id: '/admin/users'
-      path: '/users'
-      fullPath: '/admin/users'
-      preLoaderRoute: typeof AdminUsersRouteImport
-      parentRoute: typeof AdminRoute
-    }
+      id: '/admin/users';
+      path: '/users';
+      fullPath: '/admin/users';
+      preLoaderRoute: typeof AdminUsersRouteImport;
+      parentRoute: typeof AdminRoute;
+    };
     '/_app/genre/$genre': {
-      id: '/_app/genre/$genre'
-      path: '/genre/$genre'
-      fullPath: '/genre/$genre'
-      preLoaderRoute: typeof AppGenreGenreRouteImport
-      parentRoute: typeof AppRoute
-    }
+      id: '/_app/genre/$genre';
+      path: '/genre/$genre';
+      fullPath: '/genre/$genre';
+      preLoaderRoute: typeof AppGenreGenreRouteImport;
+      parentRoute: typeof AppRoute;
+    };
     '/_app/movie/$id': {
-      id: '/_app/movie/$id'
-      path: '/movie/$id'
-      fullPath: '/movie/$id'
-      preLoaderRoute: typeof AppMovieIdRouteImport
-      parentRoute: typeof AppRoute
-    }
+      id: '/_app/movie/$id';
+      path: '/movie/$id';
+      fullPath: '/movie/$id';
+      preLoaderRoute: typeof AppMovieIdRouteImport;
+      parentRoute: typeof AppRoute;
+    };
     '/_app/person/$name': {
-      id: '/_app/person/$name'
-      path: '/person/$name'
-      fullPath: '/person/$name'
-      preLoaderRoute: typeof AppPersonNameRouteImport
-      parentRoute: typeof AppRoute
-    }
+      id: '/_app/person/$name';
+      path: '/person/$name';
+      fullPath: '/person/$name';
+      preLoaderRoute: typeof AppPersonNameRouteImport;
+      parentRoute: typeof AppRoute;
+    };
     '/_app/show/$id': {
-      id: '/_app/show/$id'
-      path: '/show/$id'
-      fullPath: '/show/$id'
-      preLoaderRoute: typeof AppShowIdRouteImport
-      parentRoute: typeof AppRoute
-    }
+      id: '/_app/show/$id';
+      path: '/show/$id';
+      fullPath: '/show/$id';
+      preLoaderRoute: typeof AppShowIdRouteImport;
+      parentRoute: typeof AppRoute;
+    };
     '/_app/trending/$type': {
-      id: '/_app/trending/$type'
-      path: '/trending/$type'
-      fullPath: '/trending/$type'
-      preLoaderRoute: typeof AppTrendingTypeRouteImport
-      parentRoute: typeof AppRoute
-    }
+      id: '/_app/trending/$type';
+      path: '/trending/$type';
+      fullPath: '/trending/$type';
+      preLoaderRoute: typeof AppTrendingTypeRouteImport;
+      parentRoute: typeof AppRoute;
+    };
     '/_app/watch/$id': {
-      id: '/_app/watch/$id'
-      path: '/watch/$id'
-      fullPath: '/watch/$id'
-      preLoaderRoute: typeof AppWatchIdRouteImport
-      parentRoute: typeof AppRoute
-    }
+      id: '/_app/watch/$id';
+      path: '/watch/$id';
+      fullPath: '/watch/$id';
+      preLoaderRoute: typeof AppWatchIdRouteImport;
+      parentRoute: typeof AppRoute;
+    };
     '/_app/discover/$type/$tmdbId': {
-      id: '/_app/discover/$type/$tmdbId'
-      path: '/discover/$type/$tmdbId'
-      fullPath: '/discover/$type/$tmdbId'
-      preLoaderRoute: typeof AppDiscoverTypeTmdbIdRouteImport
-      parentRoute: typeof AppRoute
-    }
+      id: '/_app/discover/$type/$tmdbId';
+      path: '/discover/$type/$tmdbId';
+      fullPath: '/discover/$type/$tmdbId';
+      preLoaderRoute: typeof AppDiscoverTypeTmdbIdRouteImport;
+      parentRoute: typeof AppRoute;
+    };
   }
 }
 
 interface AppRouteChildren {
-  AppSplatRoute: typeof AppSplatRoute
-  AppAccountRoute: typeof AppAccountRoute
-  AppComingSoonRoute: typeof AppComingSoonRoute
-  AppConnectRoute: typeof AppConnectRoute
-  AppFilmsRoute: typeof AppFilmsRoute
-  AppGenresRoute: typeof AppGenresRoute
-  AppInviteRoute: typeof AppInviteRoute
-  AppMissingRoute: typeof AppMissingRoute
-  AppMylistRoute: typeof AppMylistRoute
-  AppRequestsRoute: typeof AppRequestsRoute
-  AppSearchRoute: typeof AppSearchRoute
-  AppSeriesRoute: typeof AppSeriesRoute
-  AppIndexRoute: typeof AppIndexRoute
-  AppGenreGenreRoute: typeof AppGenreGenreRoute
-  AppMovieIdRoute: typeof AppMovieIdRoute
-  AppPersonNameRoute: typeof AppPersonNameRoute
-  AppShowIdRoute: typeof AppShowIdRoute
-  AppTrendingTypeRoute: typeof AppTrendingTypeRoute
-  AppWatchIdRoute: typeof AppWatchIdRoute
-  AppDiscoverTypeTmdbIdRoute: typeof AppDiscoverTypeTmdbIdRoute
+  AppSplatRoute: typeof AppSplatRoute;
+  AppAccountRoute: typeof AppAccountRoute;
+  AppComingSoonRoute: typeof AppComingSoonRoute;
+  AppConnectRoute: typeof AppConnectRoute;
+  AppFilmsRoute: typeof AppFilmsRoute;
+  AppGenresRoute: typeof AppGenresRoute;
+  AppInviteRoute: typeof AppInviteRoute;
+  AppMissingRoute: typeof AppMissingRoute;
+  AppMylistRoute: typeof AppMylistRoute;
+  AppRequestsRoute: typeof AppRequestsRoute;
+  AppSearchRoute: typeof AppSearchRoute;
+  AppSeriesRoute: typeof AppSeriesRoute;
+  AppIndexRoute: typeof AppIndexRoute;
+  AppGenreGenreRoute: typeof AppGenreGenreRoute;
+  AppMovieIdRoute: typeof AppMovieIdRoute;
+  AppPersonNameRoute: typeof AppPersonNameRoute;
+  AppShowIdRoute: typeof AppShowIdRoute;
+  AppTrendingTypeRoute: typeof AppTrendingTypeRoute;
+  AppWatchIdRoute: typeof AppWatchIdRoute;
+  AppDiscoverTypeTmdbIdRoute: typeof AppDiscoverTypeTmdbIdRoute;
 }
 
 const AppRouteChildren: AppRouteChildren = {
@@ -874,29 +874,29 @@ const AppRouteChildren: AppRouteChildren = {
   AppTrendingTypeRoute: AppTrendingTypeRoute,
   AppWatchIdRoute: AppWatchIdRoute,
   AppDiscoverTypeTmdbIdRoute: AppDiscoverTypeTmdbIdRoute,
-}
+};
 
-const AppRouteWithChildren = AppRoute._addFileChildren(AppRouteChildren)
+const AppRouteWithChildren = AppRoute._addFileChildren(AppRouteChildren);
 
 interface AdminRouteChildren {
-  AdminSplatRoute: typeof AdminSplatRoute
-  AdminAiRoute: typeof AdminAiRoute
-  AdminBackupRoute: typeof AdminBackupRoute
-  AdminGeneralRoute: typeof AdminGeneralRoute
-  AdminJobsRoute: typeof AdminJobsRoute
-  AdminLibrariesRoute: typeof AdminLibrariesRoute
-  AdminLogsRoute: typeof AdminLogsRoute
-  AdminModulesRoute: typeof AdminModulesRoute
-  AdminNetworkRoute: typeof AdminNetworkRoute
-  AdminNotificationsRoute: typeof AdminNotificationsRoute
-  AdminPipelineRoute: typeof AdminPipelineRoute
-  AdminReportsRoute: typeof AdminReportsRoute
-  AdminRequestsRoute: typeof AdminRequestsRoute
-  AdminStorageRoute: typeof AdminStorageRoute
-  AdminStoreRoute: typeof AdminStoreRoute
-  AdminTranscoderRoute: typeof AdminTranscoderRoute
-  AdminUsersRoute: typeof AdminUsersRoute
-  AdminIndexRoute: typeof AdminIndexRoute
+  AdminSplatRoute: typeof AdminSplatRoute;
+  AdminAiRoute: typeof AdminAiRoute;
+  AdminBackupRoute: typeof AdminBackupRoute;
+  AdminGeneralRoute: typeof AdminGeneralRoute;
+  AdminJobsRoute: typeof AdminJobsRoute;
+  AdminLibrariesRoute: typeof AdminLibrariesRoute;
+  AdminLogsRoute: typeof AdminLogsRoute;
+  AdminModulesRoute: typeof AdminModulesRoute;
+  AdminNetworkRoute: typeof AdminNetworkRoute;
+  AdminNotificationsRoute: typeof AdminNotificationsRoute;
+  AdminPipelineRoute: typeof AdminPipelineRoute;
+  AdminReportsRoute: typeof AdminReportsRoute;
+  AdminRequestsRoute: typeof AdminRequestsRoute;
+  AdminStorageRoute: typeof AdminStorageRoute;
+  AdminStoreRoute: typeof AdminStoreRoute;
+  AdminTranscoderRoute: typeof AdminTranscoderRoute;
+  AdminUsersRoute: typeof AdminUsersRoute;
+  AdminIndexRoute: typeof AdminIndexRoute;
 }
 
 const AdminRouteChildren: AdminRouteChildren = {
@@ -918,25 +918,16 @@ const AdminRouteChildren: AdminRouteChildren = {
   AdminTranscoderRoute: AdminTranscoderRoute,
   AdminUsersRoute: AdminUsersRoute,
   AdminIndexRoute: AdminIndexRoute,
-}
+};
 
-const AdminRouteWithChildren = AdminRoute._addFileChildren(AdminRouteChildren)
+const AdminRouteWithChildren = AdminRoute._addFileChildren(AdminRouteChildren);
 
 const rootRouteChildren: RootRouteChildren = {
   AppRoute: AppRouteWithChildren,
   AdminRoute: AdminRouteWithChildren,
   JoinRoute: JoinRoute,
   LoginRoute: LoginRoute,
-}
+};
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>()
-
-import type { getRouter } from './router.tsx'
-import type { createStart } from '@tanstack/react-start'
-declare module '@tanstack/react-start' {
-  interface Register {
-    ssr: true
-    router: Awaited<ReturnType<typeof getRouter>>
-  }
-}
+  ._addFileTypes<FileRouteTypes>();

--- a/packages/bundler/src/site.ts
+++ b/packages/bundler/src/site.ts
@@ -7,6 +7,7 @@ import react from '@vitejs/plugin-react';
 import type { Plugin, UserConfig } from 'vite';
 
 const WORKERD_ONLY = 'cloudflare:workers';
+const OUTSIDE_WORKERD = `${WORKERD_ONLY} is unavailable outside workerd`;
 
 // That module exists only inside workerd. `vite dev` resolves it like any other
 // import, fails the transform, and drops an error overlay over the page which
@@ -19,9 +20,7 @@ const workerdBuiltins = (): Plugin => ({
   apply: 'serve',
   resolveId: (id) => (id === WORKERD_ONLY ? `\0${WORKERD_ONLY}` : undefined),
   load: (id) =>
-    id === `\0${WORKERD_ONLY}`
-      ? `throw new Error(${JSON.stringify(`${WORKERD_ONLY} is unavailable outside workerd`)})`
-      : undefined,
+    id === `\0${WORKERD_ONLY}` ? `throw new Error(${JSON.stringify(OUTSIDE_WORKERD)})` : undefined,
 });
 
 export interface KromaSiteOptions {

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -423,7 +423,7 @@ split.
 
 The cost, measured: a namespace import cannot be tree-shaken, so left alone the
 whole set ships, and the kit site went from 258 KB to 741 KB gzipped. A build-time
-subset in `@kroma/ui/bundler` buys it back on every target: 296 of 6,250 glyphs
+subset in `@kroma/ui/bundler` buys it back on every target: 299 of 6,250 glyphs
 kept, and `<Icon>` costs 49 KB gzipped instead of 573 KB. `vite dev` is not
 subset (`apply: 'build'`); Metro is, in both `start` and `export`.
 

--- a/packages/ui/bundler/index.test.ts
+++ b/packages/ui/bundler/index.test.ts
@@ -237,6 +237,7 @@ describe('the workspace walk', () => {
     writeFileSync(join(dir, 'd.md'), 'd');
     writeFileSync(join(dir, 'node_modules', 'e.ts'), 'e');
     writeFileSync(join(dir, '.expo', 'f.ts'), 'f');
+    writeFileSync(join(dir, 'g.page.mdx'), 'g');
     return dir;
   }
 
@@ -268,8 +269,8 @@ describe('the workspace walk', () => {
 
       walkSources([dir], [all.pass, shipped.pass]);
 
-      expect(all.saw.sort()).toEqual(['a', 'b', 'c']);
-      expect(shipped.saw.sort()).toEqual(['a', 'c']);
+      expect(all.saw.sort()).toEqual(['a', 'b', 'c', 'g']);
+      expect(shipped.saw.sort()).toEqual(['a', 'c', 'g']);
       expect(all.ended()).toBe(1);
       expect(shipped.ended()).toBe(1);
     } finally {
@@ -321,6 +322,7 @@ describe('the workspace walk', () => {
     );
 
     expect(walkReaches(roots, join('/repo', 'packages', 'ui', 'src', 'a.tsx'))).toBe(true);
+    expect(walkReaches(roots, join('/repo', 'packages', 'ui', 'src', 'a.page.mdx'))).toBe(true);
     expect(walkReaches(roots, join('/repo', 'packages', 'node_modules', 'a.ts'))).toBe(false);
     expect(walkReaches(roots, join('/repo', 'packages', '.expo', 'a.ts'))).toBe(false);
     expect(walkReaches(roots, join('/repo', 'packages', 'a.md'))).toBe(false);
@@ -379,6 +381,26 @@ describe('the scan', () => {
       const code = kromaUi.vite({ repoRoot: dir }).load.call({}, join(dir, GLYPH_SOURCE));
       expect(code).toContain('IconRocket');
       expect(code).not.toContain('IconBanana');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps a name only a guide page draws, since the workbench ships those too', () => {
+    // An .mdx names a glyph the same way a .tsx does, and it is not typechecked,
+    // so a name missing from the subset there fails in the built site alone.
+    const dir = rootWithBarrel(
+      [
+        "export { default as IconHelpCircle } from './icons/IconHelpCircle.mjs';",
+        "export { default as IconHeart } from './icons/IconHeart.mjs';",
+      ].join('\n'),
+    );
+    try {
+      const guides = join(dir, 'packages', 'ui', 'src', 'guides');
+      mkdirSync(guides, { recursive: true });
+      writeFileSync(join(guides, 'levels.page.mdx'), '<IconButton icon="heart" />\n');
+      const code = kromaUi.vite({ repoRoot: dir }).load.call({}, join(dir, GLYPH_SOURCE));
+      expect(code).toContain('IconHeart');
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/ui/bundler/index.ts
+++ b/packages/ui/bundler/index.ts
@@ -18,7 +18,7 @@ const GLYPH_SOURCE = join('packages', 'ui', 'src', 'lib', 'icons', 'glyph-source
 
 type TablerPkg = '@tabler/icons-react' | '@tabler/icons-react-native';
 
-const SOURCE_EXT = /\.(ts|tsx)$/;
+const SOURCE_EXT = /\.(ts|tsx|mdx)$/; // an .mdx guide ships too, and draws icons
 // A slug a fixture happens to spell is a false hit costing a real glyph.
 // Stories are NOT excluded: the workbench ships them.
 const NOT_SHIPPED = /\.(test|spec)\.(ts|tsx)$/;
@@ -39,8 +39,8 @@ const LITERAL = /['"`]([a-z][a-z0-9]*(?:-[a-z0-9]+)*)['"`]/g;
 
 export interface KromaUiOptions {
   repoRoot: string;
-  /** `full` keeps all of Tabler, which an app that reflects over the catalogue
-   * needs: `iconNames()` and `hasGlyph()` answer from whatever shipped. */
+  /** `full` keeps all of Tabler, which `iconNames()` and `hasGlyph()` then answer
+   * from. Metro only in practice: a web build fetches the rest instead. */
   icons?: 'subset' | 'full';
 }
 

--- a/packages/ui/src/guides/01-installing-the-kit.page.mdx
+++ b/packages/ui/src/guides/01-installing-the-kit.page.mdx
@@ -138,10 +138,11 @@ the build succeeds and ships `background: var(--kroma-bg)` pointing at nothing:
 
 A glyph resolves by name (`<Icon name="wave-sine" />`), so no bundler can prove
 which of Tabler's thousands are reachable. `kromaUI()` therefore walks the
-app's sources for anything shaped like a glyph name and keeps only those. An
-app that reflects over the catalogue - `iconNames()`, `hasGlyph()` - opts out
-with `kromaUI({ icons: 'full' })`, and a workbench adds `kromaIconCatalog()` on
-top for Tabler's tags and categories.
+app's sources for anything shaped like a glyph name and keeps only those, in
+`.ts`, `.tsx` and `.mdx` alike. An app that reflects over the catalogue -
+`iconNames()`, `hasGlyph()` - either opts out with `kromaUI({ icons: 'full' })`
+or fetches the rest when a page needs it, which is what this site does. A
+workbench adds `kromaIconCatalog()` on top for Tabler's tags and categories.
 
 ## A Metro app
 

--- a/packages/ui/src/guides/05-icons.page.mdx
+++ b/packages/ui/src/guides/05-icons.page.mdx
@@ -89,7 +89,7 @@ TV builds do.
 ## Both arrive when this page does
 
 A build keeps the glyphs its own sources name and cuts the rest, because a name
-resolved at runtime is a name no bundler can shake: 296 of Tabler's 6,250 for
+resolved at runtime is a name no bundler can shake: 299 of Tabler's 6,250 for
 this workbench. A gallery needs all of them, so the browser above fetches the
 set and the catalogue as it mounts and spins until they land, two chunks
 (490 KB and 119 KB gzipped) that the workbench does not start with and only this

--- a/packages/ui/src/lib/icons/README.md
+++ b/packages/ui/src/lib/icons/README.md
@@ -46,8 +46,13 @@ A namespace import cannot be tree-shaken, so left alone the whole set ships: the
 kit site went from 258 KB to 741 KB gzipped. Every target gets the scanned
 subset from [`@kroma/ui/bundler`](../../../bundler), which walks the workspace
 for slug literals and rewrites this folder's `glyph-source.ts` down to the names
-it found: 296 of 6,250 today. Measured on the repo's own Vite, `<Icon>` costs
+it found: 299 of 6,250 today. Measured on the repo's own Vite, `<Icon>` costs
 49 KB gzipped with the subset against 573 KB with the full set.
+
+The walk reads `.ts`, `.tsx` **and `.mdx`**: a guide page draws icons like any
+other source and is not typechecked, so a name only its prose spells would
+otherwise be missing from the subset and draw the fallback in the built site
+alone.
 
 Which paths get it: the Vite half is `apply: 'build'`, so `vite dev` still
 serves all 6,250 and only the built bundle is subset. The Metro half runs at
@@ -61,6 +66,12 @@ what arrives into the drawable set through `addGlyphs`, alongside the catalogue
 the workbench registered, and `useIconLibrary()` is what the icon browser waits
 on. That keeps 2,529 KB of glyphs and 373 KB of metadata (490 KB and 119 KB
 gzipped) out of the chunk `apps/kit` starts from, where they were 60% of it.
+
+The widening reaches the NEXT render: `addGlyphs` drops the memoised
+resolutions, but nothing already on screen re-renders, so a component that drew
+the fallback keeps it until something else moves it. Which is why the scan reads
+`.mdx` - so no page draws a fallback for a name it spells - and why the widening
+stays a workbench affair.
 
 Native has no such door: Metro cannot split a chunk off, so `every-glyph.ts` is
 `null`, the browser waits for nothing, and a Metro workbench that wants the

--- a/packages/ui/src/lib/icons/every-glyph.ts
+++ b/packages/ui/src/lib/icons/every-glyph.ts
@@ -1,8 +1,5 @@
-// Fetching the glyphs the build cut, native (Metro).
-//
-// There is nothing to fetch: Metro has no dynamic import to split the rest of
-// Tabler off with, so a native build draws from whatever glyph-source kept and
-// the icon browser lists exactly that.
+// Nothing to fetch: Metro has no dynamic import to split the rest of Tabler off
+// with, so a native build draws from whatever glyph-source kept.
 
 import type { GlyphExports } from './glyphs';
 

--- a/packages/ui/src/lib/icons/every-glyph.web.ts
+++ b/packages/ui/src/lib/icons/every-glyph.web.ts
@@ -1,8 +1,6 @@
-// Fetching the glyphs the build cut, web (the workbench, in a browser).
-//
-// Its own chunk, so the entry carries the scanned subset alone; the specifier is
-// the React Native one because every web bundler aliases it to the DOM package
-// (see the sibling glyph-source.ts).
+// The glyphs the build cut, in a chunk of their own. The specifier is the React
+// Native one because every web bundler aliases it to the DOM package, as in the
+// sibling glyph-source.ts.
 
 import type { GlyphExports } from './glyphs';
 

--- a/packages/ui/src/lib/icons/library.test.ts
+++ b/packages/ui/src/lib/icons/library.test.ts
@@ -5,9 +5,10 @@ import { iconLibraryReady, loadIconLibrary, setIconCatalogLoader } from './libra
 
 // One glyph stands in for the chunk the web half fetches: the runner resolves
 // `./every-glyph` to that half, and it would hand back all six thousand.
-vi.mock('./every-glyph', () => ({
-  everyGlyph: async () => ({ IconNotShipped: () => null }),
+const chunk = vi.hoisted(() => ({
+  glyphs: { IconNotShipped: () => null } as Record<string, unknown>,
 }));
+vi.mock('./every-glyph', () => ({ everyGlyph: async () => chunk.glyphs }));
 
 afterEach(() => {
   setIconCatalog({});
@@ -47,6 +48,16 @@ describe('the icon library', () => {
     await expect(loadIconLibrary()).resolves.toBeUndefined();
 
     expect(iconLibraryReady()).toBe(true);
+    expect(iconCategories()).toEqual([]);
+  });
+
+  it('keeps the half that landed when the other chunk does not', async () => {
+    chunk.glyphs = { IconArrivedAlone: () => null };
+    setIconCatalogLoader(() => Promise.reject(new Error('no such chunk')));
+
+    await loadIconLibrary();
+
+    expect(hasGlyph('arrived-alone')).toBe(true);
     expect(iconCategories()).toEqual([]);
   });
 });

--- a/packages/ui/src/lib/icons/library.ts
+++ b/packages/ui/src/lib/icons/library.ts
@@ -29,13 +29,15 @@ function iconLibraryReady(): boolean {
   return loaded || (everyGlyph === null && fetchCatalog === null);
 }
 
-async function fetchLibrary(): Promise<void> {
-  const [glyphs, catalog] = await Promise.all([everyGlyph?.(), fetchCatalog?.()]);
-  if (glyphs) addGlyphs(glyphs);
-  if (catalog) setIconCatalog(catalog);
-}
+const ignore = () => undefined;
 
-function settled(): void {
+// Applied as each arrives, not once both have: the two are separate chunks, and
+// half a library beats none of it.
+async function fetchLibrary(): Promise<void> {
+  await Promise.all([
+    everyGlyph?.().then(addGlyphs).catch(ignore),
+    fetchCatalog?.().then(setIconCatalog).catch(ignore),
+  ]);
   loaded = true;
 }
 
@@ -44,7 +46,7 @@ function settled(): void {
  * build kept, which is a smaller gallery rather than a page that never opens. */
 function loadIconLibrary(): Promise<void> {
   if (iconLibraryReady()) return Promise.resolve();
-  fetching ??= fetchLibrary().then(settled, settled);
+  fetching ??= fetchLibrary();
   return fetching;
 }
 
@@ -53,7 +55,6 @@ function loadIconLibrary(): Promise<void> {
 function useIconLibrary(): boolean {
   const [ready, setReady] = useState(iconLibraryReady);
   useEffect(() => {
-    if (ready) return;
     let live = true;
     loadIconLibrary().then(() => {
       if (live) setReady(true);
@@ -61,7 +62,7 @@ function useIconLibrary(): boolean {
     return () => {
       live = false;
     };
-  }, [ready]);
+  }, []);
   return ready;
 }
 

--- a/packages/workbench/README.md
+++ b/packages/workbench/README.md
@@ -385,8 +385,9 @@ beside it are Vite's and Metro's halves of discovery. Vite can read files as tex
 demo code, story code and prop docs are present on the web and absent on a
 television, rather than stale on both.
 
-Prop docs are `props` on the lazy index (the third argument to `discoverVite`),
-and they are DATA: a host reads them at build time (`propDocs` from
+Prop docs are `props`: a thunk on the lazy index, fetched with the first story,
+and the third argument to `discoverVite`. They are DATA either way: a host reads
+them at build time (`propDocs` from
 `@kroma/bundler/props-docs`, driving TypeScript's own checker, served as
 `virtual:kroma-props`) rather than shipping
 every component's source to the browser for a regex to read. That is what lets

--- a/packages/workbench/src/entry.test.tsx
+++ b/packages/workbench/src/entry.test.tsx
@@ -6,8 +6,8 @@
 
 import { Text } from '@kroma/ui/kit';
 import { onScreen } from '@kroma/ui/testing';
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
-import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { storyEntries } from './entry';
 import { indexVite } from './lazy';
 import { memoryRouter } from './router';
@@ -81,9 +81,35 @@ describe('a story whose module is still on its way', () => {
   it('draws the component, and stops saying it is busy, when the module lands', async () => {
     const held = show();
     held.release();
-    await waitFor(() => expect(screen.getByText('Press me')).toBeTruthy());
+    expect(await screen.findByText('Press me')).toBeTruthy();
     expect(screen.queryByRole('progressbar', { name: 'Loading Button' })).toBeNull();
     expect(screen.getAllByText('Preview')).toHaveLength(1);
+  });
+});
+
+describe('an article on the canvas', () => {
+  it('fetches no story module, because the bare address opens one', async () => {
+    const module = vi.fn(async () => ({ default: BUTTON_STORY }));
+    render(
+      onScreen(
+        <Workbench
+          stories={indexVite({ modules: { [BUTTON]: module }, codes: CODES })}
+          pages={[
+            {
+              id: 'installing',
+              title: 'Installing the kit',
+              group: 'Guides',
+              path: 'src/guides/01-installing.page.mdx',
+              content: () => <Text>Add it to your app.</Text>,
+            },
+          ]}
+          router={memoryRouter({})}
+        />,
+      ),
+    );
+
+    expect(await screen.findByText('Add it to your app.')).toBeTruthy();
+    expect(module).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/workbench/src/lazy.test.ts
+++ b/packages/workbench/src/lazy.test.ts
@@ -129,6 +129,21 @@ describe('a story, once it is asked for', () => {
     expect((await entryAt(index, AT_BUTTON).load()).docs).toBe('Inline.');
   });
 
+  it('fetches a module again after one attempt failed, rather than keeping the failure', async () => {
+    const loaders = modules();
+    const good = loaders[BUTTON] as () => Promise<unknown>;
+    const button = vi
+      .fn(good)
+      .mockImplementationOnce(() => Promise.reject(new Error('chunk gone')));
+    const index = indexVite({ modules: { ...loaders, [BUTTON]: button }, codes: CODES });
+    const entry = entryAt(index, AT_BUTTON);
+
+    await expect(entry.load()).rejects.toThrow('chunk gone');
+    expect(entry.ready()).toBeUndefined();
+    expect((await entry.load()).name).toBe('Button');
+    expect(button).toHaveBeenCalledTimes(2);
+  });
+
   it('fetches a module once, however many views ask for it', async () => {
     const loaders = modules();
     const button = vi.fn(loaders[BUTTON] as () => Promise<unknown>);

--- a/packages/workbench/src/lazy.ts
+++ b/packages/workbench/src/lazy.ts
@@ -135,7 +135,9 @@ async function compile(row: Row, registry: LazyRegistry): Promise<Story> {
 }
 
 // The promise is kept, not the work: two views of one story, and a story
-// returned to, fetch its module once.
+// returned to, fetch its module once. A failure is not kept, so a chunk lost to
+// a dropped connection or a deploy mid-session is retried on the next visit
+// rather than pinning that story to a spinner until the page is reloaded.
 function entryOf(row: Row, registry: LazyRegistry): StoryEntry {
   let pending: Promise<Story> | undefined;
   let done: Story | undefined;
@@ -147,10 +149,16 @@ function entryOf(row: Row, registry: LazyRegistry): StoryEntry {
     path: row.path,
     ready: () => done,
     load: () => {
-      pending ??= compile(row, registry).then((story) => {
-        done = story;
-        return story;
-      });
+      pending ??= compile(row, registry).then(
+        (story) => {
+          done = story;
+          return story;
+        },
+        (error: unknown) => {
+          pending = undefined;
+          throw error;
+        },
+      );
       return pending;
     },
   };

--- a/packages/workbench/src/workbench.tsx
+++ b/packages/workbench/src/workbench.tsx
@@ -82,7 +82,10 @@ function WorkbenchShell({
   const landing = !at.story && !at.page ? pages?.[0] : undefined;
   const page = landing ?? pages?.find((entry) => entry.id === at.page);
   const entry = entries.find((candidate) => candidate.id === selected) ?? entries[0];
-  const story = useStory(entry);
+  // Nothing on the canvas is the story's while an article holds it, and the
+  // landing address IS an article: fetching the first component there buys a
+  // reader who is reading the guides nothing at all.
+  const story = useStory(page ? undefined : entry);
   const args = useMemo(
     () => ({ ...story?.args, ...edits[entry?.id ?? ''] }),
     [story, edits, entry],


### PR DESCRIPTION
Two agents reviewed the lazy-loading work that landed on main (`374cd4f5`,
`2735c933`). They found four faults, all fixed here and all verified in a
browser rather than argued.

## The one that matters most: a live regression

Dropping `icons: 'full'` shrank the icon set to what a scan of `.ts`/`.tsx`
finds. `03-the-six-levels.page.mdx` draws `<IconButton icon="heart">`, and
`heart` appears in no TypeScript literal anywhere, so **the deployed site draws
a question mark on that guide page today**. Cold load of the built site:

```
heart drawn: false     help-circle (the fallback) drawn: 1
```

The scan reads `.mdx` too now. 296 glyphs to 299, costing 485 raw bytes in the
subset chunk and taking them out of the lazy one. The entry chunk is
byte-identical.

## The other three

- **The landing page fetched a story it never draws.** A bare address opens the
  first guide, not a component, but `useStory(entry)` ran anyway, pulling a
  story module and the whole 256 kB props chunk on every first visit. Five runs
  on a throttled link: 50 requests / 490,400 B / 1593 ms becomes 48 / 458,615 B
  / 1378 ms.
- **A failed chunk pinned its story to the spinner for the session.**
  `pending ??= compile(...)` memoised the *rejected* promise, so `load()` never
  retried and only a page reload recovered. The rejection clears it now.
- **A half that arrived was discarded when its sibling failed**, because the
  glyphs and the catalogue shared one `Promise.all`. With the glyph chunk
  aborted the icons page lost its category picker; now each half applies as it
  lands.

## A correction

`374cd4f5`'s message claimed a name that already drew the fallback re-resolves
once the set lands. That is true of the memo and false of the pixels: a
component mounted before the widening keeps its fallback until something else
re-renders it. Proven by holding the chunk in flight and releasing it. It is
why the scan is the fix and the widening is not.

## Verified

0 type errors across 33 workspaces, 6284 tests, lint clean. Entry chunk
unchanged and `@tabler/icons-react` still 0 bytes of it. The icons page still
reports 6250 glyphs; searching a name outside the subset draws its own artwork.

Note: these two commits are unsigned. 1Password is locked in the authoring
environment, so signing failed; they are on a branch precisely so they can be
re-signed before this lands.

https://claude.ai/code/session_01AUBr58cBBeqvhmHgLAck8B