### PR TITLE
feat(ci): kroma.tv deploys itself when what it shows changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,7 @@ on:
       - '.github/workflows/kit.yml'
       - '.github/workflows/tv-web.yml'
       - '.github/workflows/repo-worker.yml'
+      - '.github/workflows/site.yml'
       - '.github/workflows/desktop-autoupdate.yml'
       - '.github/workflows/apple-signing-doctor.yml'
       - '.github/workflows/deploy.yml'

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,0 +1,94 @@
+name: Site
+
+# kroma.tv. The site is PRERENDERED: `vite build` reads the releases feed and
+# bakes /download and /download/archive into static pages, so the download
+# page is exactly as old as the last deploy. Nothing deployed it until this
+# workflow existed, and the live page sat on 0.1.30 while main shipped 0.1.39.
+#
+# So it deploys on three occasions, all of which change what a visitor sees:
+# the site's own sources changed, a run published a release, or a run put a
+# build on the canary channel.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/www/**'
+      - 'packages/bundler/**'
+      - 'packages/registry/**'
+      - 'packages/site-kit/**'
+      - 'packages/site-meta/**'
+      - 'packages/ui/**'
+      - 'bun.lock'
+      - '.bun-version'
+      - '.github/workflows/site.yml'
+  # The fleet's canary uploads, the Synology .spk's, and a promoted release.
+  workflow_run:
+    workflows: [Build & Release, Synology, Deploy]
+    types: [completed]
+    branches: [main]
+  pull_request:
+    paths:
+      - 'apps/www/**'
+      - '.github/workflows/site.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: site-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Build + deploy (kroma.tv)
+    # A finished run that failed published nothing, so there is nothing new to
+    # bake. Every other trigger always builds: the build IS the gate.
+    if: >-
+      github.event_name != 'workflow_run'
+      || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version-file: .bun-version
+          no-cache: true
+
+      - run: bun install --frozen-lockfile
+
+      # The gate: the build IS the prerender, so a broken page, a bad link in
+      # the crawl or a release missing a platform's file fails here rather
+      # than at deploy time. The token is what keeps the releases feed off the
+      # sixty-an-hour anonymous limit runners share.
+      - name: Build the site
+        run: bun run build:site
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      # Soft gate: no token -> skip with a notice rather than a red run.
+      # Secrets cannot be read in a job-level `if`.
+      - name: Check for the Cloudflare token
+        id: guard
+        if: github.event_name != 'pull_request'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          if [ -z "$CLOUDFLARE_API_TOKEN" ]; then
+            echo "::notice::CLOUDFLARE_API_TOKEN not set; skipping the kroma.tv deploy (deploy by hand with 'bun run deploy:site')."
+            echo "has_token=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_token=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # dist/ is already built above, so deploy it directly rather than through
+      # the workspace `deploy` script, which would build it again.
+      - name: Deploy the site (kroma.tv)
+        if: steps.guard.outputs.has_token == 'true'
+        working-directory: apps/www
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: bunx wrangler@4 deploy -c dist/server/wrangler.json

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -129,16 +129,16 @@ public repository refuses to serve anonymously. With the channel on a release
 tag that path is redundant: the tag's `browser_download_url`s need no token,
 no zip wrapper and no thirty-day expiry.
 
-Two things still stand between a push and a visitor seeing it on /download:
+`site.yml` deploys it: on a change to the site's own sources, and on a
+`workflow_run` after Build & Release, Synology or Deploy, because each of
+those changes what a visitor sees. Until it existed nothing did, and the live
+page sat on 0.1.30 while main shipped 0.1.39.
 
-1. **Nothing deploys the site.** `bun run deploy:site` is run by hand, so the
-   prerendered download page is as old as the last deploy. A `site.yml` on the
-   `site` lane (already in `lanes.ts`), plus a `workflow_run` trigger after a
-   Release or a canary upload, closes that.
-2. **/download offers stable only.** The data is there (`canary` from
-   `virtual:kroma-releases`); the page needs a channel switch, the way the
-   archive already has one, and a "last canary, built N hours ago" line under
-   each platform.
+One thing still stands between a push and a visitor seeing it on /download:
+the page offers **stable only**. The data is there (`canary` from
+`virtual:kroma-releases`, which is what /download/archive renders); the page
+needs a channel switch the way the archive already has one, and a "last
+canary, built N hours ago" line under each platform.
 
 `desktop-autoupdate.yml` builds the three desktop installers a second time per
 push (without libmpv on macOS) for the updater's `desktop-latest` tag. Folding


### PR DESCRIPTION
## What

The site is prerendered: `apps/www/vite/releases.ts` reads the releases feed at build time and bakes `/download` and `/download/archive` into static pages. Nothing deployed it, so the page was as old as the last `bun run deploy:site` someone ran by hand. Live right now it is on **0.1.30**, while `main` ships 0.1.39 and the `canary` tag holds twelve builds of it from this morning.

`site.yml` deploys on:
- a change to `apps/www` or what it bundles (the same shape as `kit.yml` / `tv-web.yml`),
- `workflow_run` after **Build & Release**, **Synology** or **Deploy** completes successfully on `main`, which covers a canary upload, a new `.spk` and a promoted release,
- a pull request touching the site (build only, no deploy), and `workflow_dispatch`.

The build is the gate: it is the prerender, so a broken page, a bad link in the crawl or a release missing a platform's file fails here. No token means a skip with a notice, not a red run.

## Closes

No issue. Follow-up to #126, which documented this as the last gap between a push and the download page.

## Checks

- [x] `actionlint` clean
- [x] Same soft-token guard and deploy invocation as the two Cloudflare workflows already in the repo

## Risk

- A `workflow_run` trigger fires on the default branch's copy of the workflow, so it only takes effect once merged.
- Three of these runs can queue behind one push (Build & Release, Synology, and the site's own push trigger). The concurrency group cancels the superseded ones.
- If the newest release is missing a platform's file the build fails by design; that is the existing `releasesPlugin` behaviour, now on a schedule instead of at a human's convenience.
