### PR TITLE
ci: drop the cache entries nothing reads, or that cost more than they save

### DIFF
--- a/.github/workflows/_release-appletv.yml
+++ b/.github/workflows/_release-appletv.yml
@@ -70,6 +70,7 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: .bun-version
+          no-cache: true
 
       - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
@@ -153,16 +154,17 @@ jobs:
         id: ios-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
+          # Not ~/Library/Caches/CocoaPods: a hit skips pod install, and a miss
+          # (exact key) restores nothing, so it was weight nothing ever read.
           path: |
             clients/tv-native/ios
-            ~/Library/Caches/CocoaPods
           # The config PLUGINS are hashed too. They generate part of the
           # project - the Top Shelf extension's whole Info.plist comes from
           # one - so a plugin edit changes prebuild's output while leaving
           # every manifest untouched. Without them in the key, a cache hit
           # skips prebuild and silently rebuilds the OLD project: the arm64
           # fix would have been cached straight over.
-          key: ios-tvnative-v2-${{ env.XCODE_VERSION }}-${{ hashFiles('bun.lock', 'clients/tv-native/package.json', 'clients/tv-native/app.config.ts', 'clients/tv-native/plugins/**') }}
+          key: ios-tvnative-v3-${{ env.XCODE_VERSION }}-${{ hashFiles('bun.lock', 'clients/tv-native/package.json', 'clients/tv-native/app.config.ts', 'clients/tv-native/plugins/**') }}
 
       # The build number is minutes-since-2020, so a restored project carries
       # the one from the run that cached it and App Store Connect would refuse

--- a/.github/workflows/_release-desktop.yml
+++ b/.github/workflows/_release-desktop.yml
@@ -65,6 +65,7 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: .bun-version
+          no-cache: true
 
       # The repo's rust-toolchain.toml pins the exact version; this just ensures
       # rustup is present so it can auto-install the pin.

--- a/.github/workflows/_release-mobile.yml
+++ b/.github/workflows/_release-mobile.yml
@@ -57,6 +57,7 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: .bun-version
+          no-cache: true
 
       - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
@@ -75,6 +76,13 @@ jobs:
       - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           gradle-version: '8.13'
+          # Transforms (extracted AARs, instrumented jars) are derived from the
+          # dependencies and come back in about a minute; as a cache entry they
+          # were 0.6 GB per app, the largest single item in the repository's
+          # 10 GB quota after the Rust trees.
+          gradle-home-cache-excludes: |
+            caches/transforms-*
+            caches/*/transforms*
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -97,7 +105,7 @@ jobs:
         env:
           GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=1g
         run: |
-          ./gradlew assembleRelease --no-daemon --build-cache \
+          gradle assembleRelease --no-daemon --build-cache \
             -PreactNativeArchitectures=armeabi-v7a,arm64-v8a,x86_64
           mkdir -p "$GITHUB_WORKSPACE/out"
           cp app/build/outputs/apk/release/app-release.apk \
@@ -174,6 +182,7 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: .bun-version
+          no-cache: true
 
       - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
@@ -247,16 +256,17 @@ jobs:
         id: ios-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
+          # Not ~/Library/Caches/CocoaPods: a hit skips pod install, and a miss
+          # (exact key) restores nothing, so it was weight nothing ever read.
           path: |
             clients/mobile/ios
-            ~/Library/Caches/CocoaPods
           # The config PLUGINS are hashed too. They generate part of the
           # project - the Top Shelf extension's whole Info.plist comes from
           # one - so a plugin edit changes prebuild's output while leaving
           # every manifest untouched. Without them in the key, a cache hit
           # skips prebuild and silently rebuilds the OLD project: the arm64
           # fix would have been cached straight over.
-          key: ios-mobile-v2-${{ env.XCODE_VERSION }}-${{ hashFiles('bun.lock', 'clients/mobile/package.json', 'clients/mobile/app.json', 'clients/mobile/app.config.ts', 'clients/mobile/plugins/**') }}
+          key: ios-mobile-v3-${{ env.XCODE_VERSION }}-${{ hashFiles('bun.lock', 'clients/mobile/package.json', 'clients/mobile/app.json', 'clients/mobile/app.config.ts', 'clients/mobile/plugins/**') }}
 
       # AFTER the cache, deliberately. This rewrites app.json with a build
       # number derived from the clock, so hashing it would change the cache key

--- a/.github/workflows/_release-tv.yml
+++ b/.github/workflows/_release-tv.yml
@@ -43,6 +43,7 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: .bun-version
+          no-cache: true
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -107,6 +108,7 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: .bun-version
+          no-cache: true
 
       - uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
@@ -125,21 +127,15 @@ jobs:
           sed -i -E 's/(<widget[^>]*version=")[^"]*/\1${{ inputs.triplet }}/' clients/tizen/dist/config.xml
           grep -o 'version="[^"]*"' clients/tizen/dist/config.xml | head -1
 
