### PR TITLE
fix(player): a buffer hole stops freezing the picture, and stops reading as full

### DIFF
--- a/clients/web/src/features/playback/media-events.test.ts
+++ b/clients/web/src/features/playback/media-events.test.ts
@@ -52,18 +52,59 @@ describe('bindMediaEvents', () => {
     expect(s.setDur).toHaveBeenCalledWith(5885);
   });
 
-  it('reports the buffered end (anchor + last range), or 0 when empty', () => {
+  it('reports the buffer the playhead can reach, not the far side of a hole', () => {
     const fv = fakeVideo();
     const s = mkSetters();
     bindMediaEvents(fv.el, item, s, 100);
     fv.fire('progress');
     expect(s.setBufEnd).toHaveBeenCalledWith(0);
+
     fv.setBuffered([
       [0, 30],
       [50, 80],
     ]);
     fv.fire('progress');
+
+    expect(s.setBufEnd).toHaveBeenCalledWith(130);
+  });
+
+  it('carries the readout across a hole small enough for the engines to skip', () => {
+    const fv = fakeVideo();
+    const s = mkSetters();
+    bindMediaEvents(fv.el, item, s, 100);
+
+    fv.setBuffered([
+      [0, 30],
+      [30.2, 80],
+    ]);
+    fv.fire('progress');
+
     expect(s.setBufEnd).toHaveBeenCalledWith(180);
+  });
+
+  it('reports nothing reachable while the playhead sits in a hole', () => {
+    const fv = fakeVideo({ currentTime: 40 });
+    const s = mkSetters();
+    bindMediaEvents(fv.el, item, s, 100);
+
+    fv.setBuffered([
+      [0, 30],
+      [50, 80],
+    ]);
+    fv.fire('progress');
+
+    expect(s.setBufEnd).toHaveBeenCalledWith(0);
+  });
+
+  it('re-reads the buffer on timeupdate, when no download is in flight', () => {
+    const fv = fakeVideo();
+    const s = mkSetters();
+    bindMediaEvents(fv.el, item, s, 100);
+    fv.setBuffered([[0, 30]]);
+
+    fv.fire('timeupdate');
+
+    expect(s.setBufEnd).toHaveBeenCalledWith(130);
   });
 
   it('maps pause / waiting / playing / volume / rate events', () => {

--- a/clients/web/src/features/playback/media-events.ts
+++ b/clients/web/src/features/playback/media-events.ts
@@ -1,6 +1,7 @@
 // The `<video>` element event wiring; `useVideoPlayback` owns the React
 // state/effects that drive these helpers.
 
+import { reachableBufferEnd } from '@kroma/core';
 import type { MovieView } from '#web/shared/lib/api';
 
 export interface MediaEventSetters {
@@ -44,8 +45,10 @@ export function bindMediaEvents(
     if (total > 0) setDur(total);
     else if (Number.isFinite(v.duration)) setDur(baseSec + v.duration);
   };
-  const onProg = () =>
-    setBufEnd(v.buffered.length ? baseSec + v.buffered.end(v.buffered.length - 1) : 0);
+  const onProg = () => {
+    const end = reachableBufferEnd(v.buffered, v.currentTime);
+    setBufEnd(end > 0 ? baseSec + end : 0);
+  };
   const onPause = () => setPlaying(false);
   const onWaiting = () => setWaiting(true);
   const onPlaying = () => setWaiting(false);
@@ -71,6 +74,9 @@ export function bindMediaEvents(
   v.addEventListener('timeupdate', onTime);
   v.addEventListener('durationchange', onDur);
   v.addEventListener('progress', onProg);
+  // Also on `timeupdate`: the reachable end jumps when the playhead crosses a
+  // hole, and nothing is downloading at that moment for `progress` to fire.
+  v.addEventListener('timeupdate', onProg);
   v.addEventListener('play', onStarted);
   v.addEventListener('pause', onPause);
   v.addEventListener('waiting', onWaiting);
@@ -84,6 +90,7 @@ export function bindMediaEvents(
     v.removeEventListener('timeupdate', onTime);
     v.removeEventListener('durationchange', onDur);
     v.removeEventListener('progress', onProg);
+    v.removeEventListener('timeupdate', onProg);
     v.removeEventListener('play', onStarted);
     v.removeEventListener('pause', onPause);
     v.removeEventListener('waiting', onWaiting);

--- a/clients/web/src/features/playback/video-engine.ts
+++ b/clients/web/src/features/playback/video-engine.ts
@@ -5,18 +5,17 @@
 // so the absolute position is `baseSec + currentTime`, where `baseSec` is the
 // keyframe start the server reports rather than the anchor that was asked for.
 
-import type { AudioTrack, EngineDecision } from '@kroma/core';
+import {
+  type AudioTrack,
+  type EngineDecision,
+  hlsBufferConfig,
+  itemBufferPlan,
+  shakaStreamingConfig,
+} from '@kroma/core';
 import type { WebEnginePref } from '#web/features/playback/engine-pref';
 import { kromaClient, type MovieView } from '#web/shared/lib/api';
 
 export type HlsInstance = import('hls.js').default;
-
-// hls.js defaults cap at 30s/60MB and Shaka's bufferingGoal is only 10s, both
-// too stingy for the server's readrate-1.5 remux, which produces well ahead.
-const FORWARD_BUFFER_SEC = 120;
-const MAX_FORWARD_BUFFER_SEC = 600;
-const BACK_BUFFER_SEC = 60;
-const MAX_BUFFER_BYTES = 500 * 1000 * 1000;
 
 /** The subset of Shaka's live `getStats()` snapshot the stats panel reads; bandwidth
  * is bits/s, times are seconds. */
@@ -152,6 +151,9 @@ export function attachMediaSource(opts: AttachSourceOptions): () => void {
   }
 
   setUseHls(true);
+  // Sized from THIS title's bitrate: a flat seconds goal that a web-dl fits in
+  // asks a remux for gigabytes, and the browser answers by evicting all film.
+  const plan = itemBufferPlan(item);
   // Remuxed from `startSec`; hls.js plays it from relative 0 and the hook adds
   // the server's reported start back to report the absolute position.
   const url = kromaClient().hlsMasterUrl(item.id, decision.aacMaster, startSec, audioRel);
@@ -171,13 +173,7 @@ export function attachMediaSource(opts: AttachSourceOptions): () => void {
       }
       const player = new shaka.Player();
       shakaRef.current = player;
-      player.configure({
-        streaming: {
-          bufferingGoal: FORWARD_BUFFER_SEC,
-          bufferBehind: BACK_BUFFER_SEC,
-          rebufferingGoal: 4,
-        },
-      });
+      player.configure({ streaming: shakaStreamingConfig(plan) });
       player
         .attach(v)
         .then(() => player.load(url))
@@ -212,10 +208,7 @@ export function attachMediaSource(opts: AttachSourceOptions): () => void {
       enableWorker: true,
       lowLatencyMode: false,
       startPosition: 0,
-      maxBufferLength: FORWARD_BUFFER_SEC,
-      maxMaxBufferLength: MAX_FORWARD_BUFFER_SEC,
-      maxBufferSize: MAX_BUFFER_BYTES,
-      backBufferLength: BACK_BUFFER_SEC,
+      ...hlsBufferConfig(plan),
     });
     hlsRef.current = hls;
     hls.loadSource(url);

--- a/clients/web/src/features/playback/web-stats.ts
+++ b/clients/web/src/features/playback/web-stats.ts
@@ -156,8 +156,8 @@ function statsRows(s: WebStatsInput, m: StatsMetrics): ExtraRow[] {
   return rows;
 }
 
-// A low-water mark, not the goal: the engines buffer 120 s ahead, and 10 s is
-// Shaka's own default `bufferingGoal`.
+// A low-water mark, not the goal: the goal is per-title (see `itemBufferPlan`),
+// and 10 s is Shaka's own default `bufferingGoal`.
 const LOW_BUFFER_SEC = 10;
 
 // Bandwidth and bitrate share one chart: the gap between them is the

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,7 @@ export * from './people';
 export * from './permissions';
 export * from './person-facts';
 export * from './platform';
+export * from './playback-buffer';
 export * from './player';
 export * from './push-labels';
 export * from './remote';

--- a/packages/core/src/playback-buffer.test.ts
+++ b/packages/core/src/playback-buffer.test.ts
@@ -1,0 +1,198 @@
+import type { MediaFile, MediaItem } from '@kroma/client';
+import { describe, expect, it } from 'vitest';
+import {
+  bufferPlan,
+  hlsBufferConfig,
+  itemBufferPlan,
+  reachableBufferEnd,
+  shakaStreamingConfig,
+} from './playback-buffer';
+
+function ranges(pairs: [number, number][]): TimeRanges {
+  return {
+    length: pairs.length,
+    start: (i: number) => pairs[i]?.[0] ?? 0,
+    end: (i: number) => pairs[i]?.[1] ?? 0,
+  } as unknown as TimeRanges;
+}
+
+function item(files: Partial<MediaFile>[], over: Partial<MediaItem> = {}): MediaItem {
+  return {
+    id: 'i1',
+    durationMs: 7_200_000,
+    files: files as MediaFile[],
+    defaultFileId: files[0]?.id,
+    ...over,
+  } as unknown as MediaItem;
+}
+
+describe('bufferPlan', () => {
+  it('gives a modest bitrate minutes of buffer', () => {
+    const plan = bufferPlan(4_000_000);
+
+    expect(plan.forwardSec).toBe(120);
+    expect(plan.backSec).toBe(60);
+  });
+
+  it('holds a high bitrate to the bytes a browser will keep', () => {
+    const plan = bufferPlan(16_000_000);
+
+    expect(plan.forwardSec).toBe(30);
+    expect(plan.forwardSec * (16_000_000 / 8)).toBeLessThanOrEqual(plan.maxBytes);
+  });
+
+  it('keeps a floor of buffer even where the byte budget cannot pay for it', () => {
+    const plan = bufferPlan(80_000_000);
+
+    expect(plan.forwardSec).toBe(20);
+    expect(plan.backSec).toBe(10);
+  });
+
+  it('assumes a 1080p web-dl when the bitrate is unknown or nonsense', () => {
+    const assumed = bufferPlan(8_000_000);
+
+    expect(bufferPlan(undefined)).toEqual(assumed);
+    expect(bufferPlan(null)).toEqual(assumed);
+    expect(bufferPlan(0)).toEqual(assumed);
+    expect(bufferPlan(-1)).toEqual(assumed);
+  });
+});
+
+describe('itemBufferPlan', () => {
+  it('divides the default file size by its runtime', () => {
+    const remux = item([{ id: 'f1', size: 60_000_000_000, durationMs: 7_200_000 }]);
+
+    expect(itemBufferPlan(remux).forwardSec).toBe(20);
+  });
+
+  it('prefers the default file over the first one listed', () => {
+    const both = item(
+      [
+        { id: 'f1', size: 60_000_000_000, durationMs: 7_200_000 },
+        { id: 'f2', size: 3_000_000_000, durationMs: 7_200_000 },
+      ],
+      { defaultFileId: 'f2' },
+    );
+
+    expect(itemBufferPlan(both).forwardSec).toBe(120);
+  });
+
+  it('falls back to the runtime on the item when the file carries none', () => {
+    const unprobed = item([{ id: 'f1', size: 14_400_000_000, durationMs: null }]);
+
+    expect(itemBufferPlan(unprobed).forwardSec).toBe(30);
+  });
+
+  it('takes the assumed bitrate for an item with no sized file', () => {
+    expect(itemBufferPlan(item([])).forwardSec).toBe(bufferPlan(undefined).forwardSec);
+    expect(itemBufferPlan(item([{ id: 'f1', size: null }])).forwardSec).toBe(
+      bufferPlan(undefined).forwardSec,
+    );
+  });
+});
+
+describe('reachableBufferEnd', () => {
+  it('ends at the hole rather than reporting the far side of it', () => {
+    expect(
+      reachableBufferEnd(
+        ranges([
+          [0, 30],
+          [50, 80],
+        ]),
+        10,
+      ),
+    ).toBe(30);
+  });
+
+  it('carries across a hole narrow enough for the engines to skip', () => {
+    expect(
+      reachableBufferEnd(
+        ranges([
+          [0, 30],
+          [30.2, 60],
+          [60.4, 90],
+        ]),
+        0,
+      ),
+    ).toBe(90);
+  });
+
+  it('stops at the first hole too wide to skip', () => {
+    expect(
+      reachableBufferEnd(
+        ranges([
+          [0, 30],
+          [30.2, 60],
+          [70, 90],
+        ]),
+        0,
+      ),
+    ).toBe(60);
+  });
+
+  it('reads the range that holds the playhead, not the first one', () => {
+    expect(
+      reachableBufferEnd(
+        ranges([
+          [0, 30],
+          [50, 80],
+        ]),
+        60,
+      ),
+    ).toBe(80);
+  });
+
+  it('reports nothing reachable while the playhead sits in a hole it cannot skip', () => {
+    expect(
+      reachableBufferEnd(
+        ranges([
+          [0, 30],
+          [50, 80],
+        ]),
+        40,
+      ),
+    ).toBe(0);
+  });
+
+  it('reaches a range starting just ahead of the playhead', () => {
+    expect(reachableBufferEnd(ranges([[30.3, 90]]), 30)).toBe(90);
+  });
+
+  it('reports nothing on an empty buffer or past the end of one', () => {
+    expect(reachableBufferEnd(ranges([]), 0)).toBe(0);
+    expect(reachableBufferEnd(ranges([[0, 30]]), 90)).toBe(0);
+  });
+});
+
+describe('engine config', () => {
+  it('hands hls.js the plan plus a hole it will step over', () => {
+    const plan = bufferPlan(4_000_000);
+
+    const cfg = hlsBufferConfig(plan);
+
+    expect(cfg.maxBufferLength).toBe(plan.forwardSec);
+    expect(cfg.maxMaxBufferLength).toBe(plan.forwardSec);
+    expect(cfg.maxBufferSize).toBe(plan.maxBytes);
+    expect(cfg.backBufferLength).toBe(plan.backSec);
+    expect(cfg.maxBufferHole).toBeGreaterThan(0.1);
+    expect(cfg.highBufferWatchdogPeriod).toBeLessThan(2);
+  });
+
+  it('hands Shaka the plan and a stall detector that gives up waiting sooner', () => {
+    const plan = bufferPlan(4_000_000);
+
+    const cfg = shakaStreamingConfig(plan);
+
+    expect(cfg.bufferingGoal).toBe(plan.forwardSec);
+    expect(cfg.bufferBehind).toBe(plan.backSec);
+    expect(cfg.stallThreshold).toBeLessThan(1);
+    expect(cfg.stallSkip).toBeGreaterThan(0.1);
+  });
+
+  it('agrees with the readout on what counts as a skippable hole', () => {
+    const hole = shakaStreamingConfig(bufferPlan(4_000_000)).gapDetectionThreshold;
+
+    expect(hlsBufferConfig(bufferPlan(4_000_000)).maxBufferHole).toBe(hole);
+    expect(reachableBufferEnd(ranges([[hole, 90]]), 0)).toBe(90);
+  });
+});

--- a/packages/core/src/playback-buffer.ts
+++ b/packages/core/src/playback-buffer.ts
@@ -1,0 +1,131 @@
+// How much an MSE engine buffers, and how much of that the playhead can reach.
+// One module because the two answers share a number: the readout bridges exactly
+// the holes the engines are configured to skip, so neither can drift from the other.
+
+import type { MediaItem } from '@kroma/client';
+
+// A remux is segmented at real keyframes while its AAC frames are a fixed
+// 21.33 ms, so ffmpeg's fMP4 output leaves sub-frame holes at segment boundaries
+// that no player can append over. Holes up to this wide are skipped rather than
+// waited on.
+const SKIPPABLE_GAP_SEC = 0.5;
+
+// A SourceBuffer's real ceiling belongs to the user agent, not to us, and a goal
+// that does not fit costs the whole film in evict-and-re-append. So the goal is a
+// byte budget converted to seconds per title, and the budget is hls.js's own
+// default: the figure it ships as safe on every device it runs on, which here
+// includes televisions with far less to spare than a desktop.
+const BUDGET_BYTES = 60 * 1000 * 1000;
+const MIN_FORWARD_SEC = 20;
+const MAX_FORWARD_SEC = 120;
+const MIN_BACK_SEC = 10;
+const MAX_BACK_SEC = 60;
+// What a title runs at when the catalogue has no size to divide: a 1080p web-dl.
+const ASSUMED_BITRATE_BPS = 8_000_000;
+
+/** What one title's buffer may grow to, from [`bufferPlan`]. */
+export interface BufferPlan {
+  /** Forward goal (s), sized so its bytes stay inside the budget. */
+  forwardSec: number;
+  /** Kept behind the playhead (s). */
+  backSec: number;
+  /** Byte ceiling, for the engines that take one. */
+  maxBytes: number;
+}
+
+function clamp(n: number, lo: number, hi: number): number {
+  return Math.min(hi, Math.max(lo, n));
+}
+
+/**
+ * The buffer budget for a stream running at `bitrateBps`. A 4 Mb/s web-dl gets
+ * minutes; an 80 Mb/s remux gets the seconds that fit in the same bytes, because
+ * asking for minutes of one only buys a film-long fight with the browser's quota.
+ */
+export function bufferPlan(bitrateBps?: number | null): BufferPlan {
+  const bitrate = bitrateBps && bitrateBps > 0 ? bitrateBps : ASSUMED_BITRATE_BPS;
+  const forwardSec = Math.round(
+    clamp((BUDGET_BYTES * 8) / bitrate, MIN_FORWARD_SEC, MAX_FORWARD_SEC),
+  );
+  return {
+    forwardSec,
+    backSec: Math.round(clamp(forwardSec / 2, MIN_BACK_SEC, MAX_BACK_SEC)),
+    maxBytes: BUDGET_BYTES,
+  };
+}
+
+// The file the master is remuxed from is the item's own default, which is what
+// the server picks when the URL names none.
+function averageBitrateBps(item: MediaItem): number | undefined {
+  const files = item.files ?? [];
+  const file = files.find((f) => f.id === item.defaultFileId) ?? files[0];
+  const size = file?.size ?? 0;
+  const durationMs = file?.durationMs ?? item.durationMs ?? 0;
+  if (size <= 0 || durationMs <= 0) return undefined;
+  return (size * 8) / (durationMs / 1000);
+}
+
+/** The plan for the file of `item` that will play. */
+export function itemBufferPlan(item: MediaItem): BufferPlan {
+  return bufferPlan(averageBitrateBps(item));
+}
+
+/**
+ * The furthest point the playhead can reach from `t` without waiting on a
+ * download: the end of the range holding it, carried across every hole the
+ * engines skip. `0` when nothing reachable covers `t`.
+ *
+ * `ranges.end(ranges.length - 1)` answers a different question - the far side of
+ * a hole the playhead may be stalled against - and so reads as a healthy buffer
+ * at exactly the moment the picture freezes.
+ */
+export function reachableBufferEnd(ranges: TimeRanges, t: number): number {
+  let end = Number.NaN;
+  for (let i = 0; i < ranges.length; i += 1) {
+    const start = ranges.start(i);
+    const stop = ranges.end(i);
+    if (Number.isNaN(end)) {
+      if (start - t <= SKIPPABLE_GAP_SEC && t <= stop) end = stop;
+    } else if (start - end <= SKIPPABLE_GAP_SEC) {
+      end = stop;
+    } else {
+      break;
+    }
+  }
+  return Number.isNaN(end) ? 0 : end;
+}
+
+/**
+ * hls.js constructor options for `plan`. The gap numbers are the point: hls.js
+ * defaults to a 0.1 s `maxBufferHole` and waits 2 s before nudging one, which on
+ * a keyframe-cut remux is a frozen picture at a segment boundary.
+ */
+export function hlsBufferConfig(plan: BufferPlan) {
+  return {
+    maxBufferLength: plan.forwardSec,
+    maxMaxBufferLength: plan.forwardSec,
+    maxBufferSize: plan.maxBytes,
+    backBufferLength: plan.backSec,
+    maxBufferHole: SKIPPABLE_GAP_SEC,
+    highBufferWatchdogPeriod: 0.5,
+    nudgeOffset: 0.2,
+    nudgeMaxRetry: 6,
+  };
+}
+
+/**
+ * The `streaming` half of a Shaka config for `plan`. Shaka bounds its buffer in
+ * seconds only, so `forwardSec` is the whole of what keeps it inside the byte
+ * budget; its stall detector otherwise sits on a hole for a full second before
+ * stepping over it.
+ */
+export function shakaStreamingConfig(plan: BufferPlan) {
+  return {
+    bufferingGoal: plan.forwardSec,
+    bufferBehind: plan.backSec,
+    rebufferingGoal: 4,
+    gapDetectionThreshold: SKIPPABLE_GAP_SEC,
+    stallThreshold: 0.3,
+    stallSkip: 0.2,
+  };
+}

--- a/packages/tv/src/features/playback/player/htmlEngine.test.ts
+++ b/packages/tv/src/features/playback/player/htmlEngine.test.ts
@@ -394,15 +394,29 @@ describe('HtmlEngine transport getters', () => {
     expect(makeEngine({ fv: c, direct: false, durationSec: 0 }).engine.duration()).toBe(0);
   });
 
-  it('bufferedEnd adds the anchor to the last buffered range end', () => {
+  it('bufferedEnd reports the reachable end, not the far side of a hole', () => {
     const fv = fakeVideo();
     const { engine } = makeEngine({ fv, direct: false });
     expect(engine.bufferedEnd()).toBe(0);
+
     fv.setBuffered([
       [0, 10],
       [20, 55],
     ]);
-    expect(engine.bufferedEnd()).toBe(55);
+
+    expect(engine.bufferedEnd()).toBe(10);
+  });
+
+  it('bufferedEnd carries across a hole the engines skip', () => {
+    const fv = fakeVideo();
+    const { engine } = makeEngine({ fv, direct: false, startSec: 30 });
+
+    fv.setBuffered([
+      [0, 10],
+      [10.3, 55],
+    ]);
+
+    expect(engine.bufferedEnd()).toBe(85);
   });
 
   it('isPaused reflects the element and play/pause drive it', () => {
@@ -560,7 +574,7 @@ describe('HtmlEngine destroy', () => {
   it('detaches every listener and clears the source', () => {
     const fv = fakeVideo();
     const { engine, listeners } = makeEngine({ fv, direct: false });
-    expect(fv.listenerCount('timeupdate')).toBe(1);
+    expect(fv.listenerCount('timeupdate')).toBeGreaterThan(0);
     engine.destroy();
     expect(fv.listenerCount('timeupdate')).toBe(0);
     expect(fv.get('src')).toBe('');

--- a/packages/tv/src/features/playback/player/htmlEngine.ts
+++ b/packages/tv/src/features/playback/player/htmlEngine.ts
@@ -6,9 +6,14 @@
 
 import {
   attachDirectPlay,
+  type BufferPlan,
   decodableAudioCodecs,
+  hlsBufferConfig,
+  itemBufferPlan,
   type KromaClient,
   type MediaItem,
+  reachableBufferEnd,
+  shakaStreamingConfig,
 } from '@kroma/core';
 import {
   type EngineListeners,
@@ -58,6 +63,7 @@ export class HtmlEngine implements TvEngine {
   private readonly v: HTMLVideoElement;
   private readonly opts: HtmlOptions;
   private readonly durSec: number;
+  private readonly plan: BufferPlan;
   private baseSec: number;
   private rendition: number;
   private hls: HlsInstance | null = null;
@@ -71,6 +77,9 @@ export class HtmlEngine implements TvEngine {
     this.opts = opts;
     this.v = opts.video;
     this.durSec = opts.durationSec;
+    // Sized from THIS title's bitrate: a flat seconds goal that a web-dl fits in
+    // asks a remux for gigabytes, and the browser answers by evicting all film.
+    this.plan = itemBufferPlan(opts.item);
     this.baseSec = opts.startSec;
     this.rendition = opts.initialRendition;
     const v = this.v;
@@ -82,8 +91,10 @@ export class HtmlEngine implements TvEngine {
       if (total > 0) L.onDuration(total);
       else if (Number.isFinite(v.duration)) L.onDuration(v.duration);
     };
-    const onProg = () =>
-      L.onBuffered(v.buffered.length ? this.baseSec + v.buffered.end(v.buffered.length - 1) : 0);
+    const onProg = () => {
+      const end = reachableBufferEnd(v.buffered, v.currentTime);
+      L.onBuffered(end > 0 ? this.baseSec + end : 0);
+    };
     const onPlay = () => L.onPlay();
     const onPause = () => L.onPause();
     const onWaiting = () => L.onWaiting();
@@ -101,6 +112,9 @@ export class HtmlEngine implements TvEngine {
       ['timeupdate', onTime],
       ['durationchange', onDur],
       ['progress', onProg],
+      // Also on `timeupdate`: the reachable end jumps when the playhead crosses a
+      // hole, and nothing is downloading at that moment for `progress` to fire.
+      ['timeupdate', onProg],
       ['play', onPlay],
       ['pause', onPause],
       ['waiting', onWaiting],
@@ -193,11 +207,7 @@ export class HtmlEngine implements TvEngine {
       }
       const player = new shaka.Player();
       this.shaka = player;
-      // Buffer far ahead: Shaka's default bufferingGoal is only 10s, too stingy
-      // for the server's readrate-1.5 remux (the web client's numbers).
-      player.configure({
-        streaming: { bufferingGoal: 120, bufferBehind: 60, rebufferingGoal: 4 },
-      });
+      player.configure({ streaming: shakaStreamingConfig(this.plan) });
       // Shaka reports the same relative clock as hls.js, so `baseSec` applies
       // unchanged.
       player
@@ -216,7 +226,12 @@ export class HtmlEngine implements TvEngine {
         v.preload = 'auto';
         return;
       }
-      const hls = new Hls({ enableWorker: true, lowLatencyMode: false, startPosition: 0 });
+      const hls = new Hls({
+        enableWorker: true,
+        lowLatencyMode: false,
+        startPosition: 0,
+        ...hlsBufferConfig(this.plan),
+      });
       this.hls = hls;
       hls.loadSource(url);
       hls.attachMedia(v);
@@ -268,9 +283,8 @@ export class HtmlEngine implements TvEngine {
     return Number.isFinite(this.v.duration) ? this.v.duration : 0;
   }
   bufferedEnd(): number {
-    return this.v.buffered.length
-      ? this.baseSec + this.v.buffered.end(this.v.buffered.length - 1)
-      : 0;
+    const end = reachableBufferEnd(this.v.buffered, this.v.currentTime);
+    return end > 0 ? this.baseSec + end : 0;
   }
 
   seekTo(absSec: number): void {


### PR DESCRIPTION
## What

A remux freezes for about half a second at a time, recovers by itself, and the stats panel reads a hundred seconds of buffer the whole way through — on hls.js and on Shaka alike, so nothing engine-specific. Three things stacked on one symptom.

**The readout was why none of it was visible.** `buffered` is a *list* of ranges, and the moment MSE takes a discontinuity it splits into several. `media-events.ts` and `htmlEngine.ts` both read `end(length - 1)` — the far side of the hole the playhead is stalled against. So the panel reported a healthy buffer at exactly the moment the picture stopped. The seek paths in `use-video-transport.ts` and `htmlEngine.seekTo` already walk every range; only the readout took the shortcut. It now reports what the playhead can actually reach: carried across the holes the engines skip, stopping at the first one they will not. It also re-reads on `timeupdate`, because during a stall nothing is downloading for `progress` to fire.

**Neither engine was told anything about gaps**, so both ran their defaults, and the defaults *are* the half second. hls.js jumps a hole of 0.1 s and otherwise waits 2 s before nudging; Shaka jumps 0.5 s and otherwise waits a full second before stepping 0.1 s. A remux is segmented at real keyframes while its AAC frames are a fixed 21.33 ms, so ffmpeg's fMP4 output leaves sub-frame holes at segment boundaries that no player can append over — most fall under the threshold and are skipped in silence, and the ones that do not freeze the picture.

**The buffer goals could not be honoured.** A flat 120 s forward and 60 s behind, with a 500 MB ceiling set against hls.js's own 60 MB. A SourceBuffer's real ceiling belongs to the user agent, and 180 s of an 80 Mb/s remux is far past it, so the engine spent the film evicting and re-appending rather than buffering. The goal is now a byte budget converted to seconds per title: a 4 Mb/s web-dl still gets two minutes, a remux gets the twenty seconds that fit in the same bytes. The budget is hls.js's own default, because this same code runs on televisions with much less to spare than a desktop.

All three live in one `@kroma/core` module rather than two drifting copies — which is what the two stale `readrate-1.5` comments were, the server having been at `2.0` since the readrate landed. The TV shell's hls.js had no buffer config at all and now gets the same plan.

## Closes

No issue — reported directly: freezes on remux playback with an apparently full buffer.

## Checks

- [x] `bun run check` and `bun run typecheck` clean; `bun run test` green (7123 tests). One unrelated flake, `packages/ui/bundler/index.test.ts`, times out at 5 s under full-suite load and passes on its own.
- [x] `cargo` untouched — no server change.
- [x] Follows `CODE_STYLE.md` — exported API only, the reasoning is in the commit message.
- [x] One idea: the MSE buffer, as measured and as sized.

## Risk

The buffer goal drops for high-bitrate titles (a remux goes from a nominal 120 s to 20 s). That nominal was never reached — the browser refused it — but if a budget of 60 MB turns out to be too tight on a fast link, the symptom would be more frequent short rebuffers rather than the freeze this fixes; `BUDGET_BYTES` in `packages/core/src/playback-buffer.ts` is the one number to turn.

The gap thresholds are the other risk: `maxBufferHole` and `gapDetectionThreshold` at 0.5 s mean the player will now step over half a second of missing media instead of waiting for it. On a stream whose holes are genuinely content, that is half a second skipped rather than played. A reviewer would notice it as a clipped word at a segment boundary.

The buffer figure in the stats panel will now read *lower* than before on a stream with holes. That is the fix, not a regression — the old number was the bug.
