### PR TITLE
fix(test): give waitFor room on a loaded machine

### DIFF
--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -5,8 +5,17 @@
 // stays mounted for the whole file, with its effects still running - quietly
 // inflating the call counts of later, unrelated tests in the same file.
 
-import { cleanup } from '@testing-library/react';
+import { cleanup, configure } from '@testing-library/react';
 import { afterEach } from 'vitest';
+
+// `waitFor` defaults to giving up after 1000ms, which is a wall-clock budget on
+// a machine whose speed the test cannot see. Under `test:coverage` the istanbul
+// transform slows every render, and a CI runner is slower again: a settings-row
+// test that takes ~200ms here took 1069ms there and failed on the 69ms, which
+// failed the whole Sonar scan and with it the coverage upload. Raising the
+// ceiling costs a passing test nothing, because `waitFor` polls and returns the
+// moment its condition holds; it only buys a loaded machine room to finish.
+configure({ asyncUtilTimeout: 5000 });
 
 // `__DEV__` is a React Native global that Metro's transform defines. Anything
 // reaching `expo-modules-core` under this runner hits a bare reference to it


### PR DESCRIPTION
The SonarCloud scan on #62 failed, and with it **the coverage upload**, on a test that has nothing to do with that change:

```
packages/module-sdk/src/admin/settings.test.tsx
  × commits what was typed when the field is left   1069ms
```

It passes here 3 out of 3 under `test:coverage`.

`waitFor` gives up after **1000ms** by default, which is a wall-clock budget on a machine whose speed the test cannot see. Under `test:coverage` the istanbul transform slows every render, and a CI runner is slower again: that test takes ~200ms locally and took **1069ms** there, so it failed on the 69ms.

Raising the ceiling to 5s costs a passing test nothing — `waitFor` polls and returns the moment its condition holds — and only buys a loaded machine room to finish. A genuinely broken assertion still fails, five seconds later instead of one.

The test itself is not at fault: it already uses `waitFor` around every async step rather than sleeping.

Verified the setting actually reaches the runner rather than assuming the setup file is enough — a probe reading `getConfig().asyncUtilTimeout` sees `5000`.

## Why this matters beyond one red check

`sonar.yml` uploads `coverage/lcov.info` in the same step that runs the tests. A flake there means **no coverage is uploaded at all** for that run, so the coverage number the README now badges silently goes stale on exactly the runs that fail. This is the second time a check has been quietly non-blocking while hiding something (see #61's history reader); worth knowing the scan is not a required check, so #62 auto-merged straight through this failure.
