### PR TITLE
fix(tv): one Menu press backs out one screen on Apple TV

### DIFF
--- a/packages/ui/src/lib/focus-nav.native.test.ts
+++ b/packages/ui/src/lib/focus-nav.native.test.ts
@@ -28,6 +28,7 @@ const rn = vi.hoisted(() => ({
   enableTVMenuKey: vi.fn(),
   disableTVMenuKey: vi.fn(),
   os: 'ios' as 'ios' | 'android',
+  isTV: true,
 }));
 
 vi.mock('react-native', () => ({
@@ -44,6 +45,9 @@ vi.mock('react-native', () => ({
   Platform: {
     get OS() {
       return rn.os;
+    },
+    get isTV() {
+      return rn.isTV;
     },
   },
   TVEventControl: {
@@ -78,6 +82,7 @@ beforeEach(() => {
   rn.remote = null;
   rn.back = [];
   rn.os = 'ios';
+  rn.isTV = true;
   clearInputHolds();
   clearPressGuard();
   vi.clearAllMocks();
@@ -125,6 +130,12 @@ describe('the Menu key claim', () => {
 });
 
 describe('the hardware Back button', () => {
+  // Android TV: the only platform that routes Back through BackHandler. On tvOS
+  // it is layered on the `menu` remote event instead - see the describe below.
+  beforeEach(() => {
+    rn.os = 'android';
+  });
+
   it('runs the screen’s handler and consumes the press', () => {
     const onBack = vi.fn();
     renderHook(() => useFocusNav({ onBack }));
@@ -155,6 +166,46 @@ describe('the hardware Back button', () => {
     expect(rn.back).toHaveLength(1);
     unmount();
     expect(rn.back).toHaveLength(0);
+  });
+});
+
+describe('Back on tvOS, where BackHandler is the Menu event wearing a hat', () => {
+  it('never subscribes, so one Menu press is not routed twice', () => {
+    // tvOS implements BackHandler on top of `menu`, which BACK_EVENTS already
+    // maps below. Subscribing as well would run the screen's handler twice and
+    // back out two screens per press.
+    renderHook(() => useFocusNav({ onBack: vi.fn() }));
+    expect(rn.back).toHaveLength(0);
+  });
+
+  it('still claims the Menu key, which the subscription guard must not skip', () => {
+    // The guard sits on the subscription, not on the effect: hoisting it would
+    // drop this claim and hand Menu back to the OS, which quits the app. Every
+    // assertion above would still pass.
+    const { unmount } = renderHook(() => useFocusNav({ onBack: vi.fn() }));
+    expect(rn.enableTVMenuKey).toHaveBeenCalled();
+    unmount();
+    expect(rn.disableTVMenuKey).toHaveBeenCalled();
+  });
+
+  it('routes Menu through the remote stream exactly once', () => {
+    const onBack = vi.fn();
+    renderHook(() => useFocusNav({ onBack }));
+    act(() => rn.remote?.({ eventType: 'menu' } as HWEvent));
+    expect(onBack).toHaveBeenCalledOnce();
+  });
+});
+
+describe('Back on an Android phone', () => {
+  it('keeps the hardware button, which is not a television-only path', () => {
+    // The guard is on the OS alone, never `Platform.isTV`: mainline React Native
+    // defines no such field, so pairing the two would strip Back from the phone.
+    rn.os = 'android';
+    rn.isTV = false;
+    const onBack = vi.fn();
+    renderHook(() => useFocusNav({ onBack }));
+    expect(pressBack()).toBe(true);
+    expect(onBack).toHaveBeenCalledOnce();
   });
 });
 

--- a/packages/ui/src/lib/focus-nav.ts
+++ b/packages/ui/src/lib/focus-nav.ts
@@ -4,7 +4,7 @@
 // exist only in the react-native-tvos fork, so this no-ops on mainline RN.
 
 import { useEffect } from 'react';
-import { BackHandler, type HWEvent, useTVEventHandler } from 'react-native';
+import { BackHandler, type HWEvent, Platform, useTVEventHandler } from 'react-native';
 import { resetFocusEntry } from './focus-entry';
 import type { FocusNavHandlers } from './focus-types';
 import { inputHeld } from './input-gate';
@@ -37,13 +37,25 @@ function useFocusNav({ onBack, onPlayPause, resetKey }: FocusNavHandlers): void 
     if (!onBack) return;
     // Claim the Menu key so tvOS reports it instead of backing out of the app.
     holdMenuKey();
+    // Android only, phone and TV alike, where BackHandler is a channel of its
+    // own. On tvOS this fork implements it ON TOP of the same `menu` event
+    // `BACK_EVENTS` maps below, so subscribing there routes one press twice and
+    // backs out two screens. Nothing is lost by staying out: tvOS stubs
+    // `exitApp` to a no-op, so the `true` returned for a held remote buys
+    // nothing. NOT `Platform.isTV` as well - mainline RN defines no such field,
+    // and the phone app would lose its hardware Back. The Menu claim above runs
+    // on every platform, which is why this guard sits here and not at the top of
+    // the effect.
     // A held remote still consumes Back (`true`): letting it through would leave
     // the app while an overlay is on screen.
-    const sub = BackHandler.addEventListener('hardwareBackPress', () =>
-      inputHeld() ? true : onBack() !== false,
-    );
+    const sub =
+      Platform.OS === 'android'
+        ? BackHandler.addEventListener('hardwareBackPress', () =>
+            inputHeld() ? true : onBack() !== false,
+          )
+        : undefined;
     return () => {
-      sub.remove();
+      sub?.remove();
       releaseMenuKey();
     };
   }, [onBack]);


### PR DESCRIPTION
Every screen using `useFocusNav({ onBack })` runs its Back handler **twice** per Menu press on Apple TV, backing out two screens. 31 files use the hook; the TV screens passing `onBack` include TvAbout, TvPin, TvProfiles, TvConnect, TvDeviceSettings, TvProfileMenu and TvAddProfile.

## Cause

`focus-nav` subscribes to Back through two channels at once:

- `BackHandler.addEventListener('hardwareBackPress', ...)`, previously with no platform guard
- `useRemoteEvents`, where `BACK_EVENTS = new Set(['menu', 'back'])`

On tvOS those are the same channel. From `react-native/Libraries/Utilities/BackHandler.ios.js` in this fork:

```js
// On Apple TV, this implements back navigation using the TV remote's menu button.
const TVEventHandler = require('../Components/TV/TVEventHandler').default;
...
if (Platform.isTV) {
  TVEventHandler.addListener(function (evt) {
    if (evt && evt.eventType === 'menu') {
```

So one Menu press reaches both listeners and `onBack()` runs twice. Pre-existing; #97 fixed the same shape in `usePlayerKeys` but this hook was left.

## Fix

Subscribe only where BackHandler is a channel of its own: `Platform.OS === 'android'`.

Two things make this narrower than it looks, and both are pinned by tests:

- **The guard is on the subscription, not the effect.** `holdMenuKey()` sits in the same effect and is what stops the native Menu button quitting the app. Hoisting the guard to the top of the effect kills that claim on tvOS, and would still pass a naive suite since the menu-key switch is mocked.
- **It is `OS === 'android'` alone, not also `Platform.isTV`.** The player hook is TV-only so it can pair them; `focus-nav` is shared with the phone app, and mainline React Native defines no `Platform.isTV`, so pairing them strips hardware Back from mobile. The existing "degrades to the hardware Back button alone" test catches exactly that.

Nothing is lost on tvOS: it stubs `exitApp` to `emptyFunction`, so the `true` the BackHandler branch returned for a held remote bought nothing there. The remote-event branch keeps handling `menu`.

## Tests

Three added, and verified in both directions rather than merely passing:

- against the unfixed hook, "never subscribes, so one Menu press is not routed twice" **fails**
- against the *wrong* fix (guard hoisted to the effect top), "still claims the Menu key" **fails**, along with the two pre-existing Menu-claim tests

`bun run typecheck` clean, `bun run check` clean, 542 files / 6717 tests pass.

## Not verified

I have no Apple TV here, so this is proven from the vendored RN source and the suite, not from a device. Worth one pass on hardware to confirm Back pops one screen and that Menu still does not quit the app.
