### PR TITLE
feat(tizen): stop pre-6.0 installs early with a legible reason in doctor/preflight

### DIFF
--- a/clients/tizen/Makefile
+++ b/clients/tizen/Makefile
@@ -40,18 +40,29 @@ DEV_PORT   ?= 5174
 DEV_STAGE  := .dev-shell
 
 .DEFAULT_GOAL := help
-.PHONY: help doctor build package connect devices install run deploy redeploy logs uninstall clean cert-selfsigned dev-shell
+.PHONY: help doctor preflight build package connect devices install run deploy redeploy logs uninstall clean cert-selfsigned dev-shell
+
+# Shared preflight: attempts every check, exits non-zero only on a confirmed
+# blocker (a set below the Tizen floor). Passes tool paths + identity through env.
+PREFLIGHT = SDB='$(SDB)' TIZEN='$(TIZEN)' SERIAL='$(SERIAL)' PROFILE='$(PROFILE)' \
+	PKG_ID='$(PKG_ID)' TIZEN_HOME='$(TIZEN_HOME)' CONFIG='public/config.xml' \
+	sh scripts/preflight.sh
 
 help: ## Show this help
 	@awk 'BEGIN{FS=":.*?## "} /^[a-zA-Z_-]+:.*?## /{printf "  \033[33m%-14s\033[0m %s\n",$$1,$$2}' $(MAKEFILE_LIST)
 
-doctor: ## Check toolchain + print current config
+doctor: ## Check toolchain, config, and (if a TV is connected) deploy preflight
 	@echo "tizen   : $(TIZEN)";   $(TIZEN) version 2>/dev/null || echo "  ✗ not found see SETUP.md"
 	@echo "sdb     : $(SDB)";      $(SDB) version 2>/dev/null | head -1 || echo "  ✗ not found"
 	@echo "profile : $(PROFILE)"
 	@echo "app id  : $(APP_ID)  (package $(PKG_ID))"
 	@echo "TV      : $(if $(TV_IP),$(TV_IP):$(TV_PORT),<unset pass TV_IP=...>)"
 	@echo "device  : $(if $(SERIAL),$(SERIAL),<none connected>)"
+	@echo "preflight:"
+	@$(PREFLIGHT) || true
+
+preflight: ## Pre-install checks (platform floor, signing profile, stale install)
+	@$(PREFLIGHT)
 
 build: ## Build the web bundle (Vite → dist/). Pass SERVER=http://host:4040 to bake a default address.
 	cd $(REPO_ROOT) && $(if $(SERVER),VITE_KROMA_SERVER="$(SERVER)") bun run build:tizen
@@ -67,7 +78,7 @@ connect: ## sdb connect to the TV (requires TV_IP + Developer Mode on)
 devices: ## List connected devices
 	$(SDB) devices
 
-install: ## Install the latest .wgt on the connected TV
+install: preflight ## Install the latest .wgt on the connected TV
 	@test -n "$(WGT)" || { echo "No .wgt found run 'make package' first"; exit 1; }
 	@test -n "$(SERIAL)" || { echo "No device run 'make connect TV_IP=...'"; exit 1; }
 	# No -t: the Tizen CLI auto-targets the single connected device (its target

--- a/clients/tizen/SETUP.md
+++ b/clients/tizen/SETUP.md
@@ -126,12 +126,32 @@ the TV's network (`bun run server` on the host, or the Docker image on your NAS)
 
 ---
 
