### PR TITLE
fix(ci): install before publishing the modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,8 +346,10 @@ jobs:
         with:
           components: clippy, rustfmt
 
-      # Only to drive the per-module cargo runs below (`bun run modules cargo`);
-      # no `bun install` needed, the script imports nothing from node_modules.
+      # Only to drive the per-module cargo runs below (`bun run modules cargo`).
+      # No `bun install`: that ONE command reaches nothing outside module-tools.
+      # Adding an import from another workspace package to it - the way `release`
+      # now reaches `@kroma/registry` - breaks this job, so check before you do.
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: ${{ env.BUN_VERSION }}

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -219,6 +219,12 @@ jobs:
         with:
           bun-version: ${{ env.BUN_VERSION }}
 
+      # `modules release` reads the registry contract (`@kroma/registry`) to
+      # order versions, so this job needs the workspace links like any other.
+      # It went without one for as long as module-tools had no dependencies.
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
       - name: Collect every target's bundles
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:


### PR DESCRIPTION
The first release train after #111 died on `Cannot find module '@kroma/registry'`, after all three build matrices had succeeded — so twelve module releases were built and none were published.

`modules release` reads the registry contract to order versions against what is live, and the publish job never ran `bun install`. It did not have to while `module-tools` depended on nothing; it does now.

Also sharpens the matching comment in `ci.yml`. That job genuinely needs no install, because `modules cargo` reaches nothing outside its own package — but the comment read like a property of the CLI rather than of that one command, which is the reading that let this through.

Verified: the three build jobs on run 32223600603 succeeded; only `Publish the module releases` failed, at the first step that runs the CLI.