-      - name: Cache Tizen Studio installer
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: web-cli.bin
-          key: tizen-cli-${{ env.TIZEN_STUDIO_VER }}
-
+      # Downloaded every run rather than cached: the 259 MB installer restored
+      # no faster than it downloads, and the install itself is the slow part.
       - name: Install Tizen Studio CLI
         run: |
-          if [ ! -f web-cli.bin ]; then
-            # --max-redirect=0: the URL serves the installer directly (200, no
-            # hops), so nothing legitimate needs a redirect - and refusing them
-            # outright is what stops one being pointed somewhere else.
-            # --https-only backs it up: TLS cannot be downgraded to plain http.
-            wget -q --https-only --max-redirect=0 -O web-cli.bin "https://download.tizen.org/sdk/Installer/tizen-studio_${TIZEN_STUDIO_VER}/web-cli_Tizen_Studio_${TIZEN_STUDIO_VER}_ubuntu-64.bin"
-          fi
+          # --max-redirect=0: the URL serves the installer directly (200, no
+          # hops), so nothing legitimate needs a redirect - and refusing them
+          # outright is what stops one being pointed somewhere else.
+          # --https-only backs it up: TLS cannot be downgraded to plain http.
+          wget -q --https-only --max-redirect=0 --tries=3 --waitretry=10 -O web-cli.bin "https://download.tizen.org/sdk/Installer/tizen-studio_${TIZEN_STUDIO_VER}/web-cli_Tizen_Studio_${TIZEN_STUDIO_VER}_ubuntu-64.bin"
           chmod +x web-cli.bin
           ./web-cli.bin --accept-license --no-java-check "$HOME/tizen-studio"
           echo "$HOME/tizen-studio/tools/ide/bin" >> "$GITHUB_PATH"
@@ -203,6 +199,7 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: .bun-version
+          no-cache: true
 
       - uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
@@ -212,6 +209,13 @@ jobs:
       - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           gradle-version: '8.13'
