### PR TITLE
chore(hooks): reject pushing off-convention branch names

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Refuse to push a branch whose name breaks the <type>/<slug> convention.
+# Wired via core.hooksPath (.githooks); see CONTRIBUTING.md.
+set -eu
+
+pattern='^(feat|fix|docs|chore|ci|refactor|perf|test|build|revert|kit)/[a-z0-9][a-z0-9._-]*$'
+zero='0000000000000000000000000000000000000000'
+status=0
+
+while read -r local_ref local_sha _remote_ref _remote_sha; do
+	case "$local_ref" in
+	refs/heads/*) branch=${local_ref#refs/heads/} ;;
+	*) continue ;;
+	esac
+	[ "$local_sha" = "$zero" ] && continue
+	[ "$branch" = "main" ] && continue
+	if ! printf '%s' "$branch" | grep -Eq "$pattern"; then
+		printf 'refused: branch "%s" breaks the naming convention.\n' "$branch" >&2
+		printf 'use <type>/<slug> — type in: feat fix docs chore ci refactor perf test build revert kit\n' >&2
+		printf 'example: fix/audio-transcode-fallback\n' >&2
+		status=1
+	fi
+done
+
+exit $status

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,16 @@ bun run dev      # media server (:4040) + web client (:3000) together
 With no media configured, the server seeds demo titles so the UI is populated
 immediately. Point it at real files with `KROMA_MEDIA_DIRS=/path/to/media`.
 
+`bun install` wires the repo's git hooks (`prepare` → `core.hooksPath .githooks`).
+If you cloned before that existed, run `bun run hooks:install` once.
+
+## Branch names
+
+`<type>/<slug>`, where `<type>` is the conventional-commit type of the work:
+`feat` `fix` `docs` `chore` `ci` `refactor` `perf` `test` `build` `revert` `kit`.
+For example `fix/audio-transcode-fallback`. The `pre-push` hook refuses any branch
+that breaks this.
+
 ## Before you open a PR
 
 Everything must build and typecheck cleanly:

--- a/package.json
+++ b/package.json
@@ -78,7 +78,9 @@
     "server:watch": "bun server/preflight.ts && cd server && cargo watch -x 'run --features semantic-embeddings,whisper-metal'",
     "server:watch:cpu": "bun server/preflight.ts && cd server && cargo watch -x 'run --features semantic-embeddings,whisper-local'",
     "server:watch:lexical": "bun server/preflight.ts && cd server && cargo watch -x run",
-    "server:build": "cd server && cargo build --release"
+    "server:build": "cd server && cargo build --release",
+    "prepare": "git config core.hooksPath .githooks || true",
+    "hooks:install": "git config core.hooksPath .githooks"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.8",


### PR DESCRIPTION
## What

Adds a versioned `pre-push` git hook that refuses to push any branch whose name breaks the repo convention **`<type>/<slug>`** (types: `feat` `fix` `docs` `chore` `ci` `refactor` `perf` `test` `build` `revert` `kit`). `main` and branch deletions are allowed; everything else must match, so a stray name (e.g. `gaspard/foo`) can't reach the remote.

- `.githooks/pre-push` — POSIX sh, no dependencies. Reads the refs being pushed, validates each `refs/heads/*` name, prints a clear reason + example on refusal.
- `package.json` — `prepare` wires `core.hooksPath .githooks` on `bun install`; `hooks:install` does it on demand for existing clones.
- `CONTRIBUTING.md` — documents the branch convention and the hook.

## Closes

No issue — direct request from the owner to enforce the branch nomenclature.

## Checks

- [x] Hook end-to-end (piped refs): valid branch → exit 0; `gaspard/foo` → exit 1 with a readable message.
- [x] Self-test of the pattern across feat//fix//docs//gaspard//`Feature`//`badtype`//`main`.
- [x] `biome check package.json` clean.
- [ ] `bun run sonar:lint` fails only on a **pre-existing** `**/*.webp` exclusion warning in `sonar-project.properties` (untouched by this PR).

## Risk

Low. A hook only runs locally after `bun install` (or `bun run hooks:install`); it cannot block CI or anyone who hasn't installed it, so it is a guardrail, not a gate. Worst case a false negative lets a bad name through — the pattern is covered by the self-test above.