### PR TITLE
fix(synology): one shape, X.Y.Z.BUILD, and no version bump

### DIFF
--- a/apps/packages/src/lib/catalog.test.ts
+++ b/apps/packages/src/lib/catalog.test.ts
@@ -112,28 +112,22 @@ describe('dsmVersion', () => {
     expect(dsmVersion('0.1.31-3447024')).toBe('0.1.31-3447024');
   });
 
-  it('collapses a legacy X.Y.Z.BUILD to X.Y.Z-BUILD (DSM hides the 4th segment)', () => {
-    expect(dsmVersion('0.1.37.3480000')).toBe('0.1.37-3480000');
-  });
-
-  // The bug this whole shape exists to prevent: build.sh used to stamp INFO in
-  // one shape while the catalog advertised another, so the installed version
-  // outranked everything on offer and no Update button ever appeared. What
-  // build.sh writes now has to reach the catalog untouched.
-  it('leaves what build.sh stamps alone, so INFO and the catalog agree', () => {
-    for (const stamped of ['0.1.39-3482771', '0.1.39-3482844', '1.0.0-1']) {
+  // The bug this shape exists to prevent: build.sh stamped INFO one way while
+  // the catalog advertised another, so the installed version outranked
+  // everything on offer and no Update button ever appeared. What build.sh
+  // writes has to reach the catalog untouched.
+  it('hands back what build.sh stamps, so INFO and the catalog agree', () => {
+    for (const stamped of ['0.1.38.3482844', '0.1.38.3482771', '1.0.0.1']) {
       expect(dsmVersion(stamped)).toBe(stamped);
     }
   });
 
-  it('orders two nightlies of one X.Y.Z, so no version bump is needed between them', () => {
-    expect(
-      cmpDsmVersion(dsmVersion('0.1.39-3482844'), dsmVersion('0.1.39-3482771')),
-    ).toBeGreaterThan(0);
+  it('offers an update over an install of the same X.Y.Z, with no version bump', () => {
+    expect(cmpDsmVersion(dsmVersion('0.1.38.3482844'), '0.1.38.3480473')).toBeGreaterThan(0);
   });
 
-  it('collapses the older doubly-stamped X.Y.Z.BUILD-BUILD to the same string', () => {
-    expect(dsmVersion('0.1.31.3447024-3447024')).toBe('0.1.31-3447024');
+  it('drops the redundant suffix of the older doubly-stamped X.Y.Z.BUILD-BUILD', () => {
+    expect(dsmVersion('0.1.31.3447024-3447024')).toBe('0.1.31.3447024');
     expect(dsmVersion('0.1.36.3461233-3461233')).toBe(dsmVersion('0.1.36.3461233'));
   });
 

--- a/apps/packages/src/lib/catalog.ts
+++ b/apps/packages/src/lib/catalog.ts
@@ -191,22 +191,19 @@ const splitBuild = (raw: string): [string, string | undefined] => {
   return [raw.slice(0, cut), next < 0 ? rest : rest.slice(0, next)];
 };
 
-/** The version string DSM's Package Center will DISPLAY: `major.minor.micro-build`,
- *  the build taken from the `-suffix` or else the 4th segment. Package Center hides
- *  a package whose feature version carries a large 4th segment.
+/** The version string DSM's Package Center advertises. build.sh stamps
+ *  `X.Y.Z.BUILD`, the build in a 4th feature segment, and this hands that back
+ *  UNCHANGED: rewriting it is what broke the Update button, because DSM compares
+ *  the dotted feature version and an installed `0.1.38.3480473` outranks every
+ *  `0.1.38-*` a rewrite could offer. One shape, INFO to catalog.
  *
- *  build.sh now stamps that shape directly, so for anything it produces this is
- *  the identity. It stays because the nightly release still holds `X.Y.Z.BUILD`
- *  assets from before that change, and rewriting them is what let the catalog
- *  list them at all. Rewriting is ALSO why the Update button never appeared for
- *  them: an installed `0.1.38.3480473` outranks every `0.1.38-*` the catalog can
- *  offer, so those installs move only when X.Y.Z does. */
+ *  The only thing normalised is the older doubly-stamped `X.Y.Z.BUILD-BUILD`,
+ *  whose suffix repeats the 4th segment and carries no extra ordering. */
 export function dsmVersion(raw: string): string {
   const [feat, suffix] = splitBuild(raw);
-  const seg = feat.split('.');
-  const head = seg.slice(0, 3).join('.');
-  const build = suffix ?? seg[3];
-  return build ? `${head}-${build}` : head;
+  // A build already inside the feature version needs no suffix beside it.
+  if (feat.split('.').length > 3) return feat;
+  return suffix ? `${feat}-${suffix}` : feat;
 }
 
 /** DSM's version ordering: the dotted feature version numerically, segment by

--- a/apps/packages/src/lib/release.test.ts
+++ b/apps/packages/src/lib/release.test.ts
@@ -67,8 +67,8 @@ describe('toRelease', () => {
     expect(toRelease(entry({ channel: 'nightly', tag: 'nightly' })).channel).toBe('nightly');
   });
 
-  it('shortens a four-segment feature version to what DSM would display', () => {
+  it('keeps a four-segment feature version, which is what the .spk stamps', () => {
     const row = toRelease(entry({ info: info({ version: '1.2.3.4500' }) }));
-    expect(row.version).toBe('1.2.3-4500');
+    expect(row.version).toBe('1.2.3.4500');
   });
 });

--- a/clients/synology/build.sh
+++ b/clients/synology/build.sh
@@ -14,26 +14,28 @@ _CARGO_TOML="$(cd "$(dirname "$0")/../.." && pwd)/server/Cargo.toml"
 CARGO_VERSION="$(sed -nE 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' "$_CARGO_TOML" | head -1)"
 EXPLICIT_VERSION="${1:-}"
 VERSION="${EXPLICIT_VERSION:-${CARGO_VERSION:-0.1.0}}"
-# ONE version shape, canary and stable alike: `X.Y.Z-BUILD`, which is the format
-# DSM's INFO documents. There used to be a second one - canaries stamped
-# `X.Y.Z.BUILD`, the build in a 4th FEATURE segment - so that a manual .spk
-# install of one nightly over another read as strictly greater. It also made the
-# package undiscoverable through the repository: the catalog has to advertise
-# `X.Y.Z-BUILD` (Package Center hides a feature version carrying a large 4th
-# segment), so the installed 4-segment version outranked everything the catalog
-# offered and the Update button never appeared. Two shapes for one build cannot
-# both win; the documented one wins.
+# ONE version shape, nightly and stable alike: `X.Y.Z.BUILD`, the build in a 4th
+# FEATURE segment. There used to be a second one - the catalog rewrote this to
+# `X.Y.Z-BUILD` before advertising it - and two shapes for one build is what
+# broke the Update button: DSM compares the dotted FEATURE version, so an
+# installed `0.1.38.3480473` outranked every `0.1.38-*` on offer and Package
+# Center concluded there was nothing newer. Nothing rewrites it now.
 #
-# THE RULE: the version must only ever go UP. BUILD carries that on its own now,
+# The 4th segment is what makes this work with NO version bump: nightlies share
+# one X.Y.Z, and a build in the feature version orders them against each other
+# and against what is already installed. Synology's INFO spec allows it - the
+# delimiters are `.`, `-` and `_`, every delimited component must be a number,
+# and each is bounded by 2^31-1, which a minutes-since-2020 build clears.
+#
+# THE RULE: the version must only ever go UP, and BUILD carries that on its own,
 # so X.Y.Z does NOT have to move between nightlies. Keep BUILD as minutes since
 # 2020-01-01 UTC - shrinking its magnitude (minutes to days) once made every new
 # build read as a downgrade. Override with BUILD=...
 #
 # DSM installs a manual .spk over an existing one only when the new version is
 # strictly greater, and reports a refusal as the misleading webapi 4521 "invalid
-# file format". Nightly-over-nightly by hand therefore depends on DSM comparing
-# the -BUILD suffix; through the package source, which is how nightlies are meant
-# to be followed, the catalog and INFO now agree and it compares cleanly.
+# file format". A build inside the feature version satisfies that check too, so
+# the manual path and the package-source path agree.
 BUILD="${BUILD:-$(( ( $(date -u +%s) - 1577836800 ) / 60 ))}"
 ARCH="x86_64"
 TARGET="x86_64-unknown-linux-musl"
@@ -148,10 +150,10 @@ EXT_SIZE="$(( $(gzip -dc "$WORK/package.tgz" | wc -c | tr -d ' ') / 1024 ))"
 # Nightlies share one X.Y.Z, so BUILD is what orders them (see the note above).
 # Stamped ONCE: deploy.yml promotes a nightly .spk as-is into the stable Release,
 # which is the other reason there is only one shape to stamp.
-INFO_VERSION="$VERSION-$BUILD"
+INFO_VERSION="$VERSION.$BUILD"
 sed -e "s/@INFO_VERSION@/$INFO_VERSION/g" -e "s/@ARCH@/$ARCH/g" -e "s/@SIZE@/$EXT_SIZE/g" \
   "$SKEL/INFO.template" > "$SPK/INFO"
-say "DSM package version: $INFO_VERSION (X.Y.Z orders releases, BUILD orders every build within one)"
+say "DSM package version: $INFO_VERSION (X.Y.Z orders releases, the 4th segment orders every build within one)"
 cp "$SKEL/PACKAGE_ICON.PNG" "$SKEL/PACKAGE_ICON_256.PNG" "$SPK/"
 
 OUT_SPK="$OUT/kroma-$INFO_VERSION-$ARCH.spk"

--- a/packages/synology-repo/src/gen-catalog.test.ts
+++ b/packages/synology-repo/src/gen-catalog.test.ts
@@ -122,17 +122,27 @@ describe('the catalog entry', () => {
     expect(entry).not.toHaveProperty('beta');
   });
 
-  it('collapses a nightly version to what DSM will actually render', async () => {
-    // build.sh stamps nightlies `X.Y.Z.BUILD-BUILD`. DSM hides a package whose
-    // feature version has a 4th segment that large, so it collapses to the
-    // conventional major.minor.micro-build.
+  it('advertises a nightly exactly as the .spk stamps it', async () => {
+    // build.sh stamps `X.Y.Z.BUILD`. Rewriting that shape is what stopped DSM
+    // ever seeing an update, so the catalog carries it through; only the older
+    // doubly-stamped form loses its redundant suffix.
     const { catalog } = await generate({
-      CATALOG_SPK: makeSpk(work, 'nightly.spk', { ...BASE_INFO, version: '1.2.3.4567-4567' }),
+      CATALOG_SPK: makeSpk(work, 'nightly.spk', { ...BASE_INFO, version: '1.2.3.4567' }),
       CATALOG_DOWNLOAD_URL: 'https://github.test/kroma.spk',
       CATALOG_PAGES_URL: 'https://pages.test/repo',
       CATALOG_OUT_DIR: join(work, 'out'),
     });
-    expect(catalog.packages[0].version).toBe('1.2.3-4567');
+    expect(catalog.packages[0].version).toBe('1.2.3.4567');
+  });
+
+  it('drops the redundant suffix of the older doubly-stamped form', async () => {
+    const { catalog } = await generate({
+      CATALOG_SPK: makeSpk(work, 'legacy.spk', { ...BASE_INFO, version: '1.2.3.4567-4567' }),
+      CATALOG_DOWNLOAD_URL: 'https://github.test/kroma.spk',
+      CATALOG_PAGES_URL: 'https://pages.test/repo',
+      CATALOG_OUT_DIR: join(work, 'out'),
+    });
+    expect(catalog.packages[0].version).toBe('1.2.3.4567');
   });
 
   it('leaves a stable three-segment version untouched', async () => {

--- a/packages/synology-repo/src/gen-catalog.ts
+++ b/packages/synology-repo/src/gen-catalog.ts
@@ -61,13 +61,13 @@ const {
   md5,
 } = readSpkInfo(spk);
 
-// DSM's package-center list hides a package whose feature version has a large 4th
-// segment, so collapse to `major.minor.micro-build`. Mirrors dsmVersion() in
-// apps/packages lib/catalog.ts, including why it is now a no-op for anything
-// build.sh produces: it stamps `X.Y.Z-BUILD` itself, and this only still matters
-// for the older `X.Y.Z.BUILD` assets left on the nightly release.
+// Advertise exactly what the .spk stamps. Mirrors dsmVersion() in apps/packages
+// lib/catalog.ts: a build already inside the feature version (`X.Y.Z.BUILD`)
+// passes through untouched, and only the older doubly-stamped
+// `X.Y.Z.BUILD-BUILD` loses its redundant suffix. Rewriting the shape is what
+// stopped DSM ever seeing an update.
 const [feat = '', build] = rawVersion.split('-');
-const version = build ? `${feat.split('.').slice(0, 3).join('.')}-${build}` : feat;
+const version = feat.split('.').length > 3 || !build ? feat : `${feat}-${build}`;
 
 const iconOverride = process.env.CATALOG_ICON?.trim();
 const iconBytes = iconOverride ? readFileSync(iconOverride) : extractIcon(spk);

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2587,7 +2587,7 @@ dependencies = [
 
 [[package]]
 name = "kroma-server"
-version = "0.1.39"
+version = "0.1.38"
 dependencies = [
  "anyhow",
  "axum",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kroma-server"
-version = "0.1.39"
+version = "0.1.38"
 edition.workspace = true
 rust-version.workspace = true
 description = "KROMA a self-hosted, direct-play media streaming server"


### PR DESCRIPTION
Reverts the `0.1.39` bump #62 introduced. It was not wanted, and it was not needed.

The bump was only required because #62 picked `X.Y.Z-BUILD` as the single shape, and no 3-segment feature version can outrank the `0.1.38.3480473` already installed. Keeping the **4-segment** shape removes the need entirely:

```
build.sh stamps    : 0.1.38.3482844
catalog advertises : 0.1.38.3482844   (identical)
vs installed 0.1.38.3480473 -> UPDATE OFFERED, no bump
cargo version stays 0.1.38
```

## One shape

`X.Y.Z.BUILD` — the one `build.sh` already stamped and every published `.spk` already carries. Nothing rewrites it on the way to the catalog.

That rewrite was the whole bug. DSM compares the dotted feature version, so an installed 4-segment version outranked every 3-segment string the catalog could offer, and Package Center concluded there was nothing newer.

`dsmVersion` and `gen-catalog` now pass a 4-segment version through untouched, and only strip the redundant suffix of the older doubly-stamped `X.Y.Z.BUILD-BUILD`, whose tail repeats the 4th segment and adds no ordering.

## On the claim that justified the rewrite

I had said the "Package Center hides a large 4th segment" comment was unverifiable and used it to argue for the shape that forced a bump. I should have checked the spec first. [Synology's INFO documentation](https://help.synology.com/developer-guide/synology_package/INFO_necessary_fields.html) says:

> Each version delimiter is only allowed to be `.` `-` or `_`
> Each version number which is delimited by delimiter is only allowed to be number
> major, minor, micro and build numbers should be in the range of 0 - 2^31-1

A minutes-since-2020 build (~3.48M) clears that bound, every component is numeric, and the delimiter is legal. The spec states **no maximum segment count**.

## Nothing published is disturbed

No `0.1.39` `.spk` was ever built. #62's synology run was cancelled by concurrency and #63 did not match the path filter, so the newest asset on the nightly release is still `kroma-0.1.38.3482844`, in exactly this shape. Reverting costs no user a downgrade.

The age-based asset retention from #62, which fixed the packages.kroma.tv 404s, is untouched.

## Ordering

| transition | result |
| --- | --- |
| nightly to nightly, same X.Y.Z | newer |
| installed `0.1.38.3480473` to `0.1.38.3482844` | newer, no bump |
| nightly to a future stable `0.1.39.<build>` | newer |
| that stable to the nightly after it | newer |

126 tests pass across `apps/packages` and `packages/synology-repo`; typecheck and lint clean.
