### PR TITLE
feat(shots): capture a screen across the shells for a PR description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,4 @@ clients/web/public/sw.js
 
 # Kit DOM audit output (bun run kit:dom): review artefacts, not sources.
 .dom/
+.shots/

--- a/bun.lock
+++ b/bun.lock
@@ -629,6 +629,17 @@
         "wrangler": "^4.123.0",
       },
     },
+    "packages/shots": {
+      "name": "@kroma/shots",
+      "version": "0.0.0",
+      "dependencies": {
+        "playwright": "1.62.1",
+      },
+      "devDependencies": {
+        "bun-types": "^1.3.14",
+        "typescript": "^7.0.2",
+      },
+    },
     "packages/site-kit": {
       "name": "@kroma/site-kit",
       "version": "0.0.0",
@@ -1313,6 +1324,8 @@
     "@kroma/package-source": ["@kroma/package-source@workspace:apps/packages"],
 
     "@kroma/push-relay": ["@kroma/push-relay@workspace:packages/push-relay"],
+
+    "@kroma/shots": ["@kroma/shots@workspace:packages/shots"],
 
     "@kroma/site": ["@kroma/site@workspace:apps/www"],
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "spec:index": "bun docs/spec/scripts/spec-index.ts",
     "spec:check": "bun docs/spec/scripts/spec-index.ts --check",
     "shots": "bun run --filter '@kroma/ui' shots",
+    "shots:pr": "bun packages/shots/src/cli.ts",
     "kit:dom": "bun packages/ui/scripts/dom-audit.ts",
     "kit:compiler": "bun packages/ui/scripts/compiler-coverage.ts",
     "store:art": "bun clients/tv-build/store-art.ts .store-art && python3 clients/tv-build/store-art.py .store-art",

--- a/packages/shots/README.md
+++ b/packages/shots/README.md
@@ -1,0 +1,94 @@
+# @kroma/shots
+
+Captures the same screen across the shells a change touches, and hands back a
+markdown block a pull request or issue can carry.
+
+```bash
+bun run shots:pr about-hardware --route about --targets tizen,webos
+bun run shots:pr about-hardware --route about --targets tizen --publish
+```
+
+Not to be confused with `bun run shots`, which shoots the kit's component
+stories (`packages/ui/scripts/shoot-stories.ts`). This one shoots the product.
+
+## Why it exists
+
+A change to the design is reviewed from a description, and a description of a
+screen is not the screen. Before this, evidence was assembled by hand and
+uploaded ad hoc, so most PRs simply carried none.
+
+## What it does not do
+
+**It photographs a build, it never makes one.** The dev servers and the native
+apps are yours to start. A capture tool that also builds is a build tool that
+sometimes takes pictures, and it would hide a stale bundle behind a fresh image.
+
+## Reaching a screen
+
+A television has no address bar, which is the whole difficulty. The three
+routings:
+
+| Target | Routing | How a screen is named |
+|---|---|---|
+| `web` | `url` | `--path /settings` |
+| `tizen`, `webos` | `dev-nav` | `--route about`. A DEV build of the TV router mirrors its in-memory stack to `sessionStorage['kroma:dev-nav']` and restores it on mount (see `packages/tv/src/app/router.tsx`), so seeding that key lands on any screen with no key presses. This is why the TV targets drive a **dev server**, not a preview build. |
+| `appletv`, `androidtv` | `keys` | `--keys ArrowDown,Enter`. A native shell has neither, so a screen is reached the way a viewer reaches it. |
+
+Route names are `RouteName` in `packages/tv/src/app/router.tsx`. A route that
+takes params gets them as JSON: `--route grid --params '{"kind":"films"}'`.
+
+Most screens sit behind a profile, and a TV cannot be signed in from the
+outside. Lift a session off a device that is signed in and pass it:
+
+```bash
+bun run shots:pr home --route home --seed ~/kroma-shot-session.json
+```
+
+The file is a JSON object of localStorage entries (`{"kroma.session": "…"}`)
+and holds a real token. Keep it out of the repo.
+
+## Preconditions, and how they fail
+
+Each is checked before the shutter, because every one of them fails as a
+*plausible image* rather than as an error:
+
+- **The dev server is KROMA.** A dev port is squattable. The page title is
+  checked, and a run against something else names what it found instead. This is
+  not hypothetical: 5174 and 5175 were both occupied on the machine this was
+  written on.
+- **Metro is up.** A native development build carries no JS bundle; without
+  Metro it opens on a redbox, which simctl and adb photograph as cheerfully as
+  the real screen.
+- **The app is installed.** Checked through `simctl get_app_container` and
+  `pm list packages`, with the install command in the error.
+- **The file is a PNG.** `simctl io … -` does not stream to stdout: handed `-`
+  it writes a file called `-` in the working directory and exits 0. Every
+  capture is checked for the PNG magic before it counts.
+- **The brand intro is skipped.** It is an *overlay* over an app tree that is
+  already mounted, so a run that does not skip it photographs the splash while
+  the DOM underneath reports the right screen. `kroma:intro-seen` is seeded into
+  sessionStorage (both `BrandIntro.web.tsx` and the web client's `intro.tsx`).
+
+## Publishing
+
+`--publish` uploads to the `issue-assets` GitHub release, replacing an asset of
+the same name so re-running a capture updates the image a PR already links, then
+prints the markdown with working URLs. Without it, the run stays local under
+`.shots/<slug>/` (gitignored) and prints the same block with the URLs it *would*
+have. The release is a plain asset bucket: nothing in the repo grows a binary.
+
+## Verified
+
+| Target | State |
+|---|---|
+| `tizen` | Captured end to end (the About screen, 1920x1080). |
+| `webos` | Captured end to end. |
+| `appletv` | Captured end to end from the simulator; the app on it had no Metro, which is what prompted the Metro precondition. The `--keys` path is written but has not driven a real screen. |
+| `androidtv` | SDK, AVD and precondition paths exercised. The emulator was not booted and no capture has been taken. |
+| `web` | Not run: nothing was serving :3000 at the time. |
+
+## Ports
+
+`--port` overrides a dev server port for a single DOM target, and
+`--metro-port` the Metro port for the native ones (memory of this repo: tv-native
+is often on 8083 when mobile owns 8081).

--- a/packages/shots/package.json
+++ b/packages/shots/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@kroma/shots",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Captures the same screen across the web client, the TV shells and the two native simulators, then publishes the set as a markdown block a PR or issue can carry.",
+  "author": "Maxime Scharwath <maxscharwath@gmail.com>",
+  "license": "GPL-2.0-or-later",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "directory": "packages/shots"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "playwright": "1.62.1"
+  },
+  "devDependencies": {
+    "bun-types": "^1.3.14",
+    "typescript": "^7.0.2"
+  }
+}

