### PR TITLE
fix(tv): route the d-pad into the player chrome on Android TV

### DIFF
--- a/packages/ui/src/components/organisms/player/hooks/use-player-keys.native.test.ts
+++ b/packages/ui/src/components/organisms/player/hooks/use-player-keys.native.test.ts
@@ -35,6 +35,15 @@ vi.mock('react-native', () => ({
 const routeRemoteKey = vi.hoisted(() => vi.fn());
 vi.mock('../lib/player-keys', () => ({ routeRemoteKey }));
 
+// The Android key host, mocked to the one surface the player uses: it captures
+// the d-pad subscriber so a press can be posted through it (see focus-remote).
+const host = vi.hoisted(() => ({ onKey: null as ((key: RemoteKey) => void) | null }));
+vi.mock('#ui/lib/focus-remote', () => ({
+  useRemoteKeys: (handle: (key: RemoteKey) => void) => {
+    host.onKey = handle;
+  },
+}));
+
 import { usePlayerKeys } from './use-player-keys';
 
 const params = (tag: string) => ({ tag }) as never;
@@ -50,6 +59,7 @@ const routed = (): RemoteKey[] => routeRemoteKey.mock.calls.map(([, key]) => key
 beforeEach(() => {
   rn.os = 'ios';
   rn.remote = null;
+  host.onKey = null;
   vi.clearAllMocks();
 });
 
@@ -124,6 +134,29 @@ describe('the key-up filter', () => {
     press('playPause', 1);
     // Acting on both toggles play twice, so the film never actually pauses.
     expect(routed()).toEqual(['PlayPause']);
+    unmount();
+  });
+});
+
+describe('the Android key host', () => {
+  it('routes the d-pad in where useTVEventHandler never fires', () => {
+    const { unmount } = renderHook(() => usePlayerKeys(params('a')));
+    // On the new architecture the remote arrives through the focus root's key
+    // host, not the event handler, so the player subscribes to both.
+    act(() => {
+      for (const key of ['Up', 'Down', 'Left', 'Right', 'Enter'] as RemoteKey[]) host.onKey?.(key);
+    });
+    expect(routed()).toEqual(['Up', 'Down', 'Left', 'Right', 'Enter']);
+    unmount();
+  });
+
+  it('hands the router the latest params, like the event handler does', () => {
+    const { rerender, unmount } = renderHook(({ tag }) => usePlayerKeys(params(tag)), {
+      initialProps: { tag: 'first' },
+    });
+    rerender({ tag: 'second' });
+    act(() => host.onKey?.('Enter'));
+    expect(routeRemoteKey).toHaveBeenCalledWith({ tag: 'second' }, 'Enter');
     unmount();
   });
 });

--- a/packages/ui/src/components/organisms/player/hooks/use-player-keys.ts
+++ b/packages/ui/src/components/organisms/player/hooks/use-player-keys.ts
@@ -10,6 +10,7 @@ import {
   type PlayerKeysParams,
   routeRemoteKey,
 } from '#ui/components/organisms/player/lib/player-keys';
+import { useRemoteKeys } from '#ui/lib/focus-remote';
 import { holdMenuKey, isRemoteKeyUp, releaseMenuKey } from '#ui/lib/tv-remote';
 
 // Both the clickpad (up/down/left/right) and the touch-surface swipes
@@ -65,6 +66,9 @@ export function usePlayerKeys(params: Readonly<PlayerKeysParams>): void {
     if (key) routeRemoteKey(params, key);
   });
   useRemoteEvents(onRemote);
+  // Android's new architecture never fires `useRemoteEvents`; there the focus
+  // root's key host feeds the d-pad in through here instead (see focus-remote).
+  useRemoteKeys((key) => routeRemoteKey(params, key));
 }
 
 export type { PlayerKeysParams };

--- a/packages/ui/src/lib/focus-remote.native.test.ts
+++ b/packages/ui/src/lib/focus-remote.native.test.ts
@@ -227,6 +227,43 @@ describe('the Android key host', () => {
   });
 });
 
