### PR TITLE
fix(search): a show, not its season list

### DIFF
--- a/clients/web/src/features/requests/search-results.tsx
+++ b/clients/web/src/features/requests/search-results.tsx
@@ -2,7 +2,7 @@
 // decouvrir" (TMDB, gated), each a counted grid. Skeletons while loading, a
 // friendly empty state when nothing matches.
 
-import { posterColors, type SearchHit } from '@kroma/core';
+import { episodeTag, posterColors, type SearchHit } from '@kroma/core';
 import { useT } from '@kroma/ui';
 import { Box, EmptyState, Row, Text } from '@kroma/ui/kit';
 
@@ -57,14 +57,16 @@ function LocalHit({ hit }: Readonly<{ hit: SearchHit }>) {
   }
   const item = hit.item;
   // Episodes route to their show; movies to their own fiche.
-  const to = hit.type === 'episode' && item.showId ? '/show/$id' : '/movie/$id';
-  const id = hit.type === 'episode' && item.showId ? item.showId : item.id;
+  const episode = hit.type === 'episode' && item.showId ? item.showId : null;
+  const to = episode ? '/show/$id' : '/movie/$id';
   return (
     <Poster
-      title={item.title}
+      title={item.episodeTitle ?? item.title}
+      // An episode wears its show's poster, so it has to say which one it is.
+      genre={episode ? [item.showTitle, episodeTag(item)].filter(Boolean).join(' · ') : undefined}
       colors={posterColors(item.id)}
       poster={client.posterFor(item)}
-      onClick={() => navigate({ to, params: { id } })}
+      onClick={() => navigate({ to, params: { id: episode ?? item.id } })}
     />
   );
 }

--- a/server/crates/kroma-engine/src/services/search/mod.rs
+++ b/server/crates/kroma-engine/src/services/search/mod.rs
@@ -6,6 +6,7 @@
 mod query;
 mod schema;
 
+use std::collections::HashSet;
 use std::sync::{Arc, Mutex, RwLock};
 
 use anyhow::Result;
@@ -34,7 +35,17 @@ pub enum HitKind {
 pub struct Hit {
     pub id: String,
     pub kind: HitKind,
+    /// Set on an episode: the show it belongs to.
+    pub show_id: Option<String>,
 }
+
+// A show title lives on every one of its episodes, so a query naming the show
+// matches the whole season list. Collect several pages' worth of raw hits, fold
+// the episodes back under their show, and only then cut to `limit`.
+const CANDIDATE_FACTOR: usize = 8;
+const MAX_CANDIDATES: usize = 400;
+// A show that did NOT match itself is represented by its best few episodes.
+const MAX_EPISODES_PER_SHOW: usize = 3;
 
 struct Active {
     reader: IndexReader,
@@ -98,9 +109,11 @@ impl SearchEngine {
             return Vec::new();
         };
         let searcher = active.reader.searcher();
+        let limit = limit.max(1);
+        let candidates = limit.saturating_mul(CANDIDATE_FACTOR).min(MAX_CANDIDATES).max(limit);
         // tantivy 0.26 removed TopDocs' blanket Collector impl; `.order_by_score()`
         // yields the score-ordered collector.
-        let Ok(top) = searcher.search(&query, &TopDocs::with_limit(limit.max(1)).order_by_score())
+        let Ok(top) = searcher.search(&query, &TopDocs::with_limit(candidates).order_by_score())
         else {
             return Vec::new();
         };
@@ -116,10 +129,40 @@ impl SearchEngine {
                 "episode" => HitKind::Episode,
                 _ => HitKind::Movie,
             };
-            hits.push(Hit { id, kind });
+            let show_id = (kind == HitKind::Episode)
+                .then(|| field_str(&doc, self.fields.show_id))
+                .filter(|s| !s.is_empty());
+            hits.push(Hit { id, kind, show_id });
         }
-        hits
+        collapse_episodes(hits, limit)
     }
+}
+
+/// Drops every episode whose show is itself a hit, caps what is left at
+/// [`MAX_EPISODES_PER_SHOW`] per show, and truncates to `limit`. Relevance order
+/// is preserved, so a show keeps the rank its own document earned.
+fn collapse_episodes(hits: Vec<Hit>, limit: usize) -> Vec<Hit> {
+    let shows: HashSet<String> =
+        hits.iter().filter(|h| h.kind == HitKind::Show).map(|h| h.id.clone()).collect();
+    let mut kept_per_show: HashMap<String, usize> = HashMap::new();
+    let mut out = Vec::with_capacity(limit);
+    for hit in hits {
+        if out.len() == limit {
+            break;
+        }
+        if let Some(show_id) = hit.show_id.as_deref() {
+            if shows.contains(show_id) {
+                continue;
+            }
+            let kept = kept_per_show.entry(show_id.to_string()).or_default();
+            if *kept >= MAX_EPISODES_PER_SHOW {
+                continue;
+            }
+            *kept += 1;
+        }
+        out.push(hit);
+    }
+    out
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -163,6 +206,9 @@ fn add_item(writer: &mut IndexWriter, f: &Fields, item: &MediaItem, kind: &str, 
     }
     if let Some(st) = &item.show_title {
         doc.add_text(f.show_title, st);
+    }
+    if let Some(sid) = &item.show_id {
+        doc.add_text(f.show_id, sid);
     }
     add_meta(&mut doc, f, &item.title, item.metadata.as_ref());
     add_translations(&mut doc, f, &item.title, tr);

--- a/server/crates/kroma-engine/src/services/search/query.rs
+++ b/server/crates/kroma-engine/src/services/search/query.rs
@@ -13,12 +13,14 @@ use tantivy::Term;
 use super::schema::Fields;
 
 // Field weights: a title hit outranks an alt-title/cast hit, which outranks a
-// genre hit, which outranks a loose overview hit.
+// genre hit, which outranks a loose overview hit. `show_title` sits near the
+// bottom on purpose: it is there so "breaking bad ozymandias" resolves to the
+// episode, not so that every episode of a show competes with the show itself.
 fn weights(f: &Fields) -> [(Field, f32); 6] {
     [
         (f.title, 6.0),
         (f.alt_title, 4.0),
-        (f.show_title, 4.0),
+        (f.show_title, 1.5),
         (f.cast, 3.0),
         (f.genres, 2.0),
         (f.overview, 1.0),

--- a/server/crates/kroma-engine/src/services/search/schema.rs
+++ b/server/crates/kroma-engine/src/services/search/schema.rs
@@ -16,6 +16,7 @@ pub(super) const ANALYZER: &str = "kroma";
 pub(super) struct Fields {
     pub id: Field,
     pub kind: Field,
+    pub show_id: Field,
     pub title: Field,
     pub alt_title: Field,
     pub show_title: Field,
@@ -37,6 +38,8 @@ pub(super) fn build() -> (Schema, Fields) {
     // tokens, no fuzzy matching on them.
     let id = b.add_text_field("id", STRING | STORED);
     let kind = b.add_text_field("kind", STRING | STORED);
+    // Read back to fold an episode under its show; never itself a query target.
+    let show_id = b.add_text_field("show_id", STORED);
     let title = text(&mut b, "title");
     let alt_title = text(&mut b, "alt_title");
     let show_title = text(&mut b, "show_title");
@@ -44,7 +47,7 @@ pub(super) fn build() -> (Schema, Fields) {
     let genres = text(&mut b, "genres");
     let overview = text(&mut b, "overview");
     let schema = b.build();
-    let fields = Fields { id, kind, title, alt_title, show_title, cast, genres, overview };
+    let fields = Fields { id, kind, show_id, title, alt_title, show_title, cast, genres, overview };
     (schema, fields)
 }
 

--- a/server/crates/kroma-engine/src/services/search/tests.rs
+++ b/server/crates/kroma-engine/src/services/search/tests.rs
@@ -57,24 +57,42 @@ fn movie(id: &str, title: &str, m: Option<Metadata>) -> MediaItem {
     }
 }
 
-fn engine() -> SearchEngine {
-    let e = SearchEngine::new().unwrap();
-    let movies = vec![
-        movie("1", "The Avengers", Some(meta("The Avengers", "Earth's mightiest heroes", &["Action"], &["Robert Downey Jr"]))),
-        movie("2", "Amélie", Some(meta("Amélie", "A shy waitress in Paris", &["Romance"], &["Audrey Tautou"]))),
-    ];
-    let shows = vec![Show {
-        id: "s1".into(),
-        title: "Breaking Bad".into(),
+fn episode(id: &str, show_id: &str, show_title: &str, title: &str) -> MediaItem {
+    MediaItem {
+        kind: Kind::Episode,
+        show_id: Some(show_id.into()),
+        show_title: Some(show_title.into()),
+        episode_title: Some(title.into()),
+        ..movie(id, show_title, None)
+    }
+}
+
+fn show(id: &str, title: &str, m: Option<Metadata>) -> Show {
+    Show {
+        id: id.into(),
+        title: title.into(),
         year: None,
         library: "lib".into(),
         season_count: 0,
         episode_count: 0,
         video: None,
         added_at: String::new(),
-        metadata: Some(meta("Breaking Bad", "A chemistry teacher turns to crime", &["Crime", "Drama"], &["Bryan Cranston"])),
+        metadata: m,
         progress: None,
-    }];
+    }
+}
+
+fn engine() -> SearchEngine {
+    let e = SearchEngine::new().unwrap();
+    let movies = vec![
+        movie("1", "The Avengers", Some(meta("The Avengers", "Earth's mightiest heroes", &["Action"], &["Robert Downey Jr"]))),
+        movie("2", "Amélie", Some(meta("Amélie", "A shy waitress in Paris", &["Romance"], &["Audrey Tautou"]))),
+    ];
+    let shows = vec![show(
+        "s1",
+        "Breaking Bad",
+        Some(meta("Breaking Bad", "A chemistry teacher turns to crime", &["Crime", "Drama"], &["Bryan Cranston"])),
+    )];
     e.rebuild(&movies, &shows, &[]).unwrap();
     e
 }
@@ -102,6 +120,44 @@ fn cast_and_genre_and_prefix() {
     assert_eq!(top_id(&e, "cranston").as_deref(), Some("s1"));
     assert_eq!(top_id(&e, "crime").as_deref(), Some("s1"));
     assert_eq!(top_id(&e, "brea").as_deref(), Some("s1")); // prefix
+}
+
+fn series_engine() -> SearchEngine {
+    let e = SearchEngine::new().unwrap();
+    let episodes: Vec<MediaItem> = (1..=12)
+        .map(|n| episode(&format!("e{n}"), "s1", "House of the Dragon", &format!("Episode {n}")))
+        .chain(std::iter::once(episode("e-dance", "s1", "House of the Dragon", "A Dance of Dragons")))
+        .collect();
+    e.rebuild(&[], &[show("s1", "House of the Dragon", None)], &episodes).unwrap();
+    e
+}
+
+fn ids(e: &SearchEngine, q: &str, limit: usize) -> Vec<String> {
+    e.search(q, limit).into_iter().map(|h| h.id).collect()
+}
+
+#[test]
+fn a_show_title_returns_the_show_and_not_its_season_list() {
+    assert_eq!(ids(&series_engine(), "house of dragon", 24), ["s1"]);
+}
+
+#[test]
+fn an_episode_still_wins_when_the_query_names_it() {
+    // `show_title` is indexed so the show's name can narrow an episode search;
+    // the episode must still be the answer when its own title carries the query.
+    let got = ids(&series_engine(), "house of the dragon a dance of dragons", 24);
+    assert_eq!(got, ["e-dance"]);
+}
+
+#[test]
+fn episodes_of_a_show_that_did_not_match_are_capped() {
+    let e = SearchEngine::new().unwrap();
+    let episodes: Vec<MediaItem> =
+        (1..=10).map(|n| episode(&format!("e{n}"), "s1", "Breaking Bad", "Ozymandias")).collect();
+    // No show document at all: the episodes are the only thing that can match.
+    e.rebuild(&[], &[], &episodes).unwrap();
+
+    assert_eq!(e.search("ozymandias", 24).len(), MAX_EPISODES_PER_SHOW);
 }
 
 #[test]


### PR DESCRIPTION
Searching a series returned its whole season list. `house of dragon` gave twenty-four posters, every one of them the show's own artwork, every one of them routing to the same page — and the show itself buried somewhere among them.


## Why it happened

Every episode document indexes its show's title, which is what makes `breaking bad ozymandias` resolve to the episode. But that field was weighted `4.0`, the same neighbourhood as an alt-title — so a query naming a show scored every episode of it as a first-class answer, and short episode documents ranked well enough to fill the page.

## What changed

**Episodes fold under their show.** The engine stores each episode's `show_id`, over-fetches candidates (`limit × 8`, capped at 400) and collapses before truncating to `limit`:

- an episode whose show is *also* a hit is dropped — the show represents it;
- what remains is capped at three per show, a backstop for the case where the show document never matched at all (a shared cast name, say);
- relevance order is untouched, so a show keeps the rank its own document earned.

**`show_title` drops 4.0 → 1.5**, which is what the field is actually for: it narrows an episode search, it was never meant to let a season list outscore its show. The lower weight also guarantees the show document outranks its own episodes and so lands inside the candidate window.

Both live in `kroma-engine`, so web, TV and mobile all get this without a client change.

**Web:** an episode that does survive now reads as one — episode title above `Show · S01E09` — instead of wearing its show's poster with nothing to tell the two apart.

## Behaviour

| query | before | after |
| --- | --- | --- |
| `house of dragon` | 24 hits: the show + 23 episodes | the show |
| `house of the dragon a dance of dragons` | the episode, buried | the episode |
| an actor credited on every episode | the season list | the show |

## Tests

Three new cases in `services/search/tests.rs` pin it: a show title returns the show alone, an episode still wins when the query names it, and the per-show cap holds when no show document matched.

- `cargo test -p kroma-engine` — 17 search tests pass
- `cargo test -p kroma-server search` — 7 pass, including the existing `search_surfaces_an_episode_hit_as_episode`
- `cargo clippy -p kroma-engine --all-targets` — clean on the touched files
- `bun run --filter '@kroma/web' typecheck`, biome on the edited file

## Not in this PR

Mobile renders an episode hit through `movieCard`, so it still shows a bare show poster. Now that episodes are rare and deliberate, it deserves the same label treatment — worth a follow-up.
