### PR TITLE
fix(kit): read the kit's history off .story.mdx, not .stories.tsx

### DIFF
--- a/packages/bundler/src/git-history-convention.test.ts
+++ b/packages/bundler/src/git-history-convention.test.ts
@@ -1,0 +1,42 @@
+// The grouping in git-history-parse.ts keys every component off its story file,
+// so the suffix it looks for has to be the suffix the kit actually writes. The
+// other tests here all supply their own fixtures, which means they agree with
+// whatever the constant says and cannot notice when the two drift apart: the
+// suffix sat at `.stories.tsx` for the whole of the `.story.mdx` migration, and
+// ui.kroma.tv shipped "no history to list" while every test stayed green.
+//
+// This one reads the real tree instead, so the constant is pinned to the repo.
+
+import { readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { groupFiles } from './git-history-parse.ts';
+
+const REPO = fileURLToPath(new URL('../../../', import.meta.url));
+const ROOT = 'packages/ui/src';
+
+function tree(dir: string, prefix: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(`${REPO}${dir}`, { withFileTypes: true })) {
+    const path = `${dir}/${entry.name}`;
+    if (entry.isDirectory()) tree(path, prefix, out);
+    else out.push(path);
+  }
+  return out;
+}
+
+describe('the story suffix the grouping keys on', () => {
+  const files = tree(ROOT, ROOT);
+
+  it('finds the kit its stories', () => {
+    expect(files.length).toBeGreaterThan(0);
+    const groups = groupFiles(files);
+    expect(groups.size).toBeGreaterThan(0);
+  });
+
+  it('groups nearly every file in the kit under one of them', () => {
+    const groups = groupFiles(files);
+    const grouped = new Set([...groups.values()].flat());
+    // Not all of it: assets and a few top-level modules sit above any story.
+    expect(grouped.size).toBeGreaterThan(files.length / 2);
+  });
+});

--- a/packages/bundler/src/git-history-group.test.ts
+++ b/packages/bundler/src/git-history-group.test.ts
@@ -8,7 +8,7 @@ import {
 } from './git-history-parse.ts';
 
 const BUTTON = 'packages/ui/src/components/atoms/button/button.tsx';