+describe('the player’s d-pad subscribers', () => {
+  it('hears the same key host the navigator does, so the player works on Android', async () => {
+    const { remote } = await load('android');
+    const nav1 = navigator();
+    const keys: string[] = [];
+    renderHook(() => remote.useRemoteKeys((key) => keys.push(key)));
+    const { result } = renderHook(() => remote.useRemoteHostProps());
+
+    for (const code of ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Enter']) {
+      keyDown(result.current, { code });
+    }
+    // The chrome drives a virtual focus, so it needs the presses as keys; the
+    // navigator still gets its directions for whatever is spatial (the sheet).
+    expect(keys).toEqual(['Up', 'Down', 'Left', 'Right', 'Enter']);
+    expect(nav1.moves).toEqual(['up', 'down', 'left', 'right', 'enter']);
+  });
+
+  it('stays quiet on a key the player has no d-pad word for', async () => {
+    const { remote } = await load('android');
+    const keys: string[] = [];
+    renderHook(() => remote.useRemoteKeys((key) => keys.push(key)));
+    const { result } = renderHook(() => remote.useRemoteHostProps());
+    keyDown(result.current, { code: 'KeyA', key: 'a' });
+    expect(keys).toEqual([]);
+  });
+
+  it('drops the subscriber on unmount', async () => {
+    const { remote } = await load('android');
+    const keys: string[] = [];
+    const { unmount } = renderHook(() => remote.useRemoteKeys((key) => keys.push(key)));
+    const { result } = renderHook(() => remote.useRemoteHostProps());
+    unmount();
+    keyDown(result.current, { code: 'Enter' });
+    expect(keys).toEqual([]);
+  });
+});
+
 describe('typing on a hardware keyboard', () => {
   it('delivers letters to whoever is collecting text', async () => {
     const { remote } = await load('android');

--- a/packages/ui/src/lib/focus-remote.ts
+++ b/packages/ui/src/lib/focus-remote.ts
@@ -5,6 +5,7 @@
 // Read via `useTVEventHandler` rather than the plain emitter: this fork's
 // emitter export has been unreliable.
 
+import type { RemoteKey } from '@kroma/core';
 import { useCallback, useEffect, useEffectEvent } from 'react';
 import {
   type HWEvent,
@@ -105,6 +106,18 @@ const KEY_CODES: Record<string, Direction> = {
   Enter: ENTER,
 };
 
+// The same d-pad keys as the player's own vocabulary. The player chrome drives
+// a virtual focus of its own instead of the spatial navigator (see
+// player/lib/virtual-focus), so on Android it needs these presses from this
+// host too - the tvOS half reads them straight off `useTVEventHandler`.
+const REMOTE_KEY: Record<string, RemoteKey> = {
+  ArrowUp: 'Up',
+  ArrowDown: 'Down',
+  ArrowLeft: 'Left',
+  ArrowRight: 'Right',
+  Enter: 'Enter',
+};
+
 /** Empty off Android, where `useTVEventHandler` above is the whole story. */
 export interface RemoteHostProps {
   onKeyDown?: (event: NativeSyntheticEvent<TVKeyEvent>) => void;
@@ -112,6 +125,11 @@ export interface RemoteHostProps {
 
 // Same Set-not-slot reasoning as `handlers` above.
 const typists = new Set<(key: string) => void>();
+
+// The player chrome's d-pad subscribers. Fed by the Android key host below, so
+// a chrome that keeps its own virtual focus still hears the remote where
+// `useTVEventHandler` never fires (the new architecture, see the host comment).
+const remoteKeys = new Set<(key: RemoteKey) => void>();
 
 const NO_HOST_PROPS: RemoteHostProps = {};
 const IS_ANDROID = Platform.OS === 'android';
@@ -126,6 +144,10 @@ export function useRemoteHostProps(): RemoteHostProps {
     if (direction) {
       markPress();
       for (const handle of handlers) handle(direction);
+      // Fanned to the player chrome as well, the same way `useTVEventHandler`
+      // feeds both the navigator bridge and the player on tvOS.
+      const remoteKey = REMOTE_KEY[code];
+      if (remoteKey) for (const sub of remoteKeys) sub(remoteKey);
       return;
     }
     // Not a direction: may be someone typing. See `useHardwareKeys`.
@@ -151,6 +173,21 @@ export function useHardwareKeys(handle: (key: string) => void): void {
     typists.add(forward);
     return () => {
       typists.delete(forward);
+    };
+  }, []);
+}
+
+/**
+ * Delivers d-pad presses to a chrome driving its own virtual focus (the
+ * player): the Android mirror of the `useTVEventHandler` the player reads on
+ * tvOS. Same effect-event identity trick as {@link useHardwareKeys}.
+ */
+export function useRemoteKeys(handle: (key: RemoteKey) => void): void {
+  const forward = useEffectEvent((key: RemoteKey) => handle(key));
+  useEffect(() => {
+    remoteKeys.add(forward);
+    return () => {
+      remoteKeys.delete(forward);
     };
   }, []);
 }


### PR DESCRIPTION
## What

On Android TV the video player's on-screen controls could not be focused or used with the remote. Addresses #79.

### Root cause

The player chrome (`@kroma/ui` `<Player>`) deliberately does **not** put its controls on the spatial navigator — it drives its own *virtual* focus (`usePlayerNav`) and reads the remote directly through `useTVEventHandler` (`use-player-keys.ts`). Its Pressables are spread with `VIRTUAL_FOCUS` so the OS focus engine ignores them.

On Android's **new architecture** (`ReactSurfaceView`), `useTVEventHandler` never fires — hardware keys are delivered to the focused view's `onKeyDown` (JSKeyDispatcher). The rest of the app copes because `FocusRoot` mounts a full-screen key host that holds focus and forwards `onKeyDown` into the spatial navigator (`useRemoteHostProps` → `handlers`). The player never wired into that path, so:

- `useTVEventHandler` → dead on the device → player key router never runs.
- `onKeyDown` → spatial navigator, which has **no** player nodes (the chrome is virtual) → nothing moves.

Result: the transport, menu and buttons are unreachable. Other screens (catalog, on-screen keyboard) work because they *are* spatial-navigator nodes. This matches the device in the report (Chromecast HD / Google TV, Android TV 14).

### Fix

Feed the player's d-pad subscribers from the same Android key host, mirroring the dual dispatch `useTVEventHandler` already performs on tvOS (it fans every press to both the navigator bridge and the player):

- `focus-remote.ts`: add a `remoteKeys` subscriber set + `useRemoteKeys(handle)` hook (same effect-event idiom as the existing `useHardwareKeys`/`typists`). The `onKeyDown` host now also fans the d-pad key (`Up/Down/Left/Right/Enter`) to those subscribers, alongside the navigator directions it already posts.
- `use-player-keys.ts` (native): subscribe via `useRemoteKeys` in addition to `useTVEventHandler`.

Exactly one path is live per platform (tvOS: `useTVEventHandler`; Android new-arch: the key host), so there is no double handling. When the up-next sheet — the one genuinely spatial part of the player — is open, the player router still receives the keys but swallows them (`PanelHandle.onKey`), leaving the sheet's grid navigation to the spatial navigator exactly as before.

Scope is limited to the d-pad reachability in #79. The Back-button crash (#80) is untouched.

## Tests

- `focus-remote.native.test.ts`: the Android key host feeds the player's d-pad subscribers *and* the navigator; ignores non-d-pad keys; drops the subscriber on unmount.
- `use-player-keys.native.test.ts`: the player routes the d-pad from the key host, with the latest params, where `useTVEventHandler` never fires.

## Gate

- `typecheck` — clean (per-package; the monorepo-wide parallel run OOMs, unrelated).
- `biome check packages/ui packages/tv` — clean.
- native vitest for both touched suites — 37 passed.
- `sonar:precheck` — no findings.

## Risk / verification

**Unverified hypothesis — needs on-device (Android TV) verification.** The reasoning is strongly supported by the codebase's own documented behaviour (`focus-remote.ts` / `focus-root.tsx` explicitly note that `useTVEventHandler` does not fire on the new architecture and `onKeyDown` is the path), but I cannot run an Android TV build here. Opening as **draft** until confirmed on device.

On a Chromecast HD / Google TV build, verify:
1. During playback, the d-pad reveals the chrome and moves focus through transport → seek bar → controls; **OK** activates the focused control.
2. Opening the up-next sheet still navigates its grid normally (spatial navigator path unbroken).
3. The settings/audio/subtitles panel is reachable and navigable.
4. tvOS / Apple TV playback is unchanged (no regression, no double input).
5. `clients/tv-native/plugins/with-tv-key-events.js` `enableKeyEvents` flag is present in the build (the `onKeyDown` host depends on it).
