### PR TITLE
refactor(tv): the grids measure their room instead of assuming 1920

### DIFF
--- a/clients/desktop/src/main.tsx
+++ b/clients/desktop/src/main.tsx
@@ -14,24 +14,15 @@ import { startGamepadBridge } from './gamepad';
 import { installStage } from './stage';
 import { startUpdater } from './updater';
 
-// Fixed 1920x1080 stage ONLY on a fixed-screen shell (the Steam Deck / a fullscreen
-// Chromium kiosk - both Linux): there the 10-foot canvas is scaled to fill the panel.
-// macOS / Windows desktop windows skip it and run FREE-SIZE, like a web page (the
-// window resizes naturally, no forced ratio).
+// The 1920x1080 stage, on EVERY desktop window: the shared 10-foot UI is authored
+// in fixed pixels against that canvas (PosterGrid's 8 x 203px columns, the nav row,
+// the episode column), so a free-size window narrower than 1920 does not shrink the
+// layout, it clips it. Fitted the same way as the Steam Deck panel and the browser
+// shell (see ./stage and clients/tv-web/src/stage.ts). A genuinely fluid 10-foot
+// layout is a design-system change, not a shell one.
 const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
 const fixedScreen = /Linux/i.test(ua) && !/Android/i.test(ua);
-if (fixedScreen) {
-  installStage();
-} else {
-  // Free-size desktop (macOS/Windows). On macOS the window is TRANSPARENT so the native
-  // mpv video plane can show behind the player, so paint an opaque app background by
-  // default - otherwise the transparent window shows through everywhere. The player
-  // toggles `.kroma-native-surface` (see tv.css) to go transparent only while a native
-  // video plays.
-  const base = document.createElement('style');
-  base.textContent = 'html, body, #root { background: var(--kroma-bg, #0a0a0c); }';
-  document.head.appendChild(base);
-}
+installStage();
 
 // The Deck is driven by a gamepad, not a remote. Bridge the Gamepad API onto the
 // same synthetic key events the shared TV nav already listens for.

--- a/clients/desktop/src/stage.test.ts
+++ b/clients/desktop/src/stage.test.ts
@@ -1,10 +1,8 @@
 // @vitest-environment jsdom
 
