### PR TITLE
fix(tv): drop per-key backdrop blur on the ten-foot keyboard

### DIFF
--- a/apps/www/src/routeTree.gen.ts
+++ b/apps/www/src/routeTree.gen.ts
@@ -127,6 +127,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute;
   R404Route: typeof R404Route;
   DownloadRoute: typeof DownloadRoute;
+  ModulesRoute: typeof ModulesRoute;
   PrivacyRoute: typeof PrivacyRoute;
   SupportRoute: typeof SupportRoute;
   BlogSlugRoute: typeof BlogSlugRoute;

--- a/packages/ui/src/components/organisms/keyboard/key.tsx
+++ b/packages/ui/src/components/organisms/keyboard/key.tsx
@@ -92,8 +92,13 @@ function Key({
       {({ slots }) => (
         <>
           {/* The fill is translucent (lib/field-shell), so blur what shows
-              through: a key reads as glass, not as a window on the artwork. */}
-          <Frost radius={keyRadius[size]} />
+              through: a key reads as glass, not as a window on the artwork.
+              Never on a television, though: there the blur is a per-key native
+              surface (expo-blur), and a grid of them re-composited on every
+              focus move drops whole rows and occasionally crashes the box. The
+              ten-foot grid keeps the wash alone - the same degradation a shell
+              that registers no blur already shows (see frost.story.mdx). */}
+          {size === 'tv' ? null : <Frost radius={keyRadius[size]} />}
           {icon ? (
             <Icon name={icon} size={iconSize ?? 24} {...slots.glyph} />
           ) : (

--- a/packages/ui/src/components/organisms/keyboard/key.tsx
+++ b/packages/ui/src/components/organisms/keyboard/key.tsx
@@ -93,11 +93,9 @@ function Key({
         <>
           {/* The fill is translucent (lib/field-shell), so blur what shows
               through: a key reads as glass, not as a window on the artwork.
-              Never on a television, though: there the blur is a per-key native
-              surface (expo-blur), and a grid of them re-composited on every
-              focus move drops whole rows and occasionally crashes the box. The
-              ten-foot grid keeps the wash alone - the same degradation a shell
-              that registers no blur already shows (see frost.story.mdx). */}
+              Not on a television: there each Frost is its own native expo-blur
+              surface, and a grid of them re-composited on every focus move
+              drops rows and can take the box down. */}
           {size === 'tv' ? null : <Frost radius={keyRadius[size]} />}
           {icon ? (
             <Icon name={icon} size={iconSize ?? 24} {...slots.glyph} />

--- a/packages/ui/src/components/organisms/keyboard/keyboard.test.tsx
+++ b/packages/ui/src/components/organisms/keyboard/keyboard.test.tsx
@@ -8,8 +8,6 @@ import { UrlKeyboard } from './url-keyboard';
 
 afterEach(cleanup);
 
-// The keys' backdrop-blur layers (<Frost>): a per-key native surface on a
-// television, which is why the ten-foot grid must lay none.
 function blurLayers(container: HTMLElement): Element[] {
   return [...container.querySelectorAll('*')].filter((el) =>
     /blur/.test((el as HTMLElement).style.backdropFilter),

--- a/packages/ui/src/components/organisms/keyboard/keyboard.test.tsx
+++ b/packages/ui/src/components/organisms/keyboard/keyboard.test.tsx
@@ -8,6 +8,29 @@ import { UrlKeyboard } from './url-keyboard';
 
 afterEach(cleanup);
 
+// The keys' backdrop-blur layers (<Frost>): a per-key native surface on a
+// television, which is why the ten-foot grid must lay none.
+function blurLayers(container: HTMLElement): Element[] {
+  return [...container.querySelectorAll('*')].filter((el) =>
+    /blur/.test((el as HTMLElement).style.backdropFilter),
+  );
+}
+
+describe('ten-foot keyboard blur', () => {
+  it('frosts each key at arm’s length but never on a television', () => {
+    const armsLength = render(<SearchKeyboard value="" onValueChange={vi.fn()} size="sm" />);
+    expect(blurLayers(armsLength.container).length).toBeGreaterThan(0);
+    cleanup();
+    const tv = render(<SearchKeyboard value="" onValueChange={vi.fn()} size="tv" />);
+    expect(blurLayers(tv.container)).toHaveLength(0);
+  });
+
+  it('lays no blur under the URL grid on a television either', () => {
+    const { container } = render(<UrlKeyboard value="" onValueChange={vi.fn()} size="tv" />);
+    expect(blurLayers(container)).toHaveLength(0);
+  });
+});
+
 // space / delete / close, in that order. A glyph key draws no words, so its
 // label is its accessible name alone - which is how a test finds it.
 function tailKeys(): Element[] {


### PR DESCRIPTION
## What

On the Android TV on-screen keyboard ("Ajouter un serveur" / search), the focused
row can vanish and the app sometimes crashes (#81). This removes the most likely
native cause: **per-key backdrop blur**.

Every `Key` laid a `<Frost>` blur layer beneath its face. On a television that
`<Frost>` resolves to a **native `BlurView` (expo-blur)**, so the ten-foot grid
mounts ~40 live blur surfaces. When focus moves, the focused key and its row take a
`zIndex` lift (`liftedBox` / `FocusRegion`), and Android re-composites those blur
surfaces in the new draw order — the well-known Android failure mode where a
reordered `BlurView` drops out (a whole row disappears) or crashes the surface.

The fix: `Key` no longer renders `<Frost>` at `size="tv"`. The keys keep their
translucent wash — exactly the documented degradation a shell that registers no
blur already shows, and consistent with the kit's own guidance in
`frost.story.mdx` ("Don't blur on a television"). Arm's-length keypads (`sm`)
are unchanged.

## Why this is the suspect

- The key face fill is translucent (`surface2/72`) with a `<Frost>` under it, so on
  Android TV each of ~40 keys is a native blur surface.
- Both reported symptoms — a *specific focused* row vanishing, and an *intermittent*
  crash — match Android's re-compositing of reordered `BlurView`s on focus lift,
  not a data/index bug (the layout data and the spatial-nav grid clamp cleanly;
  I checked `urlRows`, the grid rows, and lrud's `findChildWithClosestIndex`).
- `frost.story.mdx` already documents blur-on-TV as an anti-pattern (a 2024 Samsung
  measured 40fps with it, 60 without).

## Test

`packages/ui` keyboard tests now assert the ten-foot grid lays **no** backdrop-blur
layer while the arm's-length grid still does (`keyboard.test.tsx`).

## Gate

- `bun run typecheck` — `@kroma/ui`, `@kroma/tv`, `@kroma/tv-native`, `@kroma/tv-web`,
  `@kroma/webos`, `@kroma/web` all exit 0. (`@kroma/tizen` was SIGKILLed by the
  sandbox's memory limit — an OOM in this environment, not a type error, and
  unrelated to this one-file change.)
- `biome check .` — clean (2246 files, 1 migration info only).
- `bun run sonar:precheck` — no known Sonar patterns.
- Keyboard suite — 14 tests pass; `key.tsx` 100% stmts/lines/funcs (both branches of
  the new `size` guard covered).

## Risk

Low code risk (one guarded layer removed). **Visual change on TV**: keys show the
translucent wash without a backdrop blur. Over a plain screen (the add-server page)
this reads fine; over artwork the hint of background is unblurred — acceptable and
already the fallback path.

## ⚠️ Unverified hypothesis — needs on-device (Android TV) verification

I could not run this on an Android TV / Chromecast here, so this is a strong
code-level hypothesis, not a confirmed fix. On device, please check:

1. Repro on `main` first (focus across keys; watch a row vanish / crash).
2. On this branch, move focus across every row — no row should vanish, no crash.
3. Confirm the keys still read clearly across the room without the blur.
4. If the row-vanish persists without the blur, the next suspect is the `zIndex`
   lift itself (`liftedBox` in `focusable.tsx` + `LIFTED` on `FocusRegion`) — try
   dropping the per-row/per-key lift on native TV.

Addresses #81. Draft until verified on hardware. Do not merge.