-const STORY = 'packages/ui/src/components/atoms/button/button.stories.tsx';
+const STORY = 'packages/ui/src/components/atoms/button/button.story.mdx';
 const OLD_BUTTON = 'packages/ui/src/button.tsx';
 
 describe('attribute', () => {
@@ -90,18 +90,18 @@ describe('groupFiles', () => {
   it('attaches a nested helper to the nearest story above it', () => {
     const player = 'packages/ui/src/components/organisms/player';
     const files = [
-      `${player}/player.stories.tsx`,
+      `${player}/player.story.mdx`,
       `${player}/hooks/use-controls.ts`,
-      `${player}/parts/top-bar/top-bar.stories.tsx`,
+      `${player}/parts/top-bar/top-bar.story.mdx`,
       `${player}/parts/top-bar/top-bar.tsx`,
     ];
     const groups = groupFiles(files);
-    expect(groups.get(`${player}/player.stories.tsx`)).toEqual([
-      `${player}/player.stories.tsx`,
+    expect(groups.get(`${player}/player.story.mdx`)).toEqual([
+      `${player}/player.story.mdx`,
       `${player}/hooks/use-controls.ts`,
     ]);
-    expect(groups.get(`${player}/parts/top-bar/top-bar.stories.tsx`)).toEqual([
-      `${player}/parts/top-bar/top-bar.stories.tsx`,
+    expect(groups.get(`${player}/parts/top-bar/top-bar.story.mdx`)).toEqual([
+      `${player}/parts/top-bar/top-bar.story.mdx`,
       `${player}/parts/top-bar/top-bar.tsx`,
     ]);
   });
@@ -109,19 +109,17 @@ describe('groupFiles', () => {
   it('splits a folder holding several stories by file name', () => {
     const root = 'packages/ui/src/foundations';
     const files = [
-      `${root}/colors.stories.tsx`,
+      `${root}/colors.story.mdx`,
       `${root}/colors.test.ts`,
-      `${root}/typography.stories.tsx`,
+      `${root}/typography.story.mdx`,
       `${root}/shared.ts`,
     ];
     const groups = groupFiles(files);
-    expect(groups.get(`${root}/colors.stories.tsx`)).toEqual([
-      `${root}/colors.stories.tsx`,
+    expect(groups.get(`${root}/colors.story.mdx`)).toEqual([
+      `${root}/colors.story.mdx`,
       `${root}/colors.test.ts`,
     ]);
-    expect(groups.get(`${root}/typography.stories.tsx`)).toEqual([
-      `${root}/typography.stories.tsx`,
-    ]);
+    expect(groups.get(`${root}/typography.story.mdx`)).toEqual([`${root}/typography.story.mdx`]);
     expect([...groups.values()].flat()).not.toContain(`${root}/shared.ts`);
   });
 
@@ -181,7 +179,7 @@ describe('entriesOf', () => {
   });
 
   it('keys the entries by path, whatever order the groups arrived in', () => {
-    const at = (name: string) => `packages/ui/src/components/atoms/${name}.stories.tsx`;
+    const at = (name: string) => `packages/ui/src/components/atoms/${name}.story.mdx`;
     const groups = new Map(['chip', 'avatar', 'button'].map((name) => [at(name), [at(name)]]));
     const found = new Map([...groups.keys()].map((key) => [key, commits(newer)]));
     expect(Object.keys(entriesOf(groups, found, new Set(), 6))).toEqual([

--- a/packages/bundler/src/git-history-parse.test.ts
+++ b/packages/bundler/src/git-history-parse.test.ts
@@ -15,7 +15,7 @@ function logOf(...commits: { sha: string; date: string; subject: string; body: s
 }
 
 const BUTTON = 'packages/ui/src/components/atoms/button/button.tsx';
-const STORY = 'packages/ui/src/components/atoms/button/button.stories.tsx';
+const STORY = 'packages/ui/src/components/atoms/button/button.story.mdx';
 
 describe('splitPaths', () => {
   it('reads a NUL-separated list without a trailing empty name', () => {
@@ -25,9 +25,9 @@ describe('splitPaths', () => {
 
 describe('parseStatus', () => {
   it('takes the name a staged rename came from as its earlier self', () => {
-    const status = `R  ${STORY}${NUL}packages/ui/src/button.stories.tsx${NUL}`;
+    const status = `R  ${STORY}${NUL}packages/ui/src/button.story.mdx${NUL}`;
     const working = parseStatus(status);
-    expect(working.renamedFrom.get(STORY)).toBe('packages/ui/src/button.stories.tsx');
+    expect(working.renamedFrom.get(STORY)).toBe('packages/ui/src/button.story.mdx');
     expect(working.dirty.has(STORY)).toBe(true);
   });
 

--- a/packages/bundler/src/git-history-parse.ts
+++ b/packages/bundler/src/git-history-parse.ts
@@ -23,7 +23,7 @@ export interface HistoryEntry {
 }
 
 /** Every entry the build could read, keyed by repository-relative path: a
- * component by its `*.stories.tsx`, an article by its own `.page.mdx`. `shallow`
+ * component by its `*.story.mdx`, an article by its own `.page.mdx`. `shallow`
  * says the clone was truncated, in which case there are no entries at all -
  * a creation date read from half a history is a wrong one. */
 export interface GitHistory {
@@ -60,7 +60,7 @@ interface WorkingTree {
 const COMMIT_MARK = '\x01';
 const FIELD_MARK = '\x1f';
 
-const STORY = '.stories.tsx';
+const STORY = '.story.mdx';
 const PAGE = '.page.mdx';
 
 /** The fields `readGitHistory` asks `git log` for, in the order `parseLog`

--- a/packages/bundler/src/git-history-read.test.ts
+++ b/packages/bundler/src/git-history-read.test.ts
@@ -6,8 +6,8 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { historyFingerprint, NO_HISTORY, readGitHistory } from './git-history-read';
 
 const ROOT = 'kit/src';
-const STORY = `${ROOT}/button/button.stories.tsx`;
-const MOVED = `${ROOT}/atoms/button/button.stories.tsx`;
+const STORY = `${ROOT}/button/button.story.mdx`;
+const MOVED = `${ROOT}/atoms/button/button.story.mdx`;
 const PAGE = `${ROOT}/guides/01-intro.page.mdx`;
 
 let repo = '';
@@ -107,9 +107,9 @@ describe('readGitHistory', () => {
   });
 
   it('lists something that exists only in the working tree with no dates at all', async () => {
-    write(`${ROOT}/atoms/chip/chip.stories.tsx`, 'export default {}\n');
+    write(`${ROOT}/atoms/chip/chip.story.mdx`, 'export default {}\n');
     const { entries } = await readGitHistory({ repo, root: ROOT });
-    const chip = entries[`${ROOT}/atoms/chip/chip.stories.tsx`];
+    const chip = entries[`${ROOT}/atoms/chip/chip.story.mdx`];
     expect(chip).toEqual({ dirty: true, commits: [] });
     rmSync(join(repo, ROOT, 'atoms/chip'), { recursive: true, force: true });
   });

--- a/packages/bundler/src/git-history.test.ts
+++ b/packages/bundler/src/git-history.test.ts
@@ -7,7 +7,7 @@ import { gitHistory } from './git-history';
 
 const RESOLVED = '\0virtual:kroma-history';
 const ROOT = 'kit/src';
-const STORY = `${ROOT}/button/button.stories.tsx`;
+const STORY = `${ROOT}/button/button.story.mdx`;
 
 interface Hooks {
   load: (id: string) => Promise<string | null>;

--- a/packages/bundler/src/story-scenes.mjs
+++ b/packages/bundler/src/story-scenes.mjs
@@ -12,7 +12,7 @@
 // `export const __scenes = [...]` beside the document.
 //
 // Because this runs in the shared MDX options, Metro compiles it too - so a
-// scene's source text reaches a television, which the `.stories.tsx` reader
+// scene's source text reaches a television, which the `.story.mdx` reader
 // (story-code-read.ts, Vite-only) never could.
 //
 // Plain `.mjs` for the same reason as mdx.mjs beside it: Metro's transformer

--- a/packages/workbench/src/history.ts
+++ b/packages/workbench/src/history.ts
@@ -26,7 +26,7 @@ interface HistoryEntry {
 }
 
 /** Every entry a build could read, keyed by repository-relative path: a
- * component by its `*.stories.tsx`, an article by its own `.page.mdx`.
+ * component by its `*.story.mdx`, an article by its own `.page.mdx`.
  * `shallow` says the clone was truncated, which is why there is nothing here. */
 interface KitHistory {
   entries: Readonly<Record<string, HistoryEntry>>;

--- a/packages/workbench/src/registry.ts
+++ b/packages/workbench/src/registry.ts
@@ -82,7 +82,7 @@ function tierFor(path: string): string {
   return 'Other';
 }
 
-/** `.../list-row/list-row.stories.tsx` -> `ListRow`: the name a story file
+/** `.../list-row/list-row.story.mdx` -> `ListRow`: the name a story file
  * implies, for every story that does not spell its own. */
 function nameFromPath(path: string, suffix: string): string {
   const file = path.slice(path.lastIndexOf('/') + 1, -suffix.length);

--- a/packages/workbench/src/view.ts
+++ b/packages/workbench/src/view.ts
@@ -1,7 +1,7 @@
 // Which view of a story is on the canvas, and how one is spelled in an address.
 //
 // Apart from the routing adapters that read and write it, because the story SDK
-// reads a view too: nothing here imports anything, so a `*.stories.tsx` that
+// reads a view too: nothing here imports anything, so a `*.story.mdx` that
 // pulls in `@kroma/workbench/story` does not pull in the design system with it.
 
 type View = 'preview' | 'docs' | 'matrix' | `scene:${number}` | `demo:${number}`;


### PR DESCRIPTION
`ui.kroma.tv/what-changed` has been showing:

> This build was made outside a git checkout, so there is no history to list.

It is not the environment. `kit.yml` already checks out with `fetch-depth: 0`, with a comment explaining why. Reproduced locally in a full checkout:

```
shallow: false   entries: 0
```

## Cause

`groupFiles` keys every component off its story file:

```ts
const STORY = '.stories.tsx';   // matched 0 of 877 tracked files
```

The kit moved to `.story.mdx` (101 files under `packages/ui/src`) and this constant did not. Every group came out empty, so the page fell through to its no-history branch. Each stage around it was fine: 877 files tracked, 610 commits parsed, 877 paths attributed. Only the grouping dropped everything.

After the fix, the same call returns **101 entries** with real dates.

The message compounded the confusion: an empty result reports as *"not a git checkout"* when git had answered fine and simply had nothing to group. That is why this read as an environment problem for so long.

## Why no test caught it

Every test in this area supplies its own fixtures, so they agree with whatever the constant says. They stayed green for the entire `.story.mdx` migration while production shipped an empty page.

`git-history-convention.test.ts` reads the real tree instead and asserts the suffix still finds the kit its stories. **Verified it fails on the old value** rather than only that it passes on the new one.

## Also

Four stale docstrings naming `.stories.tsx`. `nameFromPath` in the workbench already took its suffix as an argument, so no other logic assumed the old name; the constant was the only functional hit.

## Checks

`bun run test packages/bundler packages/workbench` 597 pass · typecheck clean on both packages · `biome check` clean.
