### PR TITLE
docs(spec): add the product spec skeleton, RFC flow and ADR template

### DIFF
--- a/docs/architecture/TEMPLATE.md
+++ b/docs/architecture/TEMPLATE.md
@@ -1,0 +1,27 @@
+# <decision, as a statement>
+
+Status: **PROPOSED** | ACCEPTED | SHIPPED | DESIGN, NOT IMPLEMENTED | SUPERSEDED by <file>
+
+If the status is `DESIGN, NOT IMPLEMENTED`, the first paragraph must say what shipped
+instead and why the designed thing did not — that record is the whole value of the
+document. `mobile-offline-system-storage.md` is the reference for how to do this well.
+
+## Context
+
+The forces at play: constraints, platform limitations, what we already committed to.
+Enough that a reader in a year understands the world this was decided in, without needing
+the conversation that produced it.
+
+## Decision
+
+What was decided, stated as a fact in the present tense. Not "we could" — "we do".
+
+## Consequences
+
+What this makes easy, what it makes hard, and what it forecloses. Include the bad ones;
+a consequences section with only benefits is marketing, not a record.
+
+## Alternatives rejected
+
+Each with the reason it lost. The reason matters more than the alternative — it is what
+stops the option being re-proposed.

--- a/docs/rfcs/0000-template.md
+++ b/docs/rfcs/0000-template.md
@@ -1,0 +1,38 @@
+# RFC NNNN: <title>
+
+- Status: **DRAFT** | ACCEPTED | REJECTED | SUPERSEDED by NNNN
+- PR: #NNNN
+- Affects: `docs/spec/<file>.md`, areas `area/...`
+
+## Summary
+
+One paragraph. If a reader stops here, what did you propose?
+
+## Motivation
+
+What is wrong today. Be concrete — a real scenario, a real user, a real failure. If the
+motivation is "it would be cleaner", say who it is cleaner *for* and what that buys.
+
+## Proposal
+
+The design, in enough detail that someone else could build it. State the behaviour, not
+the implementation, unless the implementation is the point.
+
+## What this costs
+
+Every proposal costs something. Maintenance, compatibility, complexity, a promise we
+cannot walk back. Name it. An RFC with no cost section has not been thought through.
+
+## Compatibility
+
+What breaks for: existing libraries, paired devices, installed modules, older clients that
+will not be updated. "Nothing" is an acceptable answer if it is true.
+
+## Alternatives
+
+What else was considered, and why this instead. Include "do nothing" and say what happens
+if we choose it.
+
+## Unresolved
+
+What is deliberately left open, and who decides it later.

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -1,0 +1,28 @@
+# RFCs
+
+For changes too large or too contested to argue in a normal PR review.
+
+## When you need one
+
+Write an RFC when a change would: alter a promise in `docs/spec/`, break compatibility for
+installed modules or paired devices, add a surface, or commit the project to maintaining
+something indefinitely.
+
+Everything else is a normal PR. Most changes are normal PRs. An RFC process that swallows
+small work is a process nobody uses.
+
+## The flow
+
+1. Copy `0000-template.md` to `NNNN-short-slug.md`, where `NNNN` is the number of the PR
+   you are about to open. Do not renumber afterwards.
+2. Open the PR with `type/question` and the relevant `area/` labels. The PR *is* the
+   discussion — no separate issue.
+3. Argue it in review. Amend the RFC as the argument changes it; the diff is the record.
+4. **Merged means accepted.** The RFC's status becomes `ACCEPTED` in the merge commit, and
+   the spec is updated in the same PR or an immediate follow-up.
+5. **Closed means rejected**, and the RFC stays closed rather than deleted. A rejected RFC
+   with its reasoning is worth as much as an accepted one — it stops the same idea coming
+   back every six months.
+
+An RFC that is merged but never implemented gets an epic issue, so the gap is visible on
+the board rather than only in a file nobody opens.

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -1,0 +1,65 @@
+# The KROMA spec
+
+What KROMA does and why, in the same repo as the code that does it.
+
+## What lives here, and what does not
+
+| | Answers | Lives in |
+|---|---|---|
+| **Spec** (this folder) | *What* the product does, and *why* that is the right behaviour | `docs/spec/` |
+| **Architecture** | *How* the code is shaped to do it | `ARCHITECTURE.md`, `docs/architecture/` |
+| **Conventions** | *How* we write it | `CODE_STYLE.md`, `CONVENTIONS.md` |
+| **Work** | *What is being done about it now* | Issues, the KROMA board |
+
+A rule that keeps them apart: if a sentence would still be true after a full rewrite of
+the implementation, it belongs in the spec. If it names a crate, a file or a framework,
+it belongs in architecture.
+
+## The domains
+
+One file per domain, using the domain nouns `ARCHITECTURE.md` already uses — the same
+words name the server's crates, the clients' feature folders, and the `area/` labels.
+Learn the vocabulary once, use it everywhere.
+
+| File | Domain | `area/` label |
+|---|---|---|
+| [`library.md`](library.md) | Sources, scanning, matching, metadata refresh | `area/server` |
+| [`media.md`](media.md) | What a title *is*: containers, codecs, streams, artwork | `area/server` |
+| [`playback.md`](playback.md) | Direct play, fallbacks, resume, continue watching | `area/server` `area/tv` |
+| [`accounts.md`](accounts.md) | Accounts, sessions, profiles, who may see what | `area/server` |
+| [`discovery.md`](discovery.md) | Finding a server on the network, pairing a television | `area/tv` |
+| [`modules.md`](modules.md) | `.kmod` bundles, the Store, out-of-process sidecars | `area/modules` |
+| [`admin.md`](admin.md) | Running a server: settings, users, jobs, diagnostics | `area/server` |
+| [`surfaces.md`](surfaces.md) | What each client must do, and what it is allowed not to do | all client areas |
+
+## Status vocabulary
+
+Every spec file and every section carries one, matching the style already used in
+`docs/architecture/`:
+
+- **SHIPPED** — implemented and released. The spec describes today's behaviour.
+- **AGREED** — decided, not built. Someone could implement it from this text.
+- **DRAFT** — being written. Do not implement from it yet.
+- **DESIGN, NOT IMPLEMENTED** — deliberately deferred. The section must say *why*, and
+  what shipped instead. See `docs/architecture/mobile-offline-system-storage.md` for the
+  shape to imitate — that record is worth more than the design was.
+
+A spec section without a status is a bug in the spec.
+
+## How the spec changes
+
+The spec changes only through a pull request, and a PR that changes behaviour changes the
+spec in the same PR. That is the whole enforcement mechanism: review is where a
+requirement gets argued, and `git blame` is where you find out why it says what it says.
+
+For anything large or contested, write it as an RFC first — see [`../rfcs/`](../rfcs/).
+Small clarifications go straight to a spec PR.
+
+## How the spec becomes work
+
+Each domain has a long-lived **epic issue**. Implementation issues are opened as
+**sub-issues** of that epic, so progress rolls up on the board without anyone maintaining
+a checklist by hand. The spec says what should be true; the sub-issues say what is left
+to make it true.
+
+Never copy spec text into an issue. Link to the section. Copies rot.

