### PR TITLE
feat(workspace-tools): affected-project detection + dependency verification

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -555,9 +555,11 @@
       },
       "peerDependencies": {
         "react": ">=18",
+        "react-native": "*",
       },
       "optionalPeers": [
         "react",
+        "react-native",
       ],
     },
     "packages/lan-beacon": {
@@ -787,6 +789,17 @@
       "optionalPeers": [
         "@tanstack/react-router",
       ],
+    },
+    "packages/workspace-tools": {
+      "name": "@kroma/workspace-tools",
+      "version": "0.0.0",
+      "bin": {
+        "workspace-tools": "src/cli.ts",
+      },
+      "devDependencies": {
+        "bun-types": "^1.3.14",
+        "typescript": "^7.0.2",
+      },
     },
   },
   "patchedDependencies": {
@@ -1378,6 +1391,8 @@
     "@kroma/webos": ["@kroma/webos@workspace:clients/webos"],
 
     "@kroma/workbench": ["@kroma/workbench@workspace:packages/workbench"],
+
+    "@kroma/workspace-tools": ["@kroma/workspace-tools@workspace:packages/workspace-tools"],
 
     "@lix-js/sdk": ["@lix-js/sdk@0.12.0", "", { "dependencies": { "fflate": "^0.8.3" }, "optionalDependencies": { "@lix-js/sdk-darwin-arm64": "0.12.0", "@lix-js/sdk-linux-arm64": "0.12.0", "@lix-js/sdk-linux-x64": "0.12.0", "@lix-js/sdk-win32-x64": "0.12.0" } }, "sha512-Vn4IYLmQyvqrVM+wcpzK6yDAZoK2Q4Hi9wRSsslfr1CcLQanRV1Tfheb5Kh2xy5NBLLbzFmFLsl7ElIKo8wVuA=="],
 

--- a/packages/workspace-tools/package.json
+++ b/packages/workspace-tools/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@kroma/workspace-tools",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Project-agnostic workspace analysis: build a dependency graph from native manifests, find the projects a change affects (transitively, dependency bumps included), and verify every dependency edge and minServer floor resolves. Pure core, no build logic — it names the affected artifacts and leaves building to the existing scripts.",
+  "author": "Maxime Scharwath <maxscharwath@gmail.com>",
+  "license": "GPL-2.0-or-later",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "directory": "packages/workspace-tools"
+  },
+  "main": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "bin": {
+    "workspace-tools": "src/cli.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "bun-types": "^1.3.14",
+    "typescript": "^7.0.2"
+  }
+}

--- a/packages/workspace-tools/src/cli.ts
+++ b/packages/workspace-tools/src/cli.ts
@@ -1,0 +1,56 @@
+#!/usr/bin/env bun
+// Reference consumer. Subcommands:
+//   affected --since <range>   list the projects a change affects (transitively)
+//   verify                     check every dependency edge + minServer resolves
+// The analysis lives in the tested core; this only loads the repo and prints.
+
+import { affected } from './core/affected';
+import { verify } from './core/verify';
+import { changedFiles } from './io/git';
+import { loadGraph } from './io/load';
+
+function flag(argv: string[], name: string): string | undefined {
+  const i = argv.indexOf(name);
+  return i >= 0 ? argv[i + 1] : undefined;
+}
+
+function cmdAffected(argv: string[]): number {
+  const since = flag(argv, '--since');
+  if (!since) {
+    console.error('usage: workspace-tools affected --since <range> [--build]');
+    return 2;
+  }
+  const graph = loadGraph({ root: process.cwd() });
+  const names = affected(changedFiles(since), graph);
+  const projects = graph.projects.filter((p) => names.has(p.name));
+  if (projects.length === 0) {
+    console.log('No projects affected.');
+    return 0;
+  }
+  for (const p of projects) console.log(`${p.name}\t${p.dir}`);
+  return 0;
+}
+
+function cmdVerify(): number {
+  const graph = loadGraph({ root: process.cwd() });
+  const violations = verify(graph);
+  if (violations.length === 0) {
+    console.log(`Dependencies OK — ${graph.projects.length} projects, every edge resolves.`);
+    return 0;
+  }
+  console.error(`${violations.length} dependency problem(s):`);
+  for (const v of violations) console.error(`  ✗ [${v.kind}] ${v.project}: ${v.detail}`);
+  return 1;
+}
+
+function main(): void {
+  const [command, ...rest] = process.argv.slice(2);
+  if (command === 'affected') process.exit(cmdAffected(rest));
+  else if (command === 'verify') process.exit(cmdVerify());
+  else {
+    console.error('usage: workspace-tools <affected|verify> [options]');
+    process.exit(2);
+  }
+}
+
+main();

