### PR TITLE
ci: make the checks reportable before main starts requiring them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,11 @@ name: CI
 # shell factory (clients/tv-build/shell.ts) strips console/debugger on build,
 # and KROMA_TV_DEVICE (on-device dev HMR) is never set in CI.
 
-# Docs-only changes build nothing and check nothing; skip the run entirely.
-# (No branch protection requires these checks, so a skipped run blocks nobody.)
+# Docs-only changes build nothing and check nothing, but the run still starts:
+# `quality` and `server` are required checks on main, and a workflow skipped by
+# `paths-ignore` never reports, which would leave a docs-only PR blocked for
+# ever. The `changes` job does the skipping instead — a skipped job reports as
+# successful, so the gate is satisfied and the docs PR pays ~20s.
 #
 # workflow_dispatch exists to re-warm the rust caches: they save only from main
 # (see the rust-cache comments below), so once evicted they stay dead until a
@@ -26,17 +29,7 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - '.claude/**'
-      - 'LICENSE'
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - '.claude/**'
-      - 'LICENSE'
 
 # Cancel superseded runs on the same ref (e.g. rapid pushes to a PR).
 concurrency:
@@ -52,9 +45,10 @@ env:
 jobs:
   # Which half of the fleet the change can actually touch. `rust` gates the
   # server job (a JS-only PR pays no clippy+test), `fleet` gates the client
-  # builds (a server-only PR pays no vite/gradle/tauri). `quality` stays
-  # unconditional: it is the cheap always-green check, and its inputs (biome,
-  # vitest, tokens) span too much of the tree to be worth a filter.
+  # builds (a server-only PR pays no vite/gradle/tauri), `code` gates `quality`
+  # and stands in for the `paths-ignore` this workflow can no longer carry:
+  # its inputs (biome, vitest, tokens) span too much of the tree for a narrower
+  # filter, so it runs for anything that is not prose.
   changes:
     name: Detect relevant changes
     runs-on: ubuntu-latest
@@ -66,6 +60,7 @@ jobs:
       # caches, so it runs everything.
       rust: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.f.outputs.rust }}
       fleet: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.f.outputs.fleet }}
+      code: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.f.outputs.code }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
@@ -98,10 +93,17 @@ jobs:
               # desktop-shell compiles Rust under the repo toolchain pin.
               - 'rust-toolchain.toml'
               - '.github/workflows/ci.yml'
+            code:
+              - '!**/*.md'
+              - '!docs/**'
+              - '!.claude/**'
+              - '!LICENSE'
 
   quality:
     name: Typecheck + unit tests + lint
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,26 @@ jobs:
               - '!.claude/**'
               - '!LICENSE'
 