--- a/packages/shots/src/android.ts
+++ b/packages/shots/src/android.ts
@@ -1,0 +1,138 @@
+import { spawn } from 'node:child_process';
+import { existsSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { assertMetro } from './metro';
+import { run } from './sh';
+import type { Screen } from './shot';
+import type { Target } from './targets';
+
+// `adb shell input keyevent` names, so the same `--keys` vocabulary as the
+// browser and the tvOS simulator reaches an Android TV too.
+const REMOTE_KEYS: Record<string, string> = {
+  ArrowUp: 'DPAD_UP',
+  ArrowDown: 'DPAD_DOWN',
+  ArrowLeft: 'DPAD_LEFT',
+  ArrowRight: 'DPAD_RIGHT',
+  Enter: 'DPAD_CENTER',
+  Escape: 'BACK',
+};
+
+const BOOT_TIMEOUT_MS = 120_000;
+const BOOT_POLL_MS = 2000;
+const LAUNCH_SETTLE_MS = 6000;
+const KEY_SETTLE_MS = 700;
+
+export async function captureAndroid(
+  target: Target,
+  screen: Screen,
+  file: string,
+  metroPort: number,
+): Promise<void> {
+  await assertMetro(metroPort, target.id, "bun run --filter '@kroma/tv-native' start");
+  const sdk = androidSdk();
+  const adb = join(sdk, 'platform-tools', 'adb');
+  const appId = target.appId ?? '';
+
+  const serial = await bootedEmulator(sdk, adb, target);
+  assertInstalled(adb, serial, appId, target);
+
+  run(adb, [
+    '-s',
+    serial,
+    'shell',
+    'monkey',
+    '-p',
+    appId,
+    '-c',
+    'android.intent.category.LEANBACK_LAUNCHER',
+    '1',
+  ]);
+  await sleep(LAUNCH_SETTLE_MS);
+
+  for (const key of screen.keys) {
+    const event = REMOTE_KEYS[key];
+    if (!event) throw new Error(`no Android TV keyevent mapping for "${key}"`);
+    run(adb, ['-s', serial, 'shell', 'input', 'keyevent', event]);
+    await sleep(KEY_SETTLE_MS);
+  }
+  await sleep(screen.settleMs);
+
+  writeFileSync(file, run(adb, ['-s', serial, 'exec-out', 'screencap', '-p'], 'buffer'));
+}
+
+function androidSdk(): string {
+  const candidates = [
+    process.env.ANDROID_HOME,
+    process.env.ANDROID_SDK_ROOT,
+    join(homedir(), 'Library/Android/sdk'),
+  ].filter((path): path is string => Boolean(path));
+  const sdk = candidates.find((path) => existsSync(join(path, 'platform-tools', 'adb')));
+  if (!sdk) {
+    throw new Error(
+      'no Android SDK found. Set ANDROID_HOME, or install the platform-tools into ~/Library/Android/sdk.',
+    );
+  }
+  return sdk;
+}
+
+async function bootedEmulator(sdk: string, adb: string, target: Target): Promise<string> {
+  const running = emulatorSerials(adb);
+  if (running.length) return running[0] ?? '';
+
+  const avd = target.avd ?? '';
+  const emulator = join(sdk, 'emulator', 'emulator');
+  const known = run(emulator, ['-list-avds'])
+    .split('\n')
+    .map((name) => name.trim());
+  if (!known.includes(avd)) {
+    throw new Error(
+      `no AVD named "${avd}". \`${emulator} -list-avds\` shows: ${known.filter(Boolean).join(', ')}`,
+    );
+  }
+  // Detached: the emulator holds the terminal for as long as it runs, and the
+  // point is to leave it up between captures.
+  spawn(emulator, ['-avd', avd, '-no-snapshot-save'], { detached: true, stdio: 'ignore' }).unref();
+  return waitForBoot(adb);
+}
+
+async function waitForBoot(adb: string): Promise<string> {
+  const deadline = Date.now() + BOOT_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const serial = emulatorSerials(adb)[0];
+    if (serial) {
+      const booted = run(adb, ['-s', serial, 'shell', 'getprop', 'sys.boot_completed'], 'text', {
+        allowFailure: true,
+      });
+      if (booted.trim() === '1') return serial;
+    }
+    await sleep(BOOT_POLL_MS);
+  }
+  throw new Error(`the emulator did not finish booting within ${BOOT_TIMEOUT_MS / 1000}s`);
+}
+
+function emulatorSerials(adb: string): string[] {
+  const listed = run(adb, ['devices'], 'text', { allowFailure: true });
+  return listed
+    .split('\n')
+    .slice(1)
+    .map((line) => line.split('\t'))
+    .filter(([serial, state]) => serial?.startsWith('emulator-') && state?.trim() === 'device')
+    .map(([serial]) => serial ?? '');
+}
+
+function assertInstalled(adb: string, serial: string, appId: string, target: Target): void {
+  const found = run(adb, ['-s', serial, 'shell', 'pm', 'list', 'packages', appId], 'text', {
+    allowFailure: true,
+  });
+  if (found.includes(appId)) return;
+  throw new Error(
+    `${target.id}: "${appId}" is not installed on the emulator. ` +
+      `This tool photographs a build, it does not make one - install it first with ` +
+      `\`bun run --filter '@kroma/tv-native' android\` (and leave Metro running).`,
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((done) => setTimeout(done, ms));
+}

--- a/packages/shots/src/apple.ts
+++ b/packages/shots/src/apple.ts
@@ -50,13 +50,18 @@ export async function captureApple(
   run('xcrun', ['simctl', 'io', udid, 'screenshot', '--type=png', file]);
 }
 
+const UDID = /\(([0-9A-F-]{36})\)/i;
+
 function deviceUdid(target: Target): string {
   const wanted = target.device ?? '';
   const listed = run('xcrun', ['simctl', 'list', 'devices', 'available']);
-  // "    Apple TV 4K (3rd generation) (at 1080p) (B6C6…) (Shutdown)"
+  // "    Apple TV 4K (3rd generation) (at 1080p) (B6C6…) (Shutdown)" - the name
+  // carries parentheses of its own, so it is whatever precedes the UDID rather
+  // than anything a single pattern can capture without backtracking over it.
   for (const line of listed.split('\n')) {
-    const [, name, udid] = /^\s*(.+?) \(([0-9A-F-]{36})\)/i.exec(line) ?? [];
-    if (name === wanted && udid) return udid;
+    const found = UDID.exec(line);
+    const udid = found?.[1];
+    if (found && udid && line.slice(0, found.index).trim() === wanted) return udid;
   }
   throw new Error(
     `no available simulator named "${wanted}". ` +

--- a/packages/shots/src/apple.ts
+++ b/packages/shots/src/apple.ts
@@ -1,0 +1,99 @@
+import { assertMetro } from './metro';
+import { run } from './sh';
+import type { Screen } from './shot';
+import type { Target } from './targets';
+
+// The tvOS simulator maps the Mac keyboard onto the Siri remote, but only
+// through the Simulator app's own key handling - there is no simctl verb for a
+// remote press - so keys go via System Events with Simulator frontmost.
+const REMOTE_KEYS: Record<string, number> = {
+  ArrowUp: 126,
+  ArrowDown: 125,
+  ArrowLeft: 123,
+  ArrowRight: 124,
+  Enter: 36,
+  Escape: 53,
+};
+
+const BOOT_SETTLE_MS = 4000;
+const LAUNCH_SETTLE_MS = 6000;
+const KEY_SETTLE_MS = 700;
+
+export async function captureApple(
+  target: Target,
+  screen: Screen,
+  file: string,
+  metroPort: number,
+): Promise<void> {
+  const udid = deviceUdid(target);
+  const appId = target.appId ?? '';
+  await assertMetro(metroPort, target.id, "bun run --filter '@kroma/tv-native' start");
+
+  if (!bootedUdids().includes(udid)) {
+    run('xcrun', ['simctl', 'boot', udid]);
+    run('open', ['-a', 'Simulator']);
+    await sleep(BOOT_SETTLE_MS);
+  }
+
+  assertInstalled(udid, appId, target);
+  run('xcrun', ['simctl', 'launch', udid, appId]);
+  await sleep(LAUNCH_SETTLE_MS);
+
+  for (const key of screen.keys) {
+    pressRemote(key);
+    await sleep(KEY_SETTLE_MS);
+  }
+  await sleep(screen.settleMs);
+
+  // simctl writes where it is told and has no stdout mode: handed `-` it
+  // creates a file called "-" in the working directory and reports success.
+  run('xcrun', ['simctl', 'io', udid, 'screenshot', '--type=png', file]);
+}
+
+function deviceUdid(target: Target): string {
+  const wanted = target.device ?? '';
+  const listed = run('xcrun', ['simctl', 'list', 'devices', 'available']);
+  // "    Apple TV 4K (3rd generation) (at 1080p) (B6C6…) (Shutdown)"
+  for (const line of listed.split('\n')) {
+    const [, name, udid] = /^\s*(.+?) \(([0-9A-F-]{36})\)/i.exec(line) ?? [];
+    if (name === wanted && udid) return udid;
+  }
+  throw new Error(
+    `no available simulator named "${wanted}". ` +
+      `\`xcrun simctl list devices available\` lists what this Mac has.`,
+  );
+}
+
+function bootedUdids(): string[] {
+  const listed = run('xcrun', ['simctl', 'list', 'devices', 'booted']);
+  return [...listed.matchAll(/\(([0-9A-F-]{36})\) \(Booted\)/gi)].map((m) => m[1] ?? '');
+}
+
+function assertInstalled(udid: string, appId: string, target: Target): void {
+  const container = run('xcrun', ['simctl', 'get_app_container', udid, appId], 'text', {
+    allowFailure: true,
+  });
+  if (container.trim()) return;
+  throw new Error(
+    `${target.id}: "${appId}" is not installed on the simulator. ` +
+      `This tool photographs a build, it does not make one - install it first with ` +
+      `\`bun run --filter '@kroma/tv-native' ios\` (and leave Metro running).`,
+  );
+}
+
+function pressRemote(key: string): void {
+  const code = REMOTE_KEYS[key];
+  if (code === undefined) {
+    throw new Error(`no Apple TV remote mapping for "${key}"`);
+  }
+  run('osascript', [
+    '-e',
+    'tell application "Simulator" to activate',
+    '-e',
+    `tell application "System Events" to key code ${code}`,
+  ]);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((done) => setTimeout(done, ms));
+}

--- a/packages/shots/src/cli.ts
+++ b/packages/shots/src/cli.ts
@@ -1,0 +1,116 @@
+// Captures one screen across the shells a change touches, and hands back the
+// markdown block a PR or issue carries.
+//
+//   bun run shots:pr about-hardware --route about --targets web,tizen,webos
+//   bun run shots:pr about-hardware --route about --targets appletv,androidtv --keys ArrowDown,Enter
+//
+// The DOM targets need their dev server up (`bun run dev:tizen`, …); the native
+// targets need the app already installed on the simulator or emulator. Neither
+// is built here: a capture tool that also builds is a build tool that sometimes
+// takes pictures.
+
+import { join } from 'node:path';
+import { captureAndroid } from './android';
+import { captureApple } from './apple';
+import { captureDom } from './dom';
+import { DEFAULT_METRO_PORT } from './metro';
+import { markdown, publish } from './publish';
+import { assertPng, assetName, outDirFor, type Screen, type Shot } from './shot';
+import { DEFAULT_TARGETS, type Target, targetsFrom } from './targets';
+
+const REPO_DIR = new URL('../../..', import.meta.url).pathname;
+const DEFAULT_REPO = 'maxscharwath/kroma';
+const DEFAULT_SETTLE_MS = 600;
+
+const USAGE = `usage: bun run shots:pr <slug> [options]
+
+  --route <name>     TV route to open (default: home). See TvRoutes in packages/tv/src/app/router.tsx.
+  --params <json>    Params for a route that takes them, e.g. --params '{"kind":"films"}'
+  --path <path>      URL path for the web client (default: /)
+  --targets <list>   Comma-separated (default: ${DEFAULT_TARGETS.join(',')})
+  --keys <list>      Remote keys pressed before the shutter, e.g. ArrowDown,Enter
+  --settle <ms>      Extra wait before the shutter (default: ${DEFAULT_SETTLE_MS})
+  --seed <file>      JSON of localStorage entries for a signed-in session
+  --port <n>         Override the dev-server port (one dom target at a time)
+  --metro-port <n>   Metro port for the native targets (default: ${DEFAULT_METRO_PORT})
+  --publish          Upload to the issue-assets release and print the published markdown
+  --repo <owner/name>`;
+
+async function main(argv: string[]): Promise<void> {
+  const [slug, ...rest] = argv;
+  if (!slug || slug.startsWith('--')) throw new Error(USAGE);
+  const flags = parseFlags(rest);
+
+  const screen: Screen = {
+    path: flags.path ?? '/',
+    route: flags.route ?? 'home',
+    params: flags.params ? JSON.parse(flags.params) : undefined,
+    keys: (flags.keys ?? '')
+      .split(',')
+      .map((k) => k.trim())
+      .filter(Boolean),
+    settleMs: Number(flags.settle ?? DEFAULT_SETTLE_MS),
+  };
+
+  const targets = targetsFrom(flags.targets ?? DEFAULT_TARGETS.join(','));
+  const port = flags.port ? Number(flags.port) : undefined;
+  const metroPort = flags['metro-port'] ? Number(flags['metro-port']) : DEFAULT_METRO_PORT;
+  if (port !== undefined && targets.filter((t) => t.kind === 'dom').length > 1) {
+    throw new Error('--port applies to one dom target at a time; narrow --targets');
+  }
+  const outDir = outDirFor(REPO_DIR, slug);
+  const shots: Shot[] = [];
+
+  for (const target of targets) {
+    const file = join(outDir, assetName(slug, target.id));
+    console.log(`${target.id} …`);
+    await capture(target, screen, file, flags.seed, port, metroPort);
+    assertPng(file, target.id);
+    shots.push({ targetId: target.id, label: target.label, file });
+    console.log(`  -> ${file}`);
+  }
+
+  const repo = flags.repo ?? DEFAULT_REPO;
+  console.log(`\n${'-'.repeat(60)}\n`);
+  console.log(flags.publish === '' ? publish(repo, shots, slug) : markdown(repo, shots, slug));
+  if (flags.publish !== '') {
+    console.log('\n(local only - pass --publish to upload and get working links)');
+  }
+}
+
+function capture(
+  target: Target,
+  screen: Screen,
+  file: string,
+  seed: string | undefined,
+  port: number | undefined,
+  metroPort: number,
+): Promise<void> {
+  if (target.kind === 'dom') return captureDom(target, screen, file, seed, port);
+  if (target.kind === 'apple') return captureApple(target, screen, file, metroPort);
+  return captureAndroid(target, screen, file, metroPort);
+}
+
+function parseFlags(argv: string[]): Record<string, string> {
+  const flags: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i] ?? '';
+    if (!arg.startsWith('--')) throw new Error(`unexpected argument "${arg}"\n\n${USAGE}`);
+    const name = arg.slice(2);
+    const next = argv[i + 1];
+    // A bare flag (--publish) takes the empty string; anything else consumes
+    // the token after it.
+    if (next === undefined || next.startsWith('--')) {
+      flags[name] = '';
+    } else {
+      flags[name] = next;
+      i += 1;
+    }
+  }
+  return flags;
+}
+
+main(process.argv.slice(2)).catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/packages/shots/src/cli.ts
+++ b/packages/shots/src/cli.ts
@@ -110,7 +110,9 @@ function parseFlags(argv: string[]): Record<string, string> {
   return flags;
 }
 
-main(process.argv.slice(2)).catch((error: unknown) => {
+try {
+  await main(process.argv.slice(2));
+} catch (error: unknown) {
   console.error(error instanceof Error ? error.message : String(error));
   process.exit(1);
-});
+}

--- a/packages/shots/src/dom.ts
+++ b/packages/shots/src/dom.ts
@@ -1,0 +1,125 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { chromium } from 'playwright';
+import type { Screen } from './shot';
+import type { Target } from './targets';
+
+// The brand intro plays on a cold launch and is an OVERLAY over an app tree that
+// is already mounted, so a run that skips this photographs the splash while the
+// DOM underneath reports the right screen. sessionStorage, in both the TV shells
+// (BrandIntro.web.tsx) and the web client (features/catalog/intro.tsx).
+const INTRO_SEEN_KEY = 'kroma:intro-seen';
+
+// Mirrored by the TV router on every navigation while `import.meta.env.DEV`,
+// and read back when the provider first mounts. Seeding it is what lets a shot
+// name a screen on a device whose router has no address bar.
+const DEV_NAV_KEY = 'kroma:dev-nav';
+
+const KEY_SETTLE_MS = 340;
+
+/** A signed-in session to seed into localStorage, as a JSON object of
+ * `{ "kroma.session": "…", … }` lifted off a device that is already signed in.
+ * Every screen worth photographing sits behind a profile, and a TV cannot be
+ * signed in from the outside. */
+function seedEntries(seedPath: string | undefined): Record<string, string> {
+  if (!seedPath) return {};
+  const parsed: unknown = JSON.parse(readFileSync(seedPath, 'utf8'));
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`${seedPath}: expected a JSON object of localStorage entries`);
+  }
+  const entries: Record<string, string> = {};
+  for (const [key, value] of Object.entries(parsed)) {
+    if (typeof value !== 'string') throw new Error(`${seedPath}: "${key}" is not a string`);
+    entries[key] = value;
+  }
+  return entries;
+}
+
+// The router restores the whole stack, so the screen is pushed on top of home:
+// that is what leaves Back somewhere to go, exactly as a viewer would have it.
+function navStack(screen: Screen): string {
+  const top = { name: screen.route, params: screen.params };
+  const stack = screen.route === 'home' ? [top] : [{ name: 'home' }, top];
+  return JSON.stringify(stack);
+}
+
+export async function captureDom(
+  target: Target,
+  screen: Screen,
+  file: string,
+  seedPath: string | undefined,
+  portOverride: number | undefined,
+): Promise<void> {
+  const { viewport } = target;
+  const port = portOverride ?? target.port;
+  if (!port || !viewport) throw new Error(`${target.id}: a dom target needs a port and a viewport`);
+  await assertServing(port, target);
+
+  const local = seedEntries(seedPath);
+  const session: Record<string, string> = { [INTRO_SEEN_KEY]: '1' };
+  if (target.routing === 'dev-nav') session[DEV_NAV_KEY] = navStack(screen);
+
+  const browser = await chromium.launch();
+  try {
+    const page = await browser.newPage({ viewport, deviceScaleFactor: 1 });
+    page.on('pageerror', (error) => console.log(`  [pageerror] ${String(error).slice(0, 200)}`));
+    await page.addInitScript(
+      ([localEntries, sessionEntries]) => {
+        for (const [key, value] of Object.entries(localEntries)) localStorage.setItem(key, value);
+        for (const [key, value] of Object.entries(sessionEntries)) {
+          sessionStorage.setItem(key, value);
+        }
+      },
+      [local, session] as const,
+    );
+
+    const path = target.routing === 'url' ? screen.path : '/';
+    await page.goto(`http://localhost:${port}${path}`, { waitUntil: 'networkidle' });
+    await assertKroma(page, target, port);
+
+    for (const key of screen.keys) {
+      await page.keyboard.press(key);
+      await page.waitForTimeout(KEY_SETTLE_MS);
+    }
+    await page.waitForTimeout(screen.settleMs);
+    writeFileSync(file, await page.screenshot({ type: 'png' }));
+
+    console.log(`  ${target.id}: ${await onScreen(page)}`);
+  } finally {
+    await browser.close();
+  }
+}
+
+// What the frame actually says, so a run that photographed the wrong screen is
+// obvious from the log instead of from the image.
+async function onScreen(page: {
+  locator: (selector: string) => { innerText: () => Promise<string> };
+}): Promise<string> {
+  const text = await page.locator('body').innerText();
+  return text.replace(/[^\S\n]{0,64}\n+[^\S\n]{0,64}/g, ' · ').slice(0, 120);
+}
+
+// A dev port is a squattable thing, and photographing whatever else answered is
+// the one failure that looks like success. Every shell titles itself KROMA.
+async function assertKroma(
+  page: { title: () => Promise<string> },
+  target: Target,
+  port: number,
+): Promise<void> {
+  const title = await page.title();
+  if (/kroma/i.test(title)) return;
+  throw new Error(
+    `port ${port} is serving "${title || 'an untitled page'}", not KROMA. ` +
+      `Something else is on that port; free it and start \`bun run ${target.serveScript}\`.`,
+  );
+}
+
+async function assertServing(port: number, target: Target): Promise<void> {
+  try {
+    await fetch(`http://localhost:${port}/`, { signal: AbortSignal.timeout(2000) });
+  } catch {
+    throw new Error(
+      `nothing is serving http://localhost:${port} for "${target.id}". ` +
+        `Start it with \`bun run ${target.serveScript}\` and run this again.`,
+    );
+  }
+}

