### PR TITLE
fix(server): transcode audio the client cannot decode instead of serving silence

### DIFF
--- a/packages/client/src/api.test.ts
+++ b/packages/client/src/api.test.ts
@@ -341,6 +341,9 @@ describe('URL builders (pure, no request)', () => {
     expect(c.hlsMasterUrl('id', true, 600.6, 2)).toBe(
       'http://kroma.test/api/items/id/hls/aac/601/2/index.m3u8',
     );
+    expect(c.hlsMasterUrl('id', false, 0, 0, undefined, ['aac', 'eac3'])).toBe(
+      'http://kroma.test/api/items/id/hls/copy/0/0/index.m3u8?copy=aac%2Ceac3',
+    );
     expect(c.posterUrl('id')).toBe('http://kroma.test/api/items/id/poster');
     expect(c.showPosterUrl('s1')).toBe('http://kroma.test/api/shows/s1/poster');
     expect(c.subtitleUrl('id', 3)).toBe('http://kroma.test/api/items/id/subtitles/3.vtt');

--- a/packages/client/src/api.ts
+++ b/packages/client/src/api.ts
@@ -323,8 +323,9 @@ export class KromaClient {
     startSec = 0,
     audio = 0,
     filter?: media.HlsAudioFilter,
+    copyCodecs?: string[],
   ): string {
-    return media.hlsMasterUrl(this.ctx, id, aac, startSec, audio, filter);
+    return media.hlsMasterUrl(this.ctx, id, aac, startSec, audio, filter, copyCodecs);
   }
   posterUrl(id: string): string {
     return artwork.posterUrl(this.ctx, id);

--- a/packages/client/src/client/media.test.ts
+++ b/packages/client/src/client/media.test.ts
@@ -165,6 +165,25 @@ describe('hlsMasterUrl', () => {
       'http://kroma.test/api/items/abc/hls/aac-standard/0/0/index.m3u8',
     );
   });
+
+  it('declares decodable codecs so the server can override an unplayable copy', () => {
+    expect(hlsMasterUrl(ctx, 'abc', false, 0, 0, undefined, ['aac', 'eac3'])).toBe(
+      'http://kroma.test/api/items/abc/hls/copy/0/0/index.m3u8?copy=aac%2Ceac3',
+    );
+    // Decodes none: an empty array is a declaration, not "no preference".
+    expect(hlsMasterUrl(ctx, 'abc', false, 0, 0, undefined, [])).toBe(
+      'http://kroma.test/api/items/abc/hls/copy/0/0/index.m3u8?copy=',
+    );
+  });
+
+  it('ignores declared codecs once the request already transcodes', () => {
+    expect(hlsMasterUrl(ctx, 'abc', true, 0, 0, undefined, ['aac'])).toBe(
+      'http://kroma.test/api/items/abc/hls/aac/0/0/index.m3u8',
+    );
+    expect(hlsMasterUrl(ctx, 'abc', false, 0, 0, 'night', ['aac'])).toBe(
+      'http://kroma.test/api/items/abc/hls/aac-night/0/0/index.m3u8',
+    );
+  });
 });
 
 describe('stream / subtitle URL builders', () => {

--- a/packages/client/src/client/media.ts
+++ b/packages/client/src/client/media.ts
@@ -184,7 +184,10 @@ export type HlsAudioFilter = 'standard' | 'night';
 /** HLS *master* playlist for one continuous remux: the video once plus EVERY
  * audio track as an alternate rendition, so language switches happen in place
  * (no reload). `aac=true` transcodes every rendition to stereo AAC for runtimes
- * that can't decode the source codec via MSE; `aac=false` stream-copies them. */
+ * that can't decode the source codec via MSE; `aac=false` stream-copies them.
+ * `copyCodecs` names what this device can decode, letting the server override a
+ * stream copy it would play silent; omitted means no declaration, an empty array
+ * means none, and it is read only for a copy request. */
 export function hlsMasterUrl(
   ctx: RequestContext,
   id: string,
@@ -204,10 +207,6 @@ export function hlsMasterUrl(
   const clean = aac ? 'aac' : 'copy';
   const mode = filter ? `aac-${filter}` : clean;
   const base = `${ctx.baseUrl}/api/items/${encodeURIComponent(id)}/hls/${mode}/${anchor}/${a}/index.m3u8`;
-  // `copyCodecs` lets the client declare what it can decode or pass through, so the
-  // server transcodes a `copy` request it would otherwise play silent (e.g. an
-  // AC-3-only title on a device with no Dolby path). Omitted = no preference; an
-  // empty array = decodes none. Only meaningful for a `copy` request.
   if (!copyCodecs || mode !== 'copy') return base;
   return `${base}?copy=${encodeURIComponent(copyCodecs.join(','))}`;
 }

--- a/packages/client/src/client/media.ts
+++ b/packages/client/src/client/media.ts
@@ -192,6 +192,7 @@ export function hlsMasterUrl(
   startSec = 0,
   audio = 0,
   filter?: HlsAudioFilter,
+  copyCodecs?: string[],
 ): string {
   // The anchor, audio index and filter mode are all in the path, so each seek
   // position and language gets its own session with its own child URLs - no
@@ -202,7 +203,13 @@ export function hlsMasterUrl(
   const a = Math.max(0, Math.round(audio));
   const clean = aac ? 'aac' : 'copy';
   const mode = filter ? `aac-${filter}` : clean;
-  return `${ctx.baseUrl}/api/items/${encodeURIComponent(id)}/hls/${mode}/${anchor}/${a}/index.m3u8`;
+  const base = `${ctx.baseUrl}/api/items/${encodeURIComponent(id)}/hls/${mode}/${anchor}/${a}/index.m3u8`;
+  // `copyCodecs` lets the client declare what it can decode or pass through, so the
+  // server transcodes a `copy` request it would otherwise play silent (e.g. an
+  // AC-3-only title on a device with no Dolby path). Omitted = no preference; an
+  // empty array = decodes none. Only meaningful for a `copy` request.
+  if (!copyCodecs || mode !== 'copy') return base;
+  return `${base}?copy=${encodeURIComponent(copyCodecs.join(','))}`;
 }
 
 /** WebVTT URL for the n-th embedded subtitle track of an item. The server

--- a/server/crates/kroma-engine/src/infra/hls/mod.rs
+++ b/server/crates/kroma-engine/src/infra/hls/mod.rs
@@ -42,14 +42,11 @@ impl StreamMode {
         }
     }
 
-    /// Second-guesses a `Copy` request the client cannot actually play. Given the
-    /// selected track's `codec` and the set of codecs the client declared it can
-    /// decode or pass through (comma-separated; `None` = no declared capability),
-    /// returns the mode whose audio will actually reach the speakers. Only `Copy`
-    /// is overridden - a filter/transcode request already re-encodes - and only
-    /// when a set is present and excludes the codec, so a client that sends no set
-    /// behaves exactly as before. Video is stream-copied in every mode, so an audio
-    /// fix never touches the picture.
+    /// The mode whose audio will actually reach the speakers, given the selected
+    /// track's codec and the comma-separated set the client declared it can decode
+    /// (`None` = declared nothing, and the request stands). Only `Copy` is ever
+    /// overridden; video is stream-copied in every mode, so this never touches
+    /// the picture.
     pub fn for_client_audio(self, codec: Option<&str>, client_decodes: Option<&str>) -> Self {
         match (self, client_decodes) {
             (Self::Copy, Some(set)) if !client_can_play(codec, set) => Self::Aac,
@@ -86,10 +83,8 @@ impl StreamMode {
     }
 }
 
-// A codec the client can play when it appears in the declared set (case-insensitive).
-// An unknown codec (unprobed track) is assumed playable: with no codec there is
-// nothing honest to override, and forcing a transcode would punish the common case.
-// A present-but-empty set means the client decodes none, so anything is overridden.
+// An unprobed track is assumed playable: with no codec there is nothing honest to
+// override, and forcing a transcode would punish the common case.
 fn client_can_play(codec: Option<&str>, client_set: &str) -> bool {
     let Some(codec) = codec else { return true };
     client_set.split(',').any(|c| c.trim().eq_ignore_ascii_case(codec))

--- a/server/crates/kroma-engine/src/infra/hls/mod.rs
+++ b/server/crates/kroma-engine/src/infra/hls/mod.rs
@@ -42,8 +42,23 @@ impl StreamMode {
         }
     }
 
+    /// Second-guesses a `Copy` request the client cannot actually play. Given the
+    /// selected track's `codec` and the set of codecs the client declared it can
+    /// decode or pass through (comma-separated; `None` = no declared capability),
+    /// returns the mode whose audio will actually reach the speakers. Only `Copy`
+    /// is overridden - a filter/transcode request already re-encodes - and only
+    /// when a set is present and excludes the codec, so a client that sends no set
+    /// behaves exactly as before. Video is stream-copied in every mode, so an audio
+    /// fix never touches the picture.
+    pub fn for_client_audio(self, codec: Option<&str>, client_decodes: Option<&str>) -> Self {
+        match (self, client_decodes) {
+            (Self::Copy, Some(set)) if !client_can_play(codec, set) => Self::Aac,
+            _ => self,
+        }
+    }
+
     // Inverse of `parse`; emitted by the client URL builder in `packages/client media.ts`.
-    fn token(self) -> &'static str {
+    pub fn token(self) -> &'static str {
         match self {
             Self::Copy => "copy",
             Self::Aac => "aac",
@@ -69,6 +84,15 @@ impl StreamMode {
             }
         }
     }
+}
+
+// A codec the client can play when it appears in the declared set (case-insensitive).
+// An unknown codec (unprobed track) is assumed playable: with no codec there is
+// nothing honest to override, and forcing a transcode would punish the common case.
+// A present-but-empty set means the client decodes none, so anything is overridden.
+fn client_can_play(codec: Option<&str>, client_set: &str) -> bool {
+    let Some(codec) = codec else { return true };
+    client_set.split(',').any(|c| c.trim().eq_ignore_ascii_case(codec))
 }
 
 // `{item_id}:{mode}:{anchor_secs}:a{audio}`. The mode is part of the key
@@ -181,6 +205,41 @@ mod tests {
         assert!(StreamMode::AacStandard.transcode());
         assert!(StreamMode::AacStandard.filter_chain().unwrap().contains("ratio=4"));
         assert!(StreamMode::AacNight.filter_chain().unwrap().contains("ratio=8"));
+    }
+
+    #[test]
+    fn copy_becomes_aac_when_the_client_cannot_decode_the_codec() {
+        // The AC-3-only Android TV case: a copy request the device can't play.
+        assert_eq!(StreamMode::Copy.for_client_audio(Some("ac3"), Some("aac")), StreamMode::Aac);
+    }
+
+    #[test]
+    fn copy_stays_copy_when_the_client_can_decode_or_passthrough() {
+        assert_eq!(StreamMode::Copy.for_client_audio(Some("ac3"), Some("aac,ac3,eac3")), StreamMode::Copy);
+        assert_eq!(StreamMode::Copy.for_client_audio(Some("AC3"), Some("aac, ac3")), StreamMode::Copy);
+    }
+
+    #[test]
+    fn no_declared_capability_leaves_the_requested_mode_untouched() {
+        assert_eq!(StreamMode::Copy.for_client_audio(Some("ac3"), None), StreamMode::Copy);
+    }
+
+    #[test]
+    fn an_empty_capability_set_transcodes_every_known_codec() {
+        assert_eq!(StreamMode::Copy.for_client_audio(Some("aac"), Some("")), StreamMode::Aac);
+    }
+
+    #[test]
+    fn an_unknown_codec_is_never_forced_to_transcode() {
+        assert_eq!(StreamMode::Copy.for_client_audio(None, Some("aac")), StreamMode::Copy);
+        assert_eq!(StreamMode::Copy.for_client_audio(None, Some("")), StreamMode::Copy);
+    }
+
+    #[test]
+    fn a_transcode_or_filter_request_is_never_second_guessed() {
+        for mode in [StreamMode::Aac, StreamMode::AacStandard, StreamMode::AacNight] {
+            assert_eq!(mode.for_client_audio(Some("ac3"), Some("")), mode);
+        }
     }
 
     #[test]

--- a/server/src/api/stream.rs
+++ b/server/src/api/stream.rs
@@ -326,10 +326,10 @@ pub async fn hls_master(
     let Some(item) = load_item(&state, id).await else {
         return json_error(StatusCode::NOT_FOUND, "item not found");
     };
-    // A copy the client can't decode (e.g. AC-3-only on a device with no Dolby path)
-    // is redirected onto its transcoded twin: the effective mode owns the session and
-    // its segment URLs, so master and segments never disagree. Video stays copied.
-    let selected_codec = item.audio_tracks.iter().find(|t| t.index == audio).map(|t| t.codec.as_str());
+    // Redirected rather than served here: the effective mode owns the session and
+    // its segment URLs, so master and segments never disagree.
+    let selected_codec =
+        item.audio_tracks.iter().find(|t| t.index == audio).map(|t| t.codec.as_str());
     let effective = mode.for_client_audio(selected_codec, q.copy.as_deref());
     if effective != mode {
         return Redirect::temporary(&hls_master_path(&item.id, effective, anchor, audio)).into_response();
@@ -409,8 +409,6 @@ pub async fn hls_file(
     }
 }
 
-// The API is mounted at `/api`; a redirected master keeps every path segment but the
-// mode, so the client's relative segment fetches resolve under the effective session.
 // Item ids are hex `short_hash`es (optionally joined by a colon), so they need no
 // escaping to sit in a path segment.
 fn hls_master_path(id: &str, mode: StreamMode, anchor: u64, audio: u32) -> String {

--- a/server/src/api/stream.rs
+++ b/server/src/api/stream.rs
@@ -6,7 +6,7 @@ use std::net::SocketAddr;
 use axum::body::Body;
 use axum::extract::{ConnectInfo, Path, Query, State};
 use axum::http::{header, HeaderMap, StatusCode};
-use axum::response::Response;
+use axum::response::{IntoResponse, Redirect, Response};
 use serde::Deserialize;
 
 use crate::api::error::json_error;
@@ -275,6 +275,15 @@ pub struct StreamQuery {
     pub file: Option<String>,
 }
 
+/// `?copy=` names the audio codecs the client can decode or pass through, so the
+/// server can refuse to stream-copy one the device would play silent. Absent means
+/// no declared capability (the requested mode is trusted); present but empty means
+/// the client decodes none, so any copied track is transcoded.
+#[derive(Debug, Deserialize)]
+pub struct HlsQuery {
+    pub copy: Option<String>,
+}
+
 /// `GET /api/items/:id/stream` (optional `?file=<fileId>`) → range-streamed
 /// original file. Without `?file`, the item's default/best file is served.
 pub async fn stream_item(
@@ -309,6 +318,7 @@ fn pick_file_path(item: &MediaItem, file_id: Option<&str>) -> Option<String> {
 pub async fn hls_master(
     State(state): State<SharedState>,
     Path((id, mode, anchor, audio)): Path<(String, String, u64, u32)>,
+    Query(q): Query<HlsQuery>,
 ) -> Response {
     let Some(mode) = StreamMode::parse(&mode) else {
         return json_error(StatusCode::BAD_REQUEST, "bad mode");
@@ -316,6 +326,14 @@ pub async fn hls_master(
     let Some(item) = load_item(&state, id).await else {
         return json_error(StatusCode::NOT_FOUND, "item not found");
     };
+    // A copy the client can't decode (e.g. AC-3-only on a device with no Dolby path)
+    // is redirected onto its transcoded twin: the effective mode owns the session and
+    // its segment URLs, so master and segments never disagree. Video stays copied.
+    let selected_codec = item.audio_tracks.iter().find(|t| t.index == audio).map(|t| t.codec.as_str());
+    let effective = mode.for_client_audio(selected_codec, q.copy.as_deref());
+    if effective != mode {
+        return Redirect::temporary(&hls_master_path(&item.id, effective, anchor, audio)).into_response();
+    }
     let Some(abs) = item.abs_path.clone() else {
         return json_error(StatusCode::NOT_FOUND, "no media file for item");
     };
@@ -389,6 +407,14 @@ pub async fn hls_file(
             resp
         }
     }
+}
+
+// The API is mounted at `/api`; a redirected master keeps every path segment but the
+// mode, so the client's relative segment fetches resolve under the effective session.
+// Item ids are hex `short_hash`es (optionally joined by a colon), so they need no
+// escaping to sit in a path segment.
+fn hls_master_path(id: &str, mode: StreamMode, anchor: u64, audio: u32) -> String {
+    format!("/api/items/{id}/hls/{}/{anchor}/{audio}/index.m3u8", mode.token())
 }
 
 async fn load_item(state: &SharedState, id: String) -> Option<MediaItem> {
@@ -538,6 +564,18 @@ pub(crate) async fn extract_webvtt(path: &str, index: usize) -> Option<Vec<u8>> 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn redirect_path_swaps_only_the_mode_segment() {
+        assert_eq!(
+            hls_master_path("abc123", StreamMode::Aac, 30, 1),
+            "/api/items/abc123/hls/aac/30/1/index.m3u8"
+        );
+        assert_eq!(
+            hls_master_path("tv:s1e2", StreamMode::Aac, 0, 0),
+            "/api/items/tv:s1e2/hls/aac/0/0/index.m3u8"
+        );
+    }
 
     #[test]
     fn parse_mode_variants() {


### PR DESCRIPTION
## What

An AC-3-only title played silent on clients with no AC-3 decode or Dolby passthrough (e.g. Chromecast HD / Android TV): the HLS remux stream-copied the audio the device could not decode. The `mode` in the HLS URL (`copy`|`aac`|…) was trusted verbatim, so a `copy` request produced an undecodable audio track with the video playing fine.

This adds the **audio rung** of the playback fallback ladder on the server. The client may now declare, via `?copy=<codecs>` on the HLS master, the audio codecs it can decode or pass through. When a `copy` request names a codec the client can't play, the server transcodes that audio track to AAC while keeping the **video stream-copied** — it never re-encodes the picture to solve an audio problem. The decision lives in one pure function, `StreamMode::for_client_audio(codec, client_decodes)`, so it is trivially testable.

Why a redirect rather than swapping the ffmpeg codec in place: the `mode` path segment is the session key and the base every relative segment URL resolves against. If the master silently transcoded a `copy` session, the client's `.../hls/copy/...` segment fetches would still find a copy-keyed session — and a decode-capable client sharing that cache key would be needlessly transcoded. Redirecting an unplayable `copy` onto its `aac` twin keeps master and segments consistent, keeps the cache keyed honestly per decision, and leaves capable clients on `copy`.

`copyCodecs` is threaded through the client's `hlsMasterUrl` builder (mirroring the existing `downloadUrl` capability set) as the minimal honest plumbing — omitted means "no preference" (unchanged behaviour), an empty array means "decodes none". Populating it truthfully on Android TV is the client-side (area/tv) half of the fix and is intentionally out of this PR's scope.

Scope: the audio-fallback decision and its plumbing only. The transcode pipeline itself is untouched.

## Closes

Closes #82

## Checks

- [x] `cargo clippy` and `cargo test` pass for the changed crates (server changed)
- [x] Follows `CODE_STYLE.md` — no narration, doc comment on the exported decision only
- [x] One idea: the server audio-fallback decision + its capability plumbing

Gate output (run on this branch):

```
# server — new decision logic (kroma-engine) + route (kroma-server)
$ cargo test -p kroma-engine hls::
test result: ok. 31 passed; 0 failed  (incl. 6 new for_client_audio cases)
$ cargo test -p kroma-server --bin kroma-server stream::
test result: ok. 7 passed; 0 failed   (incl. redirect_path_swaps_only_the_mode_segment)
$ cargo clippy -p kroma-engine -p kroma-server --all-targets
0 warnings in the changed files (hls/mod.rs, api/stream.rs)

# client wire plumbing
$ bun run --filter '@kroma/client' typecheck      # tsc --noEmit → 0 errors
$ bunx biome check packages/client/src/client/media.ts media.test.ts   # clean
$ bunx vitest run --coverage packages/client/src/client/media.test.ts
26 passed; media.ts branch coverage 93.9% (new copyCodecs branches covered)

$ bun run sonar:precheck    # No known Sonar patterns in changed files
```

Coverage of new logic: `for_client_audio` — all six branches (AC-3-only→AAC, passthrough-capable→copy, already-decodable→copy, no-declared-capability→unchanged, empty-set→transcode, unknown-codec→copy, and transcode/filter-never-second-guessed). `hls_master_path` redirect target asserted. Client `hlsMasterUrl` copyCodecs param: populated, empty, and ignored-when-transcoding.

## Risk

If wrong, a capable client could be needlessly transcoded (quality/CPU cost, not silence) or an incapable one still gets silence. Both are visible immediately on the affected title. The redirect only fires when a `?copy` set is present and excludes the selected codec, so every client that sends no set behaves exactly as before — the change is inert until a client opts in. Video is stream-copied in every mode, so the picture is never affected.

Could not verify: no end-to-end playback on real Chromecast HD hardware from here (no device/mount in this environment); the DoD's on-device check and the area/tv capability-reporting change are follow-ups. `cargo fmt --check` and `cargo clippy -- -D warnings` were not used as pass/fail gates because origin/main carries pre-existing fmt drift and clippy warnings (CI runs fmt non-blocking and clippy without `-D warnings` for this reason); the changed files add none. `bun run sonar:lint` reports one pre-existing repo-config issue (`sonar.exclusions '**/*.webp'` matches no file) that exists on origin/main and is untouched here.