--- a/docs/spec/accounts.md
+++ b/docs/spec/accounts.md
@@ -1,0 +1,28 @@
+# Accounts
+
+Status: **DRAFT** — skeleton only, nothing here is agreed yet.
+
+Who is using the server, what they may see, and how a device proves it is them.
+
+## Scope
+
+- Account model: owner vs additional users, and whether profiles exist under an account
+- Authentication: credentials, sessions, session lifetime, revocation
+- Devices: how a device is bound to an account and how it is unbound
+- Authorisation: per-user library visibility, admin rights, module install rights
+- What is per-user and what is per-server (watch state, settings, preferences)
+- Account deletion: what is destroyed, what survives
+
+## Open questions
+
+- Are profiles a separate concept from users, or the same thing named twice?
+- Does a revoked device lose downloaded content, and can it?
+
+## Must answer
+
+- [ ] The permission matrix: which roles may do what
+- [ ] Session lifetime on a television, which cannot practically re-authenticate often
+
+## Not in scope
+
+The pairing handshake itself is [`discovery.md`](discovery.md).

--- a/docs/spec/admin.md
+++ b/docs/spec/admin.md
@@ -1,0 +1,29 @@
+# Admin
+
+Status: **DRAFT** — skeleton only, nothing here is agreed yet.
+
+Running a KROMA server. The audience is one person with a NAS, not an operations team.
+
+## Scope
+
+- First-run: what is asked, in what order, and what is deferred
+- Settings that exist, and the ones deliberately not exposed
+- Users: inviting, removing, resetting
+- Jobs: scans, refreshes, transcodes — visibility, cancellation, scheduling
+- Diagnostics: logs, health, what to hand over in a bug report
+- Backup and restore: what must survive a reinstall
+- Updates: how a server learns it is out of date, and what updating risks
+
+## Open questions
+
+- How much of the server is configurable at runtime versus fixed at deploy?
+- What is the recovery path when an admin locks themselves out?
+
+## Must answer
+
+- [ ] The minimum first-run path from install to first playing title
+- [ ] What is safe to change while media is playing
+
+## Not in scope
+
+Packaging per platform is [`surfaces.md`](surfaces.md).

