### PR TITLE
chore(repo): add issue templates, PR template and ticket conventions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,102 @@
+name: Bug report
+description: Something in KROMA is broken
+labels: ["type/bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Title format: `<surface>: <what is broken>` — lowercase scope, no `[BUG]` prefix.
+        Good: `tizen: playback stalls on HEVC 10-bit after a seek`
+        Bad: `[BUG] Video problem`
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Surface
+      description: Where it breaks. Pick the one closest to the failure, not where you noticed it.
+      options:
+        - Server (Rust)
+        - Module (tv.kroma.*)
+        - Web client
+        - TV — Tizen (Samsung)
+        - TV — webOS (LG)
+        - TV — other / tv-web
+        - Mobile — iOS
+        - Mobile — Android
+        - Desktop
+        - Synology package
+        - UI kit
+        - CI / release
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Server version, and client version if they differ. `unknown` is an acceptable answer.
+      placeholder: "server 0.4.2, tizen client 0.4.1"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install
+    attributes:
+      label: How it is installed
+      options:
+        - Docker / docker-compose
+        - Synology package
+        - Built from source
+        - Not applicable
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Numbered, from a cold start. If you cannot reproduce it reliably, say so and describe how often it happens.
+      placeholder: |
+        1. Start the server with a library containing HEVC 10-bit files
+        2. Open the Tizen client, play any HEVC file
+        3. Seek forward past 10 minutes
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected vs actual
+      description: Two lines. What should have happened, and what did.
+      placeholder: |
+        Expected: playback resumes at the seek point, still direct play.
+        Actual: black screen, audio keeps playing, no error in the UI.
+    validations:
+      required: true
+
+  - type: textarea
+    id: media
+    attributes:
+      label: Media details
+      description: |
+        For any playback or transcode bug. Container, video codec, profile and bit depth, audio codec, resolution.
+        `ffprobe` output pasted verbatim is ideal — direct play is the whole point of KROMA, so the codec matters more than the filename.
+      placeholder: "mkv / hevc Main 10 / 3840x2160 / eac3 5.1"
+      render: shell
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Server logs
+      description: The relevant window, not the whole file. Redact tokens and paths you would rather not publish — this repo is public.
+      render: shell
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched open and closed issues for this
+          required: true
+        - label: I can reproduce this on the latest version, or I said above why I cannot
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/maxscharwath/kroma/security/advisories/new
+    about: Do not open a public issue. Report privately through a security advisory — see SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,76 @@
+name: Feature request
+description: A new capability, or a change to how something works
+labels: ["type/feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Title format: `<surface>: <the capability>` — imperative, lowercase scope.
+        Good: `web: resume playback across devices`
+        Bad: `Feature request: it would be nice if...`
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem
+      description: What is painful today. Describe the situation, not the solution — if the problem is only "the feature is missing", say what that costs you.
+      placeholder: "I watch on the TV, then continue on my phone, and I have to scrub to find where I stopped."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behaviour
+      description: What should happen instead, precisely enough that someone could tell whether it works.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Surfaces affected
+      multiple: true
+      options:
+        - Server (Rust)
+        - Module (tv.kroma.*)
+        - Web client
+        - TV — Tizen (Samsung)
+        - TV — webOS (LG)
+        - TV — other / tv-web
+        - Mobile — iOS
+        - Mobile — Android
+        - Desktop
+        - Synology package
+        - UI kit
+        - CI / release
+    validations:
+      required: true
+
+  - type: dropdown
+    id: module
+    attributes:
+      label: Could this be a module instead of core?
+      description: KROMA pushes optional capability into out-of-process `tv.kroma.*` sidecars. Core earns its weight.
+      options:
+        - "Yes — this belongs in a module"
+        - "No — this has to be core"
+        - "Not sure"
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What you tried, or other designs you rejected and why. "None" is a valid answer if you mean it.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched open and closed issues for this
+          required: true
+        - label: I read ARCHITECTURE.md and this does not contradict it
+          required: false

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,59 @@
+name: Task
+description: Internal work — refactor, chore, docs, CI, performance
+labels: ["type/chore"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For work with no external reporter: cleanups, dependency surgery, CI, docs, performance.
+        Swap `type/chore` for `type/refactor`, `type/docs` or `type/perf` if one of those fits better.
+
+        Title format: `<surface>: <imperative summary>`
+        Good: `ci: cache cargo builds between release jobs`
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What needs doing
+      validations:
+        required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why now
+      description: What this unblocks, or what it costs to keep not doing it. "It bothers me" is a real reason — write it down.
+    validations:
+      required: true
+
+  - type: textarea
+    id: done
+    attributes:
+      label: Definition of done
+      description: A checklist someone else could verify without asking you.
+      placeholder: |
+        - [ ] Release workflow reuses the cargo cache
+        - [ ] Cold release build under 12 minutes
+        - [ ] No change to published artefact contents
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Surfaces affected
+      multiple: true
+      options:
+        - Server (Rust)
+        - Module (tv.kroma.*)
+        - SDK / tooling
+        - Web client
+        - TV clients
+        - Mobile
+        - Desktop
+        - Synology package
+        - UI kit
+        - CI / release
+        - Docs
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+<!-- Title = the commit title. Conventional commits: fix(synology): one shape, X.Y.Z.BUILD, and no version bump -->
+
+## What
+
+<!-- One paragraph. What changes, and why this way rather than another. -->
+
+## Closes
+
+<!-- Closes #123 — or "no issue" and a sentence on why this did not need one. -->
+
+## Checks
+
+- [ ] `bun run lint` and `bun run test` pass, or I said below which failed and why
+- [ ] `cargo clippy` and `cargo test` pass, if the server changed
+- [ ] Follows `CODE_STYLE.md` — no comments narrating the work, exported API only
+- [ ] One idea. If it grew a second, it was split.
+
+## Risk
+
+<!-- What breaks if this is wrong, and how a reviewer would notice. "None, it is a docs typo" is a fine answer. -->

--- a/docs/TICKETS.md
+++ b/docs/TICKETS.md
@@ -1,0 +1,120 @@
+# Tickets
+
+How work is named, described, labelled and moved in KROMA. One issue is one unit of
+work someone could pick up cold.
+
+## Titles
+
+`<scope>: <imperative summary>` — the same lowercase scopes as the commit history, so a
+ticket and the commit that closes it read alike.
+
+```
+tizen: playback stalls on HEVC 10-bit after a seek
+server: scan skips files with a colon in the name
+ci: cache cargo builds between release jobs
+ui-kit: give Dialog a controlled open prop
+```
+
+Rules that matter more than they look:
+
+- **No prefixes.** Not `[BUG]`, not `FEAT:`, not a ticket id. Labels carry the type.
+- **Lowercase after the scope**, no trailing period.
+- **Say the symptom, not the guess.** `playback stalls after a seek`, not `seek handler
+  race condition` — unless you have proof, in which case put the proof in the body.
+- **One scope.** If a title needs two, it is two tickets.
+- Under ~70 characters so it survives the board card.
+
+## Bodies
+
+Use the templates. They exist so a ticket cannot be opened without the things that
+make it actionable. Three shapes:
+
+| Template | For | Must answer |
+|---|---|---|
+| Bug report | Something broken | surface, version, install method, steps, expected vs actual, codec details for playback |
+| Feature request | New capability | the problem, proposed behaviour, surfaces, could it be a module |
+| Task | Internal work | what, why now, definition of done |
+
+Codec details are mandatory on playback bugs. KROMA is direct-play and HEVC-first;
+`hevc Main 10 / 3840x2160 / eac3` is the bug, the filename is not.
+
+The repo is public. Redact tokens, IPs and library paths before pasting logs.
+
+## Labels
+
+Namespaced, so the set a ticket carries is readable at a glance.
+
+**`type/`** — what kind of work. **Exactly one.**
+`bug` · `feature` · `refactor` · `perf` · `docs` · `chore` · `security` · `question`
+
+**`priority/`** — how soon. **Exactly one**, set at triage, changed freely.
+
+| | Means | Looks like |
+|---|---|---|
+| `p0` | Drop everything | Data loss, a security hole, playback dead for everyone |
+| `p1` | Next up | A core flow broken with no workaround |
+| `p2` | Normal | Planned work. The default. |
+| `p3` | Someday | Real, but nobody is waiting |
+
+**`area/`** — where in the stack. **One or more**, and it is fine to have none while a
+ticket is still vague.
+`server` · `modules` · `sdk` · `web` · `tv` · `mobile` · `desktop` · `synology` ·
+`ui-kit` · `ci` · `docs`
+
+**Flow labels** — the two states a board column cannot express, because they are about
+waiting rather than working:
+
+- `needs-info` — waiting on the reporter. Closed after 14 silent days, reopened on reply.
+- `blocked` — waiting on something outside this repo. The comment must say what.
+
+**Left to automation**: `dependencies`, `javascript`, `rust`, `github_actions` are
+Dependabot's. Do not apply them by hand.
+
+Status does **not** live in labels. The board owns it. Two sources of truth for status
+is how boards die.
+
+## The board
+
+Project: **KROMA** (Projects v2, `maxscharwath/kroma`). Every issue and PR is added
+automatically; nothing is tracked in someone's head.
+
+| Column | Means | Leaves when |
+|---|---|---|
+| **Triage** | Landed, nobody has looked | It has `type/` + `priority/`, and the body is understandable |
+| **Backlog** | Understood, not now | Someone commits to doing it |
+| **Ready** | Fully specified, unassigned | Someone starts |
+| **In progress** | Being worked on now | A PR opens |
+| **In review** | PR open | The PR merges |
+| **Done** | Merged and released | Never — it stays as history |
+
+Two rules keep it honest:
+
+1. **Nothing enters `Ready` without a definition of done.** If nobody can say what
+   finished looks like, it is still `Backlog`.
+2. **`In progress` has a limit.** More than a handful of cards means work is being
+   started, not finished. Finish before starting.
+
+`needs-info` and `blocked` cards stay in whatever column they were in. They are not a
+parking column; a ticket nobody can unblock in two weeks gets closed with the reason.
+
+## Definition of ready
+
+A ticket may be picked up when it has: a title in the format above, exactly one
+`type/`, exactly one `priority/`, at least one `area/`, a body that follows its
+template, and a definition of done someone else could verify. Bugs additionally need
+steps that actually reproduce, or an explicit note that they do not reproduce reliably.
+
+## Definition of done
+
+Merged to `main` behind a PR that closes the issue with `Closes #N`; tests and lint
+green; docs updated in the same PR if behaviour changed; no new `TODO` comments left
+behind — those become tickets or they do not exist.
+
+## Closing
+
+Close with a reason, always, even on your own tickets: fixed by #N, duplicate of #N,
+cannot reproduce and here is what was tried, or won't fix and why. A silently closed
+ticket teaches the next reporter not to bother.
+
+Stale sweep: `needs-info` after 14 days, `p3` untouched for 6 months. Both get a
+comment before closing, and reopen on demand.


### PR DESCRIPTION
## What

Issue forms for bug, feature and task, a PR template, and `docs/TICKETS.md` recording how tickets are named, described, labelled and moved.

The forms require the fields that make a ticket actionable rather than hoping people volunteer them: surface and install method on every bug, codec details on playback bugs (direct play means the codec *is* the bug), and a definition of done on internal work. Blank issues are disabled so nothing lands unstructured.

Labels are namespaced — `type/` `priority/` `area/` — already created on the repo. Status deliberately has no label: the project board owns it, because two sources of truth for status is how boards rot.

## Closes

No issue — this is the scaffolding that issues will use.

## Checks

- [x] Docs and templates only, no code paths touched
- [x] YAML validated by GitHub issue-forms schema on push
- [x] One idea

## Risk

Low and fully reversible. If a form asks too much and people stop filing, delete fields. The contact link points at the security advisory page; Discussions stays off since the repo has it disabled.