### PR TITLE
docs: sharpen the coding standards (files, patterns, the quality bar)

### DIFF
--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -163,8 +163,19 @@ The same instinct applies to the code:
 
 - **Name things fully.** `remainingRetries`, not `n`, not `retriesLeft2`. Short
   names are fine only for a short life (`i`, `f`, `ok` inside a five-line block).
-- **Small functions with one job**, named after the job.
+- **Small functions with one job**, named after the job. The same rule holds
+  one level up: a file does one thing (see
+  [`CONVENTIONS.md`](CONVENTIONS.md) and the file-size policy in
+  [`ARCHITECTURE.md`](ARCHITECTURE.md#file-size-policy)).
 - **Return early**; do not nest to describe control flow.
+- **Prefer a named pattern over a bespoke tangle.** When a well-known design
+  pattern fits (a registry, a strategy, a builder, a state machine), use it and
+  let the *names* carry it: `SubtitleStrategy`, `formatRegistry`. A reader who
+  recognises the pattern reads the code for free; a comment announcing the
+  pattern is the code failing to.
+- **Leave code simpler than you found it.** A change that lands duplication,
+  dead code, or a second way of doing something the file already does is not
+  done; the refactor is part of the change, not a follow-up.
 - **Types over checks.** See [`CONVENTIONS.md`](CONVENTIONS.md) for validating
   untrusted input with zod rather than by hand.
 - **No dead code, no unused exports.** `bun run deadcode` catches them.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,9 @@ cd server && cargo build   # server (use `cargo clippy` if you have it)
 
 - Read [`CODE_STYLE.md`](CODE_STYLE.md) for how code is written here, and in
   particular when a comment is allowed to exist. The default is none.
+- The quality gate (0 Sonar issues, 0% duplication, ~100% coverage on new
+  logic) is part of done, not a follow-up: see
+  [`CONVENTIONS.md`](CONVENTIONS.md#the-quality-gate-is-not-optional).
 - Keep clients **thin** UI belongs in `@kroma/ui`, logic in `@kroma/core`, and the
   shared TV experience in `@kroma/tv`. Write platform code once.
 - Match the existing style: the design language (deep-charcoal + amber, French

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -55,6 +55,14 @@ The one thing that stays hand-written is a **size check before parsing**: a
 schema cannot reject bytes it has not read yet, so bound the body first, then
 parse.
 
+## One file, one responsibility
+
+A file does one thing, and its name says which. When a second responsibility
+grows inside it, split at the domain seam, not at an arbitrary line count;
+the thresholds and exemptions live in
+[`ARCHITECTURE.md`](ARCHITECTURE.md#file-size-policy). A file you cannot name
+without "and" is two files.
+
 ## Secrets belong where the source is not
 
 The server's source is public and self-hosted by anyone, so a credential
@@ -104,6 +112,21 @@ anyone reading the manifest to find out what this package needs. Write
 
 Shared code lives in a real `@kroma/*` workspace package, depended on by name. If
 the code has no package, that is the work: give it one.
+
+## The quality gate is not optional
+
+A change ships with **0 Sonar issues, 0% duplication on new code, and ~100%
+coverage on new logic**. Not "later", not "in a follow-up": the gate is part of
+done. The scanner's scope, coverage denominator, and every reviewed suppression
+live in [`sonar-project.properties`](sonar-project.properties); read it before
+assuming an issue is a false positive, and prefer a code fix over a new entry
+there.
+
+Run the gate locally before pushing: `bun run sonar:precheck`,
+`bun run sonar:lint`, `bun run check`, `bun run test:coverage`. Untestable glue
+is excluded from the denominator deliberately, file by file, in that same
+properties file: new logic goes where a test can reach it, not into an excluded
+file.
 
 ## No em dashes
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -85,7 +85,6 @@ sonar.exclusions=\
   **/*.PNG,\
   **/*.jpg,\
   **/*.jpeg,\
-  **/*.webp,\
   **/*.gif,\
   **/*.ico,\
   **/*.icns,\


### PR DESCRIPTION
## What

Encodes the standing quality bar in the standards docs, where it was living only in review comments. `CONVENTIONS.md` gains two house rules: **one file, one responsibility** (split at the domain seam, thresholds deferred to `ARCHITECTURE.md`'s file-size policy rather than restated) and **the quality gate is not optional** (0 Sonar issues, 0% duplication, ~100% coverage on new logic, pointing at `sonar-project.properties` and the local checks instead of re-documenting them). `CODE_STYLE.md`'s "Beyond comments" gains two bullets: prefer a named design pattern over a bespoke tangle, carried by names in the code rather than a comment; and leave code simpler than you found it, the refactor being part of the change. `CONTRIBUTING.md` gets a one-line pointer to the gate in "Before you open a PR". Additions match the existing voice and structure; nothing was rewritten or weakened.

One drive-by fix: `bun run sonar:lint` was failing on main because the `**/*.webp` exclusion in `sonar-project.properties` no longer matches any file (the config's own comment warns exactly about this failure mode). Deleted the stale line; the linter now passes.

## Closes

No issue: standing directive from the owner to sharpen the standards docs, docs-only, no behaviour to track.

## Checks

- [x] `bun run sonar:lint` passes (it did not on main; fixed here)
- [x] Docs-only change: no tests to run, `bun run lint`/`test` not applicable
- [x] Follows `CODE_STYLE.md` — no comments narrating the work, exported API only
- [x] One idea. If it grew a second, it was split.

## Risk

None to runtime. The one non-doc line removes an exclusion that matched nothing, so scanner behaviour is unchanged. If a `.webp` is ever committed, re-add the exclusion.