--- a/packages/shots/src/metro.ts
+++ b/packages/shots/src/metro.ts
@@ -1,0 +1,26 @@
+// A native shell built for development carries no JS bundle: without Metro it
+// launches straight into a redbox ("No script URL provided"), which simctl and
+// adb will photograph as cheerfully as they would the real screen. Checking
+// first is what keeps a redbox out of a pull request.
+
+const DEFAULT_METRO_PORT = 8081;
+const PROBE_TIMEOUT_MS = 2000;
+
+export async function assertMetro(port: number, targetId: string, start: string): Promise<void> {
+  let body: string;
+  try {
+    const response = await fetch(`http://localhost:${port}/status`, {
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    });
+    body = await response.text();
+  } catch {
+    body = '';
+  }
+  if (body.includes('packager-status:running')) return;
+  throw new Error(
+    `${targetId}: no Metro bundler on port ${port}, so the app would open on a redbox. ` +
+      `Start it with \`${start}\`, or pass --metro-port if it is on another one.`,
+  );
+}
+
+export { DEFAULT_METRO_PORT };

--- a/packages/shots/src/publish.ts
+++ b/packages/shots/src/publish.ts
@@ -1,0 +1,64 @@
+import { run } from './sh';
+import type { Shot } from './shot';
+
+// One release holds every screenshot the issues and PRs point at. It is a plain
+// asset bucket, never a build: GitHub serves the files, and nothing in the repo
+// grows a binary.
+const ASSET_RELEASE = 'issue-assets';
+
+/** Upload the run to the asset release, replacing an asset of the same name so
+ * re-running a capture updates the image a PR already links. Returns the
+ * markdown block, with the published URLs. */
+export function publish(repo: string, shots: readonly Shot[], slug: string): string {
+  ensureRelease(repo);
+  for (const shot of shots) {
+    run('gh', ['release', 'upload', ASSET_RELEASE, shot.file, '--clobber', '--repo', repo]);
+  }
+  return markdown(repo, shots, slug);
+}
+
+function ensureRelease(repo: string): void {
+  const found = run(
+    'gh',
+    ['release', 'view', ASSET_RELEASE, '--repo', repo, '--json', 'tagName'],
+    'text',
+    {
+      allowFailure: true,
+    },
+  );
+  if (found.includes(ASSET_RELEASE)) return;
+  run('gh', [
+    'release',
+    'create',
+    ASSET_RELEASE,
+    '--repo',
+    repo,
+    '--title',
+    'Issue and PR assets',
+    '--notes',
+    'Images referenced from issues and pull requests. Not a build.',
+  ]);
+}
+
+/** The block to paste into a PR or issue. Collapsed, because a set of five
+ * 1080p frames pushes the description itself off the screen. */
+export function markdown(repo: string, shots: readonly Shot[], slug: string): string {
+  const base = `https://github.com/${repo}/releases/download/${ASSET_RELEASE}`;
+  const images = shots
+    .map((shot) => `**${shot.label}**\n\n![${shot.label}](${base}/${basename(shot.file)})`)
+    .join('\n\n');
+  const captured = shots.map((shot) => shot.label).join(' · ');
+  return [
+    `<details><summary>Screenshots: ${captured}</summary>`,
+    '',
+    images,
+    '',
+    '</details>',
+    '',
+    `_Captured with \`bun run shots:pr ${slug}\`._`,
+  ].join('\n');
+}
+
+function basename(file: string): string {
+  return file.slice(file.lastIndexOf('/') + 1);
+}

--- a/packages/shots/src/sh.ts
+++ b/packages/shots/src/sh.ts
@@ -1,0 +1,32 @@
+import { spawnSync } from 'node:child_process';
+
+interface RunOptions {
+  /** Return what the command managed to print instead of throwing on a non-zero
+   * exit. For the probes whose failure IS the answer (is this app installed?). */
+  allowFailure?: boolean;
+}
+
+/** Run a command and return its stdout. Arguments are passed as a list, never
+ * through a shell, so a slug or device name can never become a command. */
+export function run(command: string, args: string[]): string;
+export function run(command: string, args: string[], as: 'text', options?: RunOptions): string;
+export function run(command: string, args: string[], as: 'buffer', options?: RunOptions): Buffer;
+export function run(
+  command: string,
+  args: string[],
+  as: 'text' | 'buffer' = 'text',
+  options: RunOptions = {},
+): string | Buffer {
+  const result = spawnSync(command, args, {
+    encoding: as === 'buffer' ? 'buffer' : 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (result.error) throw new Error(`${command}: ${result.error.message}`);
+  if (result.status !== 0 && !options.allowFailure) {
+    const stderr = String(result.stderr ?? '').trim();
+    throw new Error(
+      `${command} ${args.join(' ')} exited ${result.status}${stderr ? `\n${stderr}` : ''}`,
+    );
+  }
+  return as === 'buffer' ? (result.stdout as Buffer) : String(result.stdout ?? '');
+}

--- a/packages/shots/src/sh.ts
+++ b/packages/shots/src/sh.ts
@@ -24,9 +24,8 @@ export function run(
   if (result.error) throw new Error(`${command}: ${result.error.message}`);
   if (result.status !== 0 && !options.allowFailure) {
     const stderr = String(result.stderr ?? '').trim();
-    throw new Error(
-      `${command} ${args.join(' ')} exited ${result.status}${stderr ? `\n${stderr}` : ''}`,
-    );
+    const detail = stderr ? `\n${stderr}` : '';
+    throw new Error(`${command} ${args.join(' ')} exited ${result.status}${detail}`);
   }
   return as === 'buffer' ? (result.stdout as Buffer) : String(result.stdout ?? '');
 }

--- a/packages/shots/src/shot.ts
+++ b/packages/shots/src/shot.ts
@@ -1,0 +1,59 @@
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { resolve, sep } from 'node:path';
+
+/** One screen, as every target is asked for it. Each target uses the field its
+ * own routing understands and ignores the rest. */
+export interface Screen {
+  /** Web client: the URL path. */
+  path: string;
+  /** TV shells: a `RouteName` from packages/tv/src/app/router.tsx. */
+  route: string;
+  /** Params for that route, for the ones that take them (`grid`, `genre`, …). */
+  params?: unknown;
+  /** Remote keys pressed before the capture, on the targets that take them. */
+  keys: string[];
+  /** Extra settle time before the shutter, for a screen that animates in. */
+  settleMs: number;
+}
+
+export interface Shot {
+  targetId: string;
+  label: string;
+  file: string;
+}
+
+/** Where a run writes, refusing anywhere outside the repo: the slug reaches
+ * this from the command line, and the next thing that happens to it is an
+ * `mkdirSync`. */
+export function outDirFor(repo: string, slug: string): string {
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(slug)) {
+    throw new Error(`slug must be kebab-case ([a-z0-9-]), got "${slug}"`);
+  }
+  const root = resolve(repo, '.shots');
+  const dir = resolve(root, slug);
+  if (!dir.startsWith(`${root}${sep}`)) {
+    throw new Error(`refusing to write outside ${root}: ${slug}`);
+  }
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+/** The published asset name. Flat, because a GitHub release is a flat bucket
+ * and two runs of different slugs must not collide. */
+export function assetName(slug: string, targetId: string): string {
+  return `${slug}-${targetId}.png`;
+}
+
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+
+/** A capture tool that reports success on an empty file publishes a broken
+ * image into a pull request, which is worse than failing. Every target is held
+ * to this before its shot is counted. */
+export function assertPng(file: string, targetId: string): void {
+  const bytes = existsSync(file) ? readFileSync(file) : Buffer.alloc(0);
+  if (bytes.length && bytes.subarray(0, 4).equals(PNG_MAGIC)) return;
+  throw new Error(
+    `${targetId}: the capture produced ${bytes.length ? 'something that is not a PNG' : 'an empty file'}. ` +
+      `Nothing was written that could be published.`,
+  );
+}

--- a/packages/shots/src/targets.ts
+++ b/packages/shots/src/targets.ts
@@ -1,0 +1,96 @@
+/** How a target is driven: a browser page, the tvOS simulator, or an Android
+ * emulator over adb. */
+export type TargetKind = 'dom' | 'apple' | 'android';
+
+/** How a target is asked for a particular screen.
+ *
+ * - `url`: the web client has real routes, so a path is enough.
+ * - `dev-nav`: the TV router is an in-memory stack with no address bar, but a
+ *   DEV build restores it from `sessionStorage['kroma:dev-nav']` (see
+ *   packages/tv/src/app/router.tsx), so seeding that key lands on any screen.
+ *   This is why the TV targets drive a dev server rather than a preview build.
+ * - `keys`: a native shell has neither, so a screen is reached the way a
+ *   viewer reaches it: by pressing remote keys.
+ */
+export type Routing = 'url' | 'dev-nav' | 'keys';
+
+export interface Target {
+  id: string;
+  /** Caption used in the published markdown. */
+  label: string;
+  kind: TargetKind;
+  routing: Routing;
+  /** dom: the dev server this target expects, and the script that serves it. */
+  port?: number;
+  serveScript?: string;
+  viewport?: { width: number; height: number };
+  /** apple: the simulator device name, matched against `simctl list`. */
+  device?: string;
+  /** android: the AVD name, matched against `emulator -list-avds`. */
+  avd?: string;
+  /** The bundle/package id to launch, for the native targets. */
+  appId?: string;
+}
+
+export const TARGETS: readonly Target[] = [
+  {
+    id: 'web',
+    label: 'Web',
+    kind: 'dom',
+    routing: 'url',
+    port: 3000,
+    serveScript: 'dev:web',
+    viewport: { width: 1440, height: 900 },
+  },
+  {
+    id: 'tizen',
+    label: 'Tizen (Samsung)',
+    kind: 'dom',
+    routing: 'dev-nav',
+    port: 5174,
+    serveScript: 'dev:tizen',
+    viewport: { width: 1920, height: 1080 },
+  },
+  {
+    id: 'webos',
+    label: 'webOS (LG)',
+    kind: 'dom',
+    routing: 'dev-nav',
+    port: 5175,
+    serveScript: 'dev:webos',
+    viewport: { width: 1920, height: 1080 },
+  },
+  {
+    id: 'appletv',
+    label: 'Apple TV',
+    kind: 'apple',
+    routing: 'keys',
+    device: 'Apple TV 4K (3rd generation) (at 1080p)',
+    appId: 'tv.kroma.mobile',
+  },
+  {
+    id: 'androidtv',
+    label: 'Android TV',
+    kind: 'android',
+    routing: 'keys',
+    avd: 'Television_4K',
+    appId: 'tv.kroma.mobile',
+  },
+];
+
+export const DEFAULT_TARGETS = ['web', 'tizen', 'webos'] as const;
+
+export function targetsFrom(list: string): Target[] {
+  const wanted = list
+    .split(',')
+    .map((id) => id.trim())
+    .filter(Boolean);
+  return wanted.map((id) => {
+    const target = TARGETS.find((t) => t.id === id);
+    if (!target) {
+      const known = TARGETS.map((t) => t.id).join(', ');
+      throw new Error(`unknown target "${id}"; known targets are ${known}`);
+    }
+    return target;
+  });
+}

--- a/packages/shots/tsconfig.json
+++ b/packages/shots/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "lib": ["ES2022"],
+    "types": ["bun-types"]
+  },
+  "include": ["src"]
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -157,6 +157,7 @@ sonar.coverage.exclusions=\
   packages/synology-repo/src/preview.ts,\
   clients/*/index*.html,\
   clients/tv-build/**,\
+  packages/shots/**,\
   packages/bundler/src/shell.ts,\
   packages/bundler/src/rnw.ts,\
   packages/bundler/src/tv-frame.ts,\


### PR DESCRIPTION
## Why

A change to the design is reviewed from a description, and a description of a
screen is not the screen. Until now the evidence was assembled by hand and
uploaded ad hoc, so most PRs carried none, and the ones that did (#90) carried
headless renders rather than the shells.

`bun run shots:pr <slug>` captures the same screen across the web client, the
Tizen and webOS shells, the tvOS simulator and an Android TV emulator, then
prints the markdown block a PR or issue carries.

```bash
bun run shots:pr about-hardware --route about --targets tizen,webos --publish
```

Not to be confused with `bun run shots`, which shoots the kit's component
stories. This one shoots the product.

## The hard part: naming a screen on a device with no address bar

| Target | Routing | How a screen is named |
|---|---|---|
| `web` | `url` | `--path /settings` |
| `tizen`, `webos` | `dev-nav` | `--route about`. A DEV build of the TV router mirrors its in-memory stack to `sessionStorage['kroma:dev-nav']` and restores it on mount (`packages/tv/src/app/router.tsx`), so seeding that key lands on any screen with **no key presses**. |
| `appletv`, `androidtv` | `keys` | `--keys ArrowDown,Enter`, the way a viewer reaches it. |

That `dev-nav` seam is why the TV targets drive a **dev server** rather than a
preview build. `clients/tv-build/store-shots.ts` (the store-listing capture)
drives a production preview and therefore has to walk arrow-key sequences tuned
against the catalogue; for PR evidence that is far too fragile, and this needs
none of it.

**It photographs a build, it never makes one.** A capture tool that also builds
is a build tool that sometimes takes pictures, and it would hide a stale bundle
behind a fresh image.

## Every precondition here was earned

Each of these failed as a *plausible image* rather than as an error, which is
the only failure mode that matters for a tool whose output is evidence:

- **A squatted dev port.** The first real run photographed a different project
  entirely: 5174 and 5175 were both occupied. The page title is now checked, and
  the error names what it found (`port 5174 is serving "The Epic Adventure
  Remazterized", not KROMA`).
- **The brand intro.** It is an *overlay* over an app tree that is already
  mounted, so the run reported `About · Platform · Tizen · …` from the DOM while
  the PNG was the splash screen. It is keyed in `sessionStorage`, not
  `localStorage`, in both `BrandIntro.web.tsx` and the web client's `intro.tsx`.
- **`simctl io … -` does not stream to stdout.** Handed `-` it writes a file
  literally called `-` in the working directory and exits 0. The first Apple TV
  run produced a 0-byte PNG and reported success. Captures are now checked for
  the PNG magic before they count.
- **A native build with no Metro** opens on a redbox, which simctl and adb
  photograph as cheerfully as the real screen. Probed before anything is booted.

## Verified

| Target | State |
|---|---|
| `tizen` | **Captured end to end**, published below. |
| `webos` | **Captured end to end**, published below. |
| `appletv` | **Captured end to end** from the simulator (a real 1920x1080 PNG); the installed app had no Metro, which is what prompted that precondition. The `--keys` path is written but has not driven a real screen. |
| `androidtv` | SDK, AVD (`Television_4K`) and precondition paths exercised. The emulator was not booted and **no capture has been taken**. |
| `web` | **Not run**: nothing was serving :3000. |

So two of the five are proven end to end, one produced a real frame of the wrong
thing for a reason now guarded, and two are written but unexercised. The README
carries this same table rather than implying five green ticks.

## Gate

- `bun run --filter '@kroma/shots' typecheck` - exit 0
- `biome check` on the package, `package.json` and `.gitignore` - clean
- Every file well under the 300 LOC rule (largest is 138)
- `bun run typecheck` repo-wide surfaces only the known `@kroma/mobile`
  `expo-env.d.ts` failures, which predate this and are local-only

## Itself

The block below was produced by the tool, published to the `issue-assets`
release by `--publish`, and pasted here unedited.

<details><summary>Screenshots: Tizen (Samsung) · webOS (LG)</summary>

**Tizen (Samsung)**

![Tizen (Samsung)](https://github.com/maxscharwath/kroma/releases/download/issue-assets/about-hardware-tizen.png)

**webOS (LG)**

![webOS (LG)](https://github.com/maxscharwath/kroma/releases/download/issue-assets/about-hardware-webos.png)

</details>

_Captured with `bun run shots:pr about-hardware`._