+  # A ruleset would be the right home for this, but branch-name patterns are a
+  # metadata restriction and those need an org on Team or Enterprise; this repo
+  # is user-owned. So the PR head branch is checked here instead. It only fires
+  # on a pull request — a push to main is skipped, which reports as successful.
+  branch-name:
+    name: Branch name
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    timeout-minutes: 5
+    steps:
+      - name: Head branch matches type/slug
+        env:
+          BRANCH: ${{ github.head_ref }}
+          PATTERN: '^(feat|fix|chore|ci|docs|refactor|perf|test|build|kit|release|revert|claude|dependabot)/[A-Za-z0-9._/-]+$'
+        run: |
+          if [[ ! "$BRANCH" =~ $PATTERN ]]; then
+            echo "::error::branch '$BRANCH' does not match $PATTERN"
+            exit 1
+          fi
+
   quality:
     name: Typecheck + unit tests + lint
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -57,8 +57,23 @@ clients/webos/*.ipk
 
 # Env / local
 .env
-.env.local
+.env.*
+!.env.example
 *.local
+
+# Signing material, by extension rather than by location. The rules above cover
+# it wherever a build is EXPECTED to leave some - clients/*/android, and the
+# per-client ignore files in clients/mobile and clients/tv-native - which is the
+# same thing as saying they stop covering it the moment a keystore lands
+# somewhere nobody predicted. These patterns are the backstop for that case, so
+# no signing material anywhere in the tree can be swept up by a wide `git add`.
+*.jks
+*.keystore
+*.p12
+*.p8
+*.pem
+*.key
+*.mobileprovision
 
 # Local NAS serve helper kept on disk, never tracked
 scripts/serve-nas.sh

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,60 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Report privately through GitHub: **Security → Advisories → Report a vulnerability**
+([direct link](https://github.com/maxscharwath/kroma/security/advisories/new)).
+Private vulnerability reporting is enabled on this repository, so the report stays
+between you and the maintainer until a fix ships.
+
+Do not open a public issue or a pull request for a vulnerability.
+
+Include what you have: the affected component, the version or commit, the steps to
+reproduce, and what an attacker gains. A proof of concept helps; a CVSS score is not
+required.
+
+Expect an acknowledgement within a few days. KROMA is maintained by one person in the
+open, so there is no guaranteed remediation window — the advisory thread is where the
+timeline gets agreed.
+
+## Supported versions
+
+Only the latest release is supported. KROMA ships from `main` on a rolling `v0.1.x`
+line, and modules release independently on their own `<module-id>@<version>` tags.
+Fixes land in the next release rather than being backported.
+
+## Scope
+
+In scope:
+
+- the Rust server (`server/`), including the module host and supervisor
+- first-party modules (`modules/`), which run as separate processes with their own
+  network surface and their own SQLite access
+- the clients (`clients/`) and the shared libraries (`packages/`)
+- the push relay Worker (`packages/push-relay/`), which holds the credentials the
+  published apps cannot
+- the module registry and the artifact verification path
+  (see [`docs/module-registries.md`](docs/module-registries.md))
+
+Out of scope:
+
+- a self-hosted deployment exposed to the internet without a reverse proxy, TLS or
+  authentication — KROMA assumes the operator controls that boundary
+- vulnerabilities in third-party trackers, indexers or media sources a module talks to
+- findings that require an already-compromised host or physical access to it
+- reports from automated scanners with no demonstrated impact
+
+## What this project already assumes
+
+Two invariants are load-bearing, and a report that breaks either one is worth filing
+even without a full exploit:
+
+- **Secrets never live in the server or the app.** The server's source is public and
+  self-hosted; anything Apple or Google issued to the published app lives in the relay
+  Worker's secrets.
+- **Every trust boundary is parsed, not trusted.** HTTP bodies, stored blobs,
+  third-party JSON and cross-process module messages go through a zod or serde schema,
+  with the body size bounded before parsing.
+
+Module bundles are sha256-verified against their catalog entry before being unpacked,
+and the official registry wins any id clash with an operator-added one.


### PR DESCRIPTION
Groundwork for putting rules on `main`. Two commits, and the first one is the
prerequisite for the rest.

### `paths-ignore` and required checks cannot both be true

`ci.yml` skipped docs-only changes at the `on:` level. A workflow skipped that
way never reports, so the moment `Typecheck + unit tests + lint` becomes a
required check on `main`, every docs-only PR waits for a check that can never
arrive.

The skip moves down into `changes`, which already does exactly this for `rust`
and `fleet`. A new `code` filter (everything that is not `**/*.md`, `docs/**`,
`.claude/**` or `LICENSE`) gates `quality`. A skipped job reports as successful,
so the gate is satisfied and a docs-only PR pays the ~20s of the filter job
instead of the ~5min of the checks.

`sonar.yml` and `codeql.yml` keep their `paths-ignore` — they are deliberately
**not** required checks, so nothing waits on them.

### `SECURITY.md`

Private vulnerability reporting is now enabled on the repository, so reports have
a private door. The file says where it is, what is in scope, and the two
invariants worth reporting against on their own.

---

Once this is green, `main` gets a ruleset: block deletion and force-push, require
a pull request, and require `Typecheck + unit tests + lint` + `Server (Rust)
clippy + test`.