+          # Transforms (extracted AARs, instrumented jars) are derived from the
+          # dependencies and come back in about a minute; as a cache entry they
+          # were 0.6 GB per app, the largest single item in the repository's
+          # 10 GB quota after the Rust trees.
+          gradle-home-cache-excludes: |
+            caches/transforms-*
+            caches/*/transforms*
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,11 +196,10 @@ jobs:
   # a change under clients/tv-native or to the install can reach it; the
   # Metro bundle check in `build` covers the TypeScript for everything else.
   #
-  # The job id is the release job's (`tv-native` in _release-tv.yml) and the
-  # build is the same `assembleRelease`: setup-gradle falls back to another
-  # job's Gradle home by job id, so this is what makes the read-only restore
-  # land on the TV app's dependencies and task outputs rather than the phone's
-  # (which is what a differently named job got, and a seven-minute compile).
+  # The job id is the release job's (`tv-native` in _release-tv.yml) because
+  # setup-gradle keys a Gradle home on it and falls back across workflows by
+  # it: named anything else, this job restored the PHONE app's home and
+  # compiled the TV app against it.
   tv-native:
     name: Android TV compile
     needs: lanes
@@ -217,13 +216,15 @@ jobs:
         with:
           distribution: temurin
           java-version: '17'
-      # Read-only: the release build on main writes the Gradle home this job
-      # restores, so a second copy of the dependency set never lands in the
-      # repository's 10 GB cache quota.
+      # Writes from main like every other cache here. Read-only, the job
+      # restored a Gradle home with neither this app's dependencies nor its
+      # task outputs and compiled everything (592 tasks, 74 from cache, 8.5
+      # min). Dependencies and task outputs are content-hashed entries that
+      # setup-gradle shares between jobs, so writing adds one small home
+      # entry rather than a second copy of the set.
       - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           gradle-version: '8.13'
-          cache-read-only: true
           # Transforms (extracted AARs, instrumented jars) are derived from the
           # dependencies and come back in about a minute; as a cache entry they
           # were 0.6 GB per app, the largest single item in the repository's
@@ -236,9 +237,7 @@ jobs:
       # --build-cache reuses task outputs keyed on their inputs, which the
       # dependency cache alone does not. The heap is raised because the
       # generated gradle.properties asks for 2 GB, a third of the runner.
-      - run: |
-          gradle -p clients/tv-native/android assembleRelease --build-cache \
-            -PreactNativeArchitectures=armeabi-v7a,arm64-v8a,x86_64
+      - run: gradle -p clients/tv-native/android assembleDebug --build-cache
         env:
           GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=1g
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,13 @@ jobs:
   # JS-only check compiles. `android/` is generated, so prebuild first. Only
   # a change under clients/tv-native or to the install can reach it; the
   # Metro bundle check in `build` covers the TypeScript for everything else.
-  android:
+  #
+  # The job id is the release job's (`tv-native` in _release-tv.yml) and the
+  # build is the same `assembleRelease`: setup-gradle falls back to another
+  # job's Gradle home by job id, so this is what makes the read-only restore
+  # land on the TV app's dependencies and task outputs rather than the phone's
+  # (which is what a differently named job got, and a seven-minute compile).
+  tv-native:
     name: Android TV compile
     needs: lanes
     if: needs.lanes.outputs.android == 'true'
@@ -230,7 +236,9 @@ jobs:
       # --build-cache reuses task outputs keyed on their inputs, which the
       # dependency cache alone does not. The heap is raised because the
       # generated gradle.properties asks for 2 GB, a third of the runner.
-      - run: gradle -p clients/tv-native/android assembleDebug --build-cache
+      - run: |
+          gradle -p clients/tv-native/android assembleRelease --build-cache \
+            -PreactNativeArchitectures=armeabi-v7a,arm64-v8a,x86_64
         env:
           GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=1g
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: .bun-version
+          no-cache: true
       - run: bun install --frozen-lockfile --filter '@kroma/ci-tools'
       - id: lanes
         run: bun run ci lanes
@@ -87,6 +88,7 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: .bun-version
+          no-cache: true
       - run: bun install --frozen-lockfile
       - run: bun run typecheck
       - run: bun run check
@@ -106,6 +108,7 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: .bun-version
+          no-cache: true
       - run: bun install --frozen-lockfile
       - run: bun run ci test --shard ${{ matrix.shard }}/${{ env.SHARDS }}
       # A dot-directory: without include-hidden-files the upload finds nothing.
@@ -132,6 +135,7 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: .bun-version
+          no-cache: true
       - run: bun install --frozen-lockfile
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -161,6 +165,7 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: .bun-version
+          no-cache: true
       - run: bun install --frozen-lockfile
       # The site's build reads the published releases from the GitHub API to
       # bake /download. Anonymous GitHub allows sixty requests an hour per IP
@@ -201,6 +206,7 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: .bun-version
+          no-cache: true
       - uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
           distribution: temurin
@@ -212,6 +218,13 @@ jobs:
         with:
           gradle-version: '8.13'
           cache-read-only: true
+          # Transforms (extracted AARs, instrumented jars) are derived from the
+          # dependencies and come back in about a minute; as a cache entry they
+          # were 0.6 GB per app, the largest single item in the repository's
+          # 10 GB quota after the Rust trees.
+          gradle-home-cache-excludes: |
+            caches/transforms-*
+            caches/*/transforms*
       - run: bun install --frozen-lockfile
       - run: bun run --filter '@kroma/tv-native' prebuild -- --platform android
       # --build-cache reuses task outputs keyed on their inputs, which the
@@ -236,6 +249,7 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: .bun-version
+          no-cache: true
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
@@ -264,6 +278,7 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: .bun-version
+          no-cache: true
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           components: clippy, rustfmt, llvm-tools-preview
@@ -313,6 +328,7 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: .bun-version
+          no-cache: true
       - run: bun install --frozen-lockfile
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,9 +41,14 @@ jobs:
       actions: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      # No overlay database: the action otherwise keeps a ~190 MB base
+      # database per push to main in the repository's Actions cache, which
+      # buys seconds on a three-minute scan.
       - uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           languages: javascript-typescript
+        env:
+          CODEQL_OVERLAY_DATABASE_MODE: none
       - uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
 
   cargo-audit:

