### PR TITLE
fix(modules): a module's grant and its own tables, as found on a real server

### DIFF
--- a/modules/tv.kroma.torrents/server/src/downloads/mod.rs
+++ b/modules/tv.kroma.torrents/server/src/downloads/mod.rs
@@ -108,7 +108,7 @@ impl DownloadManager {
     pub async fn start_rqbit(&self, host: &dyn HostCtx) {
         // Never bring the engine up while the embedded client is disabled; a
         // missing row means first boot before seeding, treated as enabled.
-        if let Ok(conn) = self.core().get() {
+        if let Ok(conn) = self.store().get() {
             if let Ok(Some(c)) = db::get_download_client(&conn, db::EMBEDDED_CLIENT_ID) {
                 if !c.enabled {
                     drop(conn);
@@ -688,9 +688,11 @@ impl DownloadManager {
     }
 
     fn row_and_client(&self, id: &str) -> Result<(DownloadRow, DownloadClientRow)> {
-        let conn = self.core().get()?;
-        let row = db::get_download(&conn, id)?.ok_or_else(|| anyhow!("download not found"))?;
-        let client = db::get_download_client(&conn, &row.client_id)?
+        let ledger = self.core().get()?;
+        let row = db::get_download(&ledger, id)?.ok_or_else(|| anyhow!("download not found"))?;
+        drop(ledger);
+        let clients = self.store().get()?;
+        let client = db::get_download_client(&clients, &row.client_id)?
             .ok_or_else(|| anyhow!("download client no longer configured"))?;
         Ok((row, client))
     }

--- a/modules/tv.kroma.torrents/server/src/routes/clients.rs
+++ b/modules/tv.kroma.torrents/server/src/routes/clients.rs
@@ -54,7 +54,7 @@ pub async fn list<S: HostStorage + Clone + Send + Sync + 'static>(
     AuthUser(user): AuthUser,
 ) -> Result<Response, Response> {
     state.require(&user, Permission::SettingsManage)?;
-    let view = query(state.db(), |pool| {
+    let view = query(state.store(), |pool| {
         let conn = pool.get()?;
         let clients = db::list_download_clients(&conn)?.iter().map(view_of).collect();
         Ok(DownloadClientsView { clients, rqbit_compiled: crate::RQBIT_COMPILED })
@@ -96,7 +96,7 @@ pub async fn create<S: HostStorage + Clone + Send + Sync + 'static>(
         created_at: now_ms(),
     };
     let view = view_of(&row);
-    query(state.db(), move |pool| db::insert_download_client(&pool, &row)).await?;
+    query(state.store(), move |pool| db::insert_download_client(&pool, &row)).await?;
     Ok(Json(view).into_response())
 }
 
@@ -110,7 +110,7 @@ pub async fn update<S: HostStorage + Clone + Send + Sync + 'static>(
 ) -> Result<Response, Response> {
     state.require(&user, Permission::SettingsManage)?;
     let id2 = id.clone();
-    let updated = query(state.db(), move |pool| {
+    let updated = query(state.store(), move |pool| {
         db::update_download_client(
             &pool,
             &id2,
@@ -150,7 +150,7 @@ pub async fn update<S: HostStorage + Clone + Send + Sync + 'static>(
         }
     }
     let id3 = id.clone();
-    let row = query(state.db(), move |pool| {
+    let row = query(state.store(), move |pool| {
         let conn = pool.get()?;
         Ok(db::get_download_client(&conn, &id3)?)
     })
@@ -171,7 +171,7 @@ pub async fn remove<S: HostStorage + Clone + Send + Sync + 'static>(
     if id == EMBEDDED_CLIENT_ID {
         return Err(json_error(StatusCode::BAD_REQUEST, "the embedded engine cannot be deleted"));
     }
-    let deleted = query(state.db(), move |pool| db::delete_download_client(&pool, &id)).await?;
+    let deleted = query(state.store(), move |pool| db::delete_download_client(&pool, &id)).await?;
     if !deleted {
         return Err(state.lerr(&user, StatusCode::NOT_FOUND, "error.clientNotFound"));
     }
@@ -189,7 +189,7 @@ pub async fn test<S: HostStorage + Clone + Send + Sync + 'static>(
     // localized not-found response.
     let st = state.clone();
     let result = blocking(move || {
-        let conn = st.db().get()?;
+        let conn = st.store().get()?;
         let Some(row) = db::get_download_client(&conn, &id)? else {
             return Ok(None);
         };

--- a/modules/tv.kroma.torrents/server/src/routes/queue.rs
+++ b/modules/tv.kroma.torrents/server/src/routes/queue.rs
@@ -67,11 +67,18 @@ pub async fn list<S: HostStorage + Clone + Send + Sync + 'static>(
             .into_iter()
             .map(|i| (i.id, i.name))
             .collect();
+    // The client names come from this module's OWN database; the ledger below
+    // from the shared one. Two files, so two lookups: resolved here because the
+    // blocking closure gets only the one pool.
+    let clients: std::collections::HashMap<String, String> = query(state.store(), |pool| {
+        let conn = pool.get()?;
+        Ok(db::list_download_clients(&conn)?.into_iter().map(|c| (c.id, c.name)).collect())
+    })
+    .await
+    .unwrap_or_default();
     let view = query(state.db(), move |pool| {
         let conn = pool.get()?;
         let rows = db::list_downloads(&conn, HISTORY_LIMIT)?;
-        let clients: std::collections::HashMap<String, String> =
-            db::list_download_clients(&conn)?.into_iter().map(|c| (c.id, c.name)).collect();
         let downloads = rows
             .into_iter()
             .map(|d| {

--- a/modules/tv.kroma.torrents/server/tests/grant.rs
+++ b/modules/tv.kroma.torrents/server/tests/grant.rs
@@ -120,3 +120,49 @@ fn this_modules_migrations_build_its_own_table_and_leave_the_shared_one_alone() 
     assert_eq!(table("download_clients"), 1, "the credentials table is this module's own");
     assert_eq!(table("downloads"), 0, "the shared ledger belongs to the core schema");
 }
+
+#[test]
+fn the_client_configs_are_read_from_this_modules_own_database() {
+    // Four call sites read `download_clients` off the CORE pool after the table
+    // moved into this module's file, and each one failed the same way in
+    // production: "no such table: download_clients". The table is not in the
+    // core schema at all, so anything still looking there cannot work -- which
+    // is what this asserts, from the manager down.
+    let core = db::testing::temp_pool("torrents-clients");
+    let store = core.store();
+    {
+        let conn = store.get().unwrap();
+        db::apply_migrations(&conn, kroma_torrent::db::MIGRATIONS).unwrap();
+    }
+    let dir = kroma_testing::temp_dir("torrents-clients-dir");
+    let manager =
+        kroma_torrent::DownloadManager::new(dir.path(), (*core).clone(), store.clone());
+
+    // Seeding the embedded engine writes the module's own file. Without the
+    // `rqbit` feature there is no embedded engine to seed, so the seed is a
+    // no-op by design and the row below is the one this test puts there.
+    manager.seed_embedded_client();
+    if !kroma_torrent::RQBIT_COMPILED {
+        let conn = store.get().unwrap();
+        conn.execute(
+            "INSERT INTO download_clients (id,kind,name,password,enabled,priority,created_at) \
+             VALUES ('qb','qbittorrent','qBit','hunter2',1,0,1)",
+            [],
+        )
+        .unwrap();
+    }
+    let seeded = kroma_torrent::db::list_download_clients(&store.get().unwrap()).unwrap();
+    assert_eq!(seeded.len(), 1, "the client config is in this module's database");
+
+    // ...and the shared database has no such table to have written it into.
+    let absent: i64 = core
+        .get()
+        .unwrap()
+        .query_row(
+            "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='download_clients'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(absent, 0, "the credentials table is not in the shared database");
+}

--- a/server/crates/kroma-module-supervisor/src/lib.rs
+++ b/server/crates/kroma-module-supervisor/src/lib.rs
@@ -194,8 +194,14 @@ impl Supervisor {
 
     /// What `id` declared under `storage`, or `None` when it declared none -- in
     /// which case it holds no database capability at all.
+    ///
+    /// Read off disk rather than out of [`installed_manifests`](Self::installed_manifests),
+    /// which is cached: this is what a module's grant is built from, and a grant
+    /// one version out of date is not a stale listing, it is a module that gets
+    /// the wrong answer to every query. One small file, read once per spawn.
     fn storage_of(&self, id: &str) -> Option<kroma_module_manifest::Storage> {
-        self.installed_manifests().into_iter().find(|m| m.id == id).and_then(|m| m.storage)
+        let text = std::fs::read_to_string(self.dir(id).join("module.json")).ok()?;
+        serde_json::from_str::<ModuleManifest>(&text).ok()?.storage
     }
 
     /// Move any table `id` declared as its own out of the core database and into
@@ -514,6 +520,14 @@ impl Supervisor {
             let dest = self.dir(&id);
             let _ = std::fs::remove_dir_all(&dest);
             std::fs::rename(&staging, &dest)?;
+            // BEFORE anything reads a manifest again, and `spawn` below is one
+            // such reader: it builds the module's storage grant from what the
+            // manifest declares. Invalidating only at the end of this function
+            // meant a module installed and started in one go was spawned with
+            // the grant its PREVIOUS version declared -- for an upgrade from a
+            // version that predates `storage`, the empty one, so every query it
+            // made was denied.
+            self.invalidate_manifests();
             #[cfg(unix)]
             {
                 use std::os::unix::fs::PermissionsExt;
@@ -1192,7 +1206,7 @@ async fn tmdb_config<S: HostCtx>(State(host): State<S>) -> Json<Value> {
 
 #[cfg(test)]
 mod tests {
-    use super::{grant_json, registry_document_url};
+    use super::{grant_json, registry_document_url, Supervisor, SupervisorConfig};
 
     #[test]
     fn a_registry_root_resolves_to_the_descriptor_at_the_well_known_path() {
@@ -1252,5 +1266,60 @@ mod tests {
         let private_only = kroma_module_manifest::Storage::default();
         let json = grant_json(Some(&private_only));
         assert_eq!(serde_json::from_str::<kroma_db::Grant>(&json).unwrap(), kroma_db::Grant::none());
+    }
+
+    #[test]
+    fn a_modules_grant_comes_off_disk_even_when_the_listing_cache_is_stale() {
+        // The failure this pins cost every acquisition job on a real server.
+        // `install` writes the new bundle and then spawns it, and `spawn` builds
+        // the module's storage grant. Reading that grant from the CACHED listing
+        // meant an upgrade handed the new binary the grant its PREVIOUS version
+        // declared -- upgrading from a version that predates `storage`, the
+        // empty one, so every query it made came back "authorization denied".
+        let dir = kroma_testing::temp_dir("grant-stale-cache");
+        let sup = Supervisor::new(SupervisorConfig {
+            modules_dir: dir.path().to_path_buf(),
+            core_url: "http://127.0.0.1:0".into(),
+            host_token: "t".into(),
+            db_path: dir.path().join("db.sqlite"),
+            data_dir: dir.path().to_path_buf(),
+            reserved_ids: Vec::new(),
+            server_version: "0.1.4".into(),
+            log_line: None,
+        });
+
+        let write = |body: &str| {
+            let d = dir.path().join("com.example.demo");
+            std::fs::create_dir_all(&d).unwrap();
+            std::fs::write(d.join("module.json"), body).unwrap();
+        };
+        let v = kroma_module_manifest::MODULE_SCHEMA_VERSION;
+
+        // v1 declares no storage, and listing it warms the cache.
+        write(&format!(
+            r#"{{ "schemaVersion": {v}, "id": "com.example.demo", "name": "D", "version": "1.0.0" }}"#
+        ));
+        assert_eq!(sup.installed_manifests().len(), 1);
+        assert!(sup.storage_of("com.example.demo").is_none());
+
+        // v2 declares one. The cache is deliberately NOT invalidated here: this
+        // is the window `install` used to spawn in.
+        write(&format!(
+            r#"{{ "schemaVersion": {v}, "id": "com.example.demo", "name": "D", "version": "2.0.0",
+                  "storage": {{ "core": {{ "read": ["requests"], "write": ["wanted"] }} }} }}"#
+        ));
+        assert_eq!(
+            sup.installed_manifests()[0].version,
+            "1.0.0",
+            "the listing is still stale, which is the whole point"
+        );
+
+        let storage = sup.storage_of("com.example.demo").expect("the grant comes off disk");
+        assert_eq!(storage.core.read, ["requests"]);
+        assert_eq!(storage.core.write, ["wanted"]);
+
+        // ...and it is what would reach the sidecar.
+        let back: kroma_db::Grant = serde_json::from_str(&grant_json(Some(&storage))).unwrap();
+        assert_eq!(back.read, ["requests"]);
     }
 }


### PR DESCRIPTION
Follow-up to #114. Two faults it shipped, both only reachable on the **upgrade**
path, which is why the suite was green: every test installed a module fresh, and
neither bug can happen that way.

Found by reading a live server's logs after the 0.2.0 modules went out.

## What the server showed

```
[acquisition] WARN kroma_db::grant: module storage grant does not cover this statement
              module=tv.kroma.acquisition denied=read requests.id
[acquisition] import failed: access to requests.id is prohibited
[torrents]    ERROR database error: no such table: download_clients
```

Reading the live process environments settled the first one:

| module | `KROMA_MODULE_GRANT` | |
|---|---|---|
| `tv.kroma.acquisition` | `{}` | wrong — its manifest declares 18 reads |
| `tv.kroma.torrents` | `{"read":[…18…],"write":[…]}` | correct |
| `tv.kroma.indexer` | `{"read":[],"write":[]}` | correct (adopt-only) |

## 1. A module was spawned with the previous version's grant

`install()` spawns the module and *then* calls `invalidate_manifests()`. `spawn`
builds the storage grant from that cache, so a module installed and started in
one go ran with the grant its **previous** version declared. Upgrading from a
version that predates `storage` meant the empty grant, and every query the new
binary made came back `authorization denied`.

torrents and indexer happened to be installed twice during the boot sequence, so
their second spawn read a fresh cache and they were fine. acquisition was
installed once, and every acquisition job on the box failed.

`storage_of` now reads the module's own `module.json` off disk rather than the
cached listing. It is one small file per spawn, spawning is rare, and a grant one
version out of date is not a stale listing — it is a module that gets the wrong
answer to every query. The invalidation also moves ahead of the spawn.

## 2. Four readers still looked for `download_clients` in the shared database

The table moved into the module's own file, but the manager was updated and the
rest were not: the client admin routes, the queue route's name lookup, the
embedded-engine enable check, and `row_and_client`. Each failed with `no such
table: download_clients`, which is exactly what the table not being in the core
schema is supposed to mean.

My first pass at this found one of the four by grep. Only walking every
`*_download_client*` call site and checking which pool each `conn` came from
found the others.

## Verified against a real server, not only in tests

Fresh server, fresh data dir, all twelve modules installed from packed `.kmod`s:

- **Reproduced the bug**: installed a storage-stripped acquisition `0.1.9`, then
  upgraded to `0.2.0`. Empty grant before the fix, full correct grant after.
- All 9 sidecars spawn with a grant **matching their manifest**; the 3 library
  modules spawn nothing, as designed.
- `GET /downloads` 200, `/download-clients` 200, `/indexers` 200.
- All four acquisition jobs green.
- Store split correct: `indexer → indexers`, `torrents → download_clients`, core
  keeps the shared `downloads` and `whisper_jobs`.
- **0** grant denials, **0** `no such table`, **0** 500s after the fixed build.

## Tests

Two regressions, and I checked the first genuinely fails against the old code
rather than assuming it did:

- `a_modules_grant_comes_off_disk_even_when_the_listing_cache_is_stale` — warms
  the listing cache with v1, writes v2 underneath it, and asserts the grant
  follows the file. Fails on the pre-fix code.
- `the_client_configs_are_read_from_this_modules_own_database` — pins that the
  client config lives in the module's file and that the shared database has no
  such table to have written it into.

## Still unexplained

On that server, torrents' store is empty — no `download_clients` at all — while
indexer's adopt worked. Locally it behaves correctly, so it may be downstream of
bug 1 on that box, but I would rather flag it than guess. Worth re-checking there
once this ships.