+## Supported TVs the Tizen 6.0 floor
+
+KROMA requires **Tizen 6.0 (2021 models) or newer**. `config.xml` sets
+`required_version="6.0"`, and a retail set refuses a widget that demands a
+platform newer than its own with an opaque `install failed[118]` this was the
+whole of [#86](https://github.com/maxscharwath/kroma/issues/86).
+
+The floor is deliberate, not a bug. 2017/Tizen-3.0 era sets ship a Chromium
+(v53 for 3.0, v56 for 4.0) far older than the web build assumes, and lowering the
+value alone does not make the app run there see
+[`tv.target.ts`](./tv.target.ts) and [`STORE.md`](./STORE.md) for the
+Chromium-per-Tizen table and the legacy build tier that makes 6.0 honest.
+
+So the fix for a below-floor set is not to lower the number: it is to fail
+legibly. `make doctor` / `make preflight` read the connected set's platform
+version and, if it is under the floor, print
+`✗ this TV is Tizen X.Y; KROMA requires >= 6.0 — this set is not supported` and
+stop before `tizen install` runs.
+
 ## Troubleshooting
 
 | Symptom | Fix |
 | --- | --- |
 | `sdb` can't connect | Dev Mode off, wrong Host PC IP, or firewall. Re-do step 1 and reboot the TV. Port is `26101`. |
-| Install fails: *signature / certificate* | The profile isn't a **Samsung** cert, or the cert's DUID doesn't match this TV. Recreate it (step 3) with the TV connected. |
+| Install fails with an opaque code (`install failed[118]` / *Failed to install*) | Run `make doctor` (or `make preflight`) with the TV connected. The most common cause is a set **older than the Tizen floor** (see below): `make doctor` reads the set's platform version and says so plainly instead of letting `tizen install` fail blindly. |
+| Install fails: *signature / certificate* | The profile isn't a **Samsung** cert, or the cert's DUID doesn't match this TV. `make doctor` flags a non-Samsung profile and a stale differently-signed install where the firmware lets it; recreate the cert (step 3) with the TV connected, and `make uninstall` first if the app was installed under a different author. |
 | App installs but won't launch | Try `make run` again, or `sdb -s <serial> shell 0 was_execute KromaTV001.KROMA`. Check `make logs`. |
 | `tizen: command not found` | Set `TIZEN_HOME` in `.tizen.env`, or add `~/tizen-studio/tools/ide/bin` and `~/tizen-studio/tools` to `PATH`. |
 | Black screen / no data | The app can't reach the server. Re-enter `http://<server-ip>:4040` and confirm the TV and server share a network. |

--- a/clients/tizen/scripts/preflight.sh
+++ b/clients/tizen/scripts/preflight.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env sh
+# KROMA Tizen deploy preflight: catch the failures that `tizen install` only ever
+# reports as an opaque code, and say them in plain words *before* the install runs.
+#
+# The headline case (#86): a retail set older than config.xml's required_version
+# refuses the widget with `install failed[118]` / "Failed to install", no readable
+# reason. required_version="6.0" floors the app at Tizen 6.0 (2021); a 2017 set is
+# Tizen 3.0 and will never take it. We read the connected set's platform version
+# and gate on it, so the developer learns the set is unsupported instead of staring
+# at a code. The floor is a product decision, not a bug: the web build assumes a
+# Chromium far newer than Tizen 3.0 ships (see tv.target.ts / STORE.md).
+#
+# POSIX sh, no dependencies beyond the tizen/sdb tools already required. Every probe
+# is best-effort: it attempts, and on any missing tool or TV degrades to a single
+# "skipped: <why>" line rather than failing, so `make doctor` is always runnable.
+#
+# Exit status is non-zero ONLY for a hard, confirmed blocker (a set below the floor)
+# so the install/deploy path can stop early; unknowns and secondary findings never
+# block. Env in: SDB, TIZEN, SERIAL, PROFILE, PKG_ID, TIZEN_HOME, CONFIG.
+set -eu
+
+SDB="${SDB:-sdb}"
+TIZEN="${TIZEN:-tizen}"
+SERIAL="${SERIAL:-}"
+PROFILE="${PROFILE:-}"
+PKG_ID="${PKG_ID:-}"
+TIZEN_HOME="${TIZEN_HOME:-$HOME/tizen-studio}"
+CONFIG="${CONFIG:-public/config.xml}"
+
+blocked=0
+
+# True when version $1 is strictly lower than $2 (dot-separated, numeric per field).
+ver_lt() {
+  [ "$1" = "$2" ] && return 1
+  lowest=$(printf '%s\n%s\n' "$1" "$2" | sort -t. -k1,1n -k2,2n -k3,3n | head -1)
+  [ "$lowest" = "$1" ]
+}
+
+# --- Primary: connected set's platform version vs the app's required_version ------
+required=$(sed -n 's/.*required_version="\([0-9.]*\)".*/\1/p' "$CONFIG" 2>/dev/null | head -1)
+if [ -z "$required" ]; then
+  echo "  ~ platform floor: skipped: no required_version in $CONFIG"
+elif [ -z "$SERIAL" ]; then
+  echo "  ~ platform floor: skipped: no TV connected (app requires Tizen >= $required)"
+else
+  tv_ver=$("$SDB" -s "$SERIAL" capability 2>/dev/null \
+    | sed -n 's/^platform_version:\([0-9.]*\).*/\1/p' | head -1)
+  if [ -z "$tv_ver" ]; then
+    echo "  ~ platform floor: skipped: could not read platform_version from $SERIAL"
+  elif ver_lt "$tv_ver" "$required"; then
+    echo "  ✗ this TV is Tizen $tv_ver; KROMA requires >= $required — this set is not supported"
+    echo "    (2017/Tizen-3.0 era sets ship a Chromium too old for the build; not chased. See SETUP.md.)"
+    blocked=1
+  else
+    echo "  ✓ platform floor: TV is Tizen $tv_ver (>= required $required)"
+  fi
+fi
+
+# --- Secondary: signing profile looks like a Samsung cert, not self-signed --------
+# Retail sets only take a Samsung author+distributor cert; a self-signed profile
+# (make cert-selfsigned) installs on the emulator only. Best-effort: read the
+# author cert out of the profile and check its issuer with openssl when present.
+profiles="$TIZEN_HOME-data/profile/profiles.xml"
+if [ -z "$PROFILE" ] || [ ! -f "$profiles" ]; then
+  echo "  ~ signing profile: skipped: no profiles.xml under $TIZEN_HOME-data"
+elif ! command -v openssl >/dev/null 2>&1; then
+  echo "  ~ signing profile: skipped: openssl not found (cannot inspect the cert)"
+else
+  # The <profile name="X"> block's first key is the author .p12.
+  p12=$(sed -n "/name=\"$PROFILE\"/,/<\/profile>/p" "$profiles" \
+    | sed -n 's/.*key="\([^"]*\.p12\)".*/\1/p' | head -1)
+  pass=$(sed -n "/name=\"$PROFILE\"/,/<\/profile>/p" "$profiles" \
+    | sed -n 's/.*password="\([^"]*\)".*/\1/p' | head -1)
+  if [ -z "$p12" ] || [ ! -f "$p12" ]; then
+    echo "  ~ signing profile: skipped: author cert for '$PROFILE' not found"
+  else
+    issuer=$(openssl pkcs12 -in "$p12" -passin "pass:$pass" -nokeys -clcerts 2>/dev/null \
+      | openssl x509 -noout -issuer 2>/dev/null || true)
+    if [ -z "$issuer" ]; then
+      echo "  ~ signing profile: skipped: could not read '$PROFILE' cert (wrong password?)"
+    elif printf '%s' "$issuer" | grep -qi samsung; then
+      echo "  ✓ signing profile: '$PROFILE' is a Samsung cert"
+    else
+      echo "  ⚠ signing profile: '$PROFILE' is not Samsung-issued (self-signed?) — installs on the emulator only, not a retail TV"
+    fi
+  fi
+fi
+
+# --- Secondary: an app with this id already installed under a different author ----
+# A retail set rejects an update signed by a different author than the installed
+# copy. Best-effort: retail firmware locks the shell down, so this frequently and
+# legitimately degrades to skipped.
+if [ -z "$SERIAL" ] || [ -z "$PKG_ID" ]; then
+  echo "  ~ installed app: skipped: no TV connected"
+else
+  info=$("$SDB" -s "$SERIAL" shell 0 pkginfo --pkg "$PKG_ID" 2>/dev/null || true)
+  if [ -z "$info" ] || printf '%s' "$info" | grep -qi 'not.*install\|fail\|denied'; then
+    echo "  ~ installed app: skipped: '$PKG_ID' not installed or shell locked down"
+  else
+    echo "  ✓ installed app: '$PKG_ID' present (uninstall first if a cert mismatch is suspected)"
+  fi
+fi
+
+[ "$blocked" -eq 0 ] || {
+  echo "  → stopping before install: this set is below the supported floor."
+  exit 1
+}


### PR DESCRIPTION
## What

Tizen `install failed[118]` was opaque: the #1 cause is a set older than the app's Tizen floor (`required_version="6.0"`), which a retail firmware refuses with only a numeric code. This makes that failure legible instead of lowering the floor — the floor stays 6.0 by product decision (2017/Tizen-3.0 sets ship a Chromium far older than the web build assumes; see `tv.target.ts`/`STORE.md`).

New `clients/tizen/scripts/preflight.sh` (POSIX sh, no new deps) reads the connected set's `platform_version` via `sdb capability` and compares it to `config.xml`'s `required_version`. Below the floor it prints `✗ this TV is Tizen X.Y; KROMA requires >= 6.0 — this set is not supported` and exits non-zero, so `make install`/`make deploy` (which now depend on `preflight`) stop before `tizen install` runs. Two secondary best-effort checks — signing profile is a Samsung cert vs self-signed, and a stale install under a different author — degrade to `skipped: <why>` when a tool or the TV is absent. `make doctor` runs the whole thing (never fatal); `make preflight` is the gate. `SETUP.md` gains a "Supported TVs / the Tizen 6.0 floor" section and points the install-failure troubleshooting rows at `make doctor`.

## Closes

Closes #86

## Checks

- [x] `make -n doctor` and `make -n preflight` parse and expand; `make -n install` shows `preflight` runs first.
- [x] Ran `preflight.sh` for every branch: no TV → all checks `skipped`, exit 0; fake `sdb` at 3.0 → blocks with the plain message, exit 1; 6.0 and 7.0 → pass, exit 0.
- [ ] `shellcheck` — not installed in this environment; not run.
- [ ] `bun run sonar:lint` — fails only on a **pre-existing** warning in `sonar-project.properties` (`**/*.webp` matches no file), a file this PR does not touch.
- **Cannot verify here:** the live TV probes (platform version, cert issuer, installed-app author) need a real Samsung set + the tizen CLI. Verified: the script parses, the version-floor comparison, and the skipped-degradation paths.
- [x] Follows `CODE_STYLE.md` — comments explain the *why*, matched the existing Makefile/script style.
- [x] One idea.

## Risk

Small and deploy-path only. Worst case if the `sdb capability` parse is wrong on some firmware: the floor check emits `skipped: could not read platform_version` and does **not** block — it never blocks on uncertainty, only on a confirmed below-floor set — so a bad probe degrades to today's behaviour, it cannot wrongly refuse a supported TV. A reviewer would notice by running `make doctor` with a TV connected.



---
_Re-opened on the correctly-named branch after the original (`#89`) was closed by a branch rename._