--- a/.github/workflows/desktop-autoupdate.yml
+++ b/.github/workflows/desktop-autoupdate.yml
@@ -122,6 +122,7 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: .bun-version
+          no-cache: true
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       # Same key as release.yml's desktop job: identical release build of the
       # same workspace, so the two share one cache entry per OS instead of

--- a/.github/workflows/kit.yml
+++ b/.github/workflows/kit.yml
@@ -90,6 +90,7 @@ jobs:
         if: steps.delta.outputs.changed != 'false'
         with:
           bun-version-file: .bun-version
+          no-cache: true
 
       - name: Install dependencies
         if: steps.delta.outputs.changed != 'false'

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -108,6 +108,7 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: .bun-version
+          no-cache: true
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -215,6 +216,7 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: .bun-version
+          no-cache: true
 
       # `modules release` reads the registry contract (`@kroma/registry`) to
       # order versions, so this job needs the workspace links like any other.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,7 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: .bun-version
+          no-cache: true
       - run: bun install --frozen-lockfile --filter '@kroma/ci-tools'
       - id: v
         run: bun run ci version
@@ -277,6 +278,7 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: .bun-version
+          no-cache: true
       - run: bun install --frozen-lockfile --filter '@kroma/ci-tools'
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/repo-worker.yml
+++ b/.github/workflows/repo-worker.yml
@@ -68,6 +68,7 @@ jobs:
         if: steps.guard.outputs.has_token == 'true'
         with:
           bun-version-file: .bun-version
+          no-cache: true
 
       # Both are SSR apps now: `deploy` builds the client + server bundles first,
       # and wrangler serves the handler with the client assets beside it.

--- a/.github/workflows/synology.yml
+++ b/.github/workflows/synology.yml
@@ -43,6 +43,7 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: .bun-version
+          no-cache: true
       - run: bun install --frozen-lockfile --filter '@kroma/ci-tools'
       - id: lanes
         run: bun run ci lanes
@@ -81,6 +82,7 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: .bun-version
+          no-cache: true
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -96,11 +98,10 @@ jobs:
           path: |
             clients/synology/.cache
             server/target/x86_64-unknown-linux-musl
-            server/target/release
-          key: synology-v2-${{ hashFiles('server/Cargo.lock') }}
+          key: synology-v3-${{ hashFiles('server/Cargo.lock') }}
           restore-keys: |
+            synology-v3-
             synology-v2-
-            synology-
 
       # build.sh: web SPA -> static musl kroma-server -> static ffmpeg -> .spk.
       - name: Build .spk
@@ -386,6 +387,7 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: .bun-version
+          no-cache: true
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: kroma-synology-spk

--- a/.github/workflows/tv-web.yml
+++ b/.github/workflows/tv-web.yml
@@ -79,6 +79,7 @@ jobs:
         if: steps.delta.outputs.changed != 'false'
         with:
           bun-version-file: .bun-version
+          no-cache: true
 
       - name: Install dependencies
         if: steps.delta.outputs.changed != 'false'

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -152,22 +152,48 @@ signing secrets to verify, which is why it is not part of this rebuild.
 
 | entry | size | written by |
 |---|---|---|
-| `rust` (server + modules, instrumented) | ~1.7 GB | ci.yml on main |
+| `rust` (server + modules, instrumented) | ~1.0 GB | ci.yml on main |
 | `desktop-check` | ~0.4 GB | ci.yml on main |
 | `desktop-release` x3 OS | ~1.2 GB | _release-desktop.yml, desktop-autoupdate.yml |
 | `dd-tvnative-v1-*`, `dd-mobile-v1-*` | ~0.8 + 0.6 GB, one each | the Apple jobs, pruned to one |
-| `ios-tvnative-v2-*`, `ios-mobile-v2-*` | ~0.9 GB | the Apple jobs, keyed by config hash |
-| Gradle home + dependencies | ~1.5 GB | the release Android jobs |
-| `synology-*`, `kmod-*`, scanner, bun | ~1 GB | synology.yml, modules.yml |
+| `ios-tvnative-v3-*`, `ios-mobile-v3-*` | ~0.2 GB each | the Apple jobs, keyed by config hash |
+| Gradle dependencies + build cache, per app | ~0.8 GB each | the release Android jobs |
+| `synology-v3`, `synology-arm64-v2` | ~0.8 GB | synology.yml |
+| `kmod-*` x3 targets | ~0.35 GB | modules.yml |
 