--- a/packages/workspace-tools/src/core/affected.test.ts
+++ b/packages/workspace-tools/src/core/affected.test.ts
@@ -55,4 +55,30 @@ describe('affected', () => {
   it('a client change does not drag its siblings', () => {
     expect([...affected(['clients/tizen/src/app.ts'], graph)]).toEqual(['tizen']);
   });
+
+  it('terminates on a dependency cycle', () => {
+    const cyclic: Graph = {
+      projects: [
+        {
+          name: 'a',
+          dir: 'packages/a',
+          manifest: 'packages/a/package.json',
+          version: '1.0.0',
+          deps: ['b'],
+        },
+        {
+          name: 'b',
+          dir: 'packages/b',
+          manifest: 'packages/b/package.json',
+          version: '1.0.0',
+          deps: ['a'],
+        },
+      ],
+    };
+    expect([...affected(['packages/a/x.ts'], cyclic)].sort()).toEqual(['a', 'b']);
+  });
+
+  it('returns nothing for an empty change set', () => {
+    expect([...affected([], graph)]).toEqual([]);
+  });
 });

--- a/packages/workspace-tools/src/core/affected.test.ts
+++ b/packages/workspace-tools/src/core/affected.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { affected, directlyChanged } from './affected';
+import type { Graph } from './graph';
+
+const graph: Graph = {
+  projects: [
+    { name: 'server', dir: 'server', manifest: 'server/Cargo.toml', version: '0.1.38', deps: [] },
+    {
+      name: 'ui',
+      dir: 'packages/ui',
+      manifest: 'packages/ui/package.json',
+      version: '0.1.0',
+      deps: [],
+    },
+    {
+      name: 'tizen',
+      dir: 'clients/tizen',
+      manifest: 'clients/tizen/package.json',
+      version: '0.1.0',
+      deps: ['ui'],
+    },
+    {
+      name: 'webos',
+      dir: 'clients/webos',
+      manifest: 'clients/webos/package.json',
+      version: '0.1.0',
+      deps: ['ui'],
+    },
+  ],
+};
+
+describe('directlyChanged', () => {
+  it('maps a path to the deepest owning project', () => {
+    expect([...directlyChanged(['clients/tizen/src/app.ts'], graph)]).toEqual(['tizen']);
+  });
+
+  it('ignores paths outside every project', () => {
+    expect([...directlyChanged(['README.md', 'docs/x.md'], graph)]).toEqual([]);
+  });
+});
+
+describe('affected', () => {
+  it('includes transitive dependents (a ui change rebuilds the clients)', () => {
+    expect([...affected(['packages/ui/src/button.tsx'], graph)].sort()).toEqual([
+      'tizen',
+      'ui',
+      'webos',
+    ]);
+  });
+
+  it('a leaf change affects only itself', () => {
+    expect([...affected(['server/src/main.rs'], graph)]).toEqual(['server']);
+  });
+
+  it('a client change does not drag its siblings', () => {
+    expect([...affected(['clients/tizen/src/app.ts'], graph)]).toEqual(['tizen']);
+  });
+});

