### PR TITLE
fix(synology): one version shape, and assets that outlive the catalog

### DIFF
--- a/.github/workflows/synology.yml
+++ b/.github/workflows/synology.yml
@@ -367,8 +367,17 @@ jobs:
   # build uninstallable ("Failed to verify the package ... by MD5"). A build now
   # keeps its own URL until it ages out, and a client holding a slightly stale
   # catalog still downloads bytes whose md5 matches. The .info.json sidecar
-  # rides along so the dynamic source knows the real canary version + md5
+  # rides along so the dynamic source knows the real nightly version + md5
   # without downloading the .spk.
+  #
+  # Retention is by AGE, not by count. It was "keep the newest two", which is a
+  # window measured in BUILDS while the thing that outlives it - the catalog
+  # worker's stale copy - is measured in DAYS (604800s in apps/packages
+  # lib/catalog.ts, served whenever the GitHub API call fails). Two pushes eight
+  # minutes apart were enough to delete an asset a live catalog still pointed at,
+  # which is what made packages.kroma.tv hand out 404s. KEEP_DAYS must stay
+  # comfortably above that stale window; the floor keeps the last few builds
+  # whatever their age, so a quiet fortnight cannot empty the release.
   publish-nightly:
     name: Publish nightly prerelease
     if: always() && !cancelled() && needs.build.result == 'success' && github.ref == 'refs/heads/main'
@@ -398,10 +407,21 @@ jobs:
             || gh release create nightly --prerelease --title "KROMA nightly" \
                  --notes "Rolling nightly build from main. Unstable; auto-updates via the nightly package source."
           gh release upload nightly "$SPK" "$SPK.info.json" --clobber
+
+          # Older than KEEP_DAYS *and* outside the newest KEEP_MIN. Both have to
+          # hold, so neither a burst of pushes nor a quiet fortnight can strand a
+          # catalog that still advertises one of these URLs.
+          KEEP_DAYS=14
+          KEEP_MIN=5
+          CUTOFF="$(date -u -d "${KEEP_DAYS} days ago" +%s)"
           gh api "repos/${GH_REPO}/releases/tags/nightly" \
-            --jq '.assets[].name | select(endswith(".spk"))' \
-            | grep -vxF "$NAME" | sort -Vr | tail -n +3 \
-            | while read -r OLD; do
-                gh release delete-asset nightly "$OLD" -y || true
-                gh release delete-asset nightly "$OLD.info.json" -y || true
+            --jq '.assets[] | select(.name | endswith(".spk")) | [.name, .created_at] | @tsv' \
+            | awk -F'\t' -v cur="$NAME" '$1 != cur' | sort -Vr | tail -n "+${KEEP_MIN}" \
+            | while IFS="$(printf '\t')" read -r OLD CREATED; do
+                [ -n "$OLD" ] || continue
+                if [ "$(date -u -d "$CREATED" +%s)" -lt "$CUTOFF" ]; then
+                  echo "pruning $OLD (created $CREATED)"
+                  gh release delete-asset nightly "$OLD" -y || true
+                  gh release delete-asset nightly "$OLD.info.json" -y || true
+                fi
               done

--- a/apps/packages/src/lib/catalog.test.ts
+++ b/apps/packages/src/lib/catalog.test.ts
@@ -112,8 +112,24 @@ describe('dsmVersion', () => {
     expect(dsmVersion('0.1.31-3447024')).toBe('0.1.31-3447024');
   });
 