-About 8 GB when every entry is warm. If it grows past 10 GB again, the Rust
-entry is the first to go (it is the largest and the oldest between Rust
-pushes), and the symptom is a ten-minute `rust` job. `gh cache list` shows
-what is there; `bun run ci cache prune --prefix <key>-` retires duplicates.
+About 7 GB when every entry is warm, down from 11.9 GB. What went, and why
+it was not worth its space:
 
-A longer-term option is `sccache` with an R2 bucket (S3-compatible): per-object
-caching off the Actions quota, warm for pull requests too. Not done here
-because it needs bucket credentials as repository secrets.
+- Gradle transforms (0.6 GB per app, and two copies of each while the old
+  entry aged out): extracted AARs and instrumented jars, derived from the
+  dependencies in about a minute. Excluded through `gradle-home-cache-excludes`.
+- A second Gradle distribution: the phone build ran `./gradlew` (a wrapper
+  zip, 130 MB) while the TV build ran the `gradle` setup-gradle installs
+  (another 130 MB). Both use the latter now.
+- `~/Library/Caches/CocoaPods` inside the iOS project entries (about 0.25 GB
+  each): a hit skips `pod install`, and a miss on an exact key restores
+  nothing, so nothing ever read it.
+- CodeQL's overlay base database (190 MB per push to main, two copies at any
+  time): `CODEQL_OVERLAY_DATABASE_MODE=none`; the scan is three minutes
+  either way.
+- The Tizen Studio installer (259 MB): restored no faster than it downloads.
+- The bun binary (20 to 37 MB per platform and version, five copies): a
+  GitHub release download of the same size.
+- `server/target/release` in the Synology entry: the .spk build only ever
+  writes the musl target dir.
+- Earlier: two DerivedData copies per Apple app and a separate instrumented
+  Rust tree for Sonar (see above).
+
+If usage climbs past 10 GB again, the Rust entry is the first to go (it is
+the largest and the oldest between Rust pushes), and the symptom is a
+ten-minute `rust` job. `gh cache list` shows what is there;
+`bun run ci cache prune --prefix <key>-` retires duplicates.
+
+The remaining 3 GB of Rust trees are the next step, and it leaves the quota
+entirely: `sccache` with an R2 bucket (S3-compatible, no egress fees) caches
+per object, is warm for pull requests too, and needs only an access key pair
+and the bucket name as repository secrets. Not done here because the bucket
+and its token have to be created in the Cloudflare dashboard.
 
 ## Bun
 


### PR DESCRIPTION
## What

After #126 the Actions cache still sat at 11.4 GB against the 10 GB quota, and LRU eviction takes the Rust tree first. This removes what nothing reads or what costs more to keep than to rebuild:

- Gradle transforms excluded (`gradle-home-cache-excludes`): 0.6 GB per app, two copies while the old one ages out, derived from the dependencies in about a minute.
- The phone build runs `gradle` from setup-gradle like the TV build, instead of `./gradlew` pulling a second 130 MB distribution.
- `~/Library/Caches/CocoaPods` out of the iOS project entries (`ios-*-v3`): a hit skips `pod install`, a miss on an exact key restores nothing.
- `CODEQL_OVERLAY_DATABASE_MODE=none`: no 190 MB overlay base database per push.
- Tizen Studio installer downloaded each run (`--tries=3`), not cached.
- `no-cache: true` on every `setup-bun`: the binary is a release download of the same size.
- `server/target/release` dropped from the Synology entry (`synology-v3`): the .spk build only writes the musl target.

Expected steady state about 7 GB (table in `docs/ci.md`). The next step that takes the 3 GB of Rust trees out of the quota is sccache on an R2 bucket; it needs a bucket and an access key created in the Cloudflare dashboard, so it is described rather than wired.

## Closes

No issue.

## Checks

- [x] `actionlint` clean (the remaining shellcheck infos predate this PR)
- [x] No code change outside workflows and docs

## Risk

- The Android release jobs regenerate transforms on every run: expect about a minute more on each. If it is much more, put `caches/transforms-*` back.
- The phone build on `gradle` 8.13 instead of its wrapper: the TV build has used 8.13 against the same Expo template since the start.
- A `pod install` on an iOS cache miss downloads the pods fresh; misses only happen when `bun.lock` or the app config changes.
