### PR TITLE
docs(spec): fill the eight domain specs from skeleton to reviewable rules

### DIFF
--- a/docs/spec/accounts.md
+++ b/docs/spec/accounts.md
@@ -1,28 +1,196 @@
 # Accounts
 
-Status: **DRAFT** — skeleton only, nothing here is agreed yet.
-
 Who is using the server, what they may see, and how a device proves it is them.
 
-## Scope
+One server, one household. The account model is sized for that: a person who owns
+the NAS, the people they let in, and the screens each of them signs into. Anything
+grander is a cost this product declines to pay.
 
-- Account model: owner vs additional users, and whether profiles exist under an account
-- Authentication: credentials, sessions, session lifetime, revocation
-- Devices: how a device is bound to an account and how it is unbound
-- Authorisation: per-user library visibility, admin rights, module install rights
-- What is per-user and what is per-server (watch state, settings, preferences)
-- Account deletion: what is destroyed, what survives
+## The account model
 
-## Open questions
+Status: **AGREED**
 
-- Are profiles a separate concept from users, or the same thing named twice?
-- Does a revoked device lose downloaded content, and can it?
+An **account** is a person. It has credentials, its own watch state, its own
+settings, and a set of signed-in devices. Nothing else hangs off it.
 
-## Must answer
+The first account created at first-run is the **owner**. The owner is an account
+like any other that additionally holds the server itself — see the roles below.
+Every subsequent account is an ordinary **user**, created by invitation from
+[`admin.md`](admin.md); a KROMA server is never self-signup.
 
-- [ ] The permission matrix: which roles may do what
-- [ ] Session lifetime on a television, which cannot practically re-authenticate often
+**There are no profiles under an account, and there will not be.** A "profile"
+in other media servers is a login you do not have to type a password for: a way
+to split one household login into several viewing identities. KROMA already gives
+every person their own account, so a profile would be a second, weaker identity
+mechanism sitting beside the real one — two ways to be "someone", one of which
+carries no authentication. For a single-NAS household where making an account is
+one invitation, that buys nothing and costs the confusion of two overlapping
+concepts. A person who wants their own Continue Watching gets an account. A shared
+screen in the kitchen signs into one account and stays there. Profiles and users
+are the same thing named twice, so we keep the name that already carries a password.
 
-## Not in scope
+The honest cost: a genuinely shared device (one television, several viewers) mixes
+everyone's watch state under whichever account it holds. We accept that. The fix
+is switching accounts on the device, not inventing passwordless sub-identities to
+avoid it.
 
-The pairing handshake itself is [`discovery.md`](discovery.md).
+## Authentication
+
+Status: **AGREED**
+
+A person proves who they are with a **username and password**. That is the only
+credential the server stores, and it stores only a verifier for it, never the
+password. Password strength, reset, and lockout policy are the server operator's
+concern and live in [`admin.md`](admin.md).
+
+A successful authentication mints a **session**: a long-lived, server-issued token
+bound to one device. Every request carries the session; the password is typed once
+per device and, in the ordinary case, never again.
+
+**Sessions do not expire on a clock.** A session lives until it is revoked — by the
+account that owns it, by an admin, or by the person signing out. There is no forced
+periodic re-authentication. A session can be individually revoked without disturbing
+any other session the same account holds, because a session is per-device, not
+per-account.
+
+Rationale — see the television rule below, which is the hard case this policy is
+built around.
+
+## Devices and pairing
+
+Status: **AGREED**
+
+A **device** is where a session lives. Signing in on a phone, a browser, or a
+television each produces one session, and each shows up in the account's **device
+list** with enough to recognise it (shell, rough location, last-seen) and one
+action: revoke.
+
+A television binds to an account through the pairing handshake, not a typed
+password — the mechanics of that handshake are [`discovery.md`](discovery.md), and
+its raw material [`tv-pairing.md`](../tv-pairing.md). The product rule that matters
+here: **pairing ends in an ordinary session.** A paired television is not a special
+class of trust; it lands in the same device list as everything else and revokes the
+same way. There is nothing you can do to a paired television that you cannot do to a
+phone, and nothing you must do differently to unbind it.
+
+**Unbinding is revocation.** Revoke a device's session and its access ends at the
+next request it makes. The device is not consulted, wiped, or asked to cooperate;
+the server simply stops honouring its token. A revoked device that returns must
+pair or sign in afresh.
+
+### Session lifetime on a television
+
+Status: **AGREED**
+
+A television session is long-lived and revocable, and **is never forced to
+re-authenticate on a schedule.** A television has no keyboard worth using and often
+no practical way to re-run the pairing dance unattended; an expiring session would
+mean a screen that silently signs itself out and a person hunting for a phone to fix
+it. So the television keeps its session until a human revokes it. The revocation
+path — the device list — is the control that replaces expiry: security comes from
+being able to cut a specific screen off instantly from any other device, not from
+making every screen prove itself again on a timer. This is the same rule as every
+other device; the television is only the case that makes forced expiry obviously
+wrong.
+
+## Authorisation
+
+Status: **AGREED**
+
+Two roles, and a per-user visibility rule layered on top.
+
+- **Owner / admin** — runs the server. Manages users, settings, jobs, and modules.
+  The owner is the founding admin; the owner may grant admin to another account, and
+  there is always at least one admin. Admin rights are server-wide, not per-library.
+- **User** — uses the server. Browses and plays what they are permitted to see,
+  owns their own watch state and preferences, and manages their own devices.
+
+**Library visibility is per-user.** An admin decides which libraries a given user
+may see; a user sees exactly those and cannot discover the rest. Visibility gates
+browsing, search, and playback alike — a title a user cannot see is a title they
+cannot play, resume, or find.
+
+Module installation is an **admin** right, because installing a module runs new
+out-of-process code on the server — see [`modules.md`](modules.md). A plain user
+may use whatever modules an admin has installed and enabled, within their own
+library visibility; they may not install, update, or remove them.
+
+### Permission matrix
+
+Status: **AGREED**
+
+| Capability | Owner / admin | User |
+|---|---|---|
+| Browse permitted libraries | ✓ | ✓ |
+| Play permitted titles | ✓ | ✓ |
+| Manage own watch state (resume, mark, Continue Watching) | ✓ | ✓ |
+| Manage own settings and preferences | ✓ | ✓ |
+| Manage own devices (list, revoke) | ✓ | ✓ |
+| Pair a television to own account | ✓ | ✓ |
+| See all libraries | ✓ | only those granted |
+| Invite / remove users | ✓ | — |
+| Set another user's library visibility | ✓ | — |
+| Revoke another account's device | ✓ | — |
+| Grant / revoke admin | owner | — |
+| Install / update / remove modules | ✓ | — |
+| Change server settings, run and cancel jobs | ✓ | — |
+
+A user's power over their own account is total; their power over anyone else's, or
+over the server, is none. Everything in the admin column is [`admin.md`](admin.md)'s
+subject in depth.
+
+## Per-user versus per-server
+
+Status: **AGREED**
+
+The dividing line is ownership of the experience versus ownership of the machine.
+
+**Per-user** — watch state (resume points, watched flags, Continue Watching),
+personal preferences (playback defaults, language, subtitle choices, interface
+settings), the device list, and library visibility as it applies to them. Two
+people on one server share nothing here.
+
+**Per-server** — the libraries and their contents, metadata and artwork, the set of
+installed modules, transcode and job policy, and every setting under
+[`admin.md`](admin.md). One person's Continue Watching is theirs; the library that
+row points into is everyone's.
+
+Watch state is deliberately per-user and never per-device: resume a film on the
+television, finish it on the phone. The device is where a session lives, not where
+progress is kept.
+
+## Account deletion
+
+Status: **AGREED**
+
+Deleting an account destroys the person, not the media.
+
+**Destroyed** — the account's credentials, all of its sessions and paired devices
+(every one is revoked in the act of deletion), its watch state, and its personal
+preferences. After deletion the person cannot sign in, and none of their screens can
+refresh access.
+
+**Survives** — everything per-server. Libraries, media, metadata, and installed
+modules are untouched, because they were never the deleted account's to take.
+Another user's watch state is untouched even where it points at the same titles.
+
+The owner account cannot be deleted while it is the only admin; ownership must first
+pass to another account, so a server is never left with no one able to run it.
+An admin deleting another user is an [`admin.md`](admin.md) action; a user may
+request deletion of their own account, which revokes their access on the spot.
+
+### Does a revoked or deleted device lose downloaded content?
+
+Status: **AGREED**
+
+Honestly: not immediately, and the server cannot make it. Revocation stops a
+session from doing anything new — it cannot fetch, refresh, or stream another byte.
+But bytes already downloaded for offline viewing sit in local storage on the device,
+and the server has no reach into that storage. What enforces removal is the **app**:
+on discovering its session is dead, the client is required to purge downloaded media
+before it will run again. So the guarantee is "a revoked device gains nothing new and
+loses its downloads the next time the app runs", not "the download evaporates the
+instant you tap revoke". We state it plainly rather than pretend to a control we do
+not hold; the offline-download reality is [`modules.md`](modules.md)'s and the mobile
+client's to enforce, and the account model's job is only to kill the session that
+would let those downloads be refreshed.

--- a/docs/spec/accounts/README.md
+++ b/docs/spec/accounts/README.md
@@ -16,7 +16,7 @@ settings, and a set of signed-in devices. Nothing else hangs off it.
 The first account created at first-run is the **owner**. The owner is an account
 like any other that additionally holds the server itself — see the roles below.
 Every subsequent account is an ordinary **user**, created by invitation from
-[`admin.md`](admin.md); a KROMA server is never self-signup.
+[`admin.md`](../admin/README.md); a KROMA server is never self-signup.
 
 **There are no profiles under an account, and there will not be.** A "profile"
 in other media servers is a login you do not have to type a password for: a way
@@ -41,7 +41,7 @@ Status: **AGREED**
 A person proves who they are with a **username and password**. That is the only
 credential the server stores, and it stores only a verifier for it, never the
 password. Password strength, reset, and lockout policy are the server operator's
-concern and live in [`admin.md`](admin.md).
+concern and live in [`admin.md`](../admin/README.md).
 
 A successful authentication mints a **session**: a long-lived, server-issued token
 bound to one device. Every request carries the session; the password is typed once
@@ -66,8 +66,8 @@ list** with enough to recognise it (shell, rough location, last-seen) and one
 action: revoke.
 
 A television binds to an account through the pairing handshake, not a typed
-password — the mechanics of that handshake are [`discovery.md`](discovery.md), and
-its raw material [`tv-pairing.md`](../tv-pairing.md). The product rule that matters
+password — the mechanics of that handshake are [`discovery.md`](../discovery/README.md), and
+its raw material [`tv-pairing.md`](../../tv-pairing.md). The product rule that matters
 here: **pairing ends in an ordinary session.** A paired television is not a special
 class of trust; it lands in the same device list as everything else and revokes the
 same way. There is nothing you can do to a paired television that you cannot do to a
@@ -111,7 +111,7 @@ browsing, search, and playback alike — a title a user cannot see is a title th
 cannot play, resume, or find.
 
 Module installation is an **admin** right, because installing a module runs new
-out-of-process code on the server — see [`modules.md`](modules.md). A plain user
+out-of-process code on the server — see [`modules.md`](../modules/README.md). A plain user
 may use whatever modules an admin has installed and enabled, within their own
 library visibility; they may not install, update, or remove them.
 
@@ -136,7 +136,7 @@ Status: **AGREED**
 | Change server settings, run and cancel jobs | ✓ | — |
 
 A user's power over their own account is total; their power over anyone else's, or
-over the server, is none. Everything in the admin column is [`admin.md`](admin.md)'s
+over the server, is none. Everything in the admin column is [`admin.md`](../admin/README.md)'s
 subject in depth.
 
 ## Per-user versus per-server
@@ -152,7 +152,7 @@ people on one server share nothing here.
 
 **Per-server** — the libraries and their contents, metadata and artwork, the set of
 installed modules, transcode and job policy, and every setting under
-[`admin.md`](admin.md). One person's Continue Watching is theirs; the library that
+[`admin.md`](../admin/README.md). One person's Continue Watching is theirs; the library that
 row points into is everyone's.
 
 Watch state is deliberately per-user and never per-device: resume a film on the
@@ -176,7 +176,7 @@ Another user's watch state is untouched even where it points at the same titles.
 
 The owner account cannot be deleted while it is the only admin; ownership must first
 pass to another account, so a server is never left with no one able to run it.
-An admin deleting another user is an [`admin.md`](admin.md) action; a user may
+An admin deleting another user is an [`admin.md`](../admin/README.md) action; a user may
 request deletion of their own account, which revokes their access on the spot.
 
 ### Does a revoked or deleted device lose downloaded content?
@@ -191,6 +191,6 @@ on discovering its session is dead, the client is required to purge downloaded m
 before it will run again. So the guarantee is "a revoked device gains nothing new and
 loses its downloads the next time the app runs", not "the download evaporates the
 instant you tap revoke". We state it plainly rather than pretend to a control we do
-not hold; the offline-download reality is [`modules.md`](modules.md)'s and the mobile
+not hold; the offline-download reality is [`modules.md`](../modules/README.md)'s and the mobile
 client's to enforce, and the account model's job is only to kill the session that
 would let those downloads be refreshed.

--- a/docs/spec/admin.md
+++ b/docs/spec/admin.md
@@ -1,29 +1,235 @@
 # Admin
 
-Status: **DRAFT** — skeleton only, nothing here is agreed yet.
+Status: **AGREED** overall, with the update mechanism still **DRAFT** where a delivery
+choice stays open. Every section carries its own status; the file-level label is the floor.
 
 Running a KROMA server. The audience is one person with a NAS, not an operations team.
+That framing decides everything below: expose little, default sanely, and never add a knob
+without a reason a single hobbyist would recognise. Admin is the surface the owner touches
+a handful of times a year — at install, when adding a source, when something breaks — and
+should ask nothing of them the rest of the time.
 
-## Scope
+## First-run
 
-- First-run: what is asked, in what order, and what is deferred
-- Settings that exist, and the ones deliberately not exposed
-- Users: inviting, removing, resetting
-- Jobs: scans, refreshes, transcodes — visibility, cancellation, scheduling
-- Diagnostics: logs, health, what to hand over in a bug report
-- Backup and restore: what must survive a reinstall
-- Updates: how a server learns it is out of date, and what updating risks
+Status: **AGREED**
 
-## Open questions
+First-run does the least that gets to a playing title, and defers the rest to a running
+server the owner can explore at leisure. The minimum path, in exact order:
 
-- How much of the server is configurable at runtime versus fixed at deploy?
-- What is the recovery path when an admin locks themselves out?
+1. **Open the server.** The owner reaches the web surface on their own network. No account
+   exists yet, so the server presents the owner-creation step and nothing else.
+2. **Create the owner.** One account: a name and a credential. This account is the owner
+   from the moment it exists — there is no separate "make me admin" step, and roles are
+   [`accounts.md`](accounts.md), not asked here.
+3. **Add one source.** Point the server at one directory of movies or shows and tag its
+   content kind. The initial scan starts immediately as a background job with visible
+   progress, [`library.md`](library.md); the catalogue fills as it goes.
+4. **Play.** As soon as the first title matches, it is playable. First-run is over — the
+   owner did not wait for the whole scan to finish.
 
-## Must answer
+Everything else is deferred to the running server: more sources, more users, module
+installs, metadata providers, schedules, backups. First-run asks three things — who owns
+this, where is the media, and nothing more — because a first-time operator should reach a
+playing title before they are asked to make a single reversible decision. Deferred choices
+all have sane defaults, so a server that only ever completes first-run is a complete,
+correct server.
 
