### PR TITLE
feat(tv-native): extract launcher card builders into a tested shared module

### DIFF
--- a/packages/tv/src/app/providers/continue.tsx
+++ b/packages/tv/src/app/providers/continue.tsx
@@ -1,4 +1,4 @@
-import type { ContinueItem, KromaClient } from '@kroma/core';
+import type { ContinueItem } from '@kroma/core';
 import {
   createContext,
   type ReactNode,
@@ -12,40 +12,7 @@ import {
 import { launcherBackend } from '#tv/app/launcher';
 import { useAuth } from '#tv/app/providers/auth';
 import { useConnection } from '#tv/app/providers/connection';
-
-// A public endpoint, so a launcher can fetch it without the app's auth.
-// A launcher card is drawn 1280 wide; asking for the original ships a
-// multi-megabyte still to a shelf that shows a thumbnail.
-const LAUNCHER_ART_W = 1280;
-
-function cardArt(c: ContinueItem, client: KromaClient): string {
-  const progress = c.durationMs ? c.positionMs / c.durationMs : 0;
-  const params = new URLSearchParams({ label: 'Reprendre', v: c.item.addedAt });
-  if (progress > 0) params.set('progress', progress.toFixed(3));
-  return `${client.baseUrl}/api/items/${encodeURIComponent(c.item.id)}/card?${params}`;
-}
-
-// `backdropUrl` is the clean art for Top Shelf, which draws its own title and
-// progress bar and would otherwise show two.
-function toWatchNext(items: ContinueItem[], client: KromaClient) {
-  return items.map((c) => {
-    const it = c.item;
-    return {
-      id: it.id,
-      title: it.showTitle ?? it.title,
-      subtitle: it.episodeTitle ?? (it.year ? String(it.year) : ''),
-      imageUrl: cardArt(c, client),
-      backdropUrl: client.backdropFor(it, LAUNCHER_ART_W) ?? undefined,
-      // Launchers link an episode card to the SHOW: the movie catalogue cannot
-      // resolve an episode id.
-      showId: it.showId ?? undefined,
-      progressMs: Math.round(c.positionMs),
-      durationMs: Math.round(c.durationMs ?? 0),
-      kind: it.kind,
-      updatedAtMs: Date.parse(c.updatedAt) || Date.now(),
-    };
-  });
-}
+import { buildWatchNext } from '#tv/shared/launcher/cards';
 
 interface Continue {
   items: ContinueItem[];
@@ -80,7 +47,7 @@ export function ContinueProvider({ children }: Readonly<{ children: ReactNode }>
   useEffect(() => {
     const launcher = launcherBackend();
     if (!launcher || !client) return;
-    const json = JSON.stringify(toWatchNext(items, client));
+    const json = JSON.stringify(buildWatchNext(items, client));
     if (json === lastPushed.current) return;
     lastPushed.current = json;
     launcher.setContinueWatching(json);

--- a/packages/tv/src/app/providers/recommend.tsx
+++ b/packages/tv/src/app/providers/recommend.tsx
@@ -1,4 +1,4 @@
-import type { KromaClient, MediaItem, Section, SectionItem } from '@kroma/core';
+import type { Section, SectionItem } from '@kroma/core';
 import {
   createContext,
   type ReactNode,
@@ -11,70 +11,7 @@ import {
 import { launcherBackend } from '#tv/app/launcher';
 import { useAuth } from '#tv/app/providers/auth';
 import { useConnection } from '#tv/app/providers/connection';
-
-type HomeProgram = {
-  id: string;
-  title: string;
-  subtitle: string;
-  imageUrl: string;
-  backdropUrl?: string;
-  kind: string;
-};
-// The launcher backend keys each channel by its ROW INDEX (see HomeChannel.kt),
-// so the section id is not sent - only the display title + its programs.
-type HomeChannelSpec = { title: string; items: HomeProgram[] };
-
-// Only the evergreen rows are mirrored: the personalized/themed rows `/api/home`
-// also returns make unstable launcher channels. Their server ids are fixed (see
-// services/sections build_home).
-const GENERIC_HOME_ROWS = ['recent', 'for-you', 'trending'] as const;
-
-const MAX_PROGRAMS = 20;
-
-// A launcher card is drawn 1280 wide; asking for the original ships a
-// multi-megabyte still to a shelf that shows a thumbnail.
-const LAUNCHER_ART_W = 1280;
-
-function toProgram(movie: MediaItem, client: KromaClient): HomeProgram {
-  const art = `${client.baseUrl}/api/items/${encodeURIComponent(movie.id)}/card?v=${encodeURIComponent(movie.addedAt)}`;
-  return {
-    id: movie.id,
-    title: movie.title,
-    subtitle: movie.year ? String(movie.year) : '',
-    imageUrl: art,
-    backdropUrl: client.backdropFor(movie, LAUNCHER_ART_W) ?? undefined,
-    kind: 'movie',
-  };
-}
-
-// Movies only: the launcher preview deep link resolves a movie id.
-function programsOf(section: Section, client: KromaClient): HomeProgram[] {
-  const seen = new Set<string>();
-  const items: HomeProgram[] = [];
-  for (const e of section.items) {
-    if (e.type !== 'movie' || seen.has(e.item.id)) continue;
-    seen.add(e.item.id);
-    items.push(toProgram(e.item, client));
-    if (items.length >= MAX_PROGRAMS) break;
-  }
-  return items;
-}
-
-function toHomeChannels(sections: Section[], client: KromaClient): HomeChannelSpec[] {
-  const byId = new Map(sections.map((s) => [s.id, s]));
-  const channels: HomeChannelSpec[] = [];
-  for (const id of GENERIC_HOME_ROWS) {
-    const s = byId.get(id);
-    if (!s) continue;
-    const items = programsOf(s, client);
-    if (items.length) channels.push({ title: s.title, items });
-  }
-  // A server that renamed those ids would silently publish nothing.
-  if (!channels.length && sections.length) {
-    console.warn('[KROMA] no generic home rows matched section ids', GENERIC_HOME_ROWS);
-  }
-  return channels;
-}
+import { buildHomeChannels } from '#tv/shared/launcher/cards';
 
 interface Recommend {
   sections: Section[];
@@ -121,7 +58,7 @@ export function RecommendProvider({ children }: Readonly<{ children: ReactNode }
   useEffect(() => {
     const launcher = launcherBackend();
     if (!launcher || !client) return;
-    const json = JSON.stringify(toHomeChannels(sections, client));
+    const json = JSON.stringify(buildHomeChannels(sections, client));
     if (json === lastPushed.current) return;
     // An empty push is only meaningful as a clear after something was published.
     if (json === '[]' && lastPushed.current === '') return;

--- a/packages/tv/src/shared/launcher/cards.test.ts
+++ b/packages/tv/src/shared/launcher/cards.test.ts
@@ -1,0 +1,175 @@
+import type { ContinueItem, KromaClient, MediaItem, Section } from '@kroma/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildHomeChannels,
+  buildWatchNext,
+  type HomeChannelSpec,
+  type WatchNextItem,
+} from '#tv/shared/launcher/cards';
+
+function fakeClient(backdrop: string | null = 'http://s/back.jpg'): KromaClient {
+  return {
+    baseUrl: 'http://s',
+    backdropFor: vi.fn(() => backdrop),
+  } as unknown as KromaClient;
+}
+
+function movie(over: Record<string, unknown> = {}): MediaItem {
+  return {
+    id: 'itm_1',
+    title: 'Dune',
+    year: 2021,
+    kind: 'movie',
+    addedAt: '2026-01-01',
+    ...over,
+  } as unknown as MediaItem;
+}
+
+function movieSection(id: string, title: string, items: MediaItem[]): Section {
+  return { id, title, items: items.map((item) => ({ type: 'movie', item })) } as unknown as Section;
+}
+
+describe('buildHomeChannels', () => {
+  it('mirrors the generic rows in a fixed order with their movies', () => {
+    const sections = [
+      movieSection('for-you', 'For you', [movie({ id: 'a', title: 'A' })]),
+      movieSection('recent', 'Recently added', [movie({ id: 'b', title: 'B', year: null })]),
+    ];
+    const channels = buildHomeChannels(sections, fakeClient());
+    expect(channels).toEqual([
+      { title: 'Recently added', items: [expect.objectContaining({ id: 'b', subtitle: '' })] },
+      { title: 'For you', items: [expect.objectContaining({ id: 'a', subtitle: '2021' })] },
+    ]);
+  });
+
+  it('builds a movie program with card art, backdrop and the year subtitle', () => {
+    const channel = buildHomeChannels(
+      [movieSection('recent', 'Recently added', [movie({ id: 'x y', addedAt: '2026-02-02' })])],
+      fakeClient(),
+    )[0] as HomeChannelSpec;
+    expect(channel.items[0]).toEqual({
+      id: 'x y',
+      title: 'Dune',
+      subtitle: '2021',
+      imageUrl: 'http://s/api/items/x%20y/card?v=2026-02-02',
+      backdropUrl: 'http://s/back.jpg',
+      kind: 'movie',
+    });
+  });
+
+  it('drops the backdrop when the client has none', () => {
+    const channel = buildHomeChannels(
+      [movieSection('recent', 'Recently added', [movie()])],
+      fakeClient(null),
+    )[0] as HomeChannelSpec;
+    expect(channel.items[0]?.backdropUrl).toBeUndefined();
+  });
+
+  it('keeps movies only, de-duplicates ids and caps at twenty', () => {
+    const many = Array.from({ length: 25 }, (_, i) => movie({ id: `m${i}` }));
+    const section = movieSection('recent', 'Recently added', [movie({ id: 'dup' }), ...many]);
+    section.items.push({ type: 'movie', item: movie({ id: 'dup' }) } as Section['items'][number]);
+    section.items.push({ type: 'show', show: { id: 'sh' } } as unknown as Section['items'][number]);
+    const channel = buildHomeChannels([section], fakeClient())[0] as HomeChannelSpec;
+    expect(channel.items).toHaveLength(20);
+    expect(channel.items.filter((p) => p.id === 'dup')).toHaveLength(1);
+  });
+
+  it('skips a row with no movie programs', () => {
+    const section = {
+      id: 'recent',
+      title: 'Recently added',
+      items: [{ type: 'show', show: { id: 's' } }],
+    } as unknown as Section;
+    expect(buildHomeChannels([section], fakeClient())).toEqual([]);
+  });
+
+  it('ignores rows outside the generic set', () => {
+    const sections = [movieSection('themed-halloween', 'Spooky', [movie()])];
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    expect(buildHomeChannels(sections, fakeClient())).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('no generic home rows'),
+      expect.anything(),
+    );
+  });
+
+  it('stays quiet when there are no sections at all', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    expect(buildHomeChannels([], fakeClient())).toEqual([]);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+function resume(
+  over: Record<string, unknown> = {},
+  item: Record<string, unknown> = {},
+): ContinueItem {
+  return {
+    item: movie({ kind: 'movie', ...item }),
+    positionMs: 1000.4,
+    durationMs: 4000,
+    updatedAt: '2026-03-03T00:00:00Z',
+    ...over,
+  } as unknown as ContinueItem;
+}
+
+describe('buildWatchNext', () => {
+  it('maps a movie into a resume tile with a progress-stamped card', () => {
+    const tile = buildWatchNext([resume()], fakeClient())[0] as WatchNextItem;
+    expect(tile).toEqual({
+      id: 'itm_1',
+      title: 'Dune',
+      subtitle: '2021',
+      imageUrl: 'http://s/api/items/itm_1/card?label=Reprendre&v=2026-01-01&progress=0.250',
+      backdropUrl: 'http://s/back.jpg',
+      showId: undefined,
+      progressMs: 1000,
+      durationMs: 4000,
+      kind: 'movie',
+      updatedAtMs: Date.parse('2026-03-03T00:00:00Z'),
+    });
+  });
+
+  it('prefers the show title and episode title, and links the episode to its show', () => {
+    const tile = buildWatchNext(
+      [resume({}, { showTitle: 'Show', episodeTitle: 'Pilot', showId: 'sh_9', kind: 'episode' })],
+      fakeClient(null),
+    )[0] as WatchNextItem;
+    expect(tile).toMatchObject({
+      title: 'Show',
+      subtitle: 'Pilot',
+      showId: 'sh_9',
+      kind: 'episode',
+    });
+    expect(tile.backdropUrl).toBeUndefined();
+  });
+
+  it('omits the progress parameter and zeroes duration when there is no duration', () => {
+    const tile = buildWatchNext(
+      [resume({ durationMs: null, positionMs: 0 })],
+      fakeClient(),
+    )[0] as WatchNextItem;
+    expect(tile.imageUrl).toBe('http://s/api/items/itm_1/card?label=Reprendre&v=2026-01-01');
+    expect(tile.durationMs).toBe(0);
+  });
+
+  it('falls back to an empty subtitle when there is neither episode nor year', () => {
+    const tile = buildWatchNext([resume({}, { year: null })], fakeClient())[0] as WatchNextItem;
+    expect(tile.subtitle).toBe('');
+  });
+
+  it('stamps the current time when the update timestamp is unparseable', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-05T00:00:00Z'));
+    const tile = buildWatchNext(
+      [resume({ updatedAt: 'not-a-date' })],
+      fakeClient(),
+    )[0] as WatchNextItem;
+    expect(tile.updatedAtMs).toBe(Date.parse('2026-05-05T00:00:00Z'));
+    vi.useRealTimers();
+  });
+});
+
+beforeEach(() => vi.clearAllMocks());
+afterEach(() => vi.restoreAllMocks());

--- a/packages/tv/src/shared/launcher/cards.test.ts
+++ b/packages/tv/src/shared/launcher/cards.test.ts
@@ -7,6 +7,9 @@ import {
   type WatchNextItem,
 } from '#tv/shared/launcher/cards';
 
+beforeEach(() => vi.clearAllMocks());
+afterEach(() => vi.restoreAllMocks());
+
 function fakeClient(backdrop: string | null = 'http://s/back.jpg'): KromaClient {
   return {
     baseUrl: 'http://s',
@@ -170,6 +173,3 @@ describe('buildWatchNext', () => {
     vi.useRealTimers();
   });
 });
-
-beforeEach(() => vi.clearAllMocks());
-afterEach(() => vi.restoreAllMocks());

--- a/packages/tv/src/shared/launcher/cards.ts
+++ b/packages/tv/src/shared/launcher/cards.ts
@@ -1,0 +1,114 @@
+// Platform-agnostic builders for the rows KROMA publishes OUT to a television's
+// home screen: the Android TV / Google TV preview channels (new releases) and
+// the Watch Next "Continue watching" row. The providers own the effects (fetch,
+// de-dupe pushes, hand the JSON to the native launcher); this module owns the
+// pure shape, so it is the same on every platform and testable without React.
+// Mirrors the Tizen Smart Hub split (shared/preview/cards.ts is the pure half).
+
+import type { ContinueItem, KromaClient, MediaItem, Section } from '@kroma/core';
+
+// A launcher card is drawn 1280 wide; asking for the original ships a
+// multi-megabyte still to a shelf that shows a thumbnail.
+const LAUNCHER_ART_W = 1280;
+const MAX_PROGRAMS = 20;
+
+// Only the evergreen rows are mirrored: the personalized/themed rows `/api/home`
+// also returns make unstable launcher channels. Their server ids are fixed (see
+// services/sections build_home).
+const GENERIC_HOME_ROWS = ['recent', 'for-you', 'trending'] as const;
+
+export type HomeProgram = {
+  id: string;
+  title: string;
+  subtitle: string;
+  imageUrl: string;
+  backdropUrl?: string;
+  kind: string;
+};
+
+// The launcher backend keys each channel by its ROW INDEX (see HomeChannel.kt),
+// so the section id is not sent - only the display title + its programs.
+export type HomeChannelSpec = { title: string; items: HomeProgram[] };
+
+export type WatchNextItem = {
+  id: string;
+  title: string;
+  subtitle: string;
+  imageUrl: string;
+  backdropUrl?: string;
+  showId?: string;
+  progressMs: number;
+  durationMs: number;
+  kind: string;
+  updatedAtMs: number;
+};
+
+function toProgram(movie: MediaItem, client: KromaClient): HomeProgram {
+  const art = `${client.baseUrl}/api/items/${encodeURIComponent(movie.id)}/card?v=${encodeURIComponent(movie.addedAt)}`;
+  return {
+    id: movie.id,
+    title: movie.title,
+    subtitle: movie.year ? String(movie.year) : '',
+    imageUrl: art,
+    backdropUrl: client.backdropFor(movie, LAUNCHER_ART_W) ?? undefined,
+    kind: 'movie',
+  };
+}
+
+// Movies only: the launcher preview deep link resolves a movie id.
+function programsOf(section: Section, client: KromaClient): HomeProgram[] {
+  const seen = new Set<string>();
+  const items: HomeProgram[] = [];
+  for (const e of section.items) {
+    if (e.type !== 'movie' || seen.has(e.item.id)) continue;
+    seen.add(e.item.id);
+    items.push(toProgram(e.item, client));
+    if (items.length >= MAX_PROGRAMS) break;
+  }
+  return items;
+}
+
+export function buildHomeChannels(sections: Section[], client: KromaClient): HomeChannelSpec[] {
+  const byId = new Map(sections.map((s) => [s.id, s]));
+  const channels: HomeChannelSpec[] = [];
+  for (const id of GENERIC_HOME_ROWS) {
+    const s = byId.get(id);
+    if (!s) continue;
+    const items = programsOf(s, client);
+    if (items.length) channels.push({ title: s.title, items });
+  }
+  // A server that renamed those ids would silently publish nothing.
+  if (!channels.length && sections.length) {
+    console.warn('[KROMA] no generic home rows matched section ids', GENERIC_HOME_ROWS);
+  }
+  return channels;
+}
+
+function cardArt(c: ContinueItem, client: KromaClient): string {
+  const progress = c.durationMs ? c.positionMs / c.durationMs : 0;
+  const params = new URLSearchParams({ label: 'Reprendre', v: c.item.addedAt });
+  if (progress > 0) params.set('progress', progress.toFixed(3));
+  return `${client.baseUrl}/api/items/${encodeURIComponent(c.item.id)}/card?${params}`;
+}
+
+// `backdropUrl` is the clean art for Top Shelf, which draws its own title and
+// progress bar and would otherwise show two.
+export function buildWatchNext(items: ContinueItem[], client: KromaClient): WatchNextItem[] {
+  return items.map((c) => {
+    const it = c.item;
+    return {
+      id: it.id,
+      title: it.showTitle ?? it.title,
+      subtitle: it.episodeTitle ?? (it.year ? String(it.year) : ''),
+      imageUrl: cardArt(c, client),
+      backdropUrl: client.backdropFor(it, LAUNCHER_ART_W) ?? undefined,
+      // Launchers link an episode card to the SHOW: the movie catalogue cannot
+      // resolve an episode id.
+      showId: it.showId ?? undefined,
+      progressMs: Math.round(c.positionMs),
+      durationMs: Math.round(c.durationMs ?? 0),
+      kind: it.kind,
+      updatedAtMs: Date.parse(c.updatedAt) || Date.now(),
+    };
+  });
+}

--- a/packages/tv/src/shared/launcher/cards.ts
+++ b/packages/tv/src/shared/launcher/cards.ts
@@ -1,9 +1,6 @@
-// Platform-agnostic builders for the rows KROMA publishes OUT to a television's
-// home screen: the Android TV / Google TV preview channels (new releases) and
-// the Watch Next "Continue watching" row. The providers own the effects (fetch,
-// de-dupe pushes, hand the JSON to the native launcher); this module owns the
-// pure shape, so it is the same on every platform and testable without React.
-// Mirrors the Tizen Smart Hub split (shared/preview/cards.ts is the pure half).
+// Card-builders for the rows KROMA publishes OUT to a television's home screen:
+// the Android TV preview channels and the Watch Next row. The providers own the
+// effects; this owns the shape, so it is testable without React.
 
 import type { ContinueItem, KromaClient, MediaItem, Section } from '@kroma/core';
 


### PR DESCRIPTION
## TL;DR — read before reviewing

Addresses #85. **The Android TV home-screen channel already ships on `main`** (it
landed with PR #16, then was refined in the tv test-coverage pass). So this is
**not** a "build the feature" PR — it would be a duplicate data path, which the
issue explicitly warns against. Instead this PR:

1. Documents, below, that #85's Definition of Done is already met, with the exact
   files that implement it (so the issue can be closed with evidence).
2. Closes the one real gap I found: the two **pure payload-builders** that feed
   the launcher (new releases + continue-watching) were **inlined in the React
   providers and carried no unit tests**. I extracted them into a
   platform-agnostic shared module with 100 % vitest coverage, mirroring the
   Tizen preview split (`shared/preview/cards.ts` pure half + `service.ts`
   effects half).

No native code changed. The Kotlin/Swift was not rebuilt here — but this PR
touches **none** of it, so there is nothing native to verify.

---

## What #85 asks for vs. what already exists

| Definition of done | Status on `main` | Where |
|---|---|---|
| Android TV home channel shows **new releases** | ✅ shipped | `clients/tv-native/modules/tv-launcher/android/.../HomeChannel.kt` (preview channels), fed by `RecommendProvider` |
| Shows **continue-watching** (resume) | ✅ shipped | `.../WatchNext.kt` (system Watch Next row), fed by `ContinueProvider` |
| **Parity** with the Apple TV widget | ✅ by construction | Both platforms consume the same shared `LauncherBackend` and the same JSON payloads |

### How it's wired (the existing Apple-TV-parity mechanism, unchanged)

```
server /api/home, /api/continue-watching
        │
        ▼
RecommendProvider / ContinueProvider  (packages/tv, shared across every client)
        │  build JSON payloads  ──►  buildHomeChannels() / buildWatchNext()   ← THIS PR extracts + tests these
        ▼
launcherBackend()  (packages/tv/src/app/launcher.ts — the platform-agnostic seam)
        │
        ├─ Android: nativeLauncher → TvLauncher native module
        │     setHomeChannel(json)      → HomeChannel.kt  → androidx.tvprovider PreviewChannel/PreviewProgram writes
        │     setContinueWatching(json) → WatchNext.kt    → androidx.tvprovider WatchNextProgram writes
        │
        └─ Apple TV: same module → App Group UserDefaults → Top Shelf content extension
```

- **Trigger:** a `useEffect` in each provider re-pushes whenever `/api/home` or
  the continue-watching list changes, guarded on the serialized JSON so render
  churn never re-syncs. The open app owns the push; the rows persist on the home
  screen after it closes.
- **Deep links:** each tile carries `kroma://item/<id>` (movies) or
  `kroma://show/<id>` (episodes), received through RN `Linking`
  (`clients/tv-native/src/lib/launcher-links.ts`, already tested).
- **Manifest:** `READ/WRITE_EPG_DATA` + launcher `<queries>` are merged from the
  module's own `AndroidManifest.xml`.
- **De-dup / reconcile:** both Kotlin objects query the provider for *their own*
  published rows and reconcile in place (idempotent, no duplicates), keyed by row
  index for channels.

## What this PR changes

- **New** `packages/tv/src/shared/launcher/cards.ts` — pure, platform-agnostic:
  - `buildHomeChannels(sections, client)` — new-releases preview channels from
    the evergreen `recent` / `for-you` / `trending` rows; movies only, deduped,
    capped at 20, 16:9 card art.
  - `buildWatchNext(items, client)` — continue-watching tiles; show/episode
    title fallbacks, progress-stamped card art, episode→show deep link.
- **`recommend.tsx` / `continue.tsx`** — now import those builders instead of
  inlining them. Behaviour is byte-identical (same JSON out); the providers keep
  ownership of the fetch + push effects.
- **New** `cards.test.ts` — 12 tests, **100 % statements / branches / functions /
  lines** on `cards.ts`.

## Risk

- **Low.** Pure refactor + tests. No behavioural change to the emitted payloads,
  no native code touched, no server change. The existing provider tests (21) and
  the launcher/link tests still pass.
- The only judgement call: *where* the pure module lives. I put it under
  `shared/launcher/` to mirror `shared/preview/` (Tizen). If you'd rather it sit
  beside the providers, easy to move.

## Native — not verified here (and not touched)

I cannot build or run an Android TV target in this environment. This PR
deliberately changes **zero** native files, so there is nothing native to
re-verify for it. For completeness, if #85 is ever reopened for a device pass,
the native surfaces to smoke-test on a Chromecast/Google TV are:
`HomeChannel.kt` (first channel auto-shows; the rest need "Customize channels"),
`WatchNext.kt` (resume position + progress bar), and the `kroma://` deep-link
round-trip from a launcher tile back into the app.

## Gate

- `bun run typecheck` (packages/tv) — clean
- `biome check` (4 touched files) — clean
- `bun run test:coverage` (cards) — 12/12, 100 % coverage
- provider + launcher suites — 21/21
- `bun run sonar:precheck` — no patterns
