### PR TITLE
refactor(module-tools): clear the two open Sonar findings

### DIFF
--- a/packages/module-tools/src/release.ts
+++ b/packages/module-tools/src/release.ts
@@ -75,8 +75,9 @@ export function verdictFor(local: Entry, live: Entry | undefined): Verdict {
       return published !== undefined && published !== a.contentHash;
     })
     .map((a) => a.target ?? 'universal');
+  stale.sort(byCodeUnit);
   if (stale.length > 0) {
-    return { kind: 'stale', published: live.version, targets: stale.sort(byCodeUnit) };
+    return { kind: 'stale', published: live.version, targets: stale };
   }
   return { kind: 'unchanged' };
 }

--- a/packages/module-tools/src/semver.ts
+++ b/packages/module-tools/src/semver.ts
@@ -43,20 +43,16 @@ function comparePart(a: string | number, b: string | number): number {
   return sign(String(a), String(b));
 }
 
-/** Negative / zero / positive, the `Array.sort` contract. */
-function compare(a: Version, b: Version): number {
-  for (const k of ['major', 'minor', 'patch'] as const) {
-    if (a[k] !== b[k]) return a[k] < b[k] ? -1 : 1;
-  }
+function comparePrerelease(a: Version['prerelease'], b: Version['prerelease']): number {
   // A prerelease is LOWER than the release it leads to, so "has none" wins.
-  if (a.prerelease.length === 0 || b.prerelease.length === 0) {
-    if (a.prerelease.length === b.prerelease.length) return 0;
-    return a.prerelease.length === 0 ? 1 : -1;
+  if (a.length === 0 || b.length === 0) {
+    if (a.length === b.length) return 0;
+    return a.length === 0 ? 1 : -1;
   }
-  const len = Math.max(a.prerelease.length, b.prerelease.length);
+  const len = Math.max(a.length, b.length);
   for (let i = 0; i < len; i++) {
-    const x = a.prerelease[i];
-    const y = b.prerelease[i];
+    const x = a[i];
+    const y = b[i];
     // A shorter prerelease chain is the lower one: 1.0.0-a < 1.0.0-a.1.
     if (x === undefined) return -1;
     if (y === undefined) return 1;
@@ -64,6 +60,14 @@ function compare(a: Version, b: Version): number {
     if (c !== 0) return c;
   }
   return 0;
+}
+
+/** Negative / zero / positive, the `Array.sort` contract. */
+function compare(a: Version, b: Version): number {
+  for (const k of ['major', 'minor', 'patch'] as const) {
+    if (a[k] !== b[k]) return a[k] < b[k] ? -1 : 1;
+  }
+  return comparePrerelease(a.prerelease, b.prerelease);
 }
 
 /** Compares two raw strings; unparseable ones sort below anything valid. */


### PR DESCRIPTION
Both findings are in `packages/module-tools/src`, both arrived with the release train, and both are maintainability only — SonarCloud reports no open vulnerability and no security hotspot to review.

- `typescript:S3776` — `compare` in `semver.ts` was at cognitive complexity 18 against a ceiling of 15. The prerelease tail moves out to `comparePrerelease`; `compare` keeps the three numeric fields and delegates. `semver.test.ts` already pins the behaviour that would notice a regression.
- `typescript:S4043` — `verdictFor` in `release.ts` sorted inside the object literal it returned. The array is a fresh `.map()` result so the mutation was never a bug; the sort is now its own statement.

Note Sonar's suggested fix for S4043 does not apply here: it recommends `toSorted`, which is ES2023, and `packages/module-tools/tsconfig.json` sets `"lib": ["ES2022"]`.

`bun run test` on both files: 23 passed. Typecheck and Biome clean.