-- [ ] The minimum first-run path from install to first playing title
-- [ ] What is safe to change while media is playing
+## Settings philosophy
+
+Status: **AGREED**
+
+Expose little. Every setting is a support burden, a migration liability and a way for one
+person to break their own server at 1am, so the default posture is *no setting*. A knob
+earns its place only when a real hobbyist has a real reason to turn it and no default can
+serve both sides of that reason.
+
+What is exposed: **sources** and their scan schedules ([`library.md`](library.md));
+**users** and invitations (below); **metadata provider** credentials where a provider needs
+a key; **modules** and their configuration ([`modules.md`](modules.md)); **server identity**
+(a display name for the server on the network); and the **backup** controls (below).
+
+What is deliberately not exposed: transcoding ladders, cache sizes and eviction policy,
+thread and worker counts, database tuning, port and bind internals, log verbosity as a
+routine control. These are chosen by the server from the host it finds itself on. The owner
+of a NAS should not be tuning a transcode preset; if a default is wrong often enough to need
+a knob, the default is the bug, and the fix is a better default, not a setting. A setting
+that only exists because we could not decide is a decision deferred onto the user.
+
+## Runtime versus deploy
+
+Status: **AGREED**
+
+The position: **favour runtime configuration.** For a single operator, "change it in the UI
+and it takes effect" beats "edit a file and restart" every time, and the server carries its
+own configuration in its own store so that a setting survives a reinstall (below) without the
+owner reconstructing a config file by hand.
+
+Deploy-time is reserved for the few things that genuinely cannot change safely while the
+server runs: where the server's own data lives, what address and port it binds, and the
+identity of the persistent store itself. These are the parameters a restart is *for*. They
+are set once by whatever packaged KROMA for the host — [`surfaces.md`](surfaces.md) — and
+are not surfaced as settings, because changing them is a redeploy, not a preference.
+
+## Users
+
+Status: **AGREED**
+
+The owner manages who else may use the server. Three actions, kept deliberately small:
+
+- **Invite.** The owner creates an invitation the new user redeems to set their own
+  credential; the owner never sets or sees another user's password. Whether an invite is a
+  link or a code is [`surfaces.md`](surfaces.md); that a user sets their own secret is the
+  product rule.
+- **Remove.** The owner removes a user. This revokes that user's sessions and devices and
+  destroys their account per [`accounts.md`](accounts.md), but touches no media and does not
+  affect anyone else's watch state.
+- **Reset.** The owner triggers a credential reset for a user who is locked out; the user
+  re-establishes their own secret. The owner resets access, never impersonates.
+
+Roles, per-user library visibility, session lifetime and what survives an account deletion
+are all [`accounts.md`](accounts.md). This section is only the admin verbs.
+
+### Lockout recovery
+
+Status: **AGREED**
+
+The owner can lock themselves out — forgotten credential, revoked last session, a botched
+change. Because the operator physically owns the machine, recovery lives **on the host, not
+on the network**: a local recovery path, runnable by whoever has access to the box the
+server runs on, that re-establishes owner access (reset the owner credential, or mint a
+one-time recovery entry). It requires host access precisely so that it is not a remote
+attack surface — possession of the machine is the authentication. It never reads existing
+credentials, only replaces them, and it is the one and only backdoor. There is no
+cloud "forgot password"; a self-hosted server has no vendor to appeal to, so the machine's
+owner is the root of trust.
+
+## Jobs
+
+Status: **AGREED**
+
+Background work — scans, metadata refreshes, transcodes, module tasks — is visible, honest
+and interruptible. The owner should never wonder whether the server is doing something.
+
+- **Visibility.** Every running and queued job is listed with what it is, what it is working
+  on and its progress; scans and refreshes are [`library.md`](library.md), module jobs are
+  [`modules.md`](modules.md). A finished job leaves a short trace (succeeded, failed, or
+  cancelled) so a failure is not silent.
+- **Cancellation.** Any job the owner started, the owner can cancel. Cancellation is safe:
+  a cancelled scan leaves the catalogue consistent with what it had already matched, a
+  cancelled transcode discards its partial output, and nothing a cancel touches corrupts
+  the library on disk — scans are read-only ([`library.md`](library.md)) and transcodes
+  write only to regenerable cache.
+- **Scheduling.** The little scheduling that exists is per-source scan cadence
+  ([`library.md`](library.md)) and the metadata staleness sweep. These have sane defaults
+  and rarely need touching. The server also declines to pile work on itself: heavy jobs are
+  bounded so a large library does not saturate a NAS, and this bound is chosen, not
+  configured.
+
+## Diagnostics
+
+Status: **AGREED**
+
+When something is wrong, the owner needs to see it and hand it to someone who can fix it.
+
+- **Health.** A single view answers "is the server well?" — are sources reachable, are
+  modules running or crashed ([`modules.md`](modules.md)), is there room on disk, is the
+  metadata provider reachable. Green is the normal state; anything else names the specific
+  thing that is wrong and, where possible, the action that fixes it.
+- **Logs.** The server keeps a rolling log the owner can read and export. Routine operation
+  logs at a level a human can skim; verbosity is raised only around an active investigation,
+  not left high as a standing setting.
+- **The bug report.** There is one action — "Export diagnostics" — that gathers exactly what
+  a maintainer needs and nothing that identifies the person: server and module versions, the
+  recent log, the health snapshot, source and job state. It excludes credentials, media
+  paths' contents, watch history and anything else personal. What to hand over in a bug
+  report is therefore a single click, not a scavenger hunt, and it is safe to attach to a
+  public issue.
+
+## Backup and restore
+
+Status: **AGREED**
+
+The guarantee: **a reinstall loses nothing irreplaceable.** The owner should be able to lose
+the server entirely, stand up a new one, restore one backup, and be where they were — same
+accounts, same history, same settings — without re-teaching it anything.
+
+What a backup **must** contain, because it cannot be regenerated:
+
+- **Accounts** — owner and users, their bindings and access ([`accounts.md`](accounts.md)).
+- **Watch state** — history, resume positions, ratings, and the manual-match bindings the
+  library keeps against files ([`library.md`](library.md)). This is the irreplaceable heart:
+  history that outlives the bytes it describes must outlive the server too.
+- **Settings** — sources, schedules, provider credentials, server identity.
+- **Module data** — each installed module's own persisted state ([`modules.md`](modules.md)),
+  so a restore brings modules back as they were, not as blank installs.
+
+What a backup **must not** contain, because including it is waste, not safety:
+
+- **Media files.** KROMA never owns the bytes ([`library.md`](library.md)); the library is
+  the owner's, backed up by the owner however they back up a NAS. A KROMA backup is small.
+- **Regenerable caches and artwork.** Fetched metadata, generated images and transcode
+  output all rebuild themselves from the sources and providers after a restore. A backup
+  that included them would be enormous and no safer.
+
+Restore is the inverse and is the same path lockout recovery can lean on: point a fresh
+server at a backup and it becomes the old server, then re-scans sources to rebuild the
+caches it deliberately did not carry. The restored server re-matches files to the identities
+the backup remembers, so watch history reattaches to media the moment it is scanned back in.
+
+## Updates
+
+Status: **DRAFT** — delivery mechanism provisional
+
+A server learns it is out of date by checking for a newer release and saying so, quietly, in
+Admin — a passive notice, never an automatic action. The owner decides when. Nothing on a
+self-hosted media server should update itself under the family mid-film.
+
+The risk an update carries, and how KROMA bounds it:
+
+- **Server updates** may change the persistent store. The rule: an update migrates forward
+  automatically and a backup is the safety net, so the owner is nudged to have a current
+  backup before a server update, and a failed migration leaves the previous version
+  restorable rather than a half-migrated store.
+- **Module updates** are independent of the server and carry their own compatibility
+  promise ([`modules.md`](modules.md)); a module update never requires a server update and a
+  server update never silently updates modules.
+- **Active playback is not a reason an update is blocked, and an update is not a reason
+  playback stops** — but because a server update means a restart, the owner is told an update
+  will interrupt streams and chooses the moment. Updates are the one deliberate exception to
+  the live-change guarantee below.
+
+Open, with a recommendation: how the update actually arrives differs per host — a NAS
+package, a desktop auto-updater, a container image — and that delivery is
+[`surfaces.md`](surfaces.md). Recommended answer — the product rule ("passive notice, owner
+chooses, backup first, migrate-forward-or-restore") is fixed here and identical everywhere;
+only the delivery vehicle varies by surface. This split is provisional pending review.
+
+## Changing settings while media plays
+
+Status: **AGREED**
+
+The guarantee: **a settings change never interrupts active playback.** The owner can add a
+source, invite a user, kick off a scan, edit a schedule or change the server's display name
+while the household is mid-film, and no stream drops. Playback in flight is served from state
+already resolved; admin edits change what happens *next*, not what is on screen *now*.
+
+The exceptions are few, honest, and all involve a restart the owner initiates:
+
+- **Server updates** restart the server and therefore interrupt streams — the owner is
+  warned and picks the moment (above).
+- **Deploy-time parameters** (bind address, store location) cannot change without a restart,
+  which is why they are not runtime settings at all (above).
+- **Removing a user or revoking a device** intentionally ends *that* person's sessions
+  immediately ([`accounts.md`](accounts.md)); it is a security action, not a preference, and
+  interrupting the revoked stream is the point. Everyone else plays on.
+
+Everything reachable as an ordinary runtime setting is safe to change at any time, including
+while media is playing. If a change is not safe to make live, it is not a runtime setting.
 
 ## Not in scope
 
-Packaging per platform is [`surfaces.md`](surfaces.md).
+- **Roles, sessions, device binding and account deletion** are [`accounts.md`](accounts.md).
+- **Module lifecycle, the Store and sidecar failure** are [`modules.md`](modules.md).
+- **Scan and refresh behaviour** is [`library.md`](library.md); Admin only starts, shows and
+  cancels those jobs.
+- **Per-platform packaging and the update delivery vehicle** are [`surfaces.md`](surfaces.md).

--- a/docs/spec/admin/README.md
+++ b/docs/spec/admin/README.md
@@ -20,10 +20,10 @@ server the owner can explore at leisure. The minimum path, in exact order:
    exists yet, so the server presents the owner-creation step and nothing else.
 2. **Create the owner.** One account: a name and a credential. This account is the owner
    from the moment it exists — there is no separate "make me admin" step, and roles are
-   [`accounts.md`](accounts.md), not asked here.
+   [`accounts.md`](../accounts/README.md), not asked here.
 3. **Add one source.** Point the server at one directory of movies or shows and tag its
    content kind. The initial scan starts immediately as a background job with visible
-   progress, [`library.md`](library.md); the catalogue fills as it goes.
+   progress, [`library.md`](../library/README.md); the catalogue fills as it goes.
 4. **Play.** As soon as the first title matches, it is playable. First-run is over — the
    owner did not wait for the whole scan to finish.
 
@@ -43,9 +43,9 @@ person to break their own server at 1am, so the default posture is *no setting*.
 earns its place only when a real hobbyist has a real reason to turn it and no default can
 serve both sides of that reason.
 
-What is exposed: **sources** and their scan schedules ([`library.md`](library.md));
+What is exposed: **sources** and their scan schedules ([`library.md`](../library/README.md));
 **users** and invitations (below); **metadata provider** credentials where a provider needs
-a key; **modules** and their configuration ([`modules.md`](modules.md)); **server identity**
+a key; **modules** and their configuration ([`modules.md`](../modules/README.md)); **server identity**
 (a display name for the server on the network); and the **backup** controls (below).
 
 What is deliberately not exposed: transcoding ladders, cache sizes and eviction policy,
@@ -67,7 +67,7 @@ owner reconstructing a config file by hand.
 Deploy-time is reserved for the few things that genuinely cannot change safely while the
 server runs: where the server's own data lives, what address and port it binds, and the
 identity of the persistent store itself. These are the parameters a restart is *for*. They
-are set once by whatever packaged KROMA for the host — [`surfaces.md`](surfaces.md) — and
+are set once by whatever packaged KROMA for the host — [`surfaces.md`](../surfaces/README.md) — and
 are not surfaced as settings, because changing them is a redeploy, not a preference.
 
 ## Users
@@ -78,16 +78,16 @@ The owner manages who else may use the server. Three actions, kept deliberately 
 
 - **Invite.** The owner creates an invitation the new user redeems to set their own
   credential; the owner never sets or sees another user's password. Whether an invite is a
-  link or a code is [`surfaces.md`](surfaces.md); that a user sets their own secret is the
+  link or a code is [`surfaces.md`](../surfaces/README.md); that a user sets their own secret is the
   product rule.
 - **Remove.** The owner removes a user. This revokes that user's sessions and devices and
-  destroys their account per [`accounts.md`](accounts.md), but touches no media and does not
+  destroys their account per [`accounts.md`](../accounts/README.md), but touches no media and does not
   affect anyone else's watch state.
 - **Reset.** The owner triggers a credential reset for a user who is locked out; the user
   re-establishes their own secret. The owner resets access, never impersonates.
 
 Roles, per-user library visibility, session lifetime and what survives an account deletion
-are all [`accounts.md`](accounts.md). This section is only the admin verbs.
+are all [`accounts.md`](../accounts/README.md). This section is only the admin verbs.
 
 ### Lockout recovery
 
@@ -111,16 +111,16 @@ Background work — scans, metadata refreshes, transcodes, module tasks — is v
 and interruptible. The owner should never wonder whether the server is doing something.
 
 - **Visibility.** Every running and queued job is listed with what it is, what it is working
-  on and its progress; scans and refreshes are [`library.md`](library.md), module jobs are
-  [`modules.md`](modules.md). A finished job leaves a short trace (succeeded, failed, or
+  on and its progress; scans and refreshes are [`library.md`](../library/README.md), module jobs are
+  [`modules.md`](../modules/README.md). A finished job leaves a short trace (succeeded, failed, or
   cancelled) so a failure is not silent.
 - **Cancellation.** Any job the owner started, the owner can cancel. Cancellation is safe:
   a cancelled scan leaves the catalogue consistent with what it had already matched, a
   cancelled transcode discards its partial output, and nothing a cancel touches corrupts
-  the library on disk — scans are read-only ([`library.md`](library.md)) and transcodes
+  the library on disk — scans are read-only ([`library.md`](../library/README.md)) and transcodes
   write only to regenerable cache.
 - **Scheduling.** The little scheduling that exists is per-source scan cadence
-  ([`library.md`](library.md)) and the metadata staleness sweep. These have sane defaults
+  ([`library.md`](../library/README.md)) and the metadata staleness sweep. These have sane defaults
   and rarely need touching. The server also declines to pile work on itself: heavy jobs are
   bounded so a large library does not saturate a NAS, and this bound is chosen, not
   configured.
@@ -132,7 +132,7 @@ Status: **AGREED**
 When something is wrong, the owner needs to see it and hand it to someone who can fix it.
 
 - **Health.** A single view answers "is the server well?" — are sources reachable, are
-  modules running or crashed ([`modules.md`](modules.md)), is there room on disk, is the
+  modules running or crashed ([`modules.md`](../modules/README.md)), is there room on disk, is the
   metadata provider reachable. Green is the normal state; anything else names the specific
   thing that is wrong and, where possible, the action that fixes it.
 - **Logs.** The server keeps a rolling log the owner can read and export. Routine operation
@@ -155,17 +155,17 @@ accounts, same history, same settings — without re-teaching it anything.
 
 What a backup **must** contain, because it cannot be regenerated:
 
-- **Accounts** — owner and users, their bindings and access ([`accounts.md`](accounts.md)).
+- **Accounts** — owner and users, their bindings and access ([`accounts.md`](../accounts/README.md)).
 - **Watch state** — history, resume positions, ratings, and the manual-match bindings the
-  library keeps against files ([`library.md`](library.md)). This is the irreplaceable heart:
+  library keeps against files ([`library.md`](../library/README.md)). This is the irreplaceable heart:
   history that outlives the bytes it describes must outlive the server too.
 - **Settings** — sources, schedules, provider credentials, server identity.
-- **Module data** — each installed module's own persisted state ([`modules.md`](modules.md)),
+- **Module data** — each installed module's own persisted state ([`modules.md`](../modules/README.md)),
   so a restore brings modules back as they were, not as blank installs.
 
 What a backup **must not** contain, because including it is waste, not safety:
 
-- **Media files.** KROMA never owns the bytes ([`library.md`](library.md)); the library is
+- **Media files.** KROMA never owns the bytes ([`library.md`](../library/README.md)); the library is
   the owner's, backed up by the owner however they back up a NAS. A KROMA backup is small.
 - **Regenerable caches and artwork.** Fetched metadata, generated images and transcode
   output all rebuild themselves from the sources and providers after a restore. A backup
@@ -191,7 +191,7 @@ The risk an update carries, and how KROMA bounds it:
   backup before a server update, and a failed migration leaves the previous version
   restorable rather than a half-migrated store.
 - **Module updates** are independent of the server and carry their own compatibility
-  promise ([`modules.md`](modules.md)); a module update never requires a server update and a
+  promise ([`modules.md`](../modules/README.md)); a module update never requires a server update and a
   server update never silently updates modules.
 - **Active playback is not a reason an update is blocked, and an update is not a reason
   playback stops** — but because a server update means a restart, the owner is told an update
@@ -200,7 +200,7 @@ The risk an update carries, and how KROMA bounds it:
 
 Open, with a recommendation: how the update actually arrives differs per host — a NAS
 package, a desktop auto-updater, a container image — and that delivery is
-[`surfaces.md`](surfaces.md). Recommended answer — the product rule ("passive notice, owner
+[`surfaces.md`](../surfaces/README.md). Recommended answer — the product rule ("passive notice, owner
 chooses, backup first, migrate-forward-or-restore") is fixed here and identical everywhere;
 only the delivery vehicle varies by surface. This split is provisional pending review.
 
@@ -220,7 +220,7 @@ The exceptions are few, honest, and all involve a restart the owner initiates:
 - **Deploy-time parameters** (bind address, store location) cannot change without a restart,
   which is why they are not runtime settings at all (above).
 - **Removing a user or revoking a device** intentionally ends *that* person's sessions
-  immediately ([`accounts.md`](accounts.md)); it is a security action, not a preference, and
+  immediately ([`accounts.md`](../accounts/README.md)); it is a security action, not a preference, and
   interrupting the revoked stream is the point. Everyone else plays on.
 
 Everything reachable as an ordinary runtime setting is safe to change at any time, including
@@ -228,8 +228,8 @@ while media is playing. If a change is not safe to make live, it is not a runtim
 
 ## Not in scope
 
-- **Roles, sessions, device binding and account deletion** are [`accounts.md`](accounts.md).
-- **Module lifecycle, the Store and sidecar failure** are [`modules.md`](modules.md).
-- **Scan and refresh behaviour** is [`library.md`](library.md); Admin only starts, shows and
+- **Roles, sessions, device binding and account deletion** are [`accounts.md`](../accounts/README.md).
+- **Module lifecycle, the Store and sidecar failure** are [`modules.md`](../modules/README.md).
+- **Scan and refresh behaviour** is [`library.md`](../library/README.md); Admin only starts, shows and
   cancels those jobs.
-- **Per-platform packaging and the update delivery vehicle** are [`surfaces.md`](surfaces.md).
+- **Per-platform packaging and the update delivery vehicle** are [`surfaces.md`](../surfaces/README.md).

--- a/docs/spec/discovery.md
+++ b/docs/spec/discovery.md
@@ -1,29 +1,171 @@
 # Discovery
 
-Status: **DRAFT** — skeleton only, nothing here is agreed yet.
-
 How a client finds a server it was never told about, and how a television — which has no
 keyboard worth using — becomes signed in.
 
-## Scope
+Discovery ends where [`accounts.md`](accounts.md) begins: its job is to get a device
+*attached* to a server and *pointed at* an account. What the account then means, and what
+the resulting session may do, is that file. The mechanics — the wire records, the trust
+proofs, the per-shell APIs — are [`../tv-pairing.md`](../tv-pairing.md); this file states
+the product rules and links there rather than repeating them.
 
-- Finding a server on the local network, and what "the same network" is allowed to mean
-- Which shells can listen on the link themselves, and which must be told an address
-- Manual connection: address entry, remote access, what is supported outside the LAN
-- The pairing handshake: initiating, displaying, confirming, expiring
-- Trust: what a paired television may do without further confirmation
+## Finding a server on the local network
 
-## Existing material
+Status: **SHIPPED**
 
-`docs/tv-pairing.md` already documents the three roads a television takes to an account.
-That document is the raw material for this spec file — this file should state the
-*product* rules and defer the mechanics to it, not duplicate them.
+A client on the same network as a server should not have to be told the server's address.
+It announces itself; a client listens; the server appears in a list. Choosing it is the
+whole of setup on the happy path.
 
-## Must answer
+"The same network" is a claim the product makes carefully, because it decides who is shown
+which television. A server is a rendezvous, not a resident: a television and a phone in one
+room can pair through a server in another country, so the only addresses that matter are
+the two devices'. The product's rule, stated plainly and specified in full in
+[`../tv-pairing.md`](../tv-pairing.md#what-the-same-network-means):
 
-- [ ] What a user does when discovery finds nothing, on each shell
-- [ ] Pairing code lifetime, and what a user sees when it expires mid-flow
+- **On a private network the server sits inside**, "same network" means the same local
+  block — one home, whether a device is on ethernet or on wifi.
+- **When the server is reached from outside**, it means the *exact* same public address,
+  because a household leaves through one and a looser rule would rope in strangers.
+- **Over IPv6**, it means the same delegated prefix — one home's allocation.
 
-## Not in scope
+Three homes this cannot place — split across subnets, dual-stack with the two devices on
+different families, or behind carrier-grade NAT — fall back to Quick Connect below rather
+than guess. This is deliberate: the product would sooner ask a human to carry four digits
+than list a stranger's television.
 
-What the account itself means is [`accounts.md`](accounts.md).
+## Who listens, and who must be told
+
+Status: **SHIPPED**
+
+Listening on the network needs an API not every platform grants a sandboxed app, so shells
+divide by capability, not by preference. The product view — the mechanics and the per-shell
+table are in [`../tv-pairing.md`](../tv-pairing.md#what-each-shell-can-do):
+
+- **Native mobile shells** (iOS, Android) can *browse*: they find nearby televisions and
+  show them in a list. This is where a person usually pairs a TV.
+- **Native TV shells** (Apple TV, Android TV) and webOS can *announce*: they put themselves
+  on the network so a phone can find them. They do not browse for servers themselves.
+- **Web, desktop, and TV-web shells** can do neither from the browser sandbox. They learn a
+  server only from what the server itself tells them, or from an address a person enters.
+- **Tizen** cannot announce at all — its TV profile ships no way to. A Samsung set is
+  therefore only ever found *through the server*, and confirmed by a check string (below).
+  This is a platform limit, not a gap we mean to close; see the deferral section.
+
+The rule the product holds to: browsing and announcing settle *reach* — whether two devices
+are near enough to pair — and nothing more. Being near is necessary, never sufficient. A
+listed device a server could not physically place still has to prove itself with a check
+string before it may be granted.
+
+## Manual connection
+
+Status: **SHIPPED**
+
+Automatic discovery is a convenience, not a dependency. Every shell offers a manual path,
+because networks lie: multicast is filtered on guest wifi, the server is across a VPN, the
+phone is on cellular. A person can always type an address — hostname or IP, with an optional
+port — and connect directly.
+
+Manual connection is also the only supported path from *outside* the local network. KROMA
+does not run a relay or a discovery cloud; reaching a server across the internet means the
+operator has published it (a port forward, a reverse proxy, a tunnel) and the person knows
+its address. Remote access is thus a property of the *server's* deployment, documented in
+admin, not a discovery feature. What discovery guarantees is that once an address is
+reachable, every sign-in road below works over it — Quick Connect especially, which is
+built to.
+
+## The pairing handshake
+
+Status: **SHIPPED**
+
+Signing in a television is the hard case discovery exists for: a device with a screen, a
+network, and no usable keyboard. There are three roads to it, and a television takes
+whichever ones its platform allows. All three end in the same place — the server holds a
+pending request until a signed-in account approves it, then hands the television an ordinary
+session that appears in the account's device list and revokes like any other
+([`accounts.md`](accounts.md)).
+
+**Quick Connect is the floor.** The television prints a short code; the person reads it and
+types it into an already-signed-in client. It is slow by design, and that is exactly why it
+works from anywhere — across subnets, over a tunnel, from a phone on cellular, on a set that
+can do nothing else. It is never removed, on any shell.
+
+**Nearby handoff** is the shortcut for televisions the platform lets us find. Instead of
+reading a code, the person opens their phone, sees the television in a list, and taps its
+row. The tap is the approval. This is the fast path, and the one most people use.
+
+**Confirmed handoff** covers the listed television a server cannot physically place — the
+Samsung set found only through the server, or any beacon whose position the server cannot
+vouch for. It is listed, but tapping it is not enough: the person is asked for a short check
+string the television is already printing on its own screen. This is Quick Connect's
+guarantee kept *inside* the list rather than replacing it — one confirmation, on exactly the
+platforms that have no safer road in. Why a raw tap is unsafe there, and why the check
+string is the right price, is [`../tv-pairing.md`](../tv-pairing.md#who-may-raise-a-beacon).
+
+### When discovery finds nothing
+
+Discovery finding nothing is a normal state, not an error, and every shell has a designed
+fallback into a road above:
+
+- **A TV shell that can announce but not browse** (Apple TV, Android TV, webOS) is *already*
+  showing its Quick Connect code — announcing is a bonus for the phone, and the code stands
+  on its own. Nothing found means nothing lost.
+- **A TV shell that cannot announce** (Tizen) shows Quick Connect and, when it is reached
+  through the server, its confirmed-handoff check string. Both are on screen from the start.
+- **A mobile shell** that browses and sees an empty list offers, in that same space, "enter
+  a server address" and "sign a TV in with a code". The empty list is a prompt, not a
+  dead end.
+- **Web and desktop**, which never browse, present the manual address field first, with
+  Quick Connect for pairing a television afterwards.
+
+The through-line: no shell ever traps a person on a road that failed. There is always a
+manual address to type and always Quick Connect to fall to.
+
+### Code lifetime and expiry
+
+A Quick Connect or handoff code is short-lived on purpose — a short window is what keeps a
+guessable code safe. **A code is valid for five minutes.** While it is live the television
+polls quietly and shows the code plainly.
+
+When it expires mid-flow the person is not left staring at a stale number wondering why
+approval did nothing. The television replaces the expired code with a clear "this code
+expired" message and a single "show a new code" action; taking it mints a fresh code and
+resets the clock. A code already consumed by a successful sign-in likewise vanishes rather
+than lingering. The rule: an expired code is visibly dead and one tap from being alive
+again, never silently accepted late.
+
+## Trust: what a paired television may do
+
+Status: **SHIPPED**
+
+Approval is one-time and total, then boundaried. The moment an account approves a pairing,
+the television holds an ordinary session and needs no further confirmation for ordinary use
+— it browses, plays, and resumes as that account, without asking anyone to re-approve. This
+is the whole point of pairing a device that cannot type: sign in once, stay signed in.
+
+The boundary is that a paired television is a *device*, not a second key to the account. It
+can act as its account, but it cannot approve *other* devices, change credentials, or do
+anything that would let a set in a guest room mint further sessions. What a session may do,
+and how a television — which cannot practically re-authenticate often — stays valid, is
+[`accounts.md`](accounts.md). Revocation is symmetrical with every other device: the
+account sees the television in its device list and can end its session at any time, from
+anywhere, and the television falls back to unpaired.
+
+## Why Tizen and webOS stop at the server
+
+Status: **DESIGN, NOT IMPLEMENTED**
+
+Both Samsung (Tizen) and LG (webOS) televisions pair today — through the server, with a
+check string where needed. What they deliberately do *not* do is reach the deeper
+integration a native set could: being *heard on the link* to settle reach without a check
+string, via each vendor's own multiscreen stack.
+
+This is deferred, not overlooked, because it costs more than it buys. Each vendor's stack is
+a separate protocol with no shared discovery, needing a phone-side integration built and
+tested per vendor — against television hardware, some of it documented only for models years
+old. Against that cost, the gain is narrow: the beacon already reaches the server and the
+grant already travels through it, so vendor integration would only remove a check string in
+the minority of homes where the two devices' addresses disagree. The product would rather
+ship the check string everywhere than a fragile fast path on two vendors' terms. The full
+argument, and the seam left open should it ever pay off, is
+[`../tv-pairing.md`](../tv-pairing.md#why-tizen-and-webos-stop-at-the-server).

--- a/docs/spec/discovery/README.md
+++ b/docs/spec/discovery/README.md
@@ -3,10 +3,10 @@
 How a client finds a server it was never told about, and how a television — which has no
 keyboard worth using — becomes signed in.
 
-Discovery ends where [`accounts.md`](accounts.md) begins: its job is to get a device
+Discovery ends where [`accounts.md`](../accounts/README.md) begins: its job is to get a device
 *attached* to a server and *pointed at* an account. What the account then means, and what
 the resulting session may do, is that file. The mechanics — the wire records, the trust
-proofs, the per-shell APIs — are [`../tv-pairing.md`](../tv-pairing.md); this file states
+proofs, the per-shell APIs — are [`../tv-pairing.md`](../../tv-pairing.md); this file states
 the product rules and links there rather than repeating them.
 
 ## Finding a server on the local network
@@ -21,7 +21,7 @@ whole of setup on the happy path.
 which television. A server is a rendezvous, not a resident: a television and a phone in one
 room can pair through a server in another country, so the only addresses that matter are
 the two devices'. The product's rule, stated plainly and specified in full in
-[`../tv-pairing.md`](../tv-pairing.md#what-the-same-network-means):
+[`../tv-pairing.md`](../../tv-pairing.md#what-the-same-network-means):
 
 - **On a private network the server sits inside**, "same network" means the same local
   block — one home, whether a device is on ethernet or on wifi.
@@ -40,7 +40,7 @@ Status: **SHIPPED**
 
 Listening on the network needs an API not every platform grants a sandboxed app, so shells
 divide by capability, not by preference. The product view — the mechanics and the per-shell
-table are in [`../tv-pairing.md`](../tv-pairing.md#what-each-shell-can-do):
+table are in [`../tv-pairing.md`](../../tv-pairing.md#what-each-shell-can-do):
 
 - **Native mobile shells** (iOS, Android) can *browse*: they find nearby televisions and
   show them in a list. This is where a person usually pairs a TV.
@@ -83,7 +83,7 @@ network, and no usable keyboard. There are three roads to it, and a television t
 whichever ones its platform allows. All three end in the same place — the server holds a
 pending request until a signed-in account approves it, then hands the television an ordinary
 session that appears in the account's device list and revokes like any other
-([`accounts.md`](accounts.md)).
+([`accounts.md`](../accounts/README.md)).
 
 **Quick Connect is the floor.** The television prints a short code; the person reads it and
 types it into an already-signed-in client. It is slow by design, and that is exactly why it
@@ -100,7 +100,7 @@ vouch for. It is listed, but tapping it is not enough: the person is asked for a
 string the television is already printing on its own screen. This is Quick Connect's
 guarantee kept *inside* the list rather than replacing it — one confirmation, on exactly the
 platforms that have no safer road in. Why a raw tap is unsafe there, and why the check
-string is the right price, is [`../tv-pairing.md`](../tv-pairing.md#who-may-raise-a-beacon).
+string is the right price, is [`../tv-pairing.md`](../../tv-pairing.md#who-may-raise-a-beacon).
 
 ### When discovery finds nothing
 
@@ -147,7 +147,7 @@ The boundary is that a paired television is a *device*, not a second key to the 
 can act as its account, but it cannot approve *other* devices, change credentials, or do
 anything that would let a set in a guest room mint further sessions. What a session may do,
 and how a television — which cannot practically re-authenticate often — stays valid, is
-[`accounts.md`](accounts.md). Revocation is symmetrical with every other device: the
+[`accounts.md`](../accounts/README.md). Revocation is symmetrical with every other device: the
 account sees the television in its device list and can end its session at any time, from
 anywhere, and the television falls back to unpaired.
 
@@ -168,4 +168,4 @@ grant already travels through it, so vendor integration would only remove a chec
 the minority of homes where the two devices' addresses disagree. The product would rather
 ship the check string everywhere than a fragile fast path on two vendors' terms. The full
 argument, and the seam left open should it ever pay off, is
-[`../tv-pairing.md`](../tv-pairing.md#why-tizen-and-webos-stop-at-the-server).
+[`../tv-pairing.md`](../../tv-pairing.md#why-tizen-and-webos-stop-at-the-server).

--- a/docs/spec/library.md
+++ b/docs/spec/library.md
@@ -1,31 +1,224 @@
 # Library
 
-Status: **DRAFT** — skeleton only, nothing here is agreed yet.
+Status: **AGREED** overall, with two sections still **DRAFT** where a product choice
+stays open. Every section carries its own status; the file-level label is the floor.
 
 Sources on disk become titles you can browse. Everything upstream of "there is something
-to play".
+to play". What a title *is* once matched — streams, codecs, artwork — is [`media.md`](media.md);
+getting bytes onto disk in the first place is a module concern, [`modules.md`](modules.md).
 
-## Scope
+## Sources
 
-- What a **source** is, and how many a server may have
-- Scanning: initial scan, incremental rescan, what triggers each
-- **Matching**: filename and folder conventions understood, and what happens when a file
-  matches nothing or matches two things
-- Metadata providers: what is fetched, what is cached locally, what happens offline
-- Refresh: when metadata is re-fetched, and what a user can force
-- Deletions and moves: what happens to watch history when a file disappears
+Status: **AGREED**
 
-## Open questions
+A **source** is a directory tree the server is told to watch, tagged with exactly one
+content kind: **movies** or **shows**. The kind is chosen when the source is added and
+governs how files inside it are matched — a movie source never produces episodes, a show
+source never produces standalone films. Mixing kinds in one directory is unsupported;
+the answer is two sources.
 
-- Is a mis-matched title fixable from the UI, or only by renaming on disk?
-- Does a rescan ever delete user data, or only ever mark absent?
+A server has zero or more sources, and any number of them may point at the same content
+kind. Three "Movies" sources are normal — an SSD of new releases, a NAS of archives, a
+share of home video — and they present as one merged catalogue, deduplicated by matched
+identity, not by folder. A source is just an input; it is not a category the user browses
+by. Filtering the catalogue by source is an admin/diagnostic view, not the primary
+navigation.
 
-## Must answer
+A source records the mount path, its content kind, and its scan schedule. Nothing about a
+source is destructive: removing a source removes its titles from the catalogue and stops
+watching the path, but touches no bytes on disk and — per the deletions rule below —
+preserves the watch history keyed to those files should the source ever return. Adding,
+editing and removing sources is an admin surface, [`admin.md`](admin.md).
 
-- [ ] The exact naming conventions a file must follow to be matched
-- [ ] What the user sees when matching fails — the failure path is product, not an edge case
-- [ ] Whether scanning is safe to run against a library being written to
+## Naming conventions understood
+
+Status: **AGREED**
+
+Matching is convention-first: a correctly named file matches offline, with no provider
+call. The conventions below are the contract. A file that follows them is guaranteed to
+match to the right identity; a file that does not is not an error — it lands in the
+unmatched state and is fixable (see below).
+
+**Movies.** One film per folder, the folder named for the film and its year:
+
+```
+Movies/Blade Runner (1982)/Blade Runner (1982).mkv
+Movies/Dune Part Two (2024)/Dune Part Two (2024) - 2160p.mkv
+```
+
+The `Title (Year)` stem is what is matched. The year is not decoration — it disambiguates
+remakes and is the difference between a confident match and a guess. A trailing tag after
+` - ` (resolution, edition, source) is preserved as version/edition detail, [`media.md`](media.md),
+and never changes the matched identity. A loose file directly under the source root
+(`Movies/Blade Runner (1982).mkv`, no folder) is accepted with the same stem rules, but the
+folder-per-film layout is the recommended one and the only layout guaranteed to keep
+extras, artwork and sidecars grouped.
+
+**Shows.** One folder per show, one subfolder per season, episodes carrying the
+`SxxEyy` marker:
+
+```
+Shows/Severance/Season 02/Severance - S02E01 - Hello, Ms. Cobel.mkv
+Shows/The Bear/Season 01/The Bear - S01E03.mkv
+```
+
+The show folder name and the `SxxEyy` marker are load-bearing; the human episode title
+after the second ` - ` is optional and ignored for matching. `Specials` is accepted as an
+alias for `Season 00`. Multi-episode files are named with a range (`S01E01-E02`) and
+matched to both episodes. A show folder MAY carry a `(Year)` for disambiguation
+(`Shows/Ironheart (2025)/…`) and SHOULD when two shows share a name.
+
+**Common to both.** Case is ignored. Separators may be spaces, dots or underscores. Only
+recognised video containers are considered files to match; sidecars (subtitles, artwork,
+`.nfo`) attach to the matched item by shared stem and are never matched on their own.
+These are conventions, not configuration: the scheme is fixed so that a library is
+portable between servers and a rename on disk is a reliable repair, not a gamble.
+
+## Scanning
+
+Status: **AGREED**
+
+Two scans, one code path, different triggers.
+
+**Initial scan** runs when a source is added: the whole tree is walked once, every
+candidate file matched, the catalogue populated. It is a background job with visible
+progress, [`admin.md`](admin.md); the catalogue fills as it goes rather than appearing all
+at once at the end.
+
+**Incremental rescan** keeps the catalogue true to disk afterwards. It is triggered by,
+in order of preference: filesystem change notifications where the platform and mount
+provide them; a periodic sweep on the source's schedule as the reliable fallback (network
+shares and many container mounts do not deliver events); and an explicit "Scan now" from an
+admin. An incremental rescan only reconsiders what changed — new paths, vanished paths,
+files whose size or modification time moved — so it is cheap enough to run often.
+
+**Safety against a library being written to — the guarantee.** Scanning is safe to run at
+any time, including while files are being copied, moved or downloaded into a source. The
+guarantee rests on three rules:
+
+- A file is only matched once it looks **settled** — its size and modification time are
+  unchanged across the observation window. A file still growing is skipped this pass and
+  picked up on the next, so a half-copied download never enters the catalogue as a broken
+  title.
+- Scanning **reads only**. It never writes, moves, renames or deletes anything in a
+  source. The library is treated as owned by the user; KROMA observes it.
+- A vanished path is **marked absent, not deleted** (see below), so a move that briefly
+  removes then re-adds a file — the shape of most "atomic" replacements — resolves to the
+  same identity without losing anything.
+
+The corollary: KROMA never demands exclusive access to a library and never blocks the
+tools writing to it. A module mid-download and a scan mid-sweep coexist by design,
+[`modules.md`](modules.md).
+
+## Matching and its failure path
+
+Status: **AGREED**
+
+Matching resolves a settled file to an identity: convention parse first (offline,
+authoritative on the stem), then a metadata provider lookup to attach the rich record.
+Two outcomes need a designed product response, and both are first-class UI states, not
+log lines.
+
+**Matches nothing.** A file that parses to no confident identity — an unconventional name,
+a film with no year against an ambiguous title, a provider that returns nothing — becomes
+an **unmatched item**. Unmatched items are not hidden and not discarded. They appear in a
+browsable **Unmatched** view in the library UI, listed by their on-disk path, so the user
+can always see exactly which files the server is holding but cannot place. From there the
+user has two repairs, and both are supported:
+
+- **Manual match** — search the provider, pick the correct title/episode, and bind this
+  file to it. The binding is remembered against the file so a later rescan does not undo
+  it.
+- **Rename on disk** — fix the name to the convention above; the next rescan matches it
+  automatically and it leaves the Unmatched view.
+
+Answering the skeleton's open question directly: a mis-match is fixable **from the UI**,
+by manual match; renaming on disk is the equivalent, portable repair, and neither is
+privileged over the other.
+
+**Matches two things.** When a file could be more than one identity — a title shared by a
+remake with no year to separate them, two provider records that both fit — KROMA does not
+guess. It records the file as **ambiguous** (a variant of the unmatched state) with the
+competing candidates surfaced, and asks the user to choose. A wrong confident match is
+worse than an honest "which one?", so the tie is never broken silently.
+
+Nothing about either failure is fatal to the rest of the scan: one unplaceable file never
+stalls a source, and the catalogue is always the set of files that *did* match plus a
+visible tally of those that did not.
+
+## Metadata providers
+
+Status: **AGREED**
+
+The matched identity is enriched from a metadata provider: titles, summaries, cast,
+episode data and artwork. Two rules define the behaviour.
+
+**Fetched once, cached locally, owned locally.** Every field and image a provider returns
+is written to the server's own store on first fetch. After that the catalogue is served
+entirely from the local cache. The provider is a source of truth for *acquiring* metadata,
+never a runtime dependency for *reading* it.
+
+**Offline is a normal state, not a degraded one.** With no internet, everything already
+matched browses and plays exactly as before, because it is all local. Only two things are
+affected offline: a brand-new file that needs a first provider lookup stays unmatched (by
+convention it still parses its stem, so it is placeable and playable, just thin on
+metadata) until connectivity returns; and forced refreshes queue rather than fail. KROMA
+is a media server first and a metadata client second.
+
+The specific providers, and whether more than one is consulted, are configuration and
+architecture, not product rules, and are not fixed here.
+
+## Refresh
+
+Status: **DRAFT** — recommended rules provisional
+
+Metadata re-fetches on two automatic triggers and one manual one:
+
+- **New need** — a newly matched item fetches its metadata once, as above.
+- **Staleness sweep** — running series are re-checked on a slow cadence so a new episode's
+  air date and stills appear without user action; completed films are not re-checked on a
+  timer, because their metadata does not change.
+- **User force** — a "Refresh metadata" action on any title, season or whole source
+  re-fetches from the provider and overwrites the cache, letting a user pull a corrected
+  summary or better artwork on demand. A forced refresh **never** discards a manual match
+  or user-chosen artwork; it refreshes the descriptive fields around a binding the user
+  set, it does not overturn the binding.
+
+Open, with a recommendation: whether a forced refresh should also re-run *matching* (not
+just re-fetch metadata for the current identity). Recommended answer — keep them separate:
+"Refresh metadata" updates the record, and a distinct "Re-match" action re-runs
+identification, so a user never loses a correct match by asking for fresher artwork. This
+is provisional pending review.
+
+## Deletions and moves
+
+Status: **AGREED**
+
+The rule is **mark absent, never destroy user data**, and it is not negotiable enough to
+leave as an open question.
+
+When a file disappears from a source, its title is **marked absent**: removed from normal
+browsing, but its record and — critically — all watch history, resume positions, ratings
+and manual-match bindings keyed to it are retained. If the same content reappears (a NAS
+remounts, a file is moved back or relocated within the source), it re-matches to the same
+identity and everything the user built up is still there. Watch history survives a file
+outliving its bytes.
+
+A **move** is therefore not a special case: it is an absent path plus a new path that
+resolve to one identity, and the history follows the identity, not the path. This is what
+makes reorganising a library on disk safe.
+
+Genuine permanent deletion of a title's history is an explicit, user-initiated admin
+action ("Remove and forget"), never a side effect of a scan. Answering the skeleton
+directly: a rescan **only ever marks absent**; it never deletes user data. The one actor
+allowed to destroy history is a human who asks for it, on the admin surface,
+[`admin.md`](admin.md).
 
 ## Not in scope
 
-Acquisition (getting files onto disk) is a module concern — see [`modules.md`](modules.md).
+- **Acquisition** — getting files onto disk (downloads, indexers) is a module concern,
+  [`modules.md`](modules.md). The library observes what appears; it does not fetch it.
+- **What a matched title technically is** — containers, codecs, streams, artwork sizes —
+  is [`media.md`](media.md).
+- **Choosing what to send a client** at play time is [`playback.md`](playback.md).
+- **Who may see which source or title** is [`accounts.md`](accounts.md).

--- a/docs/spec/library/README.md
+++ b/docs/spec/library/README.md
@@ -4,8 +4,8 @@ Status: **AGREED** overall, with two sections still **DRAFT** where a product ch
 stays open. Every section carries its own status; the file-level label is the floor.
 
 Sources on disk become titles you can browse. Everything upstream of "there is something
-to play". What a title *is* once matched — streams, codecs, artwork — is [`media.md`](media.md);
-getting bytes onto disk in the first place is a module concern, [`modules.md`](modules.md).
+to play". What a title *is* once matched — streams, codecs, artwork — is [`media.md`](../media/README.md);
+getting bytes onto disk in the first place is a module concern, [`modules.md`](../modules/README.md).
 
 ## Sources
 
@@ -28,7 +28,7 @@ A source records the mount path, its content kind, and its scan schedule. Nothin
 source is destructive: removing a source removes its titles from the catalogue and stops
 watching the path, but touches no bytes on disk and — per the deletions rule below —
 preserves the watch history keyed to those files should the source ever return. Adding,
-editing and removing sources is an admin surface, [`admin.md`](admin.md).
+editing and removing sources is an admin surface, [`admin.md`](../admin/README.md).
 
 ## Naming conventions understood
 
@@ -48,7 +48,7 @@ Movies/Dune Part Two (2024)/Dune Part Two (2024) - 2160p.mkv
 
 The `Title (Year)` stem is what is matched. The year is not decoration — it disambiguates
 remakes and is the difference between a confident match and a guess. A trailing tag after
-` - ` (resolution, edition, source) is preserved as version/edition detail, [`media.md`](media.md),
+` - ` (resolution, edition, source) is preserved as version/edition detail, [`media.md`](../media/README.md),
 and never changes the matched identity. A loose file directly under the source root
 (`Movies/Blade Runner (1982).mkv`, no folder) is accepted with the same stem rules, but the
 folder-per-film layout is the recommended one and the only layout guaranteed to keep
@@ -82,7 +82,7 @@ Two scans, one code path, different triggers.
 
 **Initial scan** runs when a source is added: the whole tree is walked once, every
 candidate file matched, the catalogue populated. It is a background job with visible
-progress, [`admin.md`](admin.md); the catalogue fills as it goes rather than appearing all
+progress, [`admin.md`](../admin/README.md); the catalogue fills as it goes rather than appearing all
 at once at the end.
 
 **Incremental rescan** keeps the catalogue true to disk afterwards. It is triggered by,
@@ -108,7 +108,7 @@ guarantee rests on three rules:
 
 The corollary: KROMA never demands exclusive access to a library and never blocks the
 tools writing to it. A module mid-download and a scan mid-sweep coexist by design,
-[`modules.md`](modules.md).
+[`modules.md`](../modules/README.md).
 
 ## Matching and its failure path
 
@@ -212,13 +212,13 @@ Genuine permanent deletion of a title's history is an explicit, user-initiated a
 action ("Remove and forget"), never a side effect of a scan. Answering the skeleton
 directly: a rescan **only ever marks absent**; it never deletes user data. The one actor
 allowed to destroy history is a human who asks for it, on the admin surface,
-[`admin.md`](admin.md).
+[`admin.md`](../admin/README.md).
 
 ## Not in scope
 
 - **Acquisition** — getting files onto disk (downloads, indexers) is a module concern,
-  [`modules.md`](modules.md). The library observes what appears; it does not fetch it.
+  [`modules.md`](../modules/README.md). The library observes what appears; it does not fetch it.
 - **What a matched title technically is** — containers, codecs, streams, artwork sizes —
-  is [`media.md`](media.md).
-- **Choosing what to send a client** at play time is [`playback.md`](playback.md).
-- **Who may see which source or title** is [`accounts.md`](accounts.md).
+  is [`media.md`](../media/README.md).
+- **Choosing what to send a client** at play time is [`playback.md`](../playback/README.md).
+- **Who may see which source or title** is [`accounts.md`](../accounts/README.md).

--- a/docs/spec/media.md
+++ b/docs/spec/media.md
@@ -1,29 +1,188 @@
 # Media
 
-Status: **DRAFT** — skeleton only, nothing here is agreed yet.
+Status: **AGREED** — the media model and the first-class codec/stream truth are decided.
+Per-section status is called out where it differs.
 
-What a title *is* once KROMA knows about it: the technical truth about streams, which is
-what makes direct play possible or impossible.
+What a title *is* once KROMA knows about it: the technical truth about its streams. That
+truth is the input to every playback decision. If a file direct-plays, it is because its
+streams match what a client can render; if it cannot, this is where the reason comes from.
 
-## Scope
+This file owns the *vocabulary* of media — the model, the containers, the codecs, the
+stream properties. The per-device capability matrix lives in [`surfaces.md`](surfaces.md)
+and the decision of what to send lives in [`playback.md`](playback.md). Both consume the
+terms defined here; neither is redefined here.
 
-- The media model: title, version/edition, media file, stream (video, audio, subtitle)
-- Containers and codecs that are first-class, HEVC first among them
-- Bit depth, HDR variants, and what is preserved end to end
-- Audio: channel layouts, passthrough, what may be downmixed and when
-- Subtitles: embedded vs sidecar, forced and SDH, what is burned in and when
-- Artwork and images: sources, sizes, caching
+## The media model
 
-## Open questions
+Status: **AGREED**
 
-- How are multiple versions of the same title (1080p and 4K) represented and chosen between?
-- Is stream metadata trusted from probe, or re-probed on playback failure?
+Five nouns, nested, each the child of the one before:
 
-## Must answer
+- **Title** — the work a person searches for: a film, or one episode of a series. The unit
+  the [`library.md`](library.md) matches to metadata. A title carries no bytes.
+- **Edition** — a named cut of a title: theatrical, director's, extended, remastered.
+  Different runtimes, different content. A title with one cut has one unnamed edition.
+- **Media file** — one physical file on disk that realises an edition at a given fidelity.
+  An edition may have several: a 1080p file and a 4K file are two media files of the same
+  edition, not two titles and not two editions.
+- **Stream** — one track inside a media file: exactly one of video, audio, or subtitle.
+  A media file has one or more video streams (usually one), zero or more audio streams,
+  and zero or more subtitle streams.
+- **Stream properties** — the describable facts about a stream (codec, resolution, bit
+  depth, channel layout, language, disposition). These are what a client is matched against.
 
-- [ ] The definitive list of what direct-plays on each client generation
-- [ ] What KROMA does with a file it can read but not describe
+The nesting is strict and total: every stream belongs to exactly one media file, every
+media file to exactly one edition, every edition to exactly one title. Nothing floats.
 
-## Not in scope
+## Versions of one title
 
-Deciding what to send to a given client is [`playback.md`](playback.md).
+Status: **AGREED** — resolves the open question on multiple versions.
+
+A 1080p file and a 4K file of the same cut are **two media files of one edition**. They are
+never modelled as separate titles, and the library never shows a duplicate. A person picks
+a title and a cut; the fidelity is chosen for them.
+
+- KROMA ranks a title's media files and keeps a **preferred** one. Rank order: resolution,
+  then HDR over SDR, then bit depth, then audio channel count, then bitrate. The preferred
+  file is the default source for a play request.
+- The preference is a *default*, not a lock. A client that cannot render the preferred file
+  may be served a lesser file of the same edition instead of falling back to transcoding —
+  a genuinely better outcome, so the model must make the alternative reachable. Which file
+  a given client actually receives is [`playback.md`](playback.md)'s decision; media.md only
+  guarantees the alternatives are enumerated and comparable.
+- Editions are surfaced to the person (they are different content); fidelity variants are
+  not (they are the same content at different quality). A person chooses a cut, never a
+  resolution.
+
+## Containers and codecs
+
+Status: **AGREED**
+
+First-class means: KROMA fully describes it, preserves it end to end, and expects direct
+play wherever a client can render it. Everything else is *readable* but not privileged.
+
+First-class containers: **MP4**, **MKV**, **WebM**. First-class video codecs, HEVC first:
+
+- **HEVC / H.265** — the priority codec. 8-bit and 10-bit, SDR and HDR, are all first-class.
+- **H.264 / AVC** — the universal floor; assumed playable everywhere.
+- **AV1** — first-class where the client generation can render it; treated as first-class
+  media truth regardless, so a capable client direct-plays it.
+- **VP9** — first-class within WebM, chiefly for the browser surface.
+
+First-class audio and subtitle codecs are named in their sections below. A codec being
+first-class is a statement about *KROMA's* handling; whether a *particular* device renders
+it is the matrix in [`surfaces.md`](surfaces.md).
+
+## Bit depth and HDR
+
+Status: **AGREED**
+
+HDR is preserved end to end or it is not offered. KROMA never silently flattens HDR to SDR
+as if nothing happened — a tone-mapped picture is a compromise and is surfaced as one by
+[`playback.md`](playback.md).
+
+- **Bit depth** — 8-bit and 10-bit are first-class. 10-bit is retained as a first-class
+  property of the video stream, never rounded away in the model.
+- **HDR variants** KROMA distinguishes: **HDR10**, **HDR10+**, **Dolby Vision**, **HLG**.
+  Each is a distinct property, because each has distinct client support. Dolby Vision's
+  profile is recorded, because a profile a client cannot decode is not the same as one it
+  can.
+- **What is preserved**: colour primaries, transfer characteristics, and matrix
+  coefficients travel with the video stream. A client is matched against the exact HDR
+  variant, not a generic "HDR" flag. Where dynamic metadata (HDR10+, Dolby Vision) cannot
+  be carried to a client, KROMA's position is that the base HDR10 layer is preserved rather
+  than discarding HDR entirely — a fallback [`playback.md`](playback.md) makes visible.
+
+## Audio
+
+Status: **AGREED**
+
+First-class audio codecs: **AAC**, **AC-3** and **E-AC-3** (Dolby Digital / Plus),
+**TrueHD**, **DTS** and **DTS-HD**, **FLAC**, **Opus**. Each audio stream's **channel
+layout** (stereo, 5.1, 7.1, Atmos objects) is a first-class property.
+
+- **Passthrough** is the default for multichannel and lossless audio: the bitstream is sent
+  untouched to a device or receiver that can decode it. This is direct play for audio and is
+  always preferred.
+- **Downmixing** to stereo happens only when the target cannot render the source layout, and
+  only as an explicit fallback — never silently. When it happens, [`playback.md`](playback.md)
+  owns telling the person; media.md defines *what* downmix means (a channel-count reduction
+  that is a compromise) and guarantees the original stream is retained unchanged as the
+  source.
+- Multiple audio streams (languages, commentary) are all enumerated and selectable. The
+  default follows the file's own disposition flags, then profile language preference.
+
+## Subtitles
+
+Status: **AGREED**
+
+A subtitle stream is either **embedded** (a track inside the media file) or **sidecar** (a
+separate file the library associates with the media file). Both are first-class and both are
+enumerated the same way once known.
+
+- First-class text formats: **SRT**, **WebVTT**, **ASS/SSA**. First-class image formats:
+  **PGS** and **VobSub**. Text subtitles are the default because they overlay without
+  touching the video; image subtitles are heavier and sometimes force a compromise.
+- **Dispositions** are recorded and honoured: **forced** (only the foreign-language lines a
+  viewer needs) and **SDH** (for the deaf and hard of hearing). These are distinct
+  properties; a person picking "forced" gets forced, not full.
+- **Burning in** — rendering a subtitle permanently into the video — is a last resort, used
+  only when a subtitle cannot be delivered as a selectable overlay to the target. It is
+  never the default and never silent. media.md's rule: the original subtitle stream is
+  always preserved; the burn is a derived output, not a replacement. *When* it happens is
+  [`playback.md`](playback.md).
+
+## Artwork and images
+
+Status: **AGREED**
+
+Every title carries images: **poster**, **backdrop**, **logo**, and per-episode **thumb**.
+These are media too, and are treated with the same discipline.
+
+- **Sources**, in order of trust: images embedded in the media file, sidecar image files
+  next to it, then images fetched by the [`library.md`](library.md) metadata refresh. A
+  local image outranks a fetched one; a person's explicit choice outranks both.
+- **Sizes** — KROMA derives and caches a fixed set of sizes per image (a small grid
+  thumbnail through a full-bleed backdrop) so a client requests a size, never the original.
+  The original is retained as the master.
+- **Caching** — derived sizes are cached and served without re-deriving. A source image
+  changing invalidates its derivatives; nothing else. Artwork is never a reason a title
+  fails to appear — a title with no image shows a typed placeholder, never a broken one.
+
+## Probing and trust
+
+Status: **AGREED** — resolves the open question on probe trust.
+
+KROMA learns a file's streams by **probing** it once, when the library first sees it, and
+**trusts that probe** for playback decisions. Re-probing on every play would tax the server
+for a fact that rarely changes.
+
+- The probe result is the authoritative stream truth until the file's bytes change (size or
+  modification time), which invalidates it and schedules a re-probe.
+- **Re-probe on playback failure**: when a direct play fails in a way that implicates the
+  stream description (a codec the probe named but the client could not initialise), KROMA
+  re-probes that file once and records the corrected truth, so the same failure does not
+  recur. A failure that does not implicate the description (network, disk) does not trigger a
+  re-probe.
+- Trust is per-file and durable: a corrected probe is written back, not held in memory for
+  one session.
+
+## Files KROMA can read but not fully describe
+
+Status: **AGREED** — resolves the "read but not describe" must-answer.
+
+A file whose container opens and whose streams enumerate, but which contains a stream KROMA
+cannot fully describe (an unknown codec, absent or contradictory metadata), is **partially
+known** — never hidden and never silently dropped.
+
+- The title **appears** in the library with whatever *is* known. A single indescribable
+  stream does not disqualify the file; the describable streams remain first-class.
+- The unknown stream is marked **undescribed** and carries its raw identifier so a person and
+  a diagnostician can see exactly what was not understood. An undescribed stream is treated
+  as *not direct-playable* by [`playback.md`](playback.md) — KROMA will not gamble that a
+  client can render what KROMA itself cannot name.
+- A file that will not open at all — a truncated or corrupt container — is **unreadable**,
+  surfaced as a typed error against the title with the reason, and excluded from play until
+  it is re-scanned. It is a visible fault, not an absence.
+- Undescribed and unreadable are distinct states. The first is "we see it but cannot vouch
+  for it"; the second is "we cannot see it". Both are on record; neither is a blank.

--- a/docs/spec/media/README.md
+++ b/docs/spec/media/README.md
@@ -8,8 +8,8 @@ truth is the input to every playback decision. If a file direct-plays, it is bec
 streams match what a client can render; if it cannot, this is where the reason comes from.
 
 This file owns the *vocabulary* of media — the model, the containers, the codecs, the
-stream properties. The per-device capability matrix lives in [`surfaces.md`](surfaces.md)
-and the decision of what to send lives in [`playback.md`](playback.md). Both consume the
+stream properties. The per-device capability matrix lives in [`surfaces.md`](../surfaces/README.md)
+and the decision of what to send lives in [`playback.md`](../playback/README.md). Both consume the
 terms defined here; neither is redefined here.
 
 ## The media model
@@ -19,7 +19,7 @@ Status: **AGREED**
 Five nouns, nested, each the child of the one before:
 
 - **Title** — the work a person searches for: a film, or one episode of a series. The unit
-  the [`library.md`](library.md) matches to metadata. A title carries no bytes.
+  the [`library.md`](../library/README.md) matches to metadata. A title carries no bytes.
 - **Edition** — a named cut of a title: theatrical, director's, extended, remastered.
   Different runtimes, different content. A title with one cut has one unnamed edition.
 - **Media file** — one physical file on disk that realises an edition at a given fidelity.
@@ -48,7 +48,7 @@ a title and a cut; the fidelity is chosen for them.
 - The preference is a *default*, not a lock. A client that cannot render the preferred file
   may be served a lesser file of the same edition instead of falling back to transcoding —
   a genuinely better outcome, so the model must make the alternative reachable. Which file
-  a given client actually receives is [`playback.md`](playback.md)'s decision; media.md only
+  a given client actually receives is [`playback.md`](../playback/README.md)'s decision; media.md only
   guarantees the alternatives are enumerated and comparable.
 - Editions are surfaced to the person (they are different content); fidelity variants are
   not (they are the same content at different quality). A person chooses a cut, never a
@@ -71,7 +71,7 @@ First-class containers: **MP4**, **MKV**, **WebM**. First-class video codecs, HE
 
 First-class audio and subtitle codecs are named in their sections below. A codec being
 first-class is a statement about *KROMA's* handling; whether a *particular* device renders
-it is the matrix in [`surfaces.md`](surfaces.md).
+it is the matrix in [`surfaces.md`](../surfaces/README.md).
 
 ## Bit depth and HDR
 
@@ -79,7 +79,7 @@ Status: **AGREED**
 
 HDR is preserved end to end or it is not offered. KROMA never silently flattens HDR to SDR
 as if nothing happened — a tone-mapped picture is a compromise and is surfaced as one by
-[`playback.md`](playback.md).
+[`playback.md`](../playback/README.md).
 
 - **Bit depth** — 8-bit and 10-bit are first-class. 10-bit is retained as a first-class
   property of the video stream, never rounded away in the model.
@@ -91,7 +91,7 @@ as if nothing happened — a tone-mapped picture is a compromise and is surfaced
   coefficients travel with the video stream. A client is matched against the exact HDR
   variant, not a generic "HDR" flag. Where dynamic metadata (HDR10+, Dolby Vision) cannot
   be carried to a client, KROMA's position is that the base HDR10 layer is preserved rather
-  than discarding HDR entirely — a fallback [`playback.md`](playback.md) makes visible.
+  than discarding HDR entirely — a fallback [`playback.md`](../playback/README.md) makes visible.
 
 ## Audio
 
@@ -105,7 +105,7 @@ layout** (stereo, 5.1, 7.1, Atmos objects) is a first-class property.
   untouched to a device or receiver that can decode it. This is direct play for audio and is
   always preferred.
 - **Downmixing** to stereo happens only when the target cannot render the source layout, and
-  only as an explicit fallback — never silently. When it happens, [`playback.md`](playback.md)
+  only as an explicit fallback — never silently. When it happens, [`playback.md`](../playback/README.md)
   owns telling the person; media.md defines *what* downmix means (a channel-count reduction
   that is a compromise) and guarantees the original stream is retained unchanged as the
   source.
@@ -130,7 +130,7 @@ enumerated the same way once known.
   only when a subtitle cannot be delivered as a selectable overlay to the target. It is
   never the default and never silent. media.md's rule: the original subtitle stream is
   always preserved; the burn is a derived output, not a replacement. *When* it happens is
-  [`playback.md`](playback.md).
+  [`playback.md`](../playback/README.md).
 
 ## Artwork and images
 
@@ -140,7 +140,7 @@ Every title carries images: **poster**, **backdrop**, **logo**, and per-episode 
 These are media too, and are treated with the same discipline.
 
 - **Sources**, in order of trust: images embedded in the media file, sidecar image files
-  next to it, then images fetched by the [`library.md`](library.md) metadata refresh. A
+  next to it, then images fetched by the [`library.md`](../library/README.md) metadata refresh. A
   local image outranks a fetched one; a person's explicit choice outranks both.
 - **Sizes** — KROMA derives and caches a fixed set of sizes per image (a small grid
   thumbnail through a full-bleed backdrop) so a client requests a size, never the original.
@@ -179,7 +179,7 @@ known** — never hidden and never silently dropped.
   stream does not disqualify the file; the describable streams remain first-class.
 - The unknown stream is marked **undescribed** and carries its raw identifier so a person and
   a diagnostician can see exactly what was not understood. An undescribed stream is treated
-  as *not direct-playable* by [`playback.md`](playback.md) — KROMA will not gamble that a
+  as *not direct-playable* by [`playback.md`](../playback/README.md) — KROMA will not gamble that a
   client can render what KROMA itself cannot name.
 - A file that will not open at all — a truncated or corrupt container — is **unreadable**,
   surfaced as a typed error against the title with the reason, and excluded from play until

--- a/docs/spec/modules.md
+++ b/docs/spec/modules.md
@@ -1,33 +1,264 @@
 # Modules
 
-Status: **DRAFT** — skeleton only, nothing here is agreed yet.
+Status: **SHIPPED** overall — the out-of-process model, the `.kmod` bundle, the Store,
+install-by-id and by-upload, checksum verification, dependency resolution and the
+compatibility gate are all released. Two sections stay open and carry their own status:
+the trust model for third-party registries, and the abandonment story. Every section
+carries a status; the file-level label is the floor.
 
-The base build ships **zero modules** — `modules/roster.yaml` is deliberately empty — and
-every first-party capability arrives as an installable `.kmod` whose backend runs
-out-of-process. This is what makes every module uninstallable from Admin. That decision is
-load-bearing for the whole product, so it earns a spec file.
+The base build ships **zero modules**. Everything past playback and catalogue —
+downloads, indexers, acquisition, VPN, transcription, embeddings, network discovery,
+remote access — arrives as an installable `.kmod` whose backend runs *out of the server
+process*. That is what makes every module uninstallable from Admin, and it is the
+load-bearing decision of this domain, chosen for three reasons:
 
-## Scope
+- **Isolation.** A module is a separate program the server spawns and supervises. A
+  module that crashes, hangs or is incompatible takes down *itself* — the server keeps
+  serving, and every other module keeps running.
+- **Native dependencies a sandbox can't hold.** Modules carry real native code
+  (torrent engines, ML runtimes, native TLS, raw sockets) that no in-process sandbox can
+  host safely. Giving each its own process is the honest boundary.
+- **Runtime installability.** A capability is added or removed on a running server
+  without rebuilding or replacing the server binary. The base build never grows.
 
-- What a module may and may not do, and the boundary it may not cross
-- The `.kmod` bundle: what it contains, how it is versioned, how it declares compatibility
-- Installation: from the Store, and by uploading a bundle by hand
-- The Store: the GitHub-release registry, trust, and what is shown before installing
-- Lifecycle: enable, disable, update, uninstall, and what happens to a module's data
-- Failure: what a crashed or incompatible sidecar does to the rest of the server
-- First-party modules as a set, and why each is a module rather than core
+Mechanics — how a sidecar is spawned, supervised and reverse-proxied — live in
+[`../modules-as-kmod.md`](../modules-as-kmod.md); registry wiring lives in
+[`../module-registries.md`](../module-registries.md). This file states the product rules.
 
-## Open questions
+## What a module is, and the boundary it may not cross
 
-- What is the compatibility promise between a server version and an installed module?
-- May a module ship UI, and if so what is it allowed to render?
+Status: **SHIPPED**
 
-## Must answer
+A module is a self-contained capability with a reverse-DNS id (`tv.kroma.torrents`). It
+brings its own backend, its own data, its own settings and, optionally, its own admin UI.
+Within its own process it has wide latitude: it opens the shared database directly, runs
+its own migrations against its own tables, registers services, schedules jobs, and serves
+HTTP the server reverse-proxies under `/api/module/<id>/`.
 
-- [ ] The trust model for third-party modules on a public registry
-- [ ] What a user is told when a module they rely on stops being maintained
+What it may **not** do:
 
-## Existing material
+- **It may not reach into the server's process or another module's process.** Every
+  cross-boundary call is an explicit, typed request over the local callback API or a named
+  port — never a direct function call into core internals. The boundary is a wire, not a
+  linker symbol.
+- **It may not replace core.** Playback, catalogue, accounts and the library's
+  read/observe contract are the server's; a module extends the server, it does not
+  substitute for it. A module cannot claim a first-party module id it does not own (see
+  the Store).
+- **It may not assume it is present.** Because any module is uninstallable, core never
+  depends on one. Features that need a module are absent, not broken, when it is gone.
 
-`modules/README.md`, `docs/module-registries.md`, `docs/modules-as-kmod.md`, and
-`modules/module.schema.json` — this file states the product rules, those state the mechanics.
+A module *may* depend on another module (hard or optional); that dependency is declared,
+resolved and enforced (below), not discovered at runtime.
+
+## The `.kmod` bundle
+
+Status: **SHIPPED**
+
+A module ships as a single `.kmod` file: a manifest, the native backend binary, an icon,
+and the module's own frontend, packed together. At product level the manifest is the
+contract, and it declares:
+
+- **Identity and version.** The reverse-DNS id and a hand-set version. The version is the
+  source of truth for whether an update exists, and the release process refuses to publish
+  changed bytes under an unchanged version — so "there is a newer version" always means
+  "there is genuinely newer code", never a silent re-issue.
+- **`minServer` — the compatibility floor.** The minimum server version the module needs,
+  as a bare version or a range. This is the whole compatibility contract (see below).
+- **Dependencies.** Hard dependencies that must be installed alongside it, and optional
+  ones offered but not required.
+- **Target.** Which platform the backend was built for. A library-only module (manifest
+  and frontend, no native binary) declares no target and runs anywhere; everything else
+  ships per-platform, and the server picks the artifact that fits the host.
+
+Integrity is guaranteed by a published SHA-256 the server checks against the bytes it
+downloads. A bundle whose checksum does not match, or that publishes no checksum, is
+refused. Integrity is not safety: a matching checksum proves the bytes are the ones the
+registry named, not that they are trustworthy.
+
+## Installation
+
+Status: **SHIPPED**
+
+Two paths, one outcome — the module is unpacked under the server's data directory and its
+sidecar is spawned:
+
+- **From the Store**, by id. The server resolves hard dependencies automatically,
+  offers optional ones and capability providers (e.g. a module that needs a download
+  engine is offered the engines the catalogue advertises), verifies every download's
+  checksum, and enforces `minServer` before it installs anything.
+- **By upload**, handing the server a `.kmod` by hand. Same unpack, same spawn, same
+  `minServer` gate — for an air-gapped server, a private build, or a module not on any
+  registry.
+
+Both are admin actions on the [`admin.md`](admin.md) surface.
+
+## The Store
+
+Status: **SHIPPED**
+
+The Store (Admin → Modules) is the in-app browser over the configured registries. The
+official registry is pinned first and cannot be removed; operators may add their own. It
+shows the union of every registry's catalogue, and for each module it shows **this
+server's verdict**, not just the catalogue entry:
+
+- which artifact matches this host's platform,
+- the installed version, if any, and whether an update exists,
+- whether the module is **compatible with this server, and if not, the reason** (a
+  `minServer` the server does not satisfy is named, not hidden).
+
+That verdict is the point: a user decides to install or update against what *their* server
+will actually do, before committing. Registry precedence, https requirements, shadowing of
+duplicate ids and the empty-catalogue-is-a-failure rule are specified in
+[`../module-registries.md`](../module-registries.md).
+
+## Trust
+
+Status: **DRAFT**
+
+The trust model for third-party registries is genuinely open. The shipped integrity
+guarantees are settled; the *safety* posture around untrusted publishers is not. The
+proposed position:
+
+- **First-party is trusted by default.** The official registry is pinned, first-party,
+  and curated. A module from it installs without a trust prompt.
+- **A third-party registry is an explicit operator opt-in.** Adding one is admin-only and
+  is *not* a trust grant to its modules — it only makes them visible. The operator is told,
+  in plain terms, that a module is a native binary the server will execute, so adding a
+  registry they do not control is equivalent to trusting its operator with code execution
+  on the host.
+- **Checksums guarantee integrity, never safety.** The server says so where it matters:
+  on the add-registry flow and on installing a non-first-party module. Signing and a
+  curated-vs-community distinction are candidates, not decided.
+
+Until this is resolved, the honest line the user is shown is: *the server verifies this is
+the file the registry published; it does not vouch for what the file does.*
+
+## Lifecycle
+
+Status: **SHIPPED**
+
+Four actions, and what each does to the module's data:
+
+- **Enable** — the server spawns the sidecar; the module's routes, jobs and UI become
+  live. Enabled is the state that survives a reboot: enabled modules are re-spawned at boot.
+- **Disable** — the sidecar is stopped. The module stops running; its **data is kept
+  untouched**. Enabling again resumes where it left off. Disable is the reversible off
+  switch.
+- **Update** — a newer version replaces the bundle and the sidecar is re-spawned. The
+  module's migrations carry its data forward; settings and stored state persist across the
+  update. `minServer` is re-checked, so an update that outgrows the server is refused with
+  a reason rather than installed into a crash.
+- **Uninstall** — the module is removed entirely. The server refuses to uninstall a module
+  another enabled module still depends on, naming the dependant. Uninstall is the one
+  destructive action: it is the deliberate way to remove a module *and* its data, and it is
+  presented as such.
+
+Uninstalling a module never touches media on disk — a downloads module leaves the files it
+fetched exactly where they are, and the library keeps observing them,
+[`library.md`](library.md).
+
+## Failure and isolation
+
+Status: **SHIPPED**
+
+This is the guarantee the whole architecture exists to make:
+
+- **A crashed module cannot take down the server.** The sidecar is a supervised child
+  process. If it dies, the server stays up, every other module stays up, and requests to
+  the failed module get a clear error instead of a hung server.
+- **An incompatible module never runs by accident.** `minServer` is enforced at install
+  *and* again at spawn. A stale bundle that no longer fits the server fails to start with a
+  named reason, rather than starting and emitting confusing runtime errors downstream.
+- **Failure is visible, not silent.** A module that will not start or has crashed surfaces
+  on the Admin Modules surface with its state and reason, [`admin.md`](admin.md).
+
+## The compatibility promise
+
+Status: **SHIPPED**
+
+The promise, grounded in `minServer`: **the server is forward-compatible with older
+modules; a module declares the oldest server it can run against, and nothing below that
+floor is ever allowed to run.** Concretely — a module installed today keeps working as the
+server is updated, because the server does not retroactively break the boundary its
+modules were built against. What can require action is the other direction: a *newer*
+module may raise its `minServer`, and the Store says so before you install it. The floor is
+checked at install and at every spawn, so a mismatch is a clear, upfront refusal, never a
+half-running module.
+
+## Module UI
+
+Status: **AGREED**
+
+A module **may** ship UI, and the position is deliberate: a module's frontend mounts
+**inside Admin**, under that module's own section, as pages, navigation and settings for
+the capability it provides. The boundary:
+
+- A module renders **its own admin surface** — configuration, status, and controls for
+  what it does. It does not reskin core, inject into other modules' surfaces, or take over
+  the end-user playback experience.
+- Its UI is served through the same reverse-proxy as its backend and lives and dies with
+  the module: install adds the section, uninstall removes it, disable hides it.
+
+This keeps a capability's controls next to the capability, while keeping the player and the
+catalogue the server's alone.
+
+## When a module stops being maintained
+
+Status: **DRAFT**
+
+The abandonment story is not fully settled, but the user must never be left guessing, and
+their data must never be at risk. The designed visible signal:
+
+- **The compatibility gate is the early warning.** As the server moves forward, an
+  unmaintained module eventually fails its `minServer` against a newer server it was never
+  updated for. That mismatch is surfaced by name on the Modules surface — an
+  **incompatible / unmaintained** state — rather than a silent failure to spawn.
+- **Their data is retained.** An incompatible or abandoned module is not auto-removed. It
+  is stopped and flagged, its data kept, so a later fixed build (or a downgrade, or a
+  fork) can pick it back up. Only an explicit uninstall discards module data.
+- **The honest signal.** The user is told the module has not kept pace with the server and
+  is not running, is pointed at its registry entry and version history, and keeps every
+  option: leave it disabled, replace it, or uninstall it deliberately.
+
+Open: whether the registry should carry an explicit maintenance/deprecation flag a
+publisher sets, versus inferring abandonment purely from the compatibility gate.
+
+## The first-party set, and why each is a module
+
+Status: **SHIPPED**
+
+Every capability below could have been core. Each is a module instead, for the same three
+reasons the base build ships empty — isolation, unsandboxable native dependencies, and
+runtime installability — plus one product reason: a server that only ever plays a curated
+library has no need to carry any of it.
+
+- **Downloads and acquisition** (`tv.kroma.torrents`, `tv.kroma.acquisition`,
+  `tv.kroma.indexer`, `tv.kroma.torznab`, `tv.kroma.vpn`, and the download engines
+  `tv.kroma.engine.qbittorrent` / `tv.kroma.engine.transmission`). Getting bytes onto disk
+  is out of scope for the library, which only *observes* what appears, [`library.md`](library.md).
+  This stack carries the heaviest and most legally sensitive native code in the product; it
+  is exactly what should be optional, isolated and removable.
+- **Transcription** (`tv.kroma.whisper`). A speech-to-text ML runtime — a large native
+  dependency most servers will never enable. Its process can be spawned only when used.
+- **Semantic search** (`tv.kroma.vector`). Vector embeddings and search, again a native
+  ML stack, and a feature a plain catalogue does not need.
+- **Network discovery** (`tv.kroma.mdns`). Advertising the server on the LAN for pairing,
+  [`discovery.md`](discovery.md) — a capability an operator may deliberately not want
+  running, so it is opt-in.
+- **Remote access** (`tv.kroma.remote`). Reaching the server from outside the LAN — a
+  security-relevant surface that should be an explicit, removable choice, not always-on.
+- **Scene parsing** (`tv.kroma.scene`). A shared library the acquisition and downloads
+  sidecars co-link, rather than a spawned sidecar, because it sits on a hot path that must
+  not become a network hop.
+
+## Not in scope
+
+- **Getting bytes onto disk** as a library concern — matching, scanning, deletions — is
+  [`library.md`](library.md). The library observes; modules acquire.
+- **Running the server** — installing, enabling and diagnosing modules from the admin
+  surface — is [`admin.md`](admin.md).
+- **Registry wiring and precedence** — official-vs-added, shadowing, https and
+  autodiscovery — is [`../module-registries.md`](../module-registries.md).
+- **How a sidecar is built, packed, spawned and released** is
+  [`../modules-as-kmod.md`](../modules-as-kmod.md).

--- a/docs/spec/modules/README.md
+++ b/docs/spec/modules/README.md
@@ -22,8 +22,8 @@ load-bearing decision of this domain, chosen for three reasons:
   without rebuilding or replacing the server binary. The base build never grows.
 
 Mechanics — how a sidecar is spawned, supervised and reverse-proxied — live in
-[`../modules-as-kmod.md`](../modules-as-kmod.md); registry wiring lives in
-[`../module-registries.md`](../module-registries.md). This file states the product rules.
+[`../modules-as-kmod.md`](../../modules-as-kmod.md); registry wiring lives in
+[`../module-registries.md`](../../module-registries.md). This file states the product rules.
 
 ## What a module is, and the boundary it may not cross
 
@@ -91,7 +91,7 @@ sidecar is spawned:
   `minServer` gate — for an air-gapped server, a private build, or a module not on any
   registry.
 
-Both are admin actions on the [`admin.md`](admin.md) surface.
+Both are admin actions on the [`admin.md`](../admin/README.md) surface.
 
 ## The Store
 
@@ -110,7 +110,7 @@ server's verdict**, not just the catalogue entry:
 That verdict is the point: a user decides to install or update against what *their* server
 will actually do, before committing. Registry precedence, https requirements, shadowing of
 duplicate ids and the empty-catalogue-is-a-failure rule are specified in
-[`../module-registries.md`](../module-registries.md).
+[`../module-registries.md`](../../module-registries.md).
 
 ## Trust
 
@@ -156,7 +156,7 @@ Four actions, and what each does to the module's data:
 
 Uninstalling a module never touches media on disk — a downloads module leaves the files it
 fetched exactly where they are, and the library keeps observing them,
-[`library.md`](library.md).
+[`library.md`](../library/README.md).
 
 ## Failure and isolation
 
@@ -171,7 +171,7 @@ This is the guarantee the whole architecture exists to make:
   *and* again at spawn. A stale bundle that no longer fits the server fails to start with a
   named reason, rather than starting and emitting confusing runtime errors downstream.
 - **Failure is visible, not silent.** A module that will not start or has crashed surfaces
-  on the Admin Modules surface with its state and reason, [`admin.md`](admin.md).
+  on the Admin Modules surface with its state and reason, [`admin.md`](../admin/README.md).
 
 ## The compatibility promise
 
@@ -236,7 +236,7 @@ library has no need to carry any of it.
 - **Downloads and acquisition** (`tv.kroma.torrents`, `tv.kroma.acquisition`,
   `tv.kroma.indexer`, `tv.kroma.torznab`, `tv.kroma.vpn`, and the download engines
   `tv.kroma.engine.qbittorrent` / `tv.kroma.engine.transmission`). Getting bytes onto disk
-  is out of scope for the library, which only *observes* what appears, [`library.md`](library.md).
+  is out of scope for the library, which only *observes* what appears, [`library.md`](../library/README.md).
   This stack carries the heaviest and most legally sensitive native code in the product; it
   is exactly what should be optional, isolated and removable.
 - **Transcription** (`tv.kroma.whisper`). A speech-to-text ML runtime — a large native
@@ -244,7 +244,7 @@ library has no need to carry any of it.
 - **Semantic search** (`tv.kroma.vector`). Vector embeddings and search, again a native
   ML stack, and a feature a plain catalogue does not need.
 - **Network discovery** (`tv.kroma.mdns`). Advertising the server on the LAN for pairing,
-  [`discovery.md`](discovery.md) — a capability an operator may deliberately not want
+  [`discovery.md`](../discovery/README.md) — a capability an operator may deliberately not want
   running, so it is opt-in.
 - **Remote access** (`tv.kroma.remote`). Reaching the server from outside the LAN — a
   security-relevant surface that should be an explicit, removable choice, not always-on.
@@ -255,10 +255,10 @@ library has no need to carry any of it.
 ## Not in scope
 
 - **Getting bytes onto disk** as a library concern — matching, scanning, deletions — is
-  [`library.md`](library.md). The library observes; modules acquire.
+  [`library.md`](../library/README.md). The library observes; modules acquire.
 - **Running the server** — installing, enabling and diagnosing modules from the admin
-  surface — is [`admin.md`](admin.md).
+  surface — is [`admin.md`](../admin/README.md).
 - **Registry wiring and precedence** — official-vs-added, shadowing, https and
-  autodiscovery — is [`../module-registries.md`](../module-registries.md).
+  autodiscovery — is [`../module-registries.md`](../../module-registries.md).
 - **How a sidecar is built, packed, spawned and released** is
-  [`../modules-as-kmod.md`](../modules-as-kmod.md).
+  [`../modules-as-kmod.md`](../../modules-as-kmod.md).

--- a/docs/spec/playback.md
+++ b/docs/spec/playback.md
@@ -1,33 +1,201 @@
 # Playback
 
-Status: **DRAFT** — skeleton only, nothing here is agreed yet.
+Status: **DRAFT** — sections carry their own status below.
 
 The core promise: the file plays, unmodified, wherever possible. Everything else is a
-fallback, and every fallback is a compromise that should be visible and explainable.
+fallback, and every fallback is a compromise that is made visible and explained. KROMA
+never quietly degrades a stream and hopes nobody notices.
 
-## Scope
+Codec truth — what a stream actually is — lives in [`media.md`](media.md). The per-device
+capability matrix lives in [`surfaces.md`](surfaces.md). Who is allowed to watch a title at
+all lives in [`accounts.md`](accounts.md). This file owns the *decision*: given a file, a
+client and a network, what gets sent, and what is given up to send it.
 
-- **Direct play**: the conditions under which the original file is streamed untouched
-- The decision order when direct play is impossible, and what is given up at each step
-- What is never done silently
-- Seeking: behaviour while direct playing, and while any fallback is active
-- Resume and **continue watching**: where progress is stored, when it is written, how it
-  reconciles across two devices that both watched offline
-- Multiple clients on one account playing at once
-- Failure: what the user sees when a stream dies mid-playback
+## Direct play
 
-## Open questions
+Status: **AGREED**
 
-- Is transcoding a supported product feature or a last resort we tolerate?
-- Who wins when two devices report conflicting progress for the same title?
+Direct play means the client fetches the original file, byte for byte, and decodes it
+itself. The server does nothing but serve bytes and honour range requests. This is the
+default, the goal, and the only path with no compromise.
 
-## Must answer
+A file direct-plays when **all** of the following hold:
 
-- [ ] The direct-play decision table, per client generation
-- [ ] The exact resume-point semantics, including the "watched" threshold
-- [ ] What a user is told when their television cannot play a file their phone can
+1. The client declares it can demux the **container** (per [`surfaces.md`](surfaces.md)).
+2. The client can decode the **video stream** — codec, profile, level, bit depth and HDR
+   variant — in hardware, as declared for that device generation.
+3. Every **audio stream the user might select** is decodable by the client, at its native
+   channel layout, or is passthrough-capable to a connected receiver.
+4. The chosen **subtitle**, if any, is either a format the client renders itself or is a
+   sidecar it can fetch alongside.
+5. The **link** sustains the file's peak bitrate. Local network: always assumed. Remote:
+   only when measured throughput clears peak with headroom.
 
-## Not in scope
+The capability inputs (1–4) are surface facts and are not restated here; KROMA reads them
+from the device profile. The decision below is what KROMA does with them.
 
-Codec truth lives in [`media.md`](media.md); the per-client capability matrix in
-[`surfaces.md`](surfaces.md).
+## The fallback ladder
+
+Status: **AGREED**
+
+When a title cannot direct-play, KROMA walks a fixed ladder and stops at the first rung
+that works. Each rung gives up strictly more than the one above it. The rule: **change the
+least, and never touch the video stream while a cheaper change on another stream would do.**
+
+1. **Direct play** — original file, untouched. No compromise.
+2. **Remux (direct stream)** — the video and audio *bitstreams* are copied unchanged into a
+   container the client can demux (e.g. an unsupported container holding a supported codec).
+   Nothing is re-encoded; picture and sound are bit-identical. Cheap, near-instant, no
+   quality loss.
+3. **Audio-only fallback** — the video is still copied, but one audio stream is dealt with:
+   - **passthrough** to a receiver if the client can pass the bitstream on; else
+   - **downmix** a multichannel track to stereo when the client cannot decode the layout;
+     else
+   - **transcode the audio** to a codec the client decodes. Video is never touched to solve
+     an audio problem.
+4. **Subtitle burn-in** — only when a selected subtitle cannot be rendered by the client and
+   cannot be delivered as a sidecar (e.g. bitmap subs on a client without an overlay). This
+   forces re-encoding the video, so it sits below audio fixes: a subtitle preference must
+   not silently cost picture quality — see *What is never done silently*.
+5. **Video transcode** — the last resort. The video stream is re-encoded to a codec, profile
+   and bitrate the client can decode, downscaling resolution and tone-mapping HDR to SDR only
+   as far as required. Everything above has failed; this rung always loses quality and costs
+   the server real work.
+
+KROMA takes the highest rung that satisfies the client. It does not skip rungs for
+convenience: if remux suffices, it remuxes; it does not transcode because a session is
+already warm.
+
+### Is transcoding a feature or a last resort?
+
+**Decision:** a tolerated last resort, not a headline feature. KROMA is built so the original
+plays; transcode exists so a title is *never unplayable* on a client the user actually owns,
+not so KROMA can pretend any file suits any screen. Consequences on record:
+
+- Transcode is always the lowest rung and is never the default for a capable client.
+- An admin may **cap or disable** video transcode per server and per user
+  ([`accounts.md`](accounts.md), [`admin.md`](admin.md)); disabling it means an incompatible
+  file reports as unplayable on that client rather than degrading.
+- We do not invest in adaptive multi-bitrate ladders, quality knobs, or bandwidth-based
+  auto-transcode. The product's answer to "it won't play" is "get a client that direct-plays
+  it", and the honest message below says exactly that.
+
+## What is never done silently
+
+Status: **AGREED**
+
+Any rung below direct play is a compromise, and the client always shows which one is active
+before or at the moment playback starts — a small, honest badge, not a buried log line:
+
+- **Video transcode** and **subtitle burn-in** are shown as *reduced quality* with the reason
+  (codec / resolution / HDR / subtitle). These change the picture and are the loudest.
+- **Audio downmix** and **audio transcode** are shown as *audio adjusted*.
+- **Remux** is shown as *repackaged* — quality is untouched, so this is informational, not a
+  warning.
+- Direct play shows nothing; the absence of a badge *is* the signal that the file is pristine.
+
+KROMA never re-encodes video to save bandwidth without the user's device profile forcing it,
+never tone-maps HDR without saying so, and never burns in subtitles the user did not ask to
+see. If the only playable path is one the user or admin has disabled, playback fails loudly
+(see *Failure*) rather than falling further down the ladder.
+
+## Seeking
+
+Status: **AGREED**
+
+- **Direct play and remux:** seeking is instant and exact. The client issues a range request
+  against a fully-known file; any position is reachable immediately, including scrubbing.
+- **Transcode (audio or video):** the stream is produced live from a play position, so a seek
+  outside the buffered window **re-anchors** the transcode at the target and resumes there.
+  This costs a short re-buffer, and backward seeks are as expensive as forward ones. KROMA
+  favours anchoring at the requested position over pre-producing the whole file, so a user who
+  jumps around pays a small pause each time rather than waiting once for a full encode.
+
+Seeking accuracy is never silently coarsened; a transcoded seek lands on the requested frame's
+keyframe, not a rounded chapter.
+
+## Resume and continue watching
+
+Status: **AGREED**
+
+Progress is **per user, per media version**, stored on the server — it is the server's watch
+state, not a device's ([`accounts.md`](accounts.md)). Any client the user signs into sees the
+same resume point.
+
+**When progress is written.** The playing client reports position on a steady heartbeat while
+playing (a small fixed interval), on pause, on seek settling, and on stop. A crash loses at
+most one heartbeat interval. The write is idempotent on `(user, version, position, wall-clock
+time)` so a replayed or offline-queued report cannot move progress backwards.
+
+**Resume point.** Reopening a title in progress offers *Resume* from the stored position and
+*Play from start*; resume is the default. The stored position is the reported one, not a
+rounded chapter.
+
+**The "watched" threshold.** A title is **watched** at **≥ 90% of runtime**, or at reaching a
+credits/end marker if the media has one. At that point continue-watching drops the title and,
+for episodic content, surfaces the next episode instead. 90% is chosen because trailing credits
+routinely run the last several minutes: requiring 100% would strand finished titles in the row
+forever, and a fixed "last N minutes" misjudges both a 22-minute episode and a 200-minute film.
+Below 90%, progress is retained and the title stays in continue-watching. Starting a watched
+title again resets it to unwatched and clears the stored position.
+
+**Offline reconciliation.** Mobile downloads let a user watch with no server connection, and two
+devices can each accrue progress offline against the same version. Downloads survive app kills
+and are re-adopted on launch (see
+[`../architecture/mobile-offline-system-storage.md`](../architecture/mobile-offline-system-storage.md)),
+and so does the **queue of unsent progress reports**. On reconnect each device flushes its queue,
+every report stamped with the **wall-clock time the user was actually at that position**.
+
+### Who wins when two devices disagree?
+
+**Decision: furthest-position-wins, not last-writer-wins.** When queued reports from two offline
+sessions land for the same `(user, version)`, KROMA keeps the **furthest position reached**, not
+the one whose report arrived or was stamped last. Rationale: watch progress is monotonic in
+intent — a user who watched to 0:55 on a plane and to 0:20 on a phone has *seen* up to 0:55, and
+resuming there loses nothing, whereas last-writer-wins would rewind them to 0:20 because that
+sync happened to flush second. The one exception is an explicit **reset to start** (finishing a
+title, or "play from start"), which is an intent, not a position, and always wins over a stale
+higher position. If either device crossed the watched threshold, the title is watched.
+
+## Multiple clients at once
+
+Status: **AGREED**
+
+One account may play on several clients simultaneously; KROMA does not enforce a concurrent-stream
+limit as a product rule (an admin may cap server load — [`admin.md`](admin.md)). Each playing
+client is an independent session with its own fallback decision: the same title may direct-play on
+a phone and transcode on a television at the same moment, because the decision is per device, not
+per title.
+
+Shared progress means the sessions interleave into one continue-watching state under the
+furthest-position rule above; two devices on the same title do not fight, they simply both advance
+it. KROMA does not "hand off" an active session between devices as a first-class gesture — a user
+resumes on the second device from shared progress, which achieves the same end without a pairing
+dance.
+
+## Failure
+
+Status: **AGREED**
+
+When a stream dies mid-playback — the network drops, a transcode process fails, the source file
+becomes unreadable — the client shows a plain, specific message and keeps the last known position
+so the user resumes exactly where they were, never from the start.
+
+- **Transient (network, brief server hiccup):** the client retries quietly for a few seconds
+  behind the scrubber before surfacing anything; most recover invisibly.
+- **Fatal (source gone, transcode cannot start, path disabled by policy):** playback stops with a
+  reason — *This file can't be played on this device*, or *This title is no longer available* —
+  never a raw error code.
+
+### When the television can't play what the phone can
+
+This is the common, honest case: a modern phone direct-plays a file a television's older decoder
+cannot, and the server is configured not to transcode it (or the admin disabled transcode). The
+television must not fail with a blank error. It says, plainly:
+
+> **Can't play this here.** This TV can't decode this file. It plays fine on the KROMA phone and
+> web apps — or ask the server owner to enable conversion for this device.
+
+The message names the real cause (the device, not the file), points at a surface that *does* work,
+and names the one lever that would fix it (admin-enabled transcode). It never blames the user, and
+it never pretends the file is broken — the file is fine; this screen just can't decode it.

--- a/docs/spec/playback/README.md
+++ b/docs/spec/playback/README.md
@@ -6,9 +6,9 @@ The core promise: the file plays, unmodified, wherever possible. Everything else
 fallback, and every fallback is a compromise that is made visible and explained. KROMA
 never quietly degrades a stream and hopes nobody notices.
 
-Codec truth — what a stream actually is — lives in [`media.md`](media.md). The per-device
-capability matrix lives in [`surfaces.md`](surfaces.md). Who is allowed to watch a title at
-all lives in [`accounts.md`](accounts.md). This file owns the *decision*: given a file, a
+Codec truth — what a stream actually is — lives in [`media.md`](../media/README.md). The per-device
+capability matrix lives in [`surfaces.md`](../surfaces/README.md). Who is allowed to watch a title at
+all lives in [`accounts.md`](../accounts/README.md). This file owns the *decision*: given a file, a
 client and a network, what gets sent, and what is given up to send it.
 
 ## Direct play
@@ -21,7 +21,7 @@ default, the goal, and the only path with no compromise.
 
 A file direct-plays when **all** of the following hold:
 
-1. The client declares it can demux the **container** (per [`surfaces.md`](surfaces.md)).
+1. The client declares it can demux the **container** (per [`surfaces.md`](../surfaces/README.md)).
 2. The client can decode the **video stream** — codec, profile, level, bit depth and HDR
    variant — in hardware, as declared for that device generation.
 3. Every **audio stream the user might select** is decodable by the client, at its native
@@ -74,7 +74,7 @@ not so KROMA can pretend any file suits any screen. Consequences on record:
 
 - Transcode is always the lowest rung and is never the default for a capable client.
 - An admin may **cap or disable** video transcode per server and per user
-  ([`accounts.md`](accounts.md), [`admin.md`](admin.md)); disabling it means an incompatible
+  ([`accounts.md`](../accounts/README.md), [`admin.md`](../admin/README.md)); disabling it means an incompatible
   file reports as unplayable on that client rather than degrading.
 - We do not invest in adaptive multi-bitrate ladders, quality knobs, or bandwidth-based
   auto-transcode. The product's answer to "it won't play" is "get a client that direct-plays
@@ -119,7 +119,7 @@ keyframe, not a rounded chapter.
 Status: **AGREED**
 
 Progress is **per user, per media version**, stored on the server — it is the server's watch
-state, not a device's ([`accounts.md`](accounts.md)). Any client the user signs into sees the
+state, not a device's ([`accounts.md`](../accounts/README.md)). Any client the user signs into sees the
 same resume point.
 
 **When progress is written.** The playing client reports position on a steady heartbeat while
@@ -142,7 +142,7 @@ title again resets it to unwatched and clears the stored position.
 **Offline reconciliation.** Mobile downloads let a user watch with no server connection, and two
 devices can each accrue progress offline against the same version. Downloads survive app kills
 and are re-adopted on launch (see
-[`../architecture/mobile-offline-system-storage.md`](../architecture/mobile-offline-system-storage.md)),
+[`../architecture/mobile-offline-system-storage.md`](../../architecture/mobile-offline-system-storage.md)),
 and so does the **queue of unsent progress reports**. On reconnect each device flushes its queue,
 every report stamped with the **wall-clock time the user was actually at that position**.
 
@@ -162,7 +162,7 @@ higher position. If either device crossed the watched threshold, the title is wa
 Status: **AGREED**
 
 One account may play on several clients simultaneously; KROMA does not enforce a concurrent-stream
-limit as a product rule (an admin may cap server load — [`admin.md`](admin.md)). Each playing
+limit as a product rule (an admin may cap server load — [`admin.md`](../admin/README.md)). Each playing
 client is an independent session with its own fallback decision: the same title may direct-play on
 a phone and transcode on a television at the same moment, because the decision is per device, not
 per title.

--- a/docs/spec/surfaces.md
+++ b/docs/spec/surfaces.md
@@ -1,10 +1,17 @@
 # Surfaces
 
-Status: **DRAFT** — skeleton only, nothing here is agreed yet.
+Status: **AGREED** — sections carry their own status below.
 
 KROMA runs on a television, a phone, a browser, a desktop and a NAS. This file says what
 every surface must do, what each may do differently, and what a surface is explicitly
 allowed *not* to do — so a missing feature is a decision on record rather than a gap.
+
+It owns the *surface* view: which surfaces exist, what they promise, and which class of
+media each can direct-play. It does not own the codec decision — given a file, a client and
+a network, what gets sent is [`playback.md`](playback.md)'s job, and what a stream *is* comes
+from [`media.md`](media.md). This file reads those as facts and states the consequence per
+surface. The shared component kit that makes the surfaces look alike is architecture, not
+spec — see [`packages/ui`](../../packages/ui).
 
 ## The surfaces
 
@@ -13,25 +20,195 @@ allowed *not* to do — so a missing feature is a decision on record rather than
 | Web | `clients/web` | The reference implementation |
 | TV — Samsung | `clients/tizen` | 10-foot UI, remote-only input |
 | TV — LG | `clients/webos` | 10-foot UI, remote-only input |
-| TV — other | `clients/tv-web`, `clients/tv-native` | |
+| TV — other | `clients/tv-web`, `clients/tv-native` | Apple TV / Android TV native; generic web fallback |
 | Mobile | `clients/mobile` | Offline downloads |
 | Desktop | `clients/desktop` | Auto-update |
 | NAS | `clients/synology` | Packaging, not a client |
 
-## Scope
+## The baseline
 
-- The baseline every surface must provide to be called KROMA
-- Per-surface capability matrix, including direct-play capability by device generation
-- Input models: remote, touch, pointer — and what changes in the UI because of each
-- Offline: which surfaces support it and what it means on each
-- Packaging and update mechanism per surface
-- Deprecation: when a surface stops being supported, and what its users are told
+Status: **AGREED**
 
-## Must answer
+There is one baseline, and it is the whole definition of the word *KROMA* on a surface. A
+build that runs but cannot do all six is a preview, not a surface, and the capability matrix
+below records exactly which rung it is missing. Every first-class surface does all six; a
+best-effort surface that drops one says so here rather than failing silently.
 
-- [ ] The baseline feature set, stated once, so "not on TV yet" is measurable
-- [ ] Which surfaces are first-class and which are best-effort
+1. **Sign in / pair** — reach a server and become an account on it. On a surface with a
+   keyboard this is address-plus-credentials; on a television it is the pairing handshake
+   ([`discovery.md`](discovery.md), [`docs/tv-pairing.md`](../tv-pairing.md)).
+2. **Browse the library** — move through titles the account may see, by section and by search.
+3. **View a title** — its artwork, its metadata, its editions and available fidelities.
+4. **Start playback** — play the title, taking whatever rung the device needs
+   ([`playback.md`](playback.md)).
+5. **Resume** — reopen an in-progress title at the server-held position, per user, per version.
+6. **Sign out** — end the session and drop the server from the surface, revocably.
 
-## Not in scope
+Everything past these six is a *may*, not a *must*. "Not on TV yet" is measurable against
+this list and nothing else: name the rung, and the gap is a line in the matrix rather than an
+argument.
 
-The shared component kit is architecture — see `packages/ui/src/components/README.md`.
+## First-class and best-effort
+
+Status: **AGREED**
+
+Surfaces are tiered, and the tier is a commitment, not a description of current polish.
+
+**Web is the reference implementation.** A behaviour is correct when it matches web; a
+feature is not shipped until web has it; a disagreement between surfaces is resolved in web's
+favour unless the input model forbids it. Web is where the baseline is *defined*, so web is
+first-class by construction and cannot regress below it.
+
+- **First-class** — Web, Mobile, Desktop, and the native television shells (`tv-native`,
+  Apple TV / Android TV). They carry the full baseline, ship on the release train, and a
+  baseline regression on one of them blocks the release. Each is allowed to *diverge* where
+  its input model demands (below), never to *drop* a baseline rung.
+- **Best-effort** — the sandboxed television shells (`tizen`, `webos`) and the generic
+  `tv-web` fallback. They carry the baseline but are held to the platform's ceiling, not to
+  web's: a capability the platform cannot express (LAN discovery on Tizen; a codec the panel's
+  decoder lacks) is a recorded absence here, not a defect. They ship when the platform allows
+  and may lag the train.
+- **NAS is not a surface.** `clients/synology` is packaging — it puts the *server* on a
+  Synology box. Its users reach KROMA through one of the surfaces above; it has no UI of its
+  own and no baseline to meet. It appears here so the reader stops looking for one.
+
+## Capability matrix
+
+Status: **AGREED**
+
+What each surface must, may, and may not do, beyond the baseline all of them share.
+
+| Capability | Web | Mobile | Desktop | TV native | TV sandboxed (Tizen/webOS) |
+|---|---|---|---|---|---|
+| Baseline (six above) | must | must | must | must | must |
+| Input model | pointer | touch | pointer | remote | remote |
+| Discover a server on the LAN | no | browses | no | publishes | Tizen no / webOS publishes |
+| Pair a television *to* this surface | n/a | yes (scanner) | n/a | is the TV | is the TV |
+| Offline downloads | no | yes | no | no | no |
+| Direct-play ceiling | browser codecs | device generation | browser codecs | panel generation | panel generation |
+
+"Discover" and "pair" are the surface's *reach*, and the per-shell truth — who publishes,
+who browses, why Tizen cannot — is [`discovery.md`](discovery.md)'s, grounded in
+[`docs/tv-pairing.md`](../tv-pairing.md). This table names the outcome; that file names the
+mechanism.
+
+### Direct-play by device generation
+
+Status: **AGREED**
+
+Whether a file direct-plays is decided per session by [`playback.md`](playback.md) against a
+device profile; the *class* of media a surface can decode is a surface fact, and it is the
+device's generation, not the surface's brand, that sets it. The rule KROMA holds to:
+
+- **Browser-backed surfaces** (Web, and the sandboxed television shells) direct-play what the
+  host browser's media stack exposes — reliably H.264 and, on a current engine, HEVC, VP9 and
+  AV1 where hardware-backed. They inherit the browser's ceiling exactly, including its HDR and
+  channel-layout limits, and cannot exceed it.
+- **Native surfaces** (Mobile, Desktop, `tv-native`) direct-play to the *device's* decoder,
+  which is where generation bites: a current phone decodes 10-bit HEVC and Dolby Vision in
+  hardware that a three-year-old panel of the same brand cannot. KROMA reads the generation
+  from the profile and never assumes newer than it measures.
+- **The honest consequence** is on record in [`playback.md`](playback.md): when a television's
+  older decoder cannot play a file a modern phone can, and transcode is capped or disabled, the
+  television says so plainly and points at a surface that *does* play it. The matrix here is the
+  input to that message; it is not a promise every surface plays everything.
+
+KROMA does not paper over a generation gap by silently transcoding for a capable surface, and
+it does not pretend a panel decodes a codec its generation predates. The first-class media
+truth (which codecs, containers, HDR variants exist) is [`media.md`](media.md); this section
+only says which surface can take it unmodified.
+
+## Input models
+
+Status: **AGREED**
+
+The input model is the one thing a surface may *not* copy from web, because copying it would
+break the surface. Three models, and each rewrites the UI, not just the event handling.
+
+- **Pointer** (Web, Desktop) — the reference model. Dense layouts, hover affordances, a
+  visible cursor, right-click and keyboard shortcuts. This is what every other model is a
+  deliberate departure *from*.
+- **Touch** (Mobile) — targets sized for a thumb, gestures for scrub and dismiss, no hover
+  state to depend on, and layouts that reflow to a held phone. Anything that only works with a
+  cursor is redesigned, not shrunk.
+- **Remote, 10-foot** (all televisions) — a directional focus ring, not a cursor: everything
+  reachable by up/down/left/right and OK, legible across a room, and no interaction that
+  assumes text entry the remote cannot supply. Sign-in is the pairing handshake precisely
+  because a television keyboard is unusable ([`discovery.md`](discovery.md)). A television
+  build that ships a pointer-shaped screen has not met the baseline's *view* and *browse*
+  rungs, however complete it looks on a monitor.
+
+One product surface may serve more than one model — a hybrid tablet is touch-first with a
+pointer attached — and the surface adapts to the *active* input rather than the hardware badge.
+
+## Offline
+
+Status: **AGREED**
+
+**Only Mobile is offline.** Web, Desktop and every television are online surfaces: they hold
+no library on the device and do nothing without a reachable server, and this is a decision,
+not a gap — a browser tab and a shared-living-room television are the wrong places to accrue
+gigabytes of a personal library, and the storage, eviction and reconciliation cost is not
+worth paying five times.
+
+On Mobile, offline means **downloads**: a title is fetched to the phone as a progressive
+file — the raw original when the device direct-plays it, else a server-side remux to a single
+fMP4 — and plays with no server connection. Downloads survive backgrounding and app kills and
+are re-adopted on next launch, and so is the queue of unsent progress reports, which flushes
+under the furthest-position rule when the server is reachable again
+([`playback.md`](playback.md),
+[`../architecture/mobile-offline-system-storage.md`](../architecture/mobile-offline-system-storage.md)).
+
+### OS-managed download rows
+
+Status: **DESIGN, NOT IMPLEMENTED**
+
+Netflix-style per-title rows in the OS storage manager (iOS Settings ▸ iPhone Storage,
+deletable by the system with the app closed) did **not** ship. What shipped instead is the
+background-transfer pipeline above — transfers that outlive the app, which is the half users
+feel. The OS rows need system-managed HLS assets (`AVAssetDownloadTask`, a finite VOD playlist,
+tokenised segment URLs, delete-reconciliation on every launch): a server-plus-native-plus-player
+project, iOS-only, with no Android equivalent to match. It is deferred as a unit rather than
+half-built. The full record, and what it would take, is in
+[`../architecture/mobile-offline-system-storage.md`](../architecture/mobile-offline-system-storage.md).
+
+## Packaging and updates
+
+Status: **AGREED**
+
+Each surface ships and updates the way its host expects; the product rule is only that a
+surface stays current without asking a person to babysit it. Deploy mechanics are
+[`admin.md`](admin.md)'s; here is the product-level shape.
+
+- **Web** — served by the server itself; the server embeds the web build. There is no separate
+  install and no version skew: updating the server updates the web surface, and a browser
+  always loads the version its server ships.
+- **Desktop** — auto-updates. The app checks, fetches and applies updates in the background and
+  a person is never asked to reinstall to stay current.
+- **Mobile** — the app stores (App Store, Play Store). Update cadence is the store's, and a
+  server must tolerate a range of shipped app versions because a person's phone updates on its
+  own schedule.
+- **Televisions** — each platform's own channel: Samsung and LG through their TV app stores,
+  Apple TV and Android TV through theirs. KROMA does not self-update a television; the platform
+  does, on its terms.
+- **NAS** — a Synology `.spk` package installed and updated through Package Center. This ships
+  the *server*, so the same "server embeds web" rule applies to everything it serves.
+
+## Deprecation
+
+Status: **AGREED**
+
+A surface is dropped when its host platform can no longer meet the baseline — a browser
+generation KROMA can no longer target, a television OS the vendor has abandoned, a mobile OS
+below the floor the app can build against. Deprecation is announced, never silent.
+
+- **Notice first.** A surface entering deprecation tells its users *in the surface* before it
+  stops working: what is ending, when, and which surface to move to. A person is never met with
+  a dead app and no explanation.
+- **Sessions survive the app.** A deprecated surface's sessions are ordinary sessions; they
+  keep working until the surface is retired and revoke like any other from the device list
+  ([`accounts.md`](accounts.md)). Retiring a surface does not strand an account.
+- **The library outlives any surface.** Nothing about a person's library, watch state or
+  account is tied to a surface — it is the server's — so moving to another surface loses only
+  the retired app, never the account behind it. That is the point of stating the baseline once:
+  every surface is a replaceable window onto the same server.

--- a/docs/spec/surfaces/README.md
+++ b/docs/spec/surfaces/README.md
@@ -8,10 +8,10 @@ allowed *not* to do — so a missing feature is a decision on record rather than
 
 It owns the *surface* view: which surfaces exist, what they promise, and which class of
 media each can direct-play. It does not own the codec decision — given a file, a client and
-a network, what gets sent is [`playback.md`](playback.md)'s job, and what a stream *is* comes
-from [`media.md`](media.md). This file reads those as facts and states the consequence per
+a network, what gets sent is [`playback.md`](../playback/README.md)'s job, and what a stream *is* comes
+from [`media.md`](../media/README.md). This file reads those as facts and states the consequence per
 surface. The shared component kit that makes the surfaces look alike is architecture, not
-spec — see [`packages/ui`](../../packages/ui).
+spec — see [`packages/ui`](../../../packages/ui).
 
 ## The surfaces
 
@@ -36,11 +36,11 @@ best-effort surface that drops one says so here rather than failing silently.
 
 1. **Sign in / pair** — reach a server and become an account on it. On a surface with a
    keyboard this is address-plus-credentials; on a television it is the pairing handshake
-   ([`discovery.md`](discovery.md), [`docs/tv-pairing.md`](../tv-pairing.md)).
+   ([`discovery.md`](../discovery/README.md), [`docs/tv-pairing.md`](../../tv-pairing.md)).
 2. **Browse the library** — move through titles the account may see, by section and by search.
 3. **View a title** — its artwork, its metadata, its editions and available fidelities.
 4. **Start playback** — play the title, taking whatever rung the device needs
-   ([`playback.md`](playback.md)).
+   ([`playback.md`](../playback/README.md)).
 5. **Resume** — reopen an in-progress title at the server-held position, per user, per version.
 6. **Sign out** — end the session and drop the server from the surface, revocably.
 
@@ -88,15 +88,15 @@ What each surface must, may, and may not do, beyond the baseline all of them sha
 | Direct-play ceiling | browser codecs | device generation | browser codecs | panel generation | panel generation |
 
 "Discover" and "pair" are the surface's *reach*, and the per-shell truth — who publishes,
-who browses, why Tizen cannot — is [`discovery.md`](discovery.md)'s, grounded in
-[`docs/tv-pairing.md`](../tv-pairing.md). This table names the outcome; that file names the
+who browses, why Tizen cannot — is [`discovery.md`](../discovery/README.md)'s, grounded in
+[`docs/tv-pairing.md`](../../tv-pairing.md). This table names the outcome; that file names the
 mechanism.
 
 ### Direct-play by device generation
 
 Status: **AGREED**
 
-Whether a file direct-plays is decided per session by [`playback.md`](playback.md) against a
+Whether a file direct-plays is decided per session by [`playback.md`](../playback/README.md) against a
 device profile; the *class* of media a surface can decode is a surface fact, and it is the
 device's generation, not the surface's brand, that sets it. The rule KROMA holds to:
 
@@ -108,14 +108,14 @@ device's generation, not the surface's brand, that sets it. The rule KROMA holds
   which is where generation bites: a current phone decodes 10-bit HEVC and Dolby Vision in
   hardware that a three-year-old panel of the same brand cannot. KROMA reads the generation
   from the profile and never assumes newer than it measures.
-- **The honest consequence** is on record in [`playback.md`](playback.md): when a television's
+- **The honest consequence** is on record in [`playback.md`](../playback/README.md): when a television's
   older decoder cannot play a file a modern phone can, and transcode is capped or disabled, the
   television says so plainly and points at a surface that *does* play it. The matrix here is the
   input to that message; it is not a promise every surface plays everything.
 
 KROMA does not paper over a generation gap by silently transcoding for a capable surface, and
 it does not pretend a panel decodes a codec its generation predates. The first-class media
-truth (which codecs, containers, HDR variants exist) is [`media.md`](media.md); this section
+truth (which codecs, containers, HDR variants exist) is [`media.md`](../media/README.md); this section
 only says which surface can take it unmodified.
 
 ## Input models
@@ -134,7 +134,7 @@ break the surface. Three models, and each rewrites the UI, not just the event ha
 - **Remote, 10-foot** (all televisions) — a directional focus ring, not a cursor: everything
   reachable by up/down/left/right and OK, legible across a room, and no interaction that
   assumes text entry the remote cannot supply. Sign-in is the pairing handshake precisely
-  because a television keyboard is unusable ([`discovery.md`](discovery.md)). A television
+  because a television keyboard is unusable ([`discovery.md`](../discovery/README.md)). A television
   build that ships a pointer-shaped screen has not met the baseline's *view* and *browse*
   rungs, however complete it looks on a monitor.
 
@@ -156,8 +156,8 @@ file — the raw original when the device direct-plays it, else a server-side re
 fMP4 — and plays with no server connection. Downloads survive backgrounding and app kills and
 are re-adopted on next launch, and so is the queue of unsent progress reports, which flushes
 under the furthest-position rule when the server is reachable again
-([`playback.md`](playback.md),
-[`../architecture/mobile-offline-system-storage.md`](../architecture/mobile-offline-system-storage.md)).
+([`playback.md`](../playback/README.md),
+[`../architecture/mobile-offline-system-storage.md`](../../architecture/mobile-offline-system-storage.md)).
 
 ### OS-managed download rows
 
@@ -170,7 +170,7 @@ feel. The OS rows need system-managed HLS assets (`AVAssetDownloadTask`, a finit
 tokenised segment URLs, delete-reconciliation on every launch): a server-plus-native-plus-player
 project, iOS-only, with no Android equivalent to match. It is deferred as a unit rather than
 half-built. The full record, and what it would take, is in
-[`../architecture/mobile-offline-system-storage.md`](../architecture/mobile-offline-system-storage.md).
+[`../architecture/mobile-offline-system-storage.md`](../../architecture/mobile-offline-system-storage.md).
 
 ## Packaging and updates
 
@@ -178,7 +178,7 @@ Status: **AGREED**
 
 Each surface ships and updates the way its host expects; the product rule is only that a
 surface stays current without asking a person to babysit it. Deploy mechanics are
-[`admin.md`](admin.md)'s; here is the product-level shape.
+[`admin.md`](../admin/README.md)'s; here is the product-level shape.
 
 - **Web** — served by the server itself; the server embeds the web build. There is no separate
   install and no version skew: updating the server updates the web surface, and a browser
@@ -207,7 +207,7 @@ below the floor the app can build against. Deprecation is announced, never silen
   a dead app and no explanation.
 - **Sessions survive the app.** A deprecated surface's sessions are ordinary sessions; they
   keep working until the surface is retired and revoke like any other from the device list
-  ([`accounts.md`](accounts.md)). Retiring a surface does not strand an account.
+  ([`accounts.md`](../accounts/README.md)). Retiring a surface does not strand an account.
 - **The library outlives any surface.** Nothing about a person's library, watch state or
   account is tied to a surface — it is the server's — so moving to another surface loses only
   the retired app, never the account behind it. That is the point of stating the baseline once:


### PR DESCRIPTION
## What

The spec skeleton landed in #66 — scope lists, open questions, and `DRAFT — skeleton only` on every file. This fills all eight domains so a reader could actually implement from them, following the contract in `docs/spec/README.md`:

- **Behaviour and why, never implementation.** If a sentence would survive a full rewrite of the code it stayed; anything naming a crate or file was left to architecture.
- **Every section carries a status.** SHIPPED where the code already does it, AGREED where the behaviour is decidable and stated as the rule, DRAFT only where a real product choice remains — and even those carry a recommendation.
- **Every "must answer" item is answered** with a concrete rule, not deferred.

Domain highlights:
- **library** — concrete naming conventions (`Title (Year)`, `Show/Season NN/Show - SxxEyy`), a first-class browsable *Unmatched* state, scans safe against a live library (mark-absent, never delete).
- **media** — title → version → file → stream model; multiple fidelities are files of one edition, not duplicate titles; single-probe truth with a targeted re-probe on failure.
- **playback** — the fixed fallback ladder (direct → remux → audio fix → subtitle burn-in → video transcode), transcode ruled a tolerated last resort, ≥90% watched threshold, furthest-position-wins offline reconciliation, and the honest "this TV can't decode this" message.
- **accounts** — users-not-profiles, long-lived revocable sessions (TVs never force re-auth; the device list is the control), a two-role permission matrix.
- **discovery** — pairing described as product experience (SHIPPED), mechanics deferred to `tv-pairing.md`; Tizen/webOS vendor stacks recorded as DESIGN, NOT IMPLEMENTED.
- **modules** — the zero-module base and out-of-process isolation as load-bearing; Store/compat-gate SHIPPED; third-party trust and the abandonment story left DRAFT with proposals.
- **admin** — single-operator framing, a 4-step first-run path, a "settings never interrupt playback" guarantee, host-local lockout recovery.
- **surfaces** — the six-rung baseline stated once so "not on TV yet" is measurable, plus an explicit first-class/best-effort tiering.

## Closes

No issue closed. This advances the Spec v1 epics #67–#74 (one per domain) by drafting each domain's spec section, but those epics also track implementation sub-issues, so they stay open. If you consider the spec-writing portion done, close them on merge.

## Checks

- [x] Docs-only change — no `bun`/`cargo` code touched, so lint/test/clippy are N/A. Verified instead: no architecture leakage (no crate/file names in `docs/spec/*.md`), every section carries a status, all cross-file links resolve, no cross-file contradictions on roles / watched-threshold / direct-play ownership.
- [x] Follows `CODE_STYLE.md` — prose only.
- [ ] One idea — *not* split: eight files in one PR, deliberately, because they cross-reference heavily and splitting would make the boundaries unreviewable. Happy to split if you'd rather review per-domain.

## Risk

It's documentation, so nothing breaks at runtime. The real risk is a decision I made that you'd have made differently — the DRAFT sections (module trust model, module abandonment, library refresh rules, admin update mechanism) are where I was least sure, and the AGREED sections are proposals you're free to overturn in review. `git blame` will show why each rule says what it says.