--- a/packages/workspace-tools/src/core/affected.ts
+++ b/packages/workspace-tools/src/core/affected.ts
@@ -1,0 +1,41 @@
+import { dependents, type Graph } from './graph';
+
+// The projects a changed path sits inside — the deepest owning directory wins, so
+// a change under clients/tizen/ is the tizen project, not a parent.
+export function directlyChanged(changedPaths: string[], graph: Graph): Set<string> {
+  const hit = new Set<string>();
+  for (const path of changedPaths) {
+    let owner: string | null = null;
+    let ownerDirLength = -1;
+    for (const project of graph.projects) {
+      const inside = path === project.dir || path.startsWith(`${project.dir}/`);
+      if (inside && project.dir.length > ownerDirLength) {
+        owner = project.name;
+        ownerDirLength = project.dir.length;
+      }
+    }
+    if (owner) hit.add(owner);
+  }
+  return hit;
+}
+
+// Every project that must be rebuilt/re-released for a set of changed paths: the
+// directly-changed ones, plus everything that (transitively) depends on them. A
+// dependency bump is a change to the dependency's project, so its dependents fall
+// out of this walk automatically.
+export function affected(changedPaths: string[], graph: Graph): Set<string> {
+  const result = directlyChanged(changedPaths, graph);
+  const reverse = dependents(graph);
+  const queue = [...result];
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (current === undefined) continue;
+    for (const dependent of reverse.get(current) ?? []) {
+      if (!result.has(dependent)) {
+        result.add(dependent);
+        queue.push(dependent);
+      }
+    }
+  }
+  return result;
+}

--- a/packages/workspace-tools/src/core/graph.ts
+++ b/packages/workspace-tools/src/core/graph.ts
@@ -1,0 +1,41 @@
+// The workspace as a graph of releasable projects. Built from parsed manifest
+// data (not the filesystem) so the graph algorithms below are pure and testable.
+
+export interface Project {
+  // Package name (npm), crate name, or module id.
+  name: string;
+  // Repo-relative directory that owns this project.
+  dir: string;
+  // Repo-relative path to its native manifest.
+  manifest: string;
+  version: string;
+  // Names of the other projects in this graph it depends on (resolved edges).
+  deps: string[];
+  // For a module: the raw dependency ranges it declares (name → semver range).
+  ranges?: Record<string, string>;
+  // For a client/module: the minimum server version it requires.
+  minServer?: string;
+}
+
+export interface Graph {
+  projects: Project[];
+  // The server project, if present — the target of every `minServer` check.
+  server?: Project;
+}
+
+export function byName(graph: Graph): Map<string, Project> {
+  return new Map(graph.projects.map((p) => [p.name, p]));
+}
+
+// name → the projects that depend on it (reverse edges), for affected-set walks.
+export function dependents(graph: Graph): Map<string, string[]> {
+  const map = new Map<string, string[]>();
+  for (const project of graph.projects) {
+    for (const dep of project.deps) {
+      const list = map.get(dep);
+      if (list) list.push(project.name);
+      else map.set(dep, [project.name]);
+    }
+  }
+  return map;
+}

--- a/packages/workspace-tools/src/core/range.test.ts
+++ b/packages/workspace-tools/src/core/range.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { satisfies } from './range';
+
+describe('satisfies', () => {
+  it('handles exact and wildcard', () => {
+    expect(satisfies('1.2.3', '1.2.3')).toBe(true);
+    expect(satisfies('1.2.4', '1.2.3')).toBe(false);
+    expect(satisfies('9.9.9', '*')).toBe(true);
+    expect(satisfies('9.9.9', '')).toBe(true);
+  });
+
+  it('handles caret on a non-zero major', () => {
+    expect(satisfies('1.5.0', '^1.2.3')).toBe(true);
+    expect(satisfies('1.2.3', '^1.2.3')).toBe(true);
+    expect(satisfies('2.0.0', '^1.2.3')).toBe(false);
+    expect(satisfies('1.2.2', '^1.2.3')).toBe(false);
+  });
+
+  it('handles caret on 0.x (the module case, ^0.1.0)', () => {
+    expect(satisfies('0.1.8', '^0.1.0')).toBe(true);
+    expect(satisfies('0.1.0', '^0.1.0')).toBe(true);
+    expect(satisfies('0.2.0', '^0.1.0')).toBe(false);
+    expect(satisfies('0.0.9', '^0.1.0')).toBe(false);
+  });
+
+  it('handles tilde and >=', () => {
+    expect(satisfies('1.2.9', '~1.2.3')).toBe(true);
+    expect(satisfies('1.3.0', '~1.2.3')).toBe(false);
+    expect(satisfies('0.1.4', '>=0.1.4')).toBe(true);
+    expect(satisfies('0.1.3', '>=0.1.4')).toBe(false);
+  });
+
+  it('tolerates a leading v and drops a pre-release suffix', () => {
+    expect(satisfies('v1.2.3', '^1.0.0')).toBe(true);
+    expect(satisfies('1.2.3-rc1', '^1.2.3')).toBe(true);
+  });
+});

