### PR TITLE
fix(torrents): bump to 0.2.1 so the download-client fix actually ships

### DIFF
--- a/modules/tv.kroma.torrents/module.json
+++ b/modules/tv.kroma.torrents/module.json
@@ -3,7 +3,7 @@
   "schemaVersion": 2,
   "id": "tv.kroma.torrents",
   "name": "Torrent downloads",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "The embedded librqbit download engine + the downloads queue. Transmission and qBittorrent are their own engine sub-modules that plug into this one.",
   "engines": {
     "server": ">=0.1.38"


### PR DESCRIPTION
#115 changed four call sites in `tv.kroma.torrents` and left its version at 0.2.0. The publish step then refused the run on main:

```
✗ tv.kroma.torrents: the bundle changed but the version did not.
  module.json says 0.2.0, which is already published
  differing target(s): aarch64-apple-darwin, aarch64-unknown-linux-musl, x86_64-unknown-linux-musl
```

That guard is doing its job: the Store decides "update available" by comparing versions, so a silent republish reaches nobody. Without this bump the download-client fix sits in the repo and on no one's server.

One line. Every other module reported `unchanged`, so torrents is the only one that needs it.

`^0.2.0` in acquisition and the two engine sub-modules is satisfied by 0.2.1, so no dependent needs touching.