--- a/docs/spec/discovery.md
+++ b/docs/spec/discovery.md
@@ -1,0 +1,29 @@
+# Discovery
+
+Status: **DRAFT** — skeleton only, nothing here is agreed yet.
+
+How a client finds a server it was never told about, and how a television — which has no
+keyboard worth using — becomes signed in.
+
+## Scope
+
+- Finding a server on the local network, and what "the same network" is allowed to mean
+- Which shells can listen on the link themselves, and which must be told an address
+- Manual connection: address entry, remote access, what is supported outside the LAN
+- The pairing handshake: initiating, displaying, confirming, expiring
+- Trust: what a paired television may do without further confirmation
+
+## Existing material
+
+`docs/tv-pairing.md` already documents the three roads a television takes to an account.
+That document is the raw material for this spec file — this file should state the
+*product* rules and defer the mechanics to it, not duplicate them.
+
+## Must answer
+
+- [ ] What a user does when discovery finds nothing, on each shell
+- [ ] Pairing code lifetime, and what a user sees when it expires mid-flow
+
+## Not in scope
+
+What the account itself means is [`accounts.md`](accounts.md).

--- a/docs/spec/library.md
+++ b/docs/spec/library.md
@@ -1,0 +1,31 @@
+# Library
+
+Status: **DRAFT** — skeleton only, nothing here is agreed yet.
+
+Sources on disk become titles you can browse. Everything upstream of "there is something
+to play".
+
+## Scope
+
+- What a **source** is, and how many a server may have
+- Scanning: initial scan, incremental rescan, what triggers each
+- **Matching**: filename and folder conventions understood, and what happens when a file
+  matches nothing or matches two things
+- Metadata providers: what is fetched, what is cached locally, what happens offline
+- Refresh: when metadata is re-fetched, and what a user can force
+- Deletions and moves: what happens to watch history when a file disappears
+
+## Open questions
+
+- Is a mis-matched title fixable from the UI, or only by renaming on disk?
+- Does a rescan ever delete user data, or only ever mark absent?
+
+## Must answer
+
+- [ ] The exact naming conventions a file must follow to be matched
+- [ ] What the user sees when matching fails — the failure path is product, not an edge case
+- [ ] Whether scanning is safe to run against a library being written to
+
+## Not in scope
+
+Acquisition (getting files onto disk) is a module concern — see [`modules.md`](modules.md).

--- a/docs/spec/media.md
+++ b/docs/spec/media.md
@@ -1,0 +1,29 @@
+# Media
+
+Status: **DRAFT** — skeleton only, nothing here is agreed yet.
+
+What a title *is* once KROMA knows about it: the technical truth about streams, which is
+what makes direct play possible or impossible.
+
+## Scope
+
+- The media model: title, version/edition, media file, stream (video, audio, subtitle)
+- Containers and codecs that are first-class, HEVC first among them
+- Bit depth, HDR variants, and what is preserved end to end
+- Audio: channel layouts, passthrough, what may be downmixed and when
+- Subtitles: embedded vs sidecar, forced and SDH, what is burned in and when
+- Artwork and images: sources, sizes, caching
+
+## Open questions
+
+- How are multiple versions of the same title (1080p and 4K) represented and chosen between?
+- Is stream metadata trusted from probe, or re-probed on playback failure?
+
+## Must answer
+
+- [ ] The definitive list of what direct-plays on each client generation
+- [ ] What KROMA does with a file it can read but not describe
+
+## Not in scope
+
+Deciding what to send to a given client is [`playback.md`](playback.md).

--- a/docs/spec/modules.md
+++ b/docs/spec/modules.md
@@ -1,0 +1,33 @@
+# Modules
+
+Status: **DRAFT** — skeleton only, nothing here is agreed yet.
+
+The base build ships **zero modules** — `modules/roster.yaml` is deliberately empty — and
+every first-party capability arrives as an installable `.kmod` whose backend runs
+out-of-process. This is what makes every module uninstallable from Admin. That decision is
+load-bearing for the whole product, so it earns a spec file.
+
+## Scope
+
+- What a module may and may not do, and the boundary it may not cross
+- The `.kmod` bundle: what it contains, how it is versioned, how it declares compatibility
+- Installation: from the Store, and by uploading a bundle by hand
+- The Store: the GitHub-release registry, trust, and what is shown before installing
+- Lifecycle: enable, disable, update, uninstall, and what happens to a module's data
+- Failure: what a crashed or incompatible sidecar does to the rest of the server
+- First-party modules as a set, and why each is a module rather than core
+
+## Open questions
+
+- What is the compatibility promise between a server version and an installed module?
+- May a module ship UI, and if so what is it allowed to render?
+
+## Must answer
+
+- [ ] The trust model for third-party modules on a public registry
+- [ ] What a user is told when a module they rely on stops being maintained
+
+## Existing material
+
+`modules/README.md`, `docs/module-registries.md`, `docs/modules-as-kmod.md`, and
+`modules/module.schema.json` — this file states the product rules, those state the mechanics.

--- a/docs/spec/playback.md
+++ b/docs/spec/playback.md
@@ -1,0 +1,33 @@
+# Playback
+
+Status: **DRAFT** — skeleton only, nothing here is agreed yet.
+
+The core promise: the file plays, unmodified, wherever possible. Everything else is a
+fallback, and every fallback is a compromise that should be visible and explainable.
+
+## Scope
+
+- **Direct play**: the conditions under which the original file is streamed untouched
+- The decision order when direct play is impossible, and what is given up at each step
+- What is never done silently
+- Seeking: behaviour while direct playing, and while any fallback is active
+- Resume and **continue watching**: where progress is stored, when it is written, how it
+  reconciles across two devices that both watched offline
+- Multiple clients on one account playing at once
+- Failure: what the user sees when a stream dies mid-playback
+
+## Open questions
+
+- Is transcoding a supported product feature or a last resort we tolerate?
+- Who wins when two devices report conflicting progress for the same title?
+
+## Must answer
+
+- [ ] The direct-play decision table, per client generation
+- [ ] The exact resume-point semantics, including the "watched" threshold
+- [ ] What a user is told when their television cannot play a file their phone can
+
+## Not in scope
+
+Codec truth lives in [`media.md`](media.md); the per-client capability matrix in
+[`surfaces.md`](surfaces.md).

--- a/docs/spec/surfaces.md
+++ b/docs/spec/surfaces.md
@@ -1,0 +1,37 @@
+# Surfaces
+
+Status: **DRAFT** — skeleton only, nothing here is agreed yet.
+
+KROMA runs on a television, a phone, a browser, a desktop and a NAS. This file says what
+every surface must do, what each may do differently, and what a surface is explicitly
+allowed *not* to do — so a missing feature is a decision on record rather than a gap.
+
+## The surfaces
+
+| Surface | Shell | Notes |
+|---|---|---|
+| Web | `clients/web` | The reference implementation |
+| TV — Samsung | `clients/tizen` | 10-foot UI, remote-only input |
+| TV — LG | `clients/webos` | 10-foot UI, remote-only input |
+| TV — other | `clients/tv-web`, `clients/tv-native` | |
+| Mobile | `clients/mobile` | Offline downloads |
+| Desktop | `clients/desktop` | Auto-update |
+| NAS | `clients/synology` | Packaging, not a client |
+
+## Scope
+
+- The baseline every surface must provide to be called KROMA
+- Per-surface capability matrix, including direct-play capability by device generation
+- Input models: remote, touch, pointer — and what changes in the UI because of each
+- Offline: which surfaces support it and what it means on each
+- Packaging and update mechanism per surface
+- Deprecation: when a surface stops being supported, and what its users are told
+
+## Must answer
+
+- [ ] The baseline feature set, stated once, so "not on TV yet" is measurable
+- [ ] Which surfaces are first-class and which are best-effort
+
+## Not in scope
+
+The shared component kit is architecture — see `packages/ui/src/components/README.md`.


### PR DESCRIPTION
## What

A place for the product spec that CI and agents can read, structured so it cannot drift from the code.

`docs/spec/` has one file per domain, using the nouns `ARCHITECTURE.md` already declares — media, accounts, playback, library, admin, discovery — plus `modules` (the zero-module base build is load-bearing enough to earn a spec file) and `surfaces` (so "not on TV yet" is a recorded decision rather than a gap).

The files are deliberately **skeletons**: scope, open questions, and a short must-answer list. No requirements are invented in this PR. They get filled in as they are decided — through `docs/rfcs/` for anything that changes a promise, breaks module or device compatibility, or adds a surface, and through ordinary spec PRs for everything else.

Every section carries a status (`SHIPPED` / `AGREED` / `DRAFT` / `DESIGN, NOT IMPLEMENTED`), matching the convention `docs/architecture/` already uses. `docs/architecture/TEMPLATE.md` gives those notes a common spine, modelled on `mobile-offline-system-storage.md`.

## Closes

No issue — this is the scaffolding. Domain epics follow, with spec sections as their sub-issues.

## Checks

- [x] Docs only, no code paths touched
- [x] Uses the repo's existing vocabulary rather than introducing a parallel one
- [x] One idea

## Risk

None to the build. The real risk is social: a spec nobody updates is worse than no spec. That is why the rule is that a PR changing behaviour changes the spec in the same PR, and why the RFC process is scoped narrowly enough that small work never touches it.
