### PR TITLE
ci: the phone build keeps its own Gradle wrapper

### DIFF
--- a/.github/workflows/_release-mobile.yml
+++ b/.github/workflows/_release-mobile.yml
@@ -105,7 +105,7 @@ jobs:
         env:
           GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=1g
         run: |
-          gradle assembleRelease --no-daemon --build-cache \
+          ./gradlew assembleRelease --no-daemon --build-cache \
             -PreactNativeArchitectures=armeabi-v7a,arm64-v8a,x86_64
           mkdir -p "$GITHUB_WORKSPACE/out"
           cp app/build/outputs/apk/release/app-release.apk \

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -167,9 +167,10 @@ it was not worth its space:
 - Gradle transforms (0.6 GB per app, and two copies of each while the old
   entry aged out): extracted AARs and instrumented jars, derived from the
   dependencies in about a minute. Excluded through `gradle-home-cache-excludes`.
-- A second Gradle distribution: the phone build ran `./gradlew` (a wrapper
-  zip, 130 MB) while the TV build ran the `gradle` setup-gradle installs
-  (another 130 MB). Both use the latter now.
+(The phone build keeps its own `./gradlew`. Running it on the `gradle`
+setup-gradle installs would save the 130 MB wrapper zip, and it cost four
+minutes and a fresh 798 MB dependency set instead: the generated project's
+wrapper is the version its task outputs were built with.)
 - `~/Library/Caches/CocoaPods` inside the iOS project entries (about 0.25 GB
   each): a hit skips `pod install`, and a miss on an exact key restores
   nothing, so nothing ever read it.


### PR DESCRIPTION
Part of #127 traded the 130 MB wrapper zip for a four-minute-slower phone build (Build APK 899 s -> 1156 s) and a fresh 798 MB dependency entry: the generated project's wrapper is the Gradle version its task outputs were built with, so running it on another one invalidates both. The rest of #127 stands; the TV app was unaffected (6:01 -> 5:48) because it already used the installed distribution.

## Risk

None beyond restoring the previous command.