### PR TITLE
chore(release): 0.1.39

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2587,7 +2587,7 @@ dependencies = [
 
 [[package]]
 name = "kroma-server"
-version = "0.1.38"
+version = "0.1.39"
 dependencies = [
  "anyhow",
  "axum",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kroma-server"
-version = "0.1.38"
+version = "0.1.39"
 edition.workspace = true
 rust-version.workspace = true
 description = "KROMA a self-hosted, direct-play media streaming server"


### PR DESCRIPTION
Opens the version the next candidate builds under. v0.1.38 is already released from its own commit, so every candidate since is unpromotable until this moves — the deploy verify step refuses a tag already claimed by a different sha.

## What lands in 0.1.39

31 commits since v0.1.38, notably:
- **Android TV** — d-pad routed into the player chrome (#95), Back no longer quits the app (#97), on-screen keyboard row-vanish/crash fix (#96) → closed #79, #80, #81
- **Playback** — libVLC engine + FFmpeg audio decoders + four playback fixes (#105), transcode audio the client can't decode instead of serving silence (#94)
- **Apple TV** — one Menu press backs out one screen (#104)
- **Diagnostics** — opt-in TV crash reporting (#101)
- **Spec** — requirement-ID nomenclature, machine index, spaces, spec-reviewer agent (#76, #77)

## After merge

Push to main rebuilds the fleet as the 0.1.39 candidate; I promote it with `deploy.yml -f build_run_id=<green run>` and the publish waits on your approval of the `production` gate. Nothing is published by this PR.