-  it('collapses a canary X.Y.Z.BUILD to X.Y.Z-BUILD (DSM hides the 4th segment)', () => {
+  it('collapses a legacy X.Y.Z.BUILD to X.Y.Z-BUILD (DSM hides the 4th segment)', () => {
     expect(dsmVersion('0.1.37.3480000')).toBe('0.1.37-3480000');
+  });
+
+  // The bug this whole shape exists to prevent: build.sh used to stamp INFO in
+  // one shape while the catalog advertised another, so the installed version
+  // outranked everything on offer and no Update button ever appeared. What
+  // build.sh writes now has to reach the catalog untouched.
+  it('leaves what build.sh stamps alone, so INFO and the catalog agree', () => {
+    for (const stamped of ['0.1.39-3482771', '0.1.39-3482844', '1.0.0-1']) {
+      expect(dsmVersion(stamped)).toBe(stamped);
+    }
+  });
+
+  it('orders two nightlies of one X.Y.Z, so no version bump is needed between them', () => {
+    expect(
+      cmpDsmVersion(dsmVersion('0.1.39-3482844'), dsmVersion('0.1.39-3482771')),
+    ).toBeGreaterThan(0);
   });
 
   it('collapses the older doubly-stamped X.Y.Z.BUILD-BUILD to the same string', () => {

--- a/apps/packages/src/lib/catalog.ts
+++ b/apps/packages/src/lib/catalog.ts
@@ -192,8 +192,15 @@ const splitBuild = (raw: string): [string, string | undefined] => {
 };
 
 /** The version string DSM's Package Center will DISPLAY: `major.minor.micro-build`,
- *  the build taken from the `-suffix` or else the 4th segment. DSM hides a package
- *  whose feature version carries a large 4th segment. */
+ *  the build taken from the `-suffix` or else the 4th segment. Package Center hides
+ *  a package whose feature version carries a large 4th segment.
+ *
+ *  build.sh now stamps that shape directly, so for anything it produces this is
+ *  the identity. It stays because the nightly release still holds `X.Y.Z.BUILD`
+ *  assets from before that change, and rewriting them is what let the catalog
+ *  list them at all. Rewriting is ALSO why the Update button never appeared for
+ *  them: an installed `0.1.38.3480473` outranks every `0.1.38-*` the catalog can
+ *  offer, so those installs move only when X.Y.Z does. */
 export function dsmVersion(raw: string): string {
   const [feat, suffix] = splitBuild(raw);
   const seg = feat.split('.');

--- a/clients/synology/build.sh
+++ b/clients/synology/build.sh
@@ -14,15 +14,26 @@ _CARGO_TOML="$(cd "$(dirname "$0")/../.." && pwd)/server/Cargo.toml"
 CARGO_VERSION="$(sed -nE 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' "$_CARGO_TOML" | head -1)"
 EXPLICIT_VERSION="${1:-}"
 VERSION="${EXPLICIT_VERSION:-${CARGO_VERSION:-0.1.0}}"
-# Canary (no explicit version) gets `X.Y.Z.BUILD-BUILD`, stable gets `X.Y.Z-BUILD`.
-CANARY="${CANARY:-$([ -z "$EXPLICIT_VERSION" ] && echo 1 || echo 0)}"
-# DSM installs a manual .spk over an existing one ONLY when the new version is
+# ONE version shape, canary and stable alike: `X.Y.Z-BUILD`, which is the format
+# DSM's INFO documents. There used to be a second one - canaries stamped
+# `X.Y.Z.BUILD`, the build in a 4th FEATURE segment - so that a manual .spk
+# install of one nightly over another read as strictly greater. It also made the
+# package undiscoverable through the repository: the catalog has to advertise
+# `X.Y.Z-BUILD` (Package Center hides a feature version carrying a large 4th
+# segment), so the installed 4-segment version outranked everything the catalog
+# offered and the Update button never appeared. Two shapes for one build cannot
+# both win; the documented one wins.
+#
+# THE RULE: the version must only ever go UP. BUILD carries that on its own now,
+# so X.Y.Z does NOT have to move between nightlies. Keep BUILD as minutes since
+# 2020-01-01 UTC - shrinking its magnitude (minutes to days) once made every new
+# build read as a downgrade. Override with BUILD=...
+#
+# DSM installs a manual .spk over an existing one only when the new version is
 # strictly greater, and reports a refusal as the misleading webapi 4521 "invalid
-# file format" - which pushes you into a delete + reinstall that wipes var/. Its
-# check compares the dotted FEATURE version and ignores the -build suffix.
-# THE RULE: the version must only ever go UP. Bump X.Y.Z for every release, and
-# keep BUILD as minutes since 2020-01-01 UTC - shrinking its magnitude (minutes
-# to days) once made every new build read as a downgrade. Override with BUILD=...
+# file format". Nightly-over-nightly by hand therefore depends on DSM comparing
+# the -BUILD suffix; through the package source, which is how nightlies are meant
+# to be followed, the catalog and INFO now agree and it compares cleanly.
 BUILD="${BUILD:-$(( ( $(date -u +%s) - 1577836800 ) / 60 ))}"
 ARCH="x86_64"
 TARGET="x86_64-unknown-linux-musl"
@@ -134,17 +145,13 @@ cp "$WORK/package.tgz" "$SPK/package.tgz"
 # INFO extractsize is read in KB on DSM 6+; bytes made DSM believe the package
 # needed ~190 GB after extraction.
 EXT_SIZE="$(( $(gzip -dc "$WORK/package.tgz" | wc -c | tr -d ' ') / 1024 ))"
-# Canary/nightly builds share one X.Y.Z, so BUILD sits in a 4th feature segment
-# to keep each one strictly newer than the last (see the version note above).
-# Stamped ONCE: deploy.yml promotes a canary .spk as-is into the stable Release.
-if [ "$CANARY" = "1" ]; then
-  INFO_VERSION="$VERSION.$BUILD"
-else
-  INFO_VERSION="$VERSION-$BUILD"
-fi
+# Nightlies share one X.Y.Z, so BUILD is what orders them (see the note above).
+# Stamped ONCE: deploy.yml promotes a nightly .spk as-is into the stable Release,
+# which is the other reason there is only one shape to stamp.
+INFO_VERSION="$VERSION-$BUILD"
 sed -e "s/@INFO_VERSION@/$INFO_VERSION/g" -e "s/@ARCH@/$ARCH/g" -e "s/@SIZE@/$EXT_SIZE/g" \
   "$SKEL/INFO.template" > "$SPK/INFO"
-say "DSM package version: $INFO_VERSION ($([ "$CANARY" = 1 ] && echo 'canary: 4th-segment build keeps every nightly upgradable' || echo 'stable: X.Y.Z orders releases, BUILD is the versionCode'))"
+say "DSM package version: $INFO_VERSION (X.Y.Z orders releases, BUILD orders every build within one)"
 cp "$SKEL/PACKAGE_ICON.PNG" "$SKEL/PACKAGE_ICON_256.PNG" "$SPK/"
 
 OUT_SPK="$OUT/kroma-$INFO_VERSION-$ARCH.spk"

--- a/packages/synology-repo/src/gen-catalog.ts
+++ b/packages/synology-repo/src/gen-catalog.ts
@@ -62,8 +62,10 @@ const {
 } = readSpkInfo(spk);
 
 // DSM's package-center list hides a package whose feature version has a large 4th
-// segment, which is how build.sh stamps nightlies (`X.Y.Z.BUILD-BUILD`), so
-// collapse to `major.minor.micro-build`. Mirrors worker/catalog.ts dsmVersion().
+// segment, so collapse to `major.minor.micro-build`. Mirrors dsmVersion() in
+// apps/packages lib/catalog.ts, including why it is now a no-op for anything
+// build.sh produces: it stamps `X.Y.Z-BUILD` itself, and this only still matters
+// for the older `X.Y.Z.BUILD` assets left on the nightly release.
 const [feat = '', build] = rawVersion.split('-');
 const version = build ? `${feat.split('.').slice(0, 3).join('.')}-${build}` : feat;
 

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2587,7 +2587,7 @@ dependencies = [
 
 [[package]]
 name = "kroma-server"
-version = "0.1.38"
+version = "0.1.39"
 dependencies = [
  "anyhow",
  "axum",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kroma-server"
-version = "0.1.38"
+version = "0.1.39"
 edition.workspace = true
 rust-version.workspace = true
 description = "KROMA a self-hosted, direct-play media streaming server"


### PR DESCRIPTION
Three faults, one story: DSM never offered an update, and the download link on packages.kroma.tv 404'd.

## One version shape

`build.sh` stamped nightlies `X.Y.Z.BUILD` — the build in a **4th feature segment** — so a manual `.spk` install of one nightly over another read as strictly greater. The catalog cannot advertise that shape (Package Center hides a feature version carrying a large 4th segment), so `gen-catalog` collapsed it to `X.Y.Z-BUILD`.

Two shapes for one build. DSM compares the dotted feature version, so:

```
installed (INFO)      0.1.38.3480473
offered   (catalog)   0.1.38-3482771
cmp(offered, installed) = -3480473   ->  no Update button
```

`build.sh` now stamps `X.Y.Z-BUILD`, the shape DSM's INFO documents and the one the catalog already advertised. INFO and catalog agree, the collapse becomes a no-op for anything we build, and `BUILD` carries the ordering so **X.Y.Z no longer has to move between nightlies**:

```
build.sh INFO      : 0.1.39-3490000
catalog advertises : 0.1.39-3490000   (identical)
vs previous nightly: UPDATE OFFERED
```

### Why the version bump is here anyway

A shape change cannot rescue what is already installed. No 3-segment version beats a 4-segment one at the same `X.Y.Z`, whatever the build:

```
0.1.38-9999999 vs 0.1.38.3480473  ->  OLDER
0.1.39-3490000 vs 0.1.38.3480473  ->  UPDATE OFFERED
```

So `0.1.38` → `0.1.39` is what actually clears the currently-stuck installs. It is a one-time cost of the old scheme, not a recurring requirement.

## The 404

Not a URL-building bug: `catalog.ts` uses the real `browser_download_url`, so the link was valid when written. The asset was deleted underneath it.

Retention was `sort -Vr | tail -n +3` — the newest **two** assets, a window measured in *builds*. The catalog worker serves a stale copy for up to **seven days** (`604800` in `lib/catalog.ts`) whenever the GitHub API call fails. Two pushes eight minutes apart were enough to delete an asset a live catalog still pointed at.

Pruning is now by **age**: anything under 14 days is kept, with a floor of the newest 5 so a quiet fortnight cannot empty the release. Both conditions must hold before anything is deleted. Verified against three fixtures:

| fixture | expected | result |
| --- | --- | --- |
| 8 fresh + 3 old | only the 3 old go | 3 pruned |
| 3 assets, all ancient | nothing goes (floor) | nothing pruned |
| 20 assets, all fresh | nothing goes (age gate) | nothing pruned |

Per-build filenames stay. They are load-bearing: a fixed clobbered name broke DSM's md5 check ("Failed to verify the package").

## Tests

A regression test pins the property that actually broke — what `build.sh` stamps must reach the catalog untouched — plus one asserting two nightlies of the same `X.Y.Z` order correctly, which is what makes the no-bump workflow safe. 126 pass across `apps/packages` and `packages/synology-repo`; typecheck and lint clean.

## One thing I could not verify

The claim that Package Center *hides* a large 4th segment is an undocumented observation in a comment (traced to `58fb24f1`, a large feature commit). I took the documented `X.Y.Z-BUILD` format rather than betting on 4-segment tolerance, since if that claim is true the alternative would break listing outright. Manual nightly-over-nightly install now depends on DSM comparing the `-BUILD` suffix; through the package source, which is how nightlies are meant to be followed, the comparison is clean either way.
