### PR TITLE
fix(tv): claim Android TV Back in the player so it no longer quits the app

### DIFF
--- a/packages/ui/src/components/organisms/player/hooks/use-player-keys.native.test.ts
+++ b/packages/ui/src/components/organisms/player/hooks/use-player-keys.native.test.ts
@@ -12,7 +12,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const rn = vi.hoisted(() => ({
   os: 'ios' as 'ios' | 'android',
+  isTV: true,
   remote: null as ((event: HWEvent) => void) | null,
+  back: null as (() => boolean) | null,
+  removeBack: vi.fn(),
   enableTVMenuKey: vi.fn(),
   disableTVMenuKey: vi.fn(),
 }));
@@ -21,6 +24,15 @@ vi.mock('react-native', () => ({
   Platform: {
     get OS() {
       return rn.os;
+    },
+    get isTV() {
+      return rn.isTV;
+    },
+  },
+  BackHandler: {
+    addEventListener: (_: string, handler: () => boolean) => {
+      rn.back = handler;
+      return { remove: rn.removeBack };
     },
   },
   TVEventControl: {
@@ -58,8 +70,10 @@ const routed = (): RemoteKey[] => routeRemoteKey.mock.calls.map(([, key]) => key
 
 beforeEach(() => {
   rn.os = 'ios';
+  rn.isTV = true;
   rn.remote = null;
   host.onKey = null;
+  rn.back = null;
   vi.clearAllMocks();
 });
 
@@ -192,6 +206,41 @@ describe('the Menu claim', () => {
     rerender({ tag: 'b' });
     rerender({ tag: 'c' });
     expect(rn.enableTVMenuKey).toHaveBeenCalledOnce();
+    unmount();
+  });
+});
+
+describe('the Back button', () => {
+  it('routes Android hardware Back into the player and swallows the press', () => {
+    rn.os = 'android';
+    const { unmount } = renderHook(() => usePlayerKeys(params('a')));
+    // Back never reaches the TV event stream on Android; consuming it here is
+    // what keeps the press from finishing the activity and quitting the app.
+    let consumed: boolean | undefined;
+    act(() => {
+      consumed = rn.back?.();
+    });
+    expect(consumed).toBe(true);
+    expect(routeRemoteKey).toHaveBeenCalledWith({ tag: 'a' }, 'Back');
+    unmount();
+    expect(rn.removeBack).toHaveBeenCalledOnce();
+  });
+
+  it('leaves the OS back button alone on tvOS, where Menu already carries Back', () => {
+    const { unmount } = renderHook(() => usePlayerKeys(params('a')));
+    // This fork builds BackHandler on top of the very `menu` event the
+    // vocabulary maps to Back, so a claim here would route one press twice.
+    expect(rn.back).toBeNull();
+    press('menu');
+    expect(routed()).toEqual(['Back']);
+    unmount();
+  });
+
+  it('leaves it alone on an Android phone, where back belongs to the navigator', () => {
+    rn.os = 'android';
+    rn.isTV = false;
+    const { unmount } = renderHook(() => usePlayerKeys(params('a')));
+    expect(rn.back).toBeNull();
     unmount();
   });
 });

--- a/packages/ui/src/components/organisms/player/hooks/use-player-keys.ts
+++ b/packages/ui/src/components/organisms/player/hooks/use-player-keys.ts
@@ -5,7 +5,7 @@
 
 import type { RemoteKey } from '@kroma/core';
 import { useEffect, useEffectEvent } from 'react';
-import { type HWEvent, useTVEventHandler } from 'react-native';
+import { BackHandler, type HWEvent, Platform, useTVEventHandler } from 'react-native';
 import {
   type PlayerKeysParams,
   routeRemoteKey,
@@ -26,7 +26,8 @@ const REMOTE_KEYS: Record<string, RemoteKey> = {
   swipeRight: 'Right',
   select: 'Enter',
   // tvOS reports the Menu button as `menu` once the key is claimed (see
-  // focus-nav); Android TV's remote sends `back`.
+  // focus-nav). Android TV's Back is KEYCODE_BACK, which never reaches this
+  // stream - it arrives through BackHandler instead (see below).
   menu: 'Back',
   back: 'Back',
   playPause: 'PlayPause',
@@ -69,6 +70,24 @@ export function usePlayerKeys(params: Readonly<PlayerKeysParams>): void {
   // Android's new architecture never fires `useRemoteEvents`; there the focus
   // root's key host feeds the d-pad in through here instead (see focus-remote).
   useRemoteKeys((key) => routeRemoteKey(params, key));
+
+  // Android TV routes Back through BackHandler, not the TV event stream, so the
+  // player has to claim it here or Android finishes the activity and quits the
+  // app. Returning true keeps the press inside the player (mirrors focus-nav).
+  //
+  // Android TV and nothing else. NOT `Platform.isTV` alone: on tvOS this fork
+  // implements BackHandler *on top of* the same `menu` event REMOTE_KEYS already
+  // maps to Back, so a claim there routes one press twice. NOT `OS` alone
+  // either: on a phone the back button belongs to the navigator.
+  const onBack = useEffectEvent(() => routeRemoteKey(params, 'Back'));
+  useEffect(() => {
+    if (Platform.OS !== 'android' || !Platform.isTV) return;
+    const sub = BackHandler.addEventListener('hardwareBackPress', () => {
+      onBack();
+      return true;
+    });
+    return () => sub.remove();
+  }, []);
 }
 
 export type { PlayerKeysParams };


### PR DESCRIPTION
## What

On Android TV, pressing **Back** in the video player quit the app. Fixes #80.

**Root cause, in code:** Android delivers `KEYCODE_BACK` through the standard
`BackHandler` / `hardwareBackPress` path, not through the react-native-tvos
event stream. Two places in our own code say so:

- `react-native-tv.d.ts`: *"KEYCODE_BACK is not in that table - Back stays with BackHandler."*
- `focus-nav.ts` claims Back with `BackHandler.addEventListener('hardwareBackPress', ...)` returning `true`.

The player used a different key source: `use-player-keys.ts` read the remote only
via `useTVEventHandler`, and (since #95) the focus root's Android key host, which
maps `ArrowUp/Down/Left/Right/Enter` and nothing else. So on Android TV the Back
press reached the player through neither path, no `hardwareBackPress` subscriber
existed on the player route, and Android's default finished the activity.

The `back: 'Back'` entry in the remote map was dead on Android for the same reason.

## Fix

Subscribe `hardwareBackPress` in the native player-keys hook, route it as `Back`
through the existing `routeRemoteKey`, and return `true` to keep the press inside
the player. Same mechanism `focus-nav.ts` already uses.

### The guard is `Platform.OS === 'android' && Platform.isTV`, and that matters

An earlier revision of this PR guarded on `Platform.isTV` alone. **That was wrong
and would have shipped a regression on Apple TV.** In react-native-tvos,
`BackHandler.ios.js` is not an independent channel: under `Platform.isTV` it is
implemented *on top of the TV event stream*, listening for `eventType === 'menu'`:

```js
if (Platform.isTV) {
  TVEventHandler.addListener(function (evt) {
    if (evt && evt.eventType === 'menu') { /* calls the subscriptions */ }
```

And `REMOTE_KEYS` in this very hook already maps `menu -> 'Back'`. So on Apple TV
a single Menu press would have called `routeRemoteKey(params, 'Back')` **twice**,
and `routeRemoteKey` is not idempotent: with the chrome revealed, the second call
reaches `nav.handleKey('Back')` again and closes the player on top of closing the
panel.

Excluding phones matters too: on mainline RN the back button belongs to the
navigator, not the player.

## Tests

`use-player-keys.native.test.ts`, 16 passing, three axes on the new subscription:

- **Android TV** - hardware Back routes into the player and is swallowed
  (`return true`); the listener is removed on unmount.
- **tvOS** - the OS back button is *not* claimed, and one `menu` press routes
  exactly one `Back`. Verified to fail under the old `Platform.isTV` guard, so it
  genuinely pins the regression above.
- **Android phone** - not claimed.

## Gate

- `bun run test --project native use-player-keys` - 16/16
- `bun run --filter '@kroma/ui' typecheck` - exit 0
- `biome check` on both touched files - clean
- Rebased onto `main` past #95 (`useRemoteKeys`) and #98.

## Not verified on device

I cannot run an Android TV target here, so the fix is not on-device verified. The
root cause and the guard are grounded in the repo's own Back-handling contract and
in the fork's `BackHandler` source, quoted above.

**To verify:** on the Chromecast HD build, play a title and press Back - the player
should close and return to the previous screen, no app exit. Then confirm Back
inside an open panel closes the panel first. On Apple TV, confirm one Menu press
still only steps back one level.

Since #80 reports a *crash*, and #101 (crash reporting) has now landed on `main`,
a repro on device should also produce a real stack to confirm this is the whole
story rather than the first layer of it.

Separate from #79 (controls focus); the focus dispatch is untouched.