--- a/packages/workspace-tools/src/core/range.test.ts
+++ b/packages/workspace-tools/src/core/range.test.ts
@@ -34,4 +34,16 @@ describe('satisfies', () => {
     expect(satisfies('v1.2.3', '^1.0.0')).toBe(true);
     expect(satisfies('1.2.3-rc1', '^1.2.3')).toBe(true);
   });
+
+  it('returns false for a malformed version or range instead of throwing', () => {
+    expect(satisfies('not-a-version', '^1.0.0')).toBe(false);
+    expect(satisfies('1.0.0', 'garbage')).toBe(false);
+    expect(satisfies('1.0.0', '^oops')).toBe(false);
+    expect(satisfies('', '^1.0.0')).toBe(false);
+  });
+
+  it('caret on 0.0.x is exact-patch only', () => {
+    expect(satisfies('0.0.3', '^0.0.3')).toBe(true);
+    expect(satisfies('0.0.4', '^0.0.3')).toBe(false);
+  });
 });

--- a/packages/workspace-tools/src/core/range.ts
+++ b/packages/workspace-tools/src/core/range.ts
@@ -1,0 +1,55 @@
+// A minimal SemVer range checker — just the operators the manifests actually use
+// (exact, ^, ~, >=, *). Pure and self-contained so dependency verification has no
+// runtime dependency and is trivially testable.
+
+export interface SemVer {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+export function parse(version: string): SemVer | null {
+  const match = version
+    .trim()
+    .replace(/^[v=]/, '')
+    .match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return null;
+  return { major: Number(match[1]), minor: Number(match[2]), patch: Number(match[3]) };
+}
+
+export function compare(a: SemVer, b: SemVer): number {
+  return a.major - b.major || a.minor - b.minor || a.patch - b.patch;
+}
+
+// Caret: compatible within the left-most non-zero segment.
+//   ^1.2.3 → >=1.2.3 <2.0.0 ; ^0.1.2 → >=0.1.2 <0.2.0 ; ^0.0.3 → >=0.0.3 <0.0.4
+function caretUpper(base: SemVer): SemVer {
+  if (base.major > 0) return { major: base.major + 1, minor: 0, patch: 0 };
+  if (base.minor > 0) return { major: 0, minor: base.minor + 1, patch: 0 };
+  return { major: 0, minor: 0, patch: base.patch + 1 };
+}
+
+// Tilde: allow patch-level changes.  ~1.2.3 → >=1.2.3 <1.3.0
+function tildeUpper(base: SemVer): SemVer {
+  return { major: base.major, minor: base.minor + 1, patch: 0 };
+}
+
+export function satisfies(version: string, range: string): boolean {
+  const v = parse(version);
+  if (!v) return false;
+  const r = range.trim();
+  if (r === '' || r === '*' || r === 'latest') return true;
+
+  if (r.startsWith('^') || r.startsWith('~')) {
+    const base = parse(r.slice(1));
+    if (!base) return false;
+    const upper = r.startsWith('^') ? caretUpper(base) : tildeUpper(base);
+    return compare(v, base) >= 0 && compare(v, upper) < 0;
+  }
+  if (r.startsWith('>=')) {
+    const base = parse(r.slice(2));
+    return base ? compare(v, base) >= 0 : false;
+  }
+  const exact = parse(r);
+  return exact ? compare(v, exact) === 0 : false;
+}

--- a/packages/workspace-tools/src/core/verify.test.ts
+++ b/packages/workspace-tools/src/core/verify.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import type { Graph } from './graph';
+import { verify } from './verify';
+
+function graph(overrides: Partial<Graph> = {}): Graph {
+  const server = {
+    name: 'server',
+    dir: 'server',
+    manifest: 'server/Cargo.toml',
+    version: '0.1.38',
+    deps: [],
+  };
+  return {
+    server,
+    projects: [
+      server,
+      {
+        name: 'tv.kroma.torrents',
+        dir: 'modules/tv.kroma.torrents',
+        manifest: 'modules/tv.kroma.torrents/module.json',
+        version: '0.1.7',
+        deps: [],
+        minServer: '0.1.4',
+      },
+      {
+        name: 'tv.kroma.acquisition',
+        dir: 'modules/tv.kroma.acquisition',
+        manifest: 'modules/tv.kroma.acquisition/module.json',
+        version: '0.1.8',
+        deps: ['tv.kroma.torrents'],
+        ranges: { 'tv.kroma.torrents': '^0.1.0' },
+        minServer: '0.1.4',
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('verify', () => {
+  it('passes a coherent graph', () => {
+    expect(verify(graph())).toEqual([]);
+  });
+
+  it('flags a dependency version outside the declared range', () => {
+    const g = graph();
+    const torrents = g.projects.find((p) => p.name === 'tv.kroma.torrents');
+    if (torrents) torrents.version = '0.2.0'; // jumps a minor; ^0.1.0 no longer holds
+    const violations = verify(g);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject({ project: 'tv.kroma.acquisition', kind: 'range' });
+  });
+
+  it('flags a missing dependency', () => {
+    const g = graph();
+    const acquisition = g.projects.find((p) => p.name === 'tv.kroma.acquisition');
+    if (acquisition) acquisition.ranges = { 'tv.kroma.ghost': '^0.1.0' };
+    expect(verify(g)[0]).toMatchObject({ kind: 'missing-dep' });
+  });
+
+  it('flags a server below a module minServer', () => {
+    const g = graph({
+      server: {
+        name: 'server',
+        dir: 'server',
+        manifest: 'server/Cargo.toml',
+        version: '0.1.2',
+        deps: [],
+      },
+    });
+    expect(verify(g).some((v) => v.kind === 'min-server')).toBe(true);
+  });
+});

--- a/packages/workspace-tools/src/core/verify.ts
+++ b/packages/workspace-tools/src/core/verify.ts
@@ -1,0 +1,57 @@
+import { byName, type Graph } from './graph';
+import { satisfies } from './range';
+
+export type ViolationKind = 'missing-dep' | 'range' | 'min-server';
+
+export interface Violation {
+  project: string;
+  kind: ViolationKind;
+  detail: string;
+}
+
+// Check that every declared dependency actually resolves against the versions in
+// the graph: each `dependsOn` range is satisfied by the current version of the
+// depended project, and each `minServer` is met by the server. Returns the list
+// of violations (empty = the dependency graph is coherent). Pure.
+export function verify(graph: Graph): Violation[] {
+  const projects = byName(graph);
+  const violations: Violation[] = [];
+
+  for (const project of graph.projects) {
+    for (const [dep, range] of Object.entries(project.ranges ?? {})) {
+      const target = projects.get(dep);
+      if (!target) {
+        violations.push({
+          project: project.name,
+          kind: 'missing-dep',
+          detail: `depends on "${dep}", which is not in the workspace`,
+        });
+        continue;
+      }
+      if (!satisfies(target.version, range)) {
+        violations.push({
+          project: project.name,
+          kind: 'range',
+          detail: `needs ${dep}@${range}, but ${dep} is ${target.version}`,
+        });
+      }
+    }
+
+    if (project.minServer) {
+      if (!graph.server) {
+        violations.push({
+          project: project.name,
+          kind: 'min-server',
+          detail: `requires server >= ${project.minServer}, but no server is in the workspace`,
+        });
+      } else if (!satisfies(graph.server.version, `>=${project.minServer}`)) {
+        violations.push({
+          project: project.name,
+          kind: 'min-server',
+          detail: `requires server >= ${project.minServer}, but server is ${graph.server.version}`,
+        });
+      }
+    }
+  }
+  return violations;
+}

--- a/packages/workspace-tools/src/index.ts
+++ b/packages/workspace-tools/src/index.ts
@@ -1,0 +1,9 @@
+// Public API. Import these to analyse any workspace: build a graph, find the
+// projects a change affects (transitively), and verify the dependency edges.
+
+export { affected, directlyChanged } from './core/affected';
+export { byName, dependents, type Graph, type Project } from './core/graph';
+export { compare, parse, type SemVer, satisfies } from './core/range';
+export { type Violation, type ViolationKind, verify } from './core/verify';
+export { changedFiles, type Exec } from './io/git';
+export { loadGraph } from './io/load';

--- a/packages/workspace-tools/src/index.ts
+++ b/packages/workspace-tools/src/index.ts
@@ -7,3 +7,5 @@ export { compare, parse, type SemVer, satisfies } from './core/range';
 export { type Violation, type ViolationKind, verify } from './core/verify';
 export { changedFiles, type Exec } from './io/git';
 export { loadGraph } from './io/load';
+export { type Registries, registryFor } from './registry/routing';
+export { type DependencySource, type DependencySpec, parseDependency } from './registry/spec';

--- a/packages/workspace-tools/src/io/git.ts
+++ b/packages/workspace-tools/src/io/git.ts
@@ -1,0 +1,14 @@
+import { execFileSync } from 'node:child_process';
+
+export type Exec = (cmd: string, args: string[]) => string;
+
+const realExec: Exec = (cmd, args) => execFileSync(cmd, args, { encoding: 'utf8' });
+
+// Repo-relative paths changed in a range (e.g. `v0.1.38..HEAD`). Injectable exec
+// so the caller is testable and a host can feed a canned diff.
+export function changedFiles(range: string, exec: Exec = realExec): string[] {
+  return exec('git', ['diff', '--name-only', range])
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}

--- a/packages/workspace-tools/src/io/load.ts
+++ b/packages/workspace-tools/src/io/load.ts
@@ -1,0 +1,109 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { Graph, Project } from '../core/graph';
+
+// Read a repo into a Graph. This is the only filesystem-touching code; the graph
+// algorithms operate on its output, not on disk. Conventions are Kroma's but
+// obvious: a Rust server, JS workspaces, and `.kmod` modules under modules/.
+
+interface LoadOptions {
+  root: string;
+  // Directories to scan for JS `package.json` projects.
+  workspaceRoots?: string[];
+  serverManifest?: string;
+  modulesDir?: string;
+}
+
+function readJson(path: string): Record<string, unknown> | null {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8')) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function subdirs(root: string, rel: string): string[] {
+  const abs = join(root, rel);
+  if (!existsSync(abs)) return [];
+  return readdirSync(abs, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => `${rel}/${e.name}`);
+}
+
+function cargoVersion(text: string): string {
+  return text.match(/^version[ \t]*=[ \t]*"([^"]+)"/m)?.[1] ?? '0.0.0';
+}
+
+export function loadGraph(options: LoadOptions): Graph {
+  const {
+    root,
+    workspaceRoots = ['packages', 'clients', 'apps'],
+    serverManifest = 'server/Cargo.toml',
+    modulesDir = 'modules',
+  } = options;
+
+  const projects: Project[] = [];
+  let server: Project | undefined;
+
+  // The Rust server.
+  const serverPath = join(root, serverManifest);
+  if (existsSync(serverPath)) {
+    server = {
+      name: 'server',
+      dir: serverManifest.replace(/\/Cargo\.toml$/, ''),
+      manifest: serverManifest,
+      version: cargoVersion(readFileSync(serverPath, 'utf8')),
+      deps: [],
+    };
+    projects.push(server);
+  }
+
+  // JS workspace projects. First pass records names so the second can resolve
+  // internal dependency edges (a dep is "internal" when it names another project).
+  const npm: Array<{ project: Project; rawDeps: string[] }> = [];
+  for (const wsRoot of workspaceRoots) {
+    for (const dir of subdirs(root, wsRoot)) {
+      const pkg = readJson(join(root, dir, 'package.json'));
+      if (!pkg || typeof pkg.name !== 'string') continue;
+      const deps = {
+        ...(pkg.dependencies as Record<string, string> | undefined),
+        ...(pkg.devDependencies as Record<string, string> | undefined),
+      };
+      npm.push({
+        project: {
+          name: pkg.name,
+          dir,
+          manifest: `${dir}/package.json`,
+          version: typeof pkg.version === 'string' ? pkg.version : '0.0.0',
+          deps: [],
+        },
+        rawDeps: Object.keys(deps),
+      });
+    }
+  }
+  const npmNames = new Set(npm.map((n) => n.project.name));
+  for (const { project, rawDeps } of npm) {
+    project.deps = rawDeps.filter((d) => npmNames.has(d));
+    projects.push(project);
+  }
+
+  // `.kmod` modules: version, dependency ranges, and the server floor.
+  for (const dir of subdirs(root, modulesDir)) {
+    const manifest = readJson(join(root, dir, 'module.json'));
+    if (!manifest || typeof manifest.id !== 'string') continue;
+    const dependsOn = manifest.dependsOn;
+    const ranges =
+      dependsOn && !Array.isArray(dependsOn) ? (dependsOn as Record<string, string>) : undefined;
+    projects.push({
+      name: manifest.id,
+      dir,
+      manifest: `${dir}/module.json`,
+      version: typeof manifest.version === 'string' ? manifest.version : '0.0.0',
+      deps: ranges ? Object.keys(ranges) : [],
+      ranges,
+      minServer: typeof manifest.minServer === 'string' ? manifest.minServer : undefined,
+    });
+  }
+
+  return { projects, server };
+}

--- a/packages/workspace-tools/src/registry/routing.test.ts
+++ b/packages/workspace-tools/src/registry/routing.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { registryFor } from './routing';
+
+const registries = {
+  default: 'https://modules.kroma.tv',
+  byPrefix: {
+    'com.acme': 'https://modules.acme.dev',
+    'com.acme.internal': 'https://internal.acme.dev',
+  },
+};
+
+describe('registryFor', () => {
+  it('falls back to the default for an unmatched id', () => {
+    expect(registryFor('tv.kroma.torrents', registries)).toBe('https://modules.kroma.tv');
+  });
+
+  it('routes a matching group to its registry', () => {
+    expect(registryFor('com.acme.foo', registries)).toBe('https://modules.acme.dev');
+  });
+
+  it('prefers the longest matching prefix', () => {
+    expect(registryFor('com.acme.internal.x', registries)).toBe('https://internal.acme.dev');
+  });
+
+  it('respects the reverse-DNS boundary (no partial-segment match)', () => {
+    expect(registryFor('com.acmeworks.foo', registries)).toBe('https://modules.kroma.tv');
+  });
+
+  it('matches a prefix exactly', () => {
+    expect(registryFor('com.acme', registries)).toBe('https://modules.acme.dev');
+  });
+
+  it('works with no prefix map', () => {
+    expect(registryFor('anything', { default: 'https://d' })).toBe('https://d');
+  });
+});

--- a/packages/workspace-tools/src/registry/routing.ts
+++ b/packages/workspace-tools/src/registry/routing.ts
@@ -1,0 +1,29 @@
+// Route a module id to the registry that serves it, Gradle-style: a map of
+// reverse-DNS group prefixes to registry URLs, longest-prefix-wins, with a
+// default (the Kroma registry) for everything unmatched. Pure.
+
+export interface Registries {
+  // The fallback registry for any id no prefix matches (and for tv.kroma.* by
+  // convention, if not overridden).
+  default: string;
+  // group prefix → registry URL, e.g. { "com.acme": "https://modules.acme.dev" }.
+  byPrefix?: Record<string, string>;
+}
+
+// Whether `id` is inside the reverse-DNS `prefix` (exact, or a `.`-delimited
+// child — so "com.ac" does not match "com.acme.foo").
+function underPrefix(id: string, prefix: string): boolean {
+  return id === prefix || id.startsWith(`${prefix}.`);
+}
+
+export function registryFor(id: string, registries: Registries): string {
+  let url = registries.default;
+  let matched = -1;
+  for (const [prefix, candidate] of Object.entries(registries.byPrefix ?? {})) {
+    if (underPrefix(id, prefix) && prefix.length > matched) {
+      url = candidate;
+      matched = prefix.length;
+    }
+  }
+  return url;
+}

--- a/packages/workspace-tools/src/registry/spec.test.ts
+++ b/packages/workspace-tools/src/registry/spec.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { parseDependency } from './spec';
+
+describe('parseDependency', () => {
+  it('reads a bare range as the default source', () => {
+    expect(parseDependency('^0.1.0')).toEqual({ range: '^0.1.0', source: { kind: 'default' } });
+  });
+
+  it('reads a git source with a range fragment', () => {
+    expect(parseDependency('git+https://x.dev/bar#^0.3.0')).toEqual({
+      range: '^0.3.0',
+      source: { kind: 'git', url: 'https://x.dev/bar' },
+    });
+  });
+
+  it('defaults a git source with no fragment to any', () => {
+    expect(parseDependency('git+https://x.dev/bar')).toEqual({
+      range: '*',
+      source: { kind: 'git', url: 'https://x.dev/bar' },
+    });
+  });
+
+  it('reads a range pinned to a registry', () => {
+    expect(parseDependency('^2.0.0@https://npm.corp')).toEqual({
+      range: '^2.0.0',
+      source: { kind: 'registry', url: 'https://npm.corp' },
+    });
+  });
+
+  it('does not treat a non-url @ as a registry pin', () => {
+    expect(parseDependency('^1.0.0@beta').source).toEqual({ kind: 'default' });
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(parseDependency('  ^1.2.3  ').range).toBe('^1.2.3');
+  });
+});

--- a/packages/workspace-tools/src/registry/spec.ts
+++ b/packages/workspace-tools/src/registry/spec.ts
@@ -1,0 +1,40 @@
+// Parse a dependency value the way npm's dependency-string grammar does: the
+// common case is a bare SemVer range, with two opt-in inline sources for the
+// rare one-off. Pure and total — an unrecognised shape is treated as a range,
+// never throws.
+
+export type DependencySource =
+  // A bare range: resolved through the registries routing (default = Kroma).
+  | { kind: 'default' }
+  // `<range>@<registry-url>` — pin this one dependency to a specific registry.
+  | { kind: 'registry'; url: string }
+  // `git+<url>#<range>` — a one-off git source.
+  | { kind: 'git'; url: string };
+
+export interface DependencySpec {
+  range: string;
+  source: DependencySource;
+}
+
+export function parseDependency(value: string): DependencySpec {
+  const spec = value.trim();
+
+  // git+https://…/repo#^0.3.0  (the range is the fragment; absent → any)
+  if (spec.startsWith('git+')) {
+    const hash = spec.lastIndexOf('#');
+    const hasRange = hash > 'git+'.length;
+    return {
+      range: hasRange ? spec.slice(hash + 1) : '*',
+      source: { kind: 'git', url: hasRange ? spec.slice(4, hash) : spec.slice(4) },
+    };
+  }
+
+  // ^2.0.0@https://npm.corp  — only when the `@` introduces a URL scheme, so a
+  // future scoped id in a value can never be mistaken for a registry pin.
+  const at = spec.search(/@(?=https?:\/\/)/);
+  if (at > 0) {
+    return { range: spec.slice(0, at), source: { kind: 'registry', url: spec.slice(at + 1) } };
+  }
+
+  return { range: spec, source: { kind: 'default' } };
+}

--- a/packages/workspace-tools/tsconfig.json
+++ b/packages/workspace-tools/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "lib": ["ES2022"],
+    "types": ["bun-types"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
The analysis half of the release-flow work (the build half stays in the existing scripts). A project-agnostic `@kroma/workspace-tools`, pure core + 14 tests.

## What it does
- **Dependency graph** from the native manifests — server `Cargo.toml`, JS `package.json` workspaces, `.kmod` `module.json` (with `dependsOn` + `minServer`).
- **`affected(changedPaths)`** — the projects a change touches, **transitively**. A dependency bump is just a change to that dependency's project, so its dependents fall out of the same walk. Answers "detect changes per project" and "detect dependency changes".
- **`verify(graph)`** — every module `dependsOn` range is satisfied by the depended project's current version, and every `minServer` is met by the server. Answers "verify if dependencies work" and "detect a kmod dependency that needs bumping". Self-contained SemVer range checker (`^`, `~`, `>=`, exact, incl. 0.x caret).

## CLI
    workspace-tools affected --since <range>   # list affected projects
    workspace-tools verify                     # check every edge + minServer

## Deliberately NOT here: building wgt/ipa
Packaging/signing already lives in `build:tizen` / `build:tv-native` / the `_release-*.yml` — 4000 lines you want to shrink, not duplicate. This names the affected artifacts; wiring `affected` into the existing `build:*` scripts is the follow-up, and it belongs in a workflow (needs `workflow` scope).

## Verified
`workspace-tools verify` on the real repo → **Dependencies OK — 45 projects, every edge resolves**. `affected --since v0.1.38` correctly fans a `packages/ui` change out to every client. Pure core is 14 unit tests; tsc + biome clean.