+import { fitStage, MIN_STAGE_W, STAGE_H, STAGE_W } from '@kroma/tv/stage';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { installStage } from './stage';
-
-const STAGE_W = 1920;
-const STAGE_H = 1080;
 
 function resizeTo(width: number, height: number) {
   Object.defineProperty(window, 'innerWidth', { value: width, configurable: true });
@@ -12,6 +10,8 @@ function resizeTo(width: number, height: number) {
 }
 
 const scale = () => Number(document.documentElement.style.getPropertyValue('--kroma-stage-scale'));
+const width = () =>
+  Number.parseFloat(document.documentElement.style.getPropertyValue('--kroma-stage-width'));
 
 const css = () => document.head.querySelector('style')?.textContent ?? '';
 
@@ -26,35 +26,33 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-describe('the scale', () => {
-  it('is 1 on an exactly 1080p screen', () => {
+describe('the fit', () => {
+  it('is the design canvas, 1:1, on an exactly 1080p screen', () => {
     installStage();
     expect(scale()).toBe(1);
+    expect(width()).toBe(STAGE_W);
   });
 
-  it('fits a smaller screen', () => {
-    resizeTo(1280, 720);
-    installStage();
-    expect(scale()).toBeCloseTo(1280 / STAGE_W, 6);
-  });
-
-  it('fills a larger one', () => {
+  it('draws the design at 2x on a 4K panel', () => {
     resizeTo(3840, 2160);
     installStage();
     expect(scale()).toBeCloseTo(2, 6);
+    expect(width()).toBe(STAGE_W);
   });
 
-  it('takes the SMALLER ratio on a wider screen', () => {
-    // 21:9. Scaling to the width pushes the whole nav row off the panel.
+  // A desktop window is any shape the user drags it to; the canvas follows its
+  // width rather than clipping the fixed-px rows at the right edge.
+  it('takes its extra width from the window', () => {
     resizeTo(2560, 1080);
     installStage();
-    expect(scale()).toBeCloseTo(1080 / STAGE_H, 6);
+    expect(width()).toBe(2560);
   });
 
-  it('takes the SMALLER ratio on a taller screen', () => {
-    resizeTo(1920, 1440);
+  it('scales down rather than narrowing past the design width', () => {
+    resizeTo(1310, 790);
     installStage();
-    expect(scale()).toBeCloseTo(1, 6);
+    expect(width()).toBe(MIN_STAGE_W);
+    expect(scale()).toBeCloseTo(1310 / MIN_STAGE_W, 6);
   });
 
   it('never overflows the window, whatever its shape', () => {
@@ -69,8 +67,8 @@ describe('the scale', () => {
       document.head.innerHTML = '';
       resizeTo(w, h);
       installStage();
-      expect(STAGE_W * scale()).toBeLessThanOrEqual(w + 0.001);
-      expect(STAGE_H * scale()).toBeLessThanOrEqual(h + 0.001);
+      expect(width() * scale()).toBeLessThanOrEqual(w + 1);
+      expect(STAGE_H * scale()).toBeLessThanOrEqual(h + 1);
     }
   });
 
@@ -80,15 +78,17 @@ describe('the scale', () => {
 
     resizeTo(960, 540);
     window.dispatchEvent(new Event('resize'));
-    expect(scale()).toBeCloseTo(0.5, 6);
+    const fit = fitStage(960, 540);
+    expect(scale()).toBeCloseTo(fit.scale, 6);
+    expect(width()).toBe(fit.width);
   });
 });
 
 describe('the stage box', () => {
-  it('renders the canvas at its authored size', () => {
+  it('renders the canvas at its authored height, as wide as the fit says', () => {
     installStage();
-    expect(css()).toContain(`width: ${STAGE_W}px`);
     expect(css()).toContain(`height: ${STAGE_H}px`);
+    expect(css()).toContain(`var(--kroma-stage-width, ${STAGE_W}px)`);
   });
 
   it('centres it and scales from the centre', () => {
@@ -113,7 +113,7 @@ describe('the stage box', () => {
   });
 });
 
-describe('the letterbox surround', () => {
+describe('the surround', () => {
   it('is painted in a browser', () => {
     installStage();
     // Nothing renders behind the web view here, so unpainted bars show whatever

--- a/clients/desktop/src/stage.ts
+++ b/clients/desktop/src/stage.ts
@@ -1,13 +1,17 @@
-// The shared @kroma/tv UI is authored on a fixed 1920x1080 canvas, so a
-// fixed-screen shell renders #root at that size and scales it to fit. The
+// The shared @kroma/tv UI is drawn on a 1080-tall canvas, so the shell renders
+// #root at that height and scales it to the window - the panel of a fixed screen
+// as much as a resizable desktop window, where the raw pixels would clip the
+// 10-foot rows rather than shrink them.
+//
+// The WIDTH is not fixed: `fitStage` hands back however much canvas the window
+// leaves at that scale, and the grids auto-fill it (see @kroma/tv/stage). The
 // `transform` also makes #root the containing block for the app's
 // `position: fixed` layers; `vh`-based `clamp()`s still resolve against the real
 // window and drift slightly on heavy scale.
 
-const STAGE_W = 1920;
-const STAGE_H = 1080;
+import { fitStage, STAGE_H, STAGE_W } from '@kroma/tv/stage';
 
-/** Installs the self-scaling 1920x1080 stage. Only for fixed-screen shells. */
+/** Installs the self-scaling stage. */
 export function installStage(): void {
   // Transparent when a native mpv window renders behind the UI.
   const inTauri = '__TAURI_INTERNALS__' in globalThis || '__TAURI__' in globalThis;
@@ -20,7 +24,7 @@ export function installStage(): void {
     html, body { height: 100%; margin: 0; overflow: hidden; background: ${bg}; }
     #root {
       position: fixed; top: 50%; left: 50%;
-      width: ${STAGE_W}px; height: ${STAGE_H}px;
+      width: var(--kroma-stage-width, ${STAGE_W}px); height: ${STAGE_H}px;
       transform: translate(-50%, -50%) scale(var(--kroma-stage-scale, 1));
       transform-origin: center center;
       overflow: hidden;
@@ -29,8 +33,10 @@ export function installStage(): void {
   document.head.appendChild(style);
 
   const apply = () => {
-    const scale = Math.min(window.innerWidth / STAGE_W, window.innerHeight / STAGE_H);
-    document.documentElement.style.setProperty('--kroma-stage-scale', String(scale));
+    const fit = fitStage(window.innerWidth, window.innerHeight);
+    const root = document.documentElement.style;
+    root.setProperty('--kroma-stage-scale', String(fit.scale));
+    root.setProperty('--kroma-stage-width', `${fit.width}px`);
   };
   apply();
   window.addEventListener('resize', apply);

--- a/clients/tv-web/src/stage.test.ts
+++ b/clients/tv-web/src/stage.test.ts
@@ -1,29 +1,23 @@
 // @vitest-environment jsdom
 //
-// The 1920x1080 stage, fitted inside a browser window.
+// The 10-foot canvas, fitted inside a browser window.
 //
-// The shared TV UI is not responsive - it is a fixed canvas in real pixels.
-// PosterGrid says so outright: 1792px of content is exactly 8 x 203px tiles plus
-// 7 x 24px gaps, which with its 2 x 64px padding is exactly 1920. Every packaged
-// shell IS that panel; a browser window is not.
+// The shared TV UI is drawn in real pixels on a 1080-tall canvas. Every packaged
+// shell IS that panel; a browser window is not, and below 1080 logical px of
+// height the browse screen's header, filter chips, grid and hint bar stop
+// fitting - so the HEIGHT is what the scale is taken from, always.
 //
-// So the canvas is what gets fitted, by the smaller of the two ratios - fitting
-// WIDTH only would starve the height (below 1080 logical px, the grid's clip box,
-// which bleeds 32px for focus rings, rides up over the filter chips), and taking
-// the larger ratio overflows the canvas (a rail's last poster clipped, the right
-// gutter gone, the grid's 8th column off the edge). Both are real regressions
-// this file guards.
+// The width is not fitted, it is HANDED OVER: the canvas is as wide as the
+// window leaves at that scale, and the layout auto-fills it. What this file
+// guards is that the canvas never overflows the window in either direction, and
+// that the surround only appears where the canvas has stopped narrowing.
 //
-// The surround it costs is painted in the app background, so it reads as the
-// frame of the picture rather than as a bug. (The desktop shell's stage makes
-// the one exception, going transparent where mpv renders behind the web view;
-// there is nothing behind a browser, so this one always paints.)
+// The maths itself is @kroma/tv's (`fitStage`, tested there); this is the
+// shell's half - the box, the custom properties, and the resize listener.
 
+import { fitStage, MIN_STAGE_W, STAGE_H, STAGE_W } from '@kroma/tv/stage';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { installStage } from './stage';
-
-const STAGE_W = 1920;
-const STAGE_H = 1080;
 
 function resizeTo(width: number, height: number) {
   Object.defineProperty(window, 'innerWidth', { value: width, configurable: true });
@@ -31,6 +25,8 @@ function resizeTo(width: number, height: number) {
 }
 
 const scale = () => Number(document.documentElement.style.getPropertyValue('--kroma-stage-scale'));
+const width = () =>
+  Number.parseFloat(document.documentElement.style.getPropertyValue('--kroma-stage-width'));
 
 const css = () => document.head.querySelector('style')?.textContent ?? '';
 
@@ -41,29 +37,31 @@ beforeEach(() => {
 });
 
 describe('fitting the canvas', () => {
-  it('is 1:1 on a 1080p window', () => {
+  it('is the design canvas, 1:1, on a 1080p window', () => {
     installStage();
     expect(scale()).toBe(1);
+    expect(width()).toBe(STAGE_W);
   });
 
-  it('fits a smaller window', () => {
-    resizeTo(1280, 720);
-    installStage();
-    expect(scale()).toBeCloseTo(1280 / STAGE_W, 6);
-  });
-
-  it('takes the HEIGHT ratio on a window wider than 16:9', () => {
+  it('hands a window wider than 16:9 the extra width instead of a pillarbox', () => {
     resizeTo(2560, 1080);
     installStage();
-    // Fitting the width instead is what pushed the grid's clip box up over the
-    // filter chips.
     expect(scale()).toBeCloseTo(1, 6);
+    expect(width()).toBe(2560);
   });
 
-  it('takes the WIDTH ratio on a window taller than 16:9', () => {
-    resizeTo(1280, 1440);
+  it('scales a narrower window down instead of clipping its chrome', () => {
+    resizeTo(1400, 900);
     installStage();
-    expect(scale()).toBeCloseTo(1280 / STAGE_W, 6);
+    expect(width()).toBe(MIN_STAGE_W);
+    expect(scale()).toBeCloseTo(1400 / MIN_STAGE_W, 6);
+  });
+
+  it('keeps the full 1080 of height whatever it costs in scale', () => {
+    resizeTo(600, 900);
+    installStage();
+    expect(width()).toBe(MIN_STAGE_W);
+    expect(STAGE_H * scale()).toBeLessThanOrEqual(900);
   });
 
   it('never lets the canvas overflow the window', () => {
@@ -79,25 +77,10 @@ describe('fitting the canvas', () => {
       document.head.innerHTML = '';
       resizeTo(w, h);
       installStage();
-      // A rail's last poster clipped, the right gutter gone, the grid's 8th
+      // A rail's last poster clipped, the right gutter gone, the grid's last
       // column off the edge - all the same overflow.
-      expect(STAGE_W * scale()).toBeLessThanOrEqual(w + 0.001);
-      expect(STAGE_H * scale()).toBeLessThanOrEqual(h + 0.001);
-    }
-  });
-
-  it('always keeps a full 1080 logical px of height', () => {
-    // The browse screen's header, chips, grid and hint bar are sized for 1080.
-    for (const [w, h] of [
-      [2560, 1080],
-      [3440, 1440],
-      [1280, 720],
-    ] as Array<[number, number]>) {
-      document.head.innerHTML = '';
-      resizeTo(w, h);
-      installStage();
-      expect(STAGE_H * scale()).toBeLessThanOrEqual(h + 0.001);
-      expect(scale()).toBeGreaterThan(0);
+      expect(width() * scale()).toBeLessThanOrEqual(w + 1);
+      expect(STAGE_H * scale()).toBeLessThanOrEqual(h + 1);
     }
   });
 
@@ -105,24 +88,30 @@ describe('fitting the canvas', () => {
     installStage();
     resizeTo(960, 540);
     window.dispatchEvent(new Event('resize'));
-    expect(scale()).toBeCloseTo(0.5, 6);
+    const fit = fitStage(960, 540);
+    expect(scale()).toBeCloseTo(fit.scale, 6);
+    expect(width()).toBe(fit.width);
   });
 });
 
 describe('the stage box', () => {
-  it('renders at the authored size and scales from the centre', () => {
+  it('is 1080 tall, as wide as the fit says, and scales from the centre', () => {
     installStage();
-    expect(css()).toContain(`width: ${STAGE_W}px`);
     expect(css()).toContain(`height: ${STAGE_H}px`);
-    // Symmetric letterboxing: a corner origin puts the whole surround on two
-    // sides.
+    expect(css()).toContain('width: var(--kroma-stage-width');
+    // Symmetric surround: a corner origin puts all of it on two sides.
     expect(css()).toContain('transform-origin: center center');
+  });
+
+  it('falls back to the design width before the first fit is written', () => {
+    installStage();
+    expect(css()).toContain(`var(--kroma-stage-width, ${STAGE_W}px)`);
   });
 
   it('makes #root the containing block for the app’s fixed layers', () => {
     installStage();
     // Home, player and detail are `position: fixed`; without the transform they
-    // fill the WINDOW and escape the letterbox.
+    // fill the WINDOW and escape the stage.
     expect(css()).toMatch(/#root\s*\{[^}]*position: fixed/);
     expect(css()).toContain('scale(var(--kroma-stage-scale, 1))');
   });

--- a/clients/tv-web/src/stage.ts
+++ b/clients/tv-web/src/stage.ts
@@ -1,43 +1,32 @@
-// The 1920x1080 stage, fitted inside the window.
+// The 10-foot canvas, fitted inside a browser window.
 //
-// The shared @kroma/tv UI is authored on a fixed 1920x1080 canvas in real pixels
-// - PosterGrid's column math depends on it: 1792px of content is exactly
-// 8 x 203px tiles plus 7 x 24px gaps, which with its 2 x 64px padding is exactly
-// 1920. Every packaged shell IS that panel; a browser window is not, and the raw
-// pixels do not survive the difference: at any other width the fixed-px rows
-// overflow, and at any height under 1080 the browse screen's header, filter
-// chips, grid and hint bar no longer fit either.
+// The shared @kroma/tv UI is drawn in real pixels on a 1080-tall canvas. Every
+// packaged shell IS that panel; a browser window is not, and the raw pixels do
+// not survive the difference: at any height under 1080 the browse screen's
+// header, filter chips, grid and hint bar no longer fit.
 //
-// So the canvas is what gets fitted, by the smaller ratio:
-//
-//   scale = min(w / 1920, h / 1080)
-//
-// FIT-INSIDE, the same rule the desktop shell's `installStage()` uses for the
-// Steam Deck. Fitting WIDTH only would starve the height requirement whenever
-// the window isn't 16:9 or taller, riding the grid's clip box (which bleeds
-// 32px for focus rings, see organisms/virtual/clip.ts) up over the filter
-// chips. The surround FIT-INSIDE costs on a non-16:9 window is painted in the
-// app background, so it reads as the frame of the picture rather than as a bug.
-//
-// The real "no surround" answer is a responsive 10-foot layout - columns and
-// gutters derived from the viewport instead of from 1920 - which is a change to
-// the design system, not to this shell.
+// So the canvas is scaled by the HEIGHT, and its WIDTH is however much the
+// window leaves at that scale (`fitStage`, see @kroma/tv/stage). The layout is
+// auto-filled from the width it is given rather than pinned to 1920, so a wide
+// window earns grid columns instead of bars either side, and a narrow one loses
+// them instead of clipping. Only below the canvas's floor does the scale come
+// down and the window keep a surround, painted in the app background so it reads
+// as the frame of the picture rather than as a bug.
 //
 // As in the desktop stage, the `transform` on #root makes it the containing
 // block for the app's `position: fixed` full-screen layers (home / player /
 // detail), so they fill the stage rather than the window.
 
-const STAGE_W = 1920;
-const STAGE_H = 1080;
+import { fitStage, STAGE_H, STAGE_W } from '@kroma/tv/stage';
 
-/** Install the self-scaling 1920x1080 stage. */
+/** Install the self-scaling stage. */
 export function installStage(): void {
   const style = document.createElement('style');
   style.textContent = `
     html, body { height: 100%; margin: 0; overflow: hidden; background: var(--kroma-bg, #0a0a0c); }
     #root {
       position: fixed; top: 50%; left: 50%;
-      width: ${STAGE_W}px; height: ${STAGE_H}px;
+      width: var(--kroma-stage-width, ${STAGE_W}px); height: ${STAGE_H}px;
       transform: translate(-50%, -50%) scale(var(--kroma-stage-scale, 1));
       transform-origin: center center;
       overflow: hidden;
@@ -46,8 +35,10 @@ export function installStage(): void {
   document.head.appendChild(style);
 
   const apply = () => {
-    const scale = Math.min(window.innerWidth / STAGE_W, window.innerHeight / STAGE_H);
-    document.documentElement.style.setProperty('--kroma-stage-scale', String(scale));
+    const fit = fitStage(window.innerWidth, window.innerHeight);
+    const root = document.documentElement.style;
+    root.setProperty('--kroma-stage-scale', String(fit.scale));
+    root.setProperty('--kroma-stage-width', `${fit.width}px`);
   };
   apply();
   window.addEventListener('resize', apply);

--- a/clients/web/src/features/requests/search-results.tsx
+++ b/clients/web/src/features/requests/search-results.tsx
@@ -2,7 +2,7 @@
 // decouvrir" (TMDB, gated), each a counted grid. Skeletons while loading, a
 // friendly empty state when nothing matches.
 
-import { posterColors, type SearchHit } from '@kroma/core';
+import { episodeTag, posterColors, type SearchHit } from '@kroma/core';
 import { useT } from '@kroma/ui';
 import { Box, EmptyState, Row, Text } from '@kroma/ui/kit';
 
@@ -57,14 +57,16 @@ function LocalHit({ hit }: Readonly<{ hit: SearchHit }>) {
   }
   const item = hit.item;
   // Episodes route to their show; movies to their own fiche.
-  const to = hit.type === 'episode' && item.showId ? '/show/$id' : '/movie/$id';
-  const id = hit.type === 'episode' && item.showId ? item.showId : item.id;
+  const episode = hit.type === 'episode' && item.showId ? item.showId : null;
+  const to = episode ? '/show/$id' : '/movie/$id';
   return (
     <Poster
-      title={item.title}
+      title={item.episodeTitle ?? item.title}
+      // An episode wears its show's poster, so it has to say which one it is.
+      genre={episode ? [item.showTitle, episodeTag(item)].filter(Boolean).join(' · ') : undefined}
       colors={posterColors(item.id)}
       poster={client.posterFor(item)}
-      onClick={() => navigate({ to, params: { id } })}
+      onClick={() => navigate({ to, params: { id: episode ?? item.id } })}
     />
   );
 }

--- a/packages/client/src/client/artwork.test.ts
+++ b/packages/client/src/client/artwork.test.ts
@@ -28,8 +28,9 @@ describe('artwork resolution setting', () => {
 
   it('scales every width a caller asks for', () => {
     setArtworkScale(0.5);
+    // 200 device pixels, served by the 240 rendition.
     expect(resolveArt(ctx, '/api/images/x.webp', 400)).toBe(
-      'http://kroma.test/api/images/x.webp?w=200',
+      'http://kroma.test/api/images/x.webp?w=240',
     );
   });
 
@@ -38,10 +39,10 @@ describe('artwork resolution setting', () => {
     expect(resolveArt(ctx, '/api/images/x.webp')).toBe('http://kroma.test/api/images/x.webp');
   });
 
-  it('never asks for a width below one pixel, however small the art', () => {
+  it('asks for the smallest rendition that exists, however small the art', () => {
     setArtworkScale(0.25);
     expect(resolveArt(ctx, '/api/images/x.webp', 1)).toBe(
-      'http://kroma.test/api/images/x.webp?w=1',
+      'http://kroma.test/api/images/x.webp?w=160',
     );
   });
 
@@ -61,7 +62,7 @@ describe('artwork resolution setting', () => {
         return artworkWidth(displayWidth);
       });
     expect(asks(320)).toEqual([320, 240, 160]);
-    expect(asks(960)).toEqual([960, 720, 480]);
+    expect(asks(960)).toEqual([960, 780, 480]);
   });
 });
 
@@ -73,9 +74,21 @@ describe('artworkWidth', () => {
 
   it('asks in device pixels, capped at 2x', () => {
     vi.stubGlobal('devicePixelRatio', 2);
-    expect(artworkWidth(96)).toBe(192);
+    // 192 device pixels, snapped up to the 240 rendition; 96 alone would take 160.
+    expect(artworkWidth(96)).toBe(240);
+    expect(artworkWidth(48)).toBe(160);
     vi.stubGlobal('devicePixelRatio', 3);
-    expect(artworkWidth(96)).toBe(192);
+    expect(artworkWidth(96)).toBe(240);
+  });
+
+  // A fluid grid's cell width moves with the window. Every ask inside one step
+  // of the ladder has to resolve to the same URL, or a resize re-fetches and
+  // re-decodes a grid's worth of artwork that the cache already held.
+  it('snaps to the ladder, so neighbouring cell widths share one URL', () => {
+    expect(artworkWidth(203)).toBe(240);
+    expect(artworkWidth(219)).toBe(240);
+    expect(artworkWidth(240)).toBe(240);
+    expect(artworkWidth(241)).toBe(320);
   });
 
   it('caps at the widest rendition, so two viewports share one cache key', () => {
@@ -91,9 +104,9 @@ describe('artworkWidth', () => {
     expect(artworkWidth(1280)).toBe(480);
   });
 
-  it('never asks for less than one pixel', () => {
+  it('never asks below the smallest rendition the server keeps', () => {
     setArtworkScale(0.25);
-    expect(artworkWidth(0)).toBe(1);
+    expect(artworkWidth(0)).toBe(160);
   });
 });
 
@@ -124,7 +137,7 @@ describe('resolveArt + art helpers', () => {
     );
     expect(
       posterFor(ctx, { id: 'i', metadata: { posterUrl: '/api/images/p.webp' } as Metadata }, 203),
-    ).toBe('http://kroma.test/api/images/p.webp?w=203');
+    ).toBe('http://kroma.test/api/images/p.webp?w=240');
     expect(backdropFor(ctx, meta({ backdropUrl: '/api/images/b.webp' }), 320)).toBe(
       'http://kroma.test/api/images/b.webp?w=320',
     );

--- a/packages/client/src/client/artwork.ts
+++ b/packages/client/src/client/artwork.ts
@@ -37,18 +37,23 @@ function artworkRatio(): number {
   return Math.min(2, Math.max(1, Math.round(dpr ?? 1)));
 }
 
-// The server's widest rendition bucket (`IMAGE_WIDTHS` in api/images.rs). It
-// caps the ask rather than the ask being capped server-side, so two viewports
-// of the same artwork mint one URL instead of two cache keys for one rendition.
-const WIDEST_ARTWORK = 960;
+// The server's rendition ladder (`IMAGE_WIDTHS` in api/images.rs). The ask is
+// snapped to it HERE rather than only server-side, because the URL is the cache
+// key: a fluid grid whose cell is 203px on one window and 219px on the next
+// would otherwise mint two keys - and two decodes - for the one rendition the
+// server hands back for both.
+const ARTWORK_WIDTHS = [160, 240, 320, 480, 780, 960];
+const WIDEST_ARTWORK = Math.max(...ARTWORK_WIDTHS);
 
 /** The `?w=` a surface drawn `displayWidth` wide must ask for: device pixels,
- * capped at the widest rendition the server keeps, then scaled by the device's
- * artwork-quality setting. The one place a drawn size becomes a request, so
- * `resolveArt` and `sizedImageUrl` cannot drift apart. */
+ * capped at the widest rendition the server keeps, scaled by the device's
+ * artwork-quality setting, then snapped up to a rendition that exists. The one
+ * place a drawn size becomes a request, so `resolveArt` and `sizedImageUrl`
+ * cannot drift apart. */
 export function artworkWidth(displayWidth: number): number {
   const devicePixels = Math.min(displayWidth * artworkRatio(), WIDEST_ARTWORK);
-  return Math.max(1, Math.round(devicePixels * artworkScale));
+  const asked = Math.max(1, Math.round(devicePixels * artworkScale));
+  return ARTWORK_WIDTHS.find((bucket) => bucket >= asked) ?? WIDEST_ARTWORK;
 }
 
 let artworkScale = 1;

--- a/packages/core/src/format.test.ts
+++ b/packages/core/src/format.test.ts
@@ -104,22 +104,22 @@ describe('sizedImageUrl', () => {
   // jsdom reports a ratio of 1, which is also what a 1920x1080 television
   // reports.
   it('asks for the display width on a 1x screen (a television)', () => {
-    expect(sizedImageUrl('/api/images/abc.webp', 200)).toBe('/api/images/abc.webp?w=200');
+    expect(sizedImageUrl('/api/images/abc.webp', 200)).toBe('/api/images/abc.webp?w=240');
   });
 
   it('asks for 2x on a retina screen', () => {
     vi.stubGlobal('devicePixelRatio', 2);
-    expect(sizedImageUrl('/api/images/abc.webp', 200)).toBe('/api/images/abc.webp?w=400');
+    expect(sizedImageUrl('/api/images/abc.webp', 200)).toBe('/api/images/abc.webp?w=480');
   });
 
   it('caps the ratio at 2, so a 3x phone does not decode 3x the pixels', () => {
     vi.stubGlobal('devicePixelRatio', 3);
-    expect(sizedImageUrl('/api/images/abc.webp', 200)).toBe('/api/images/abc.webp?w=400');
+    expect(sizedImageUrl('/api/images/abc.webp', 200)).toBe('/api/images/abc.webp?w=480');
   });
 
-  it('rounds and floors the requested width to at least 1', () => {
-    expect(sizedImageUrl('/api/images/x', 100.4)).toBe('/api/images/x?w=100');
-    expect(sizedImageUrl('/api/images/x', 0)).toBe('/api/images/x?w=1');
+  it('snaps neighbouring display widths onto one rendition', () => {
+    expect(sizedImageUrl('/api/images/x', 100.4)).toBe('/api/images/x?w=160');
+    expect(sizedImageUrl('/api/images/x', 0)).toBe('/api/images/x?w=160');
   });
 
   it('caps a full-screen ask at the widest rendition the server keeps', () => {

--- a/packages/tv/package.json
+++ b/packages/tv/package.json
@@ -14,6 +14,7 @@
   "exports": {
     ".": "./src/index.tsx",
     "./mount": "./src/mount.web.tsx",
+    "./stage": "./src/shared/stage.ts",
     "./tv.css": "./src/tv.css"
   },
   "scripts": {

--- a/packages/tv/src/features/accounts/ChoicePicker.tsx
+++ b/packages/tv/src/features/accounts/ChoicePicker.tsx
@@ -46,8 +46,8 @@ export function ChoicePicker({
         data={options}
         columns={1}
         itemHeight={ROW_HEIGHT + ROW_GAP}
+        width={ROW_WIDTH}
         style={{ height: LIST_HEIGHT, width: ROW_WIDTH }}
-        rowStyle={{ width: ROW_WIDTH }}
         initialIndex={current > 0 ? current : undefined}
         renderItem={(option) => (
           <ListRow.Root

--- a/packages/tv/src/features/catalog/TvGenreGrid.tsx
+++ b/packages/tv/src/features/catalog/TvGenreGrid.tsx
@@ -46,7 +46,7 @@ export function TvGenreGrid() {
       entries.map((e) => ({
         id: e.item.id,
         title: e.item.title,
-        poster: entryPoster(client, e),
+        poster: (width: number) => entryPoster(client, e, width),
         colors: posterColors(e.item.id),
         progress: e.kind === 'show' ? (e.item.progress ?? null) : null,
         onClick: () =>

--- a/packages/tv/src/features/catalog/TvGenres.tsx
+++ b/packages/tv/src/features/catalog/TvGenres.tsx
@@ -10,9 +10,8 @@ import { useT } from '@kroma/ui';
 import {
   Box,
   CategoryTile,
-  FocusColumn,
-  FocusRegion,
   FocusScroll,
+  Grid,
   styles,
   Text,
   tintGradient,
@@ -47,33 +46,21 @@ export function TvGenres() {
 
       {genres.length ? (
         <FocusScroll style={s.scroll} contentStyle={s.content} offsetFromStart={120}>
-          {/* The field wraps on screen, so it must be declared as a grid: a
-              single row would leave Up/Down nowhere to go. One region per
-              visible line, matching what the eye sees.
-              <FocusColumn grid> is what makes the lines a GRID rather than a
-              stack: without it the navigator has no index to align on, so
-              leaving a line forgets which column you were in and Up/Down land
-              on the first card of the next line. */}
-          <FocusColumn grid style={s.grid}>
-            {lines(genres, GENRE_COLUMNS).map((line, row) => (
-              // biome-ignore lint/suspicious/noArrayIndexKey: the index IS the line's identity.
-              <FocusRegion key={row} style={s.line}>
-                {line.map((g, column) => {
-                  const pick = showcases.get(g.name);
-                  return (
-                    <GenreCard
-                      autoFocus={row === 0 && column === 0}
-                      key={g.name}
-                      genre={g}
-                      count={t('person.titleCount', { count: g.count })}
-                      backdrop={pick ? client.backdropFor(pick, CARD_W) : null}
-                      onPress={() => nav.go('genre', { name: g.name })}
-                    />
-                  );
-                })}
-              </FocusRegion>
-            ))}
-          </FocusColumn>
+          <Grid min={CARD_MIN} gap={GAP}>
+            {genres.map((g, index) => {
+              const pick = showcases.get(g.name);
+              return (
+                <GenreCard
+                  autoFocus={index === 0}
+                  key={g.name}
+                  genre={g}
+                  count={t('person.titleCount', { count: g.count })}
+                  backdrop={pick ? client.backdropFor(pick, CARD_MIN) : null}
+                  onPress={() => nav.go('genre', { name: g.name })}
+                />
+              );
+            })}
+          </Grid>
         </FocusScroll>
       ) : (
         <Box flex center px={64}>
@@ -113,26 +100,16 @@ function GenreCard({
   );
 }
 
-// Declared rather than measured: the stage is fixed, and the navigator needs
-// the shape before anything is laid out.
-const GENRE_COLUMNS = 5;
-
-function lines<T>(items: readonly T[], size: number): T[][] {
-  const out: T[][] = [];
-  for (let at = 0; at < items.length; at += size) out.push(items.slice(at, at + size));
-  return out;
-}
-
-const CARD_W = 320;
+// The design's card at 1920 (5 across the content width), as the narrowest one
+// rather than a count: a wider window earns a sixth column instead of stretching
+// five, a narrower one drops to four instead of running off the edge.
+const CARD_MIN = 320;
 
 // One number for both directions: the lines' own gap and the gap BETWEEN them
-// are the same seam, and the grid column is what carries the second one now
-// that it stands between the content and its lines.
+// are the same seam.
 const GAP = 12;
 
 const s = styles({
-  line: { row: true, gap: GAP },
-  grid: { gap: GAP },
   scroll: { flex: true, minH: 0 },
   // Padding belongs on the content, not the scroller box: on the box it would
   // pad the viewport and clip the last row instead of the list.

--- a/packages/tv/src/features/catalog/TvGrid.tsx
+++ b/packages/tv/src/features/catalog/TvGrid.tsx
@@ -93,7 +93,7 @@ export function TvGrid() {
       entries.map((e) => ({
         id: e.item.id,
         title: e.item.title,
-        poster: entryPoster(client, e),
+        poster: (width: number) => entryPoster(client, e, width),
         colors: posterColors(e.item.id),
         watched: watched.has(e.item.id),
         progress: e.kind === 'show' ? (e.item.progress ?? null) : null,

--- a/packages/tv/src/features/catalog/TvPerson.tsx
+++ b/packages/tv/src/features/catalog/TvPerson.tsx
@@ -34,7 +34,7 @@ export function TvPerson() {
       card: {
         id: m.id,
         title: m.title,
-        poster: client.posterFor(m, POSTER_W),
+        poster: (width: number) => client.posterFor(m, width),
         colors: posterColors(m.id),
         onClick: () => nav.go('movie', { item: m }),
       } satisfies GridCard,
@@ -44,7 +44,7 @@ export function TvPerson() {
       card: {
         id: s.id,
         title: s.title,
-        poster: client.showPosterFor(s, POSTER_W),
+        poster: (width: number) => client.showPosterFor(s, width),
         colors: posterColors(s.id),
         onClick: () => nav.go('show', { show: s }),
       } satisfies GridCard,
@@ -86,5 +86,4 @@ export function TvPerson() {
   );
 }
 
-const POSTER_W = 203;
 const PORTRAIT_W = 220;

--- a/packages/tv/src/features/catalog/TvSearch.tsx
+++ b/packages/tv/src/features/catalog/TvSearch.tsx
@@ -25,6 +25,7 @@ import { addRecentSearch, getRecentSearches } from '#tv/features/catalog/searchH
 import type { SearchResult } from '#tv/features/catalog/TvSearchResults';
 import { TvSearchResults } from '#tv/features/catalog/TvSearchResults';
 import { TvVoiceSearch } from '#tv/features/catalog/TvVoiceSearch';
+import { SCREEN_PAD, STAGE_W } from '#tv/shared/stage';
 import { KromaMark, SearchKeyboard } from '#tv/shared/ui';
 
 const DEBOUNCE_MS = 250;
@@ -244,14 +245,12 @@ export function TvSearch() {
 // the width from the kit is what keeps the results pane beside the keys instead
 // of on top of them the next time a key grows.
 const KEYBOARD_W = keyRowWidth('tv');
-const SCREEN_PAD = 64;
 const COLUMN_GAP = 52;
 // The scroller's own horizontal padding, which the grid does not get to use.
 const RESULTS_PADDING = 40;
-// The 1920x1080 stage makes the rest static arithmetic: what the screen's own
-// padding, the keyboard and the gap leave is the results pane.
-const RESULTS_WIDTH = 1920 - SCREEN_PAD * 2 - KEYBOARD_W - COLUMN_GAP - RESULTS_PADDING;
-
+// What the pane is on the design's stage - the fallback the results grid divides
+// until it has measured the box it really got, not a width it is held to.
+const RESULTS_WIDTH = STAGE_W - SCREEN_PAD * 2 - KEYBOARD_W - COLUMN_GAP - RESULTS_PADDING;
 const s = styles({
   columns: { row: true, flex: true, gap: COLUMN_GAP, minH: 0 },
   keyboardColumn: { w: KEYBOARD_W, shrink: 0 },

--- a/packages/tv/src/features/catalog/TvSearchResults.tsx
+++ b/packages/tv/src/features/catalog/TvSearchResults.tsx
@@ -1,5 +1,5 @@
 import { useT } from '@kroma/ui';
-import { Box, FocusColumn, FocusScroll, Grid, Hint, PosterCard, styles, Text } from '@kroma/ui/kit';
+import { Box, FocusScroll, Grid, Hint, PosterCard, styles, Text } from '@kroma/ui/kit';
 import type { ReactNode } from 'react';
 
 /** One result, already reduced to what a poster needs. */
@@ -15,7 +15,9 @@ export interface SearchResult {
 interface TvSearchResultsProps {
   hits: SearchResult[];
   query: string;
-  width: number;
+  /** The pane's width, when the chrome around it already knows it (the
+   *  platform's own search shell). Omit and the grid measures its own box. */
+  width?: number;
   onOpen: (hit: SearchResult) => void;
   header?: ReactNode;
 }
@@ -47,22 +49,17 @@ export function TvSearchResults({
         />
       </Box>
       {hits.length ? (
-        // The grid declares its ROWS; this declares the stack of them, so the
-        // whole pane is one thing to arrive at from the keyboard beside it
-        // rather than a loose pile of rows on the screen's own column.
-        <FocusColumn grid>
-          <Grid width={width} min={POSTER} gap={GAP}>
-            {hits.map((h) => (
-              <PosterCard
-                key={h.id}
-                title={h.title}
-                art={h.poster}
-                tint={h.colors}
-                onPress={() => onOpen(h)}
-              />
-            ))}
-          </Grid>
-        </FocusColumn>
+        <Grid width={width} min={POSTER} gap={GAP}>
+          {hits.map((h) => (
+            <PosterCard
+              key={h.id}
+              title={h.title}
+              art={h.poster}
+              tint={h.colors}
+              onPress={() => onOpen(h)}
+            />
+          ))}
+        </Grid>
       ) : (
         <Text variant="leadTv" pt={20} color="text/40">
           {query.trim() ? t('search.noResults') : t('search.empty')}

--- a/packages/tv/src/features/catalog/TvShowDetail.tsx
+++ b/packages/tv/src/features/catalog/TvShowDetail.tsx
@@ -20,7 +20,6 @@ import { useWatched } from '#tv/app/providers/watched';
 import { useClient, useNav, useParams } from '#tv/app/router';
 import { TvDetailScaffold } from '#tv/features/catalog/detail/DetailScaffold';
 import { EpisodeGrid } from '#tv/features/catalog/detail/EpisodeGrid';
-import { EPISODE_COLUMN_W } from '#tv/features/catalog/detail/EpisodeRow';
 import {
   CastRow,
   EndsAtHint,
@@ -255,7 +254,7 @@ export function TvShowDetail() {
           <Box mt={40} gap={18}>
             {/* The design's header line: the label, how far through the season
                 you are, and the remote legend pushed to the column's far edge. */}
-            <Row gap={18} wrap maxW={EPISODE_COLUMN_W}>
+            <Row gap={18} wrap>
               <Text style={s.episodesLabel} color="text/55">
                 {t('content.episodesHeader')}
               </Text>

--- a/packages/tv/src/features/catalog/detail/EpisodeGrid.tsx
+++ b/packages/tv/src/features/catalog/detail/EpisodeGrid.tsx
@@ -4,12 +4,8 @@
 
 import type { MediaItem } from '@kroma/core';
 import { Grid, useGrowingCount } from '@kroma/ui/kit';
-import {
-  EPISODE_COLUMN_W,
-  EPISODE_COLUMNS,
-  EPISODE_W,
-  EpisodeRow,
-} from '#tv/features/catalog/detail/EpisodeRow';
+import { EPISODE_COLUMNS, EPISODE_W, EpisodeRow } from '#tv/features/catalog/detail/EpisodeRow';
+import { CONTENT_W } from '#tv/shared/stage';
 
 const GAP = 24;
 const ROW_GAP = 14;
@@ -35,7 +31,7 @@ export function EpisodeGrid({
 }>) {
   const { count, isNearEnd, grow } = useGrowingCount(episodes.length, CHUNK);
   return (
-    <Grid width={EPISODE_COLUMN_W} columns={EPISODE_COLUMNS} gap={GAP} rowGap={ROW_GAP}>
+    <Grid width={CONTENT_W} columns={EPISODE_COLUMNS} gap={GAP} rowGap={ROW_GAP}>
       {episodes.slice(0, count).map((ep, index) => (
         <EpisodeRow
           key={ep.id}

--- a/packages/tv/src/features/catalog/detail/EpisodeRow.tsx
+++ b/packages/tv/src/features/catalog/detail/EpisodeRow.tsx
@@ -29,7 +29,6 @@ import { type ReactNode, useState } from 'react';
 export const EPISODE_W = 480;
 
 export const EPISODE_COLUMNS = 1;
-export const EPISODE_COLUMN_W = 1920 - 64 * 2;
 
 const STILL_W = 240;
 const PLAY_DISC = 54;

--- a/packages/tv/src/features/catalog/home/AmbientBackdrop.tsx
+++ b/packages/tv/src/features/catalog/home/AmbientBackdrop.tsx
@@ -62,14 +62,13 @@ export const AMBIENT_FALLBACK: [string, string] = [colors.surface2, colors.bg];
 
 export type CatalogEntry = { kind: 'movie'; item: MediaItem } | { kind: 'show'; item: Show };
 
-export function entryPoster(client: KromaClient, e: CatalogEntry): string {
-  return e.kind === 'movie'
-    ? client.posterFor(e.item, GRID_POSTER_W)
-    : client.showPosterFor(e.item, GRID_POSTER_W);
+export function entryPoster(client: KromaClient, e: CatalogEntry, width = GRID_POSTER_W): string {
+  return e.kind === 'movie' ? client.posterFor(e.item, width) : client.showPosterFor(e.item, width);
 }
 
-// A browse-grid cell is 203pt wide on the 1920 stage; asking the server for a
-// bucketed rendition is what keeps a 120-tile grid from stuttering on a TV.
+// What a browse-grid cell is on the 1920 stage, for a caller with no measured
+// column to hand over; asking the server for a bucketed rendition is what keeps
+// a 120-tile grid from stuttering on a TV.
 const GRID_POSTER_W = 203;
 
 /** The focused entry's backdrop, falling back to its poster. */

--- a/packages/tv/src/features/catalog/home/PosterGrid.test.tsx
+++ b/packages/tv/src/features/catalog/home/PosterGrid.test.tsx
@@ -20,7 +20,7 @@ function cards(n: number, over: Partial<GridCard> = {}): GridCard[] {
   return Array.from({ length: n }, (_, i) => ({
     id: `id-${i}`,
     title: `Film ${i}`,
-    poster: `/art/${i}.jpg`,
+    poster: (width: number) => `/art/${i}.jpg?w=${width}`,
     colors: ['#3A2E4F', '#1B1524'] as [string, string],
     onClick: () => {},
     ...over,
@@ -64,10 +64,16 @@ describe('PosterGrid', () => {
     expect(getComputedStyle(fill).right).toBe('60%');
   });
 
-  it('lays the tiles out at the design column width', () => {
+  it('lays the tiles out at the design column width until it has measured a box', () => {
     const { container } = render(<PosterGrid cards={cards(3)} />);
     // 1792px of content, 8 columns, 24px gaps -> 203px tiles.
     const tile = container.querySelector('[role="button"]') as HTMLElement;
     expect(getComputedStyle(tile).width).toBe('203px');
+  });
+
+  it('asks for artwork at the width of the cell the tile lands in', () => {
+    const { container } = render(<PosterGrid cards={cards(1)} />);
+    const art = container.querySelector('img') as HTMLImageElement;
+    expect(art.getAttribute('src')).toBe('/art/0.jpg?w=203');
   });
 });

--- a/packages/tv/src/features/catalog/home/PosterGrid.tsx
+++ b/packages/tv/src/features/catalog/home/PosterGrid.tsx
@@ -1,10 +1,13 @@
-import { PosterCard, styles, VirtualGrid } from '@kroma/ui/kit';
+import { PosterCard, VirtualGrid } from '@kroma/ui/kit';
 import { memo } from 'react';
+import { SCREEN_PAD, STAGE_W } from '#tv/shared/stage';
 
 export interface GridCard {
   id: string;
   title: string;
-  poster: string;
+  /** Portrait art at the width of the cell the tile lands in: the column is
+   *  measured, so the rendition asked for follows it. */
+  poster: (width: number) => string;
   colors: [string, string];
   watched?: boolean;
   progress?: number | null;
@@ -12,41 +15,37 @@ export interface GridCard {
   onFocus?: () => void;
 }
 
-// The 1920px stage makes the column maths static: 1792px of content is exactly
-// 8 x 203px tiles plus 7 x 24px gaps. Flex wrap, never CSS grid, because the
-// legacy webOS tier (Chromium 53) has no grid and React Native has none either.
-const CONTENT_WIDTH = 1792;
-const COLUMNS = 8;
+// The design's column: 1792px of content is 8 x 203px tiles plus 7 x 24px gaps.
+// As a MINIMUM rather than a count, so the exact design lands on a 1920 panel
+// and a window of any other width fits whole tiles instead of clipping them.
+const TILE_MIN = 203;
+const POSTER_RATIO = 3 / 2;
 const GAP = 24;
 const ROW_GAP = 32;
-const TILE_W = Math.floor((CONTENT_WIDTH - GAP * (COLUMNS - 1)) / COLUMNS);
 
-// A computed number rather than something measured, because scroll offsets
-// are derived from it before anything is laid out; being a little out costs
-// a slightly wrong resting position, not a broken grid.
-const ROW_HEIGHT = Math.round((TILE_W * 3) / 2) + ROW_GAP;
-
-// The 2:3 poster grid for the Films / Séries browse views. Virtualised: only the rows near the
-// viewport are mounted, so a 2000-title library costs the same as a 40-title one.
+/** The 2:3 poster grid for the Films / Séries browse views. Virtualised: only the rows near the
+ * viewport are mounted, so a 2000-title library costs the same as a 40-title one. */
 function PosterGridImpl({ cards }: Readonly<{ cards: GridCard[] }>) {
   return (
     <VirtualGrid
       data={cards}
-      columns={COLUMNS}
-      itemHeight={ROW_HEIGHT}
-      style={s.viewport}
-      contentStyle={s.content}
-      rowStyle={s.row}
-      renderItem={(c, index) => (
+      min={TILE_MIN}
+      ratio={POSTER_RATIO}
+      gap={GAP}
+      rowGap={ROW_GAP}
+      px={SCREEN_PAD}
+      pt={32}
+      width={STAGE_W}
+      renderItem={(c, index, width) => (
         <PosterCard
           // The grid's entry point. tvOS picks by geometry and the web engine by
           // DOM order without one, so neither lands where the design says.
           autoFocus={index === 0}
           title={c.title}
-          art={c.poster}
+          art={c.poster(width)}
           tint={c.colors}
           watched={c.watched}
-          width={TILE_W}
+          width={width}
           // GridCard carries a percentage (the server's series-completion
           // figure); <PosterCard> takes a 0..1 ratio.
           progress={c.progress == null ? null : c.progress / 100}
@@ -61,14 +60,3 @@ function PosterGridImpl({ cards }: Readonly<{ cards: GridCard[] }>) {
 // memo: the browse screens re-render on every focus move (the ambient header
 // tracks the focused tile); an unchanged `cards` array must skip this subtree.
 export const PosterGrid = memo(PosterGridImpl);
-
-const s = styles({
-  // The grid owns the remaining height and is also what clips (see
-  // <VirtualGrid>): padding here would inset the clip and shave the rows.
-  viewport: { flex: true, minH: 0 },
-  // Padding belongs on the content, not the viewport. `pt` gives a focused
-  // row's ring and scale room to grow inside the clip, since <VirtualGrid>
-  // clips flush at its top.
-  content: { px: 64, pt: 32 },
-  row: { gap: GAP },
-});

--- a/packages/tv/src/shared/stage.test.ts
+++ b/packages/tv/src/shared/stage.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { fitStage, MIN_STAGE_W, STAGE_H, STAGE_W } from './stage';
+
+describe('fitStage', () => {
+  it('is the design canvas, untouched, on a 1080p television', () => {
+    expect(fitStage(STAGE_W, STAGE_H)).toEqual({ scale: 1, width: STAGE_W });
+  });
+
+  it('draws the design at 2x on a 4K panel rather than twice as many columns', () => {
+    expect(fitStage(3840, 2160)).toEqual({ scale: 2, width: STAGE_W });
+  });
+
+  // The point of taking the scale from the height: the window's extra width
+  // becomes canvas the grids fill, instead of bars either side of a 16:9 box.
+  it('hands a wider-than-16:9 window the extra width as canvas', () => {
+    const fit = fitStage(2560, 1080);
+    expect(fit.scale).toBe(1);
+    expect(fit.width).toBe(2560);
+  });
+
+  // The floor is the design width, so a window narrower than 16:9 loses size
+  // rather than canvas: the top bar has no column to drop.
+  it('scales down rather than narrowing past the floor', () => {
+    const fit = fitStage(1310, 790);
+    expect(fit.width).toBe(MIN_STAGE_W);
+    expect(fit.scale).toBeCloseTo(1310 / MIN_STAGE_W, 6);
+  });
+
+  it('holds the floor on a portrait window too', () => {
+    const fit = fitStage(800, 1280);
+    expect(fit.width).toBe(MIN_STAGE_W);
+    expect(fit.scale).toBeCloseTo(800 / MIN_STAGE_W, 6);
+  });
+
+  it('never overflows the window, whatever its shape', () => {
+    for (const [w, h] of [
+      [1280, 800],
+      [1366, 768],
+      [1920, 1080],
+      [2560, 1080],
+      [3440, 1440],
+      [800, 1280],
+      [640, 480],
+    ] as Array<[number, number]>) {
+      const fit = fitStage(w, h);
+      expect(fit.width * fit.scale).toBeLessThanOrEqual(w + 1);
+      expect(STAGE_H * fit.scale).toBeLessThanOrEqual(h + 1);
+    }
+  });
+
+  it('falls back to the design canvas for a window with no size yet', () => {
+    expect(fitStage(0, 0)).toEqual({ scale: 1, width: STAGE_W });
+  });
+});

--- a/packages/tv/src/shared/stage.ts
+++ b/packages/tv/src/shared/stage.ts
@@ -1,0 +1,46 @@
+// The DESIGN stage: the canvas the 10-foot layout is drawn against, and how it
+// is fitted to a window that is not a television.
+//
+// A packaged television shell IS this canvas, exactly. A desktop window is not,
+// so anything a screen can measure it measures, and these are what it assumes
+// until the measurement arrives - a first frame drawn at the design width
+// rather than a blank one. Nothing here is a limit: a grid handed more room
+// fills it with more columns.
+
+/** The design canvas, in the pixels the layout is authored in. */
+export const STAGE_W = 1920;
+export const STAGE_H = 1080;
+
+/** The gutter every full-screen surface keeps clear at the panel edges. */
+export const SCREEN_PAD = 64;
+
+/** The design's content width: the stage inside its gutters. */
+export const CONTENT_W = STAGE_W - SCREEN_PAD * 2;
+
+// The canvas grows past the design width but never below it, because the top
+// bar is what holds the floor: a fixed set of labels either side of a centred
+// pill, roughly 1760px of them, not a grid that can drop a column. Below this
+// the canvas is scaled down instead of narrowed, and the window keeps a
+// surround. Lowering it is a change to the CHROME, not to this number.
+export const MIN_STAGE_W = STAGE_W;
+
+export interface StageFit {
+  scale: number;
+  width: number;
+}
+
+/**
+ * The canvas for a window of `windowW` x `windowH` device-independent pixels.
+ *
+ * The scale comes from the HEIGHT, so 10-foot type is drawn at the size it was
+ * designed at whatever the window's shape, and the WIDTH is however much of the
+ * canvas the window leaves in those same units: a wide window earns columns
+ * instead of a pillarbox, a narrow one loses them instead of clipping. The
+ * width floors at {@link MIN_STAGE_W}, past which the scale comes down and the
+ * window keeps a surround top and bottom.
+ */
+export function fitStage(windowW: number, windowH: number): StageFit {
+  if (windowW <= 0 || windowH <= 0) return { scale: 1, width: STAGE_W };
+  const scale = Math.min(windowH / STAGE_H, windowW / MIN_STAGE_W);
+  return { scale, width: Math.round(windowW / scale) };
+}

--- a/packages/ui/audit/budget.json
+++ b/packages/ui/audit/budget.json
@@ -89,7 +89,7 @@
   "form/scene:Without a catalog": [7, 4, 1],
   "frost/preview": [7, 3, 1],
   "frost/scene:Where there is no blur": [6, 3, 1],
-  "grid/preview": [80, 9, 1],
+  "grid/preview": [81, 10, 1],
   "ground/preview": [15, 5, 1],
   "ground/scene:Chrome over artwork": [13, 5, 1],
   "ground/scene:Nested": [10, 6, 1],

--- a/packages/ui/src/components/atoms/grid/grid.test.tsx
+++ b/packages/ui/src/components/atoms/grid/grid.test.tsx
@@ -67,11 +67,12 @@ describe('a grid that was handed no width', () => {
   it('re-measures into a new column count when the room changes', () => {
     const { container } = render(<Grid min={260}>{tiles}</Grid>);
     const box = container.firstElementChild as HTMLElement;
+    const rows = () => (box.firstElementChild as HTMLElement).children;
 
     layout(box, { width: 1000 });
-    expect(box.children).toHaveLength(3);
+    expect(rows()).toHaveLength(3);
 
     layout(box, { width: 560 });
-    expect(box.children).toHaveLength(4);
+    expect(rows()).toHaveLength(4);
   });
 });

--- a/packages/ui/src/components/atoms/grid/grid.tsx
+++ b/packages/ui/src/components/atoms/grid/grid.tsx
@@ -8,12 +8,15 @@
 // The grid also DECLARES its rows to the spatial navigator. Wrapping is a
 // visual arrangement, not a navigational one: without the declaration the whole
 // grid is one long line and Down from the first tile walks to the second rather
-// than to the tile underneath it.
+// than to the tile underneath it. The rows are declared as a GRID rather than a
+// stack, which is what keeps the column position across a row change: Down from
+// the third tile lands on the third tile of the next row, not on whichever one
+// that row last held.
 
-import { Children, type ReactNode, useState } from 'react';
+import { Children, type ReactNode, useCallback, useMemo, useState } from 'react';
 import type { LayoutChangeEvent } from 'react-native';
 import { Box } from '#ui/components/atoms/box';
-import { FocusRegion } from '#ui/lib/focus-scope';
+import { FocusColumn, FocusRegion } from '#ui/lib/focus-scope';
 import { FocusLine } from '#ui/lib/focus-scroll';
 
 interface GridProps {
@@ -23,8 +26,9 @@ interface GridProps {
   /** A fixed count, for a design that demands one whatever the width. Wins
    *  over `min`. */
   columns?: number;
-  /** The width to divide, when the caller already knows it. Omit and the grid
-   *  measures its own box, which costs one frame before the first paint. */
+  /** The width to divide until the grid has measured its own box: the design
+   *  width, or a room the caller already knows. Omit and the first frame has no
+   *  columns to draw; a measurement, once it arrives, always wins. */
   width?: number;
   /** Horizontal gap, which is also what the column maths removes. */
   gap?: number;
@@ -50,19 +54,22 @@ function columnsFor(width: number, min: number, gap: number): number {
 
 function Grid({ min, columns, width, gap = 24, rowGap, children }: Readonly<GridProps>) {
   const [measured, setMeasured] = useState(0);
-  // Both the cell width and an auto-fill count need the room, so a grid that was
-  // not handed one paints nothing until it has measured itself.
-  const room = width ?? measured;
+  // Both the cell width and an auto-fill count need the room, so a grid handed
+  // no width paints nothing until it has measured itself.
+  const room = measured || width || 0;
   const count = columns ?? (min ? columnsFor(room, min, gap) : 1);
 
-  const onLayout = (event: LayoutChangeEvent) => {
+  const onLayout = useCallback((event: LayoutChangeEvent) => {
     const next = Math.round(event.nativeEvent.layout.width);
     setMeasured((current) => (current === next ? current : next));
-  };
+  }, []);
 
+  const style = useMemo(() => ({ gap: rowGap ?? gap }), [gap, rowGap]);
   return (
-    <Box gap={rowGap ?? gap} onLayout={width === undefined ? onLayout : undefined}>
-      {room > 0 ? lines(children, count, cellWidth(room, count, gap), gap) : null}
+    <Box onLayout={onLayout}>
+      <FocusColumn grid style={style}>
+        {room > 0 ? lines(children, count, cellWidth(room, count, gap), gap) : null}
+      </FocusColumn>
     </Box>
   );
 }

--- a/packages/ui/src/components/molecules/category-tile/category-tile.tsx
+++ b/packages/ui/src/components/molecules/category-tile/category-tile.tsx
@@ -46,6 +46,8 @@ interface CategoryTileProps extends Omit<FocusableProps, 'children' | 'style' | 
   wash?: string;
   accent?: ColorValue;
   size?: CategoryTileSize;
+  /** An explicit tile width. Omit inside a <Grid>, whose cell already sets the
+   *  column width. */
   width?: number;
   aspect?: number;
   children?: ReactNode;
@@ -60,7 +62,7 @@ function CategoryTile({
   wash,
   accent,
   size = 'tv',
-  width = 340,
+  width,
   aspect = WIDESCREEN,
   children,
   style,
@@ -76,7 +78,7 @@ function CategoryTile({
       // Frame and artwork are the same box, on the same radius: the ring keeps
       // itself clear of the art (RING_GAP), so padding here would be a second
       // gap and a corner nobody could keep concentric.
-      style={[s.frame, { width }, style]}
+      style={[s.frame, { width: width ?? '100%' }, style]}
     >
       <Box aspect={aspect} radius="lg" overflow="hidden" bg="surface1" shadow="card">
         <Img src={art} background={background} position="50% 25%" fill />

--- a/packages/ui/src/components/organisms/virtual/virtual-grid/virtual-grid.fixtures.tsx
+++ b/packages/ui/src/components/organisms/virtual/virtual-grid/virtual-grid.fixtures.tsx
@@ -5,6 +5,11 @@ export const TITLES = Array.from({ length: 400 }, (_, at) => ({
   title: `Title ${at + 1}`,
 }));
 
-export const TILE_W = 203;
+export const TILE_MIN = 203;
 
-export const ROW_HEIGHT = Math.round((TILE_W * 3) / 2) + 32;
+export const POSTER_RATIO = 3 / 2;
+
+// What the preview assumes until it has measured its own canvas: the design's
+// stage inside the story's own padding, so an unmeasured render is the 8-column
+// grid the browse screens draw.
+export const PREVIEW_W = 1840;

--- a/packages/ui/src/components/organisms/virtual/virtual-grid/virtual-grid.story.mdx
+++ b/packages/ui/src/components/organisms/virtual/virtual-grid/virtual-grid.story.mdx
@@ -3,33 +3,35 @@ import { Box } from '#ui/components/atoms/box';
 import { PosterCard } from '#ui/components/molecules/poster-card';
 import { posterArt } from '#ui/lib/sample-art';
 import { VirtualGrid } from './virtual-grid';
-import { TINT, TITLES, TILE_W, ROW_HEIGHT } from './virtual-grid.fixtures';
+import { TINT, TITLES, TILE_MIN, POSTER_RATIO, PREVIEW_W } from './virtual-grid.fixtures';
 
 export const story = defineStory({
   group: 'Media',
   width: { min: 640, max: 1600 },
-  args: { columns: 8, count: 400 },
+  args: { min: TILE_MIN, count: 400 },
   controls: {
-    columns: { min: 2, max: 10, step: 1 },
+    min: { min: 120, max: 320, step: 1 },
     count: { min: 40, max: 400, step: 40 },
   },
-  render: ({ columns, count }) => (
+  render: ({ min, count }) => (
     <Box style={{ height: 620 }}>
       <VirtualGrid
         data={TITLES.slice(0, count)}
-        columns={columns}
-        itemHeight={ROW_HEIGHT}
-        style={{ flex: 1, minHeight: 0 }}
-        // paddingTop = FOCUS_BLEED: the grid clips flush at its top, so a focused
-        // row's ring room has to come from the content.
-        contentStyle={{ paddingHorizontal: 24, paddingTop: 32 }}
-        rowStyle={{ gap: 24 }}
-        renderItem={(item, at) => (
+        min={min}
+        ratio={POSTER_RATIO}
+        gap={24}
+        rowGap={32}
+        // pt = FOCUS_BLEED: the grid clips flush at its top, so a focused row's
+        // ring room has to come from the content.
+        px={24}
+        pt={32}
+        width={PREVIEW_W}
+        renderItem={(item, at, width) => (
           <PosterCard
             title={item.title}
             art={posterArt(at)}
             tint={TINT}
-            width={TILE_W}
+            width={width}
             autoFocus={at === 0}
           />
         )}
@@ -40,25 +42,32 @@ export const story = defineStory({
 
 The browse screens' poster grid: a library of thousands, of which only the rows near the viewport are mounted. Focus reaches the end anyway, because the navigator registers a *virtual* node per row that outlives the tile rendered into it. On the web the wheel scrolls it too, and that moves the selection, unlike a `VirtualRail`'s wheel, because the navigator's `scrollTo` is implemented as a focus grab.
 
+The columns are auto-filled from the grid's measured box, like `<Grid min>`: drag the preview's width and watch the count change rather than the last column leave the frame. Each tile is handed the width of the cell it lands in, which is what lets it size its own artwork request.
+
 ```tsx
 <VirtualGrid
   data={cards}
-  columns={8}
-  itemHeight={336}
-  style={{ flex: 1, minHeight: 0 }}
-  contentStyle={{ paddingHorizontal: 64 }}
-  rowStyle={{ gap: 24 }}
-  renderItem={(c, i) => <PosterCard title={c.title} art={c.poster} autoFocus={i === 0} />}
+  min={203}
+  ratio={3 / 2}
+  gap={24}
+  rowGap={32}
+  px={64}
+  pt={32}
+  width={STAGE_W}
+  renderItem={(c, i, width) => (
+    <PosterCard title={c.title} art={c.poster(width)} width={width} autoFocus={i === 0} />
+  )}
 />
 ```
 
 <Do>
-- Give the grid a bounded height (`flex: 1`): it is the viewport, and it is what clips.
-- Put the padding in `contentStyle`: on the viewport it insets the clip and shaves the rows.
-- `itemHeight` is the row PITCH: the tile plus the gap beneath it.
+- Give the grid a bounded height: it is the viewport, and it is what clips. It fills its parent unless `style` says otherwise.
+- Hand it a `width` to divide until it has measured itself, or the first frame has no columns to draw.
+- Pass the padding as `px` / `pt`: the grid puts it on the rows, since on the viewport it would inset the clip and shave them.
 </Do>
 
 <Dont>
 - Use it for a handful of tiles; a plain wrapped Box costs less.
 - Give it rows of different heights: the offset maths assumes one pitch.
+- Pin `columns` to keep a design honest on a television; `min` lands the same count at 1920 and still fits a window.
 </Dont>

--- a/packages/ui/src/components/organisms/virtual/virtual-grid/virtual-grid.test.tsx
+++ b/packages/ui/src/components/organisms/virtual/virtual-grid/virtual-grid.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+
+import { render } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { describe, expect, it } from 'vitest';
+import { Box } from '#ui/components/atoms/box';
+import { Focusable } from '#ui/components/atoms/focusable';
+import { layout, onScreen } from '#ui/testing';
+import { VirtualGrid } from './virtual-grid';
+
+const TILES = Array.from({ length: 60 }, (_, at) => ({ id: at }));
+
+const draw = (ui: ReactElement) => render(onScreen(ui));
+
+function grid(width?: number) {
+  return (
+    <VirtualGrid
+      data={TILES}
+      min={200}
+      ratio={3 / 2}
+      gap={24}
+      px={64}
+      width={width}
+      style={{ height: 600 }}
+      renderItem={(item, _index, cell) => (
+        <Focusable label={`tile ${item.id}`} style={{ width: cell }}>
+          <Box style={{ width: cell, height: 10 }} />
+        </Focusable>
+      )}
+    />
+  );
+}
+
+const tileWidth = (root: HTMLElement) =>
+  getComputedStyle(root.querySelector('[role="button"]') as HTMLElement).width;
+
+describe('VirtualGrid', () => {
+  it('draws the width it was handed until it has measured its own box', () => {
+    const { container } = draw(grid(1920));
+    // 1792 of content, 8 x 200-and-up columns, 24px gaps.
+    expect(tileWidth(container)).toBe('203px');
+  });
+
+  it('has no columns to draw without one', () => {
+    const { container } = draw(grid());
+    expect(container.querySelector('[role="button"]')).toBeNull();
+  });
+
+  it('re-fills into the box it measures, and hands each tile its cell', () => {
+    const { container } = draw(grid(1920));
+    const viewport = container.firstElementChild as HTMLElement;
+
+    layout(viewport, { width: 1400 });
+    // 1272 of content: 5 columns of 235, not 8 columns off the right edge.
+    expect(tileWidth(container)).toBe('235px');
+
+    layout(viewport, { width: 2560 });
+    expect(tileWidth(container)).toBe('221px');
+  });
+
+  it('keeps a fixed column count when the design demands one', () => {
+    const { container } = render(
+      onScreen(
+        <VirtualGrid
+          data={TILES}
+          columns={4}
+          ratio={3 / 2}
+          gap={24}
+          width={1920}
+          style={{ height: 600 }}
+          renderItem={(item, _index, cell) => (
+            <Focusable label={`tile ${item.id}`} style={{ width: cell }}>
+              <Box style={{ width: cell, height: 10 }} />
+            </Focusable>
+          )}
+        />,
+      ),
+    );
+    const viewport = container.firstElementChild as HTMLElement;
+    layout(viewport, { width: 1400 });
+    // (1400 - 3 x 24) / 4, still four across.
+    expect(tileWidth(container)).toBe('332px');
+  });
+});

--- a/packages/ui/src/components/organisms/virtual/virtual-grid/virtual-grid.tsx
+++ b/packages/ui/src/components/organisms/virtual/virtual-grid/virtual-grid.tsx
@@ -1,35 +1,72 @@
 // <VirtualGrid>: the browse screens' poster grid, virtualising a library of
 // thousands of tiles via react-tv-space-navigation's virtual focus nodes.
+//
+// The columns are auto-filled from the grid's own measured box, in <Grid>'s
+// vocabulary (`min` / `columns` / `gap`), rather than computed by the caller
+// against a fixed stage: a television is 1920 wide, a desktop window is
+// whatever the user dragged it to, and a fixed column count on the second one
+// runs the last tiles off the right edge.
 
-import { type ReactElement, type RefObject, useEffect, useRef } from 'react';
-import { View, type ViewStyle } from 'react-native';
+import {
+  type ReactElement,
+  type RefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { type LayoutChangeEvent, View, type ViewStyle } from 'react-native';
 import {
   SpatialNavigationVirtualizedGrid,
   type SpatialNavigationVirtualizedListRef,
 } from 'react-tv-space-navigation';
+import { cellWidth, columnsFor } from '#ui/components/atoms/grid';
 import { clipStyles, OVERSCAN } from '#ui/components/organisms/virtual/clip';
 import { FocusReporter } from '#ui/lib/focus-report';
 import { markGridFocus } from '#ui/lib/perf';
 
 const NO_POINTER = { pointerEvents: 'none' } as const;
+const VIEWPORT: ViewStyle = { flex: 1, minHeight: 0 };
 
 import { useWheelScroll } from './use-wheel-rows';
 
 interface VirtualGridProps<T> {
   data: readonly T[];
-  columns: number;
-  /** Row pitch in px (tile height + gap); rows must share a single height, since
-   *  scroll offsets are computed from it up front. */
-  itemHeight: number;
-  renderItem: (item: T, index: number) => ReactElement;
+  /** The narrowest a tile may be. The grid fits as many as the room allows, the
+   *  way `auto-fill` does in CSS and `<Grid min>` does for a static grid. */
+  min?: number;
+  /** A fixed column count, for a design that demands one whatever the width.
+   *  Wins over `min`. */
+  columns?: number;
+  /** Tile height ÷ tile width (a 2:3 poster is 1.5), which with the measured
+   *  cell width is the row pitch. */
+  ratio?: number;
+  /** An explicit row pitch in px (tile height + `rowGap`), for tiles that are
+   *  not `ratio`-shaped. Wins over `ratio`. */
+  itemHeight?: number;
+  /** Between tiles in a row, and what the column maths removes. */
+  gap?: number;
+  /** Between rows. Defaults to `gap`. */
+  rowGap?: number;
+  /** Inset of the rows. Not of the viewport, which is what clips: padding there
+   *  would inset the clip and shave the rows. */
+  px?: number;
+  /** Room above the first row, for a focused tile's ring and scale: the list
+   *  parks the focused row at the content origin and the clip is flush there. */
+  pt?: number;
+  /** The box width to assume until the grid has measured its own: the design
+   *  width. Without one the first frame has no columns to draw. */
+  width?: number;
+  /** Given the tile's index and the pixel width of the cell it lands in, so a
+   *  tile can size its own artwork request to the column it is drawn at. */
+  renderItem: (item: T, index: number, width: number) => ReactElement;
   /** Scrolls with the first row; needs `headerHeight` set alongside it. */
   header?: ReactElement;
   headerHeight?: number;
-  rowStyle?: ViewStyle;
-  /** The viewport that clips: give it a bounded height (`flex: 1`) or nothing scrolls. */
+  /** The viewport that clips. Defaults to filling its parent; give it a bounded
+   *  height either way, or nothing scrolls. */
   style?: ViewStyle;
-  /** Padding for the rows, not the viewport (there it would clip into them). */
-  contentStyle?: ViewStyle;
   onEndReached?: () => void;
   /** Opens the list on this ROW (not item index) with focus, via the list's ref
    *  since the row isn't mounted yet for `autoFocus` to reach. */
@@ -37,7 +74,7 @@ interface VirtualGridProps<T> {
 }
 
 /**
- * A vertically scrolling grid of fixed-size tiles, rendering only the rows near
+ * A vertically scrolling grid of auto-filled tiles, rendering only the rows near
  * the viewport.
  *
  * The library translates its content rather than scrolling a real viewport, so
@@ -45,19 +82,25 @@ interface VirtualGridProps<T> {
  */
 function VirtualGrid<T>({
   data,
+  min,
   columns,
+  ratio = 1,
   itemHeight,
+  gap = 24,
+  rowGap,
+  px = 0,
+  pt = 0,
+  width,
   renderItem,
   header,
   headerHeight,
-  rowStyle,
   style,
-  contentStyle,
   onEndReached,
   initialIndex,
 }: Readonly<VirtualGridProps<T>>) {
   const list = useRef<SpatialNavigationVirtualizedListRef>(null);
   const viewport = useRef<View>(null);
+  const [measured, setMeasured] = useState(0);
 
   // Mount-only: this is where the list OPENS. Re-running on prop change would
   // yank focus back out from under the D-pad.
@@ -66,48 +109,78 @@ function VirtualGrid<T>({
     if (initialIndex) list.current?.focus(initialIndex);
   }, []);
 
-  const lastRow = Math.max(0, Math.ceil(data.length / columns) - 1);
+  // A television never resizes, so this settles on the first layout and the
+  // state never changes again; a desktop window pays one re-render per width it
+  // comes to rest at, which is why the width is rounded before it is compared.
+  const onLayout = useCallback((event: LayoutChangeEvent) => {
+    const next = Math.round(event.nativeEvent.layout.width);
+    setMeasured((current) => (current === next ? current : next));
+  }, []);
+
+  const rowGapPx = rowGap ?? gap;
+  const geometry = useMemo(() => {
+    const room = Math.max(0, (measured || width || 0) - px * 2);
+    const count = columns ?? (min ? columnsFor(room, min, gap) : 1);
+    const cell = cellWidth(room, count, gap);
+    return { count, cell, pitch: itemHeight ?? Math.round(cell * ratio) + rowGapPx };
+  }, [columns, gap, itemHeight, measured, min, px, ratio, rowGapPx, width]);
+
+  const contentStyle = useMemo<ViewStyle>(
+    () => ({ paddingHorizontal: px, paddingTop: pt }),
+    [px, pt],
+  );
+  const rowStyle = useMemo<ViewStyle>(() => ({ gap }), [gap]);
+
+  const cell = geometry.cell;
+  const renderCell = useCallback(
+    ({ item, index }: { item: T; index: number }) => (
+      // Reports which cell took focus, for the on-screen read-out: a remote bug
+      // on a television has no inspector to ask.
+      <FocusReporter
+        onFocus={() => markGridFocus(Math.floor(index / geometry.count), index % geometry.count)}
+      >
+        {renderItem(item, index, cell)}
+      </FocusReporter>
+    ),
+    [cell, geometry.count, renderItem],
+  );
+
+  const lastRow = Math.max(0, Math.ceil(data.length / geometry.count) - 1);
   // While a gesture runs (fraction non-null) the pointer is shut out, or the
   // navigator would focus whatever slides beneath the stationary cursor.
-  const fraction = useWheelScroll(viewport, list, lastRow, header ? 1 : 0, itemHeight);
+  const fraction = useWheelScroll(viewport, list, lastRow, header ? 1 : 0, geometry.pitch);
 
   return (
-    <View style={style} ref={viewport}>
+    <View style={style ?? VIEWPORT} ref={viewport} onLayout={onLayout}>
       {/* Inert on the inner clip, not the viewport: the wheel listener lives on
           the viewport's node, and pointer-events none there would drop the pan
           events too. */}
       <View style={[clipStyles.column, fraction === null ? null : NO_POINTER]}>
-        {/* The library's ref type omits `| null`, which every real ref has before it attaches. */}
-        <SpatialNavigationVirtualizedGrid
-          ref={list as RefObject<SpatialNavigationVirtualizedListRef>}
-          data={data as T[]}
-          numberOfColumns={columns}
-          itemHeight={itemHeight}
-          additionalRenderedRows={OVERSCAN}
-          // A GRID is not a rail. The library's default, `stick-to-start`,
-          // parks the focused row at the top of the viewport, so every press of
-          // Down scrolls the grid by exactly one row and the ring never moves:
-          // the posters slide underneath it and the set reads as if the arrow
-          // did nothing. Rails want that behaviour - a rail's focused tile
-          // belongs at the left edge - but a grid has rows above and below worth
-          // seeing, so it scrolls only when the selection reaches an edge.
-          scrollBehavior="jump-on-scroll"
-          header={header}
-          headerSize={headerHeight}
-          rowContainerStyle={rowStyle}
-          style={contentStyle}
-          freeScrollFraction={fraction}
-          onEndReached={onEndReached}
-          renderItem={({ item, index }) => (
-            // Reports which cell took focus, for the on-screen read-out: a
-            // remote bug on a television has no inspector to ask.
-            <FocusReporter
-              onFocus={() => markGridFocus(Math.floor(index / columns), index % columns)}
-            >
-              {renderItem(item, index)}
-            </FocusReporter>
-          )}
-        />
+        {cell > 0 ? (
+          /* The library's ref type omits `| null`, which every real ref has before it attaches. */
+          <SpatialNavigationVirtualizedGrid
+            ref={list as RefObject<SpatialNavigationVirtualizedListRef>}
+            data={data as T[]}
+            numberOfColumns={geometry.count}
+            itemHeight={geometry.pitch}
+            additionalRenderedRows={OVERSCAN}
+            // A GRID is not a rail. The library's default, `stick-to-start`,
+            // parks the focused row at the top of the viewport, so every press of
+            // Down scrolls the grid by exactly one row and the ring never moves:
+            // the posters slide underneath it and the set reads as if the arrow
+            // did nothing. Rails want that behaviour - a rail's focused tile
+            // belongs at the left edge - but a grid has rows above and below worth
+            // seeing, so it scrolls only when the selection reaches an edge.
+            scrollBehavior="jump-on-scroll"
+            header={header}
+            headerSize={headerHeight}
+            rowContainerStyle={rowStyle}
+            style={contentStyle}
+            freeScrollFraction={fraction}
+            onEndReached={onEndReached}
+            renderItem={renderCell}
+          />
+        ) : null}
       </View>
     </View>
   );

--- a/server/crates/kroma-engine/src/services/search/mod.rs
+++ b/server/crates/kroma-engine/src/services/search/mod.rs
@@ -6,6 +6,7 @@
 mod query;
 mod schema;
 
+use std::collections::HashSet;
 use std::sync::{Arc, Mutex, RwLock};
 
 use anyhow::Result;
@@ -34,7 +35,17 @@ pub enum HitKind {
 pub struct Hit {
     pub id: String,
     pub kind: HitKind,
+    /// Set on an episode: the show it belongs to.
+    pub show_id: Option<String>,
 }
+
+// A show title lives on every one of its episodes, so a query naming the show
+// matches the whole season list. Collect several pages' worth of raw hits, fold
+// the episodes back under their show, and only then cut to `limit`.
+const CANDIDATE_FACTOR: usize = 8;
+const MAX_CANDIDATES: usize = 400;
+// A show that did NOT match itself is represented by its best few episodes.
+const MAX_EPISODES_PER_SHOW: usize = 3;
 
 struct Active {
     reader: IndexReader,
@@ -98,9 +109,11 @@ impl SearchEngine {
             return Vec::new();
         };
         let searcher = active.reader.searcher();
+        let limit = limit.max(1);
+        let candidates = limit.saturating_mul(CANDIDATE_FACTOR).min(MAX_CANDIDATES).max(limit);
         // tantivy 0.26 removed TopDocs' blanket Collector impl; `.order_by_score()`
         // yields the score-ordered collector.
-        let Ok(top) = searcher.search(&query, &TopDocs::with_limit(limit.max(1)).order_by_score())
+        let Ok(top) = searcher.search(&query, &TopDocs::with_limit(candidates).order_by_score())
         else {
             return Vec::new();
         };
@@ -116,10 +129,40 @@ impl SearchEngine {
                 "episode" => HitKind::Episode,
                 _ => HitKind::Movie,
             };
-            hits.push(Hit { id, kind });
+            let show_id = (kind == HitKind::Episode)
+                .then(|| field_str(&doc, self.fields.show_id))
+                .filter(|s| !s.is_empty());
+            hits.push(Hit { id, kind, show_id });
         }
-        hits
+        collapse_episodes(hits, limit)
     }
+}
+
+/// Drops every episode whose show is itself a hit, caps what is left at
+/// [`MAX_EPISODES_PER_SHOW`] per show, and truncates to `limit`. Relevance order
+/// is preserved, so a show keeps the rank its own document earned.
+fn collapse_episodes(hits: Vec<Hit>, limit: usize) -> Vec<Hit> {
+    let shows: HashSet<String> =
+        hits.iter().filter(|h| h.kind == HitKind::Show).map(|h| h.id.clone()).collect();
+    let mut kept_per_show: HashMap<String, usize> = HashMap::new();
+    let mut out = Vec::with_capacity(limit);
+    for hit in hits {
+        if out.len() == limit {
+            break;
+        }
+        if let Some(show_id) = hit.show_id.as_deref() {
+            if shows.contains(show_id) {
+                continue;
+            }
+            let kept = kept_per_show.entry(show_id.to_string()).or_default();
+            if *kept >= MAX_EPISODES_PER_SHOW {
+                continue;
+            }
+            *kept += 1;
+        }
+        out.push(hit);
+    }
+    out
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -163,6 +206,9 @@ fn add_item(writer: &mut IndexWriter, f: &Fields, item: &MediaItem, kind: &str, 
     }
     if let Some(st) = &item.show_title {
         doc.add_text(f.show_title, st);
+    }
+    if let Some(sid) = &item.show_id {
+        doc.add_text(f.show_id, sid);
     }
     add_meta(&mut doc, f, &item.title, item.metadata.as_ref());
     add_translations(&mut doc, f, &item.title, tr);

--- a/server/crates/kroma-engine/src/services/search/query.rs
+++ b/server/crates/kroma-engine/src/services/search/query.rs
@@ -13,12 +13,14 @@ use tantivy::Term;
 use super::schema::Fields;
 
 // Field weights: a title hit outranks an alt-title/cast hit, which outranks a
-// genre hit, which outranks a loose overview hit.
+// genre hit, which outranks a loose overview hit. `show_title` sits near the
+// bottom on purpose: it is there so "breaking bad ozymandias" resolves to the
+// episode, not so that every episode of a show competes with the show itself.
 fn weights(f: &Fields) -> [(Field, f32); 6] {
     [
         (f.title, 6.0),
         (f.alt_title, 4.0),
-        (f.show_title, 4.0),
+        (f.show_title, 1.5),
         (f.cast, 3.0),
         (f.genres, 2.0),
         (f.overview, 1.0),

--- a/server/crates/kroma-engine/src/services/search/schema.rs
+++ b/server/crates/kroma-engine/src/services/search/schema.rs
@@ -16,6 +16,7 @@ pub(super) const ANALYZER: &str = "kroma";
 pub(super) struct Fields {
     pub id: Field,
     pub kind: Field,
+    pub show_id: Field,
     pub title: Field,
     pub alt_title: Field,
     pub show_title: Field,
@@ -37,6 +38,8 @@ pub(super) fn build() -> (Schema, Fields) {
     // tokens, no fuzzy matching on them.
     let id = b.add_text_field("id", STRING | STORED);
     let kind = b.add_text_field("kind", STRING | STORED);
+    // Read back to fold an episode under its show; never itself a query target.
+    let show_id = b.add_text_field("show_id", STORED);
     let title = text(&mut b, "title");
     let alt_title = text(&mut b, "alt_title");
     let show_title = text(&mut b, "show_title");
@@ -44,7 +47,7 @@ pub(super) fn build() -> (Schema, Fields) {
     let genres = text(&mut b, "genres");
     let overview = text(&mut b, "overview");
     let schema = b.build();
-    let fields = Fields { id, kind, title, alt_title, show_title, cast, genres, overview };
+    let fields = Fields { id, kind, show_id, title, alt_title, show_title, cast, genres, overview };
     (schema, fields)
 }
 

--- a/server/crates/kroma-engine/src/services/search/tests.rs
+++ b/server/crates/kroma-engine/src/services/search/tests.rs
@@ -57,24 +57,42 @@ fn movie(id: &str, title: &str, m: Option<Metadata>) -> MediaItem {
     }
 }
 
-fn engine() -> SearchEngine {
-    let e = SearchEngine::new().unwrap();
-    let movies = vec![
-        movie("1", "The Avengers", Some(meta("The Avengers", "Earth's mightiest heroes", &["Action"], &["Robert Downey Jr"]))),
-        movie("2", "Amélie", Some(meta("Amélie", "A shy waitress in Paris", &["Romance"], &["Audrey Tautou"]))),
-    ];
-    let shows = vec![Show {
-        id: "s1".into(),
-        title: "Breaking Bad".into(),
+fn episode(id: &str, show_id: &str, show_title: &str, title: &str) -> MediaItem {
+    MediaItem {
+        kind: Kind::Episode,
+        show_id: Some(show_id.into()),
+        show_title: Some(show_title.into()),
+        episode_title: Some(title.into()),
+        ..movie(id, show_title, None)
+    }
+}
+
+fn show(id: &str, title: &str, m: Option<Metadata>) -> Show {
+    Show {
+        id: id.into(),
+        title: title.into(),
         year: None,
         library: "lib".into(),
         season_count: 0,
         episode_count: 0,
         video: None,
         added_at: String::new(),
-        metadata: Some(meta("Breaking Bad", "A chemistry teacher turns to crime", &["Crime", "Drama"], &["Bryan Cranston"])),
+        metadata: m,
         progress: None,
-    }];
+    }
+}
+
+fn engine() -> SearchEngine {
+    let e = SearchEngine::new().unwrap();
+    let movies = vec![
+        movie("1", "The Avengers", Some(meta("The Avengers", "Earth's mightiest heroes", &["Action"], &["Robert Downey Jr"]))),
+        movie("2", "Amélie", Some(meta("Amélie", "A shy waitress in Paris", &["Romance"], &["Audrey Tautou"]))),
+    ];
+    let shows = vec![show(
+        "s1",
+        "Breaking Bad",
+        Some(meta("Breaking Bad", "A chemistry teacher turns to crime", &["Crime", "Drama"], &["Bryan Cranston"])),
+    )];
     e.rebuild(&movies, &shows, &[]).unwrap();
     e
 }
@@ -102,6 +120,44 @@ fn cast_and_genre_and_prefix() {
     assert_eq!(top_id(&e, "cranston").as_deref(), Some("s1"));
     assert_eq!(top_id(&e, "crime").as_deref(), Some("s1"));
     assert_eq!(top_id(&e, "brea").as_deref(), Some("s1")); // prefix
+}
+
+fn series_engine() -> SearchEngine {
+    let e = SearchEngine::new().unwrap();
+    let episodes: Vec<MediaItem> = (1..=12)
+        .map(|n| episode(&format!("e{n}"), "s1", "House of the Dragon", &format!("Episode {n}")))
+        .chain(std::iter::once(episode("e-dance", "s1", "House of the Dragon", "A Dance of Dragons")))
+        .collect();
+    e.rebuild(&[], &[show("s1", "House of the Dragon", None)], &episodes).unwrap();
+    e
+}
+
+fn ids(e: &SearchEngine, q: &str, limit: usize) -> Vec<String> {
+    e.search(q, limit).into_iter().map(|h| h.id).collect()
+}
+
+#[test]
+fn a_show_title_returns_the_show_and_not_its_season_list() {
+    assert_eq!(ids(&series_engine(), "house of dragon", 24), ["s1"]);
+}
+
+#[test]
+fn an_episode_still_wins_when_the_query_names_it() {
+    // `show_title` is indexed so the show's name can narrow an episode search;
+    // the episode must still be the answer when its own title carries the query.
+    let got = ids(&series_engine(), "house of the dragon a dance of dragons", 24);
+    assert_eq!(got, ["e-dance"]);
+}
+
+#[test]
+fn episodes_of_a_show_that_did_not_match_are_capped() {
+    let e = SearchEngine::new().unwrap();
+    let episodes: Vec<MediaItem> =
+        (1..=10).map(|n| episode(&format!("e{n}"), "s1", "Breaking Bad", "Ozymandias")).collect();
+    // No show document at all: the episodes are the only thing that can match.
+    e.rebuild(&[], &[], &episodes).unwrap();
+
+    assert_eq!(e.search("ozymandias", 24).len(), MAX_EPISODES_PER_SHOW);
 }
 
 #[test]


### PR DESCRIPTION
Un poil de contexte: sur macOS la fenêtre du shell desktop est libre, et les écrans de navigation ne rétrécissaient pas, ils se faisaient couper — dernière colonne de posters, cartes de genres, ligne d'épisodes, tout partait à droite.

## Ce qui n'allait pas

Chaque grille était de l'arithmétique contre un plateau de 1920 :

| Endroit | Constante |
|---|---|
| `home/PosterGrid.tsx` | `CONTENT_WIDTH = 1792`, `COLUMNS = 8` |
| `TvGenres.tsx` | `GENRE_COLUMNS = 5`, `CARD_W = 320` |
| `detail/EpisodeRow.tsx` | `EPISODE_COLUMN_W = 1920 - 128` |
| `TvSearch.tsx` | `RESULTS_WIDTH` dérivé de 1920 |

`clients/tv-web/src/stage.ts` documentait déjà le diagnostic et la sortie : *« The real "no surround" answer is a responsive 10-foot layout — columns and gutters derived from the viewport instead of from 1920 — which is a change to the design system, not to this shell. »* C'est ce changement-là.

## Le kit

**`VirtualGrid`** parle la grammaire de `<Grid>` (`min` / `columns` / `gap` / `rowGap` / `px` / `pt`), mesure son viewport et en déduit colonnes, largeur de cellule et pas de ligne. `renderItem(item, index, width)` reçoit la cellule, donc la tuile dimensionne sa propre requête d'artwork. `contentStyle` / `rowStyle` disparaissent — le composant construit ses styles, le calcul ne peut plus diverger de la mise en page.

Perf : l'état de mesure n'est réécrit que si la largeur arrondie change (une TV se stabilise à la première passe et ne re-rend jamais), géométrie et styles mémoïsés, `renderItem` enveloppé dans un `useCallback` (il ne l'était pas), et `width` sert de largeur assumée avant mesure — pas de frame blanche.

**`Grid`** déclare lui-même ses lignes comme grille de navigation, ce que `TvGenres` et `TvSearchResults` recopiaient à la main. Coût : +1 nœud / +1 profondeur sur `grid/preview` (budget DOM regénéré) ; les snapshots de peinture sont inchangés à l'octet près.

**`CategoryTile`** remplit sa cellule au lieu d'imposer `width = 340`.

## L'artwork

`artworkWidth` snappe sur l'échelle du serveur (`[160, 240, 320, 480, 780, 960]`, miroir de `IMAGE_WIDTHS` dans `server/src/api/images.rs`). Sans ça, une cellule à 203px puis 219px après un resize crée deux clés de cache — deux fetches, deux décodages — pour la même rendition. Rien de servi ne change, seule l'URL se stabilise.

## Le plateau

`fitStage(w, h)` (`@kroma/tv/stage`) prend l'échelle sur la **hauteur** — la typo 10-foot garde sa taille dessinée — et rend la **largeur** au canvas : une fenêtre plus large qu'un 16:9 gagne des colonnes au lieu de bandes latérales. Les deux shells l'utilisent via `--kroma-stage-width` / `--kroma-stage-scale`.

Le plancher reste la largeur de design : la barre du haut est un jeu de libellés fixes de part et d'autre d'une pilule centrée (~1760px), elle n'a pas de colonne à lâcher. **Le descendre est un changement du chrome, pas de ce nombre** — c'est le prochain morceau si on veut qu'une fenêtre étroite remplisse le cadre.

Et tout shell desktop reçoit ce plateau, plus seulement les écrans fixes Linux : le mode « free-size » était une promesse que la mise en page en pixels fixes n'a jamais tenue.

## Vérification

`typecheck`, `check` et `test` verts sur `packages/ui packages/tv packages/client packages/core clients` (3975 tests). Nouveaux tests : `fitStage` (7 formes de fenêtre), `VirtualGrid` sur le chemin de mesure (1920 → 203px, 1400 → 235px, 2560 → 221px, et `columns` qui tient), et le snapping d'artwork.

Pas de vérification dans l'app réelle : `server/target` est périmé (crates encore nommés `luma_*`) et un build serveur complet aurait été long. Tout est validé par tests, pas par capture.