### PR TITLE
fix(desktop): mirror libmpv, and say so when a download is not an archive

### DIFF
--- a/clients/desktop/scripts/fetch-libmpv-windows.ps1
+++ b/clients/desktop/scripts/fetch-libmpv-windows.ps1
@@ -18,19 +18,27 @@ Outputs (for the caller / CI):
 Idempotent: skips the download when the archive is already present with the right sha.
 Bump ASSET + SHA256 together to upgrade.
 
-FROM SOURCEFORGE, NOT GITHUB. This used to pull zhongfly/mpv-winbuild releases,
-which are a rolling ~30-day window: everything older is deleted, so the pin
-eventually stopped resolving and the Windows job failed on a 404 with nothing in
-the diff to explain it. mpv-player-windows is shinchiro's own distribution and
-keeps every build ever published - the 2020-01-05 archive still downloads - so a
-pin here stays good and the build breaks only when we choose to move it.
+FROM OUR OWN MIRROR. The upstreams each fail one of the two things this needs.
+zhongfly/mpv-winbuild on GitHub keeps a rolling ~30-day window and deletes the
+rest, so the pin stopped resolving and the job failed on a 404. SourceForge
+(shinchiro's own channel) keeps every build ever published, but answers a
+non-browser user-agent with a 131 KB HTML interstitial, so the job downloaded a
+web page and failed on the sha instead.
+
+So the archive is mirrored byte-for-byte onto a `vendor-libmpv-*` release of
+this repo, which is neither rolling nor user-agent sniffed. To move it: take the
+build you want from
+  https://sourceforge.net/projects/mpv-player-windows/files/libmpv/
+in a BROWSER, upload it to a new `vendor-libmpv-<date>` prerelease, and bump the
+two values below. Keep it a prerelease with no `.spk`: that is what keeps it out
+of the download page and the Synology package source.
 #>
 $ErrorActionPreference = 'Stop'
 
-# --- pin (bump the two together) ----------------------------------------------
-# Listing: https://sourceforge.net/projects/mpv-player-windows/files/libmpv/
-$Asset  = 'mpv-dev-x86_64-20260809-git-dd5d17d328.7z'
-$Sha256 = 'C6AEBF40BB722EFE79090BFEB61E68625F0837770347E5A8B610AEF78900CF12'
+# --- pin (bump the three together) --------------------------------------------
+$VendorTag = 'vendor-libmpv-20260809'
+$Asset     = 'mpv-dev-x86_64-20260809-git-dd5d17d328.7z'
+$Sha256    = 'C6AEBF40BB722EFE79090BFEB61E68625F0837770347E5A8B610AEF78900CF12'
 # ------------------------------------------------------------------------------
 
 $here   = Split-Path -Parent $MyInvocation.MyCommand.Path
@@ -44,9 +52,18 @@ function Get-Sha256($path) {
 }
 
 if (-not (Test-Path $archive) -or (Get-Sha256 $archive) -ne $Sha256) {
-  $url = "https://downloads.sourceforge.net/project/mpv-player-windows/libmpv/$Asset"
+  $url = "https://github.com/maxscharwath/kroma/releases/download/$VendorTag/$Asset"
   Write-Host "fetch-libmpv-windows: downloading $Asset"
   Invoke-WebRequest -Uri $url -OutFile $archive
+  # A mismatch is usually not a tampered archive, it is not an archive at all:
+  # a host that answers a script with an HTML page still writes 200 bytes to
+  # disk. Say which of the two happened.
+  $magic = [System.IO.File]::ReadAllBytes($archive)[0..1]
+  if ($magic[0] -ne 0x37 -or $magic[1] -ne 0x7A) {
+    $head = (Get-Content $archive -TotalCount 1 -ErrorAction SilentlyContinue)
+    throw "fetch-libmpv-windows: $url did not answer with a 7z archive " +
+          "($((Get-Item $archive).Length) bytes, starts: $head)"
+  }
   $got = Get-Sha256 $archive
   if ($got -ne $Sha256) {
     throw "fetch-libmpv-windows: sha256 MISMATCH for $Asset (got $got, want $Sha256)"


### PR DESCRIPTION
## What

#123 switched the libmpv fetch to SourceForge and I shipped it unverified. It fails on the runner: SourceForge answers a PowerShell user-agent with a 131 KB HTML interstitial, so `Invoke-WebRequest` writes a web page to disk and the job dies on a sha mismatch that says nothing about why. I had "verified" it with `curl`, which sends its own user-agent and gets the real bytes. main is broken until this lands.

Each upstream fails one half of what this needs:

| Source | Keeps old builds | Serves a script |
|---|---|---|
| `zhongfly/mpv-winbuild` (GitHub) | no, rolling ~30 days | yes |
| `mpv-player-windows` (SourceForge) | yes, back to 2020 | no, HTML interstitial |

So the archive is mirrored byte-for-byte onto [`vendor-libmpv-20260809`](https://github.com/maxscharwath/kroma/releases/tag/vendor-libmpv-20260809) on this repo, which is neither rolling nor user-agent sniffed. It is a prerelease carrying no `.spk`, so neither `/download` nor the Synology package source lists it.

The second half is a guard. A host that answers a script with HTML still writes bytes to disk, so the script now checks the 7z magic before the hash and reports the size and first line. Yesterday's failure would have read `not a 7z archive (132364 bytes, starts: <!doctype html>...)` instead of two hashes that differ.

## Closes

No issue. Fixes a regression from #123.

## Checks

- [x] Ran the fetch through a real `Invoke-WebRequest` (installed pwsh locally): HTTP 200, 31,173,907 bytes, 7z magic, sha256 matches
- [x] Ran the guard against the SourceForge URL that broke it: fires, and names the HTML
- [x] `bun run check` and `bun run typecheck` clean
- [x] `cargo` untouched — no Rust in this diff

## Risk

**The Windows job still cannot be proven from here.** `Build & Release` ignores PRs, so this runs for real only once it is on main. What I can say is that the exact client that failed, `Invoke-WebRequest`, now gets the right bytes, which is the thing I did not check last time.

**The mirror is a manual step when it moves.** Bumping means downloading from SourceForge in a browser, uploading a new `vendor-libmpv-<date>` prerelease, and changing three values. That is worse ergonomics than a URL, and better than a build that breaks on someone else's retention policy. The procedure is written in the script's header.

**One more asset in the releases list**, 31 MB, prerelease. It is excluded from the download page by `isProductTag` and from the package source by the prerelease flag and by having no `.spk`.
