### PR TITLE
feat(tv-installer): one command puts KROMA on every television in the room

### DIFF
--- a/.github/workflows/_release-tools.yml
+++ b/.github/workflows/_release-tools.yml
@@ -1,0 +1,94 @@
+name: Release the television installer
+
+# `bun run tv` as a single executable, for a machine that has no checkout of
+# this repository. Called by release.yml; never triggered on its own.
+#
+# Three targets, and Windows is not one of them: the installer drives sdb, adb,
+# ares and devicectl, and reads an ARP table, a keychain and a System Settings
+# pane, which is a POSIX machine's worth of assumptions.
+#
+# The macOS binaries are built ON macOS rather than cross-compiled, because
+# `bun build --compile` leaves an ad-hoc signature the system refuses to run
+# ("killed: 9") until `codesign --force --sign -` replaces it, and codesign
+# exists nowhere else. scripts/compile.ts does that as part of the build.
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        type: string
+        required: true
+      channel:
+        type: string
+        required: true
+
+jobs:
+  installer:
+    name: kroma-tv ${{ matrix.label }}
+    if: ${{ (github.event_name != 'workflow_dispatch' || contains(fromJSON('["all","tools"]'), github.event.inputs.targets)) }}
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: write # attach assets to the Release
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: bun-darwin-arm64
+            label: macOS (Apple silicon)
+            runner: macos-15
+          - target: bun-darwin-x64
+            label: macOS (Intel)
+            runner: macos-15
+          - target: bun-linux-x64
+            label: Linux (x86_64)
+            runner: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version-file: .bun-version
+          no-cache: true
+
+      # The installer's own dependencies and nothing else: it links no client.
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --filter '@kroma/tv-installer'
+
+      - name: Compile
+        run: bun run build:tv-cli --target=${{ matrix.target }}
+
+      # The version is in the name because nothing inside the binary carries it
+      # and a downloaded tool outlives the tab it came from.
+      - name: Name it after this build
+        id: binary
+        run: |
+          BUILT="packages/tv-installer/dist/kroma-tv-${{ matrix.target }}"
+          BUILT="${BUILT/bun-/}"
+          NAMED="packages/tv-installer/dist/kroma-tv-${{ inputs.version }}-${{ matrix.target }}"
+          NAMED="${NAMED/bun-/}"
+          mv "$BUILT" "$NAMED"
+          echo "path=$NAMED" >> "$GITHUB_OUTPUT"
+          ls -l "$NAMED"
+
+      - name: Check it runs
+        # A cross-compiled binary cannot be, so only the host's own is tried.
+        if: matrix.target != 'bun-darwin-x64'
+        run: ${{ steps.binary.outputs.path }} --help
+
+      - name: Upload the binary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: kroma-tv-${{ matrix.target }}
+          path: ${{ steps.binary.outputs.path }}
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Attach to the Release
+        # Only a STABLE release attaches here. A candidate build uploads its
+        # artifacts and stops; deploy.yml publishes them later.
+        if: inputs.channel == 'stable'
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        with:
+          draft: true
+          files: ${{ steps.binary.outputs.path }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ on:
       targets:
         description: 'What to build'
         type: choice
-        options: [all, spk, desktop, tv, mobile]
+        options: [all, spk, desktop, tv, mobile, tools]
         default: all
         required: false
       distribute:
@@ -143,6 +143,23 @@ jobs:
   # `<module-id>@<version>` tags from .github/workflows/modules.yml, on their own
   # cadence, so a module fix no longer waits for a server version to ship. A
   # server release therefore neither builds nor gates on them.
+
+  # ----------------------------------------------------------------- TOOLS ---
+
+  # `bun run tv` as a downloadable executable. Not a client, and not in the
+  # candidate gate below: a television ships whether or not the tool that
+  # installs it compiled.
+  tools:
+    name: Installer
+    needs: version
+    if: ${{ (github.event_name != 'workflow_dispatch' || contains(fromJSON('["all","tools"]'), github.event.inputs.targets)) }}
+    uses: ./.github/workflows/_release-tools.yml
+    permissions:
+      contents: write # passed down to the called workflow
+    with:
+      version: ${{ needs.version.outputs.version }}
+      channel: ${{ needs.version.outputs.channel }}
+    secrets: inherit
 
   # -------------------------------------------------------------------- TV ---
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -59,6 +59,23 @@ the server address on first launch and remembers it.
 
 ---
 
+## The easy path for TVs (`bun run tv`)
+
+From a clone of the repo (`bun install` once), one command sweeps the network for
+televisions, installs the Samsung, LG or Android tooling it needs, finds the
+newest package built here or pulls the latest release asset with `gh`, and
+installs KROMA on the sets you tick:
+
+```bash
+bun run tv
+```
+
+The developer-mode steps below still have to be done once on each television:
+nothing turns them on over the network. What the scan probes, the commands it
+takes without the picker, where each toolchain lands and the Local Network
+permission macOS asks for on the first sweep are in
+[packages/tv-installer/README.md](packages/tv-installer/README.md).
+
 ## Samsung TV (Tizen) `.wgt`
 
 One-time **developer mode** on the TV:
@@ -73,10 +90,13 @@ One-time **developer mode** on the TV:
 
 There is **no npm package** for Samsung's tooling (unlike LG's
 `@webos-tools/cli`): the `tizen` and `sdb` commands only ship with
-**Tizen Studio**. You do NOT need the IDE though - the **CLI-only**
-installer is enough, and installing a prebuilt `.wgt` needs **no
-certificate** (ours is already signed; certificates are only required to
-*package*):
+**Tizen Studio**. You do NOT need the IDE, the **CLI-only** installer is enough.
+
+You DO need a **certificate of your own**. A retail Samsung accepts only a
+distributor certificate Samsung issued against that set's DUID, so the release
+`.wgt` has to be re-signed before it installs; ours carries a build certificate
+that every retail set refuses with `Invalid certificate chain with certificate
+in signature`. `bun run tv` does the re-signing for you. By hand:
 
 ```bash
 # 1. Get the .wgt
@@ -93,8 +113,14 @@ export PATH="$PATH:$HOME/tizen-studio/tools:$HOME/tizen-studio/tools/ide/bin"
 sdb connect 192.168.1.50
 sdb devices                                # note the device id, e.g. UE50AU7172...
 
-# 4. Install
-tizen install -n KROMA-tizen-*.wgt -t <device-id>
+# 4. One-time: Tizen Studio > Tools > Certificate Manager > + > Samsung > TV.
+#    Sign in with a Samsung account, with the TV connected so it reads the DUID.
+
+# 5. Re-sign the release package with that profile, then install
+mkdir stage && cd stage && unzip -q ../KROMA-tizen-*.wgt
+rm -f author-signature.xml signature1.xml
+tizen package -t wgt -s <your-profile> -- .
+tizen install -n KROMA.wgt -- .
 ```
 
 ### Or build + deploy from the repo
@@ -104,10 +130,11 @@ make -C clients/tizen deploy TV_IP=192.168.1.50   # build + sign + install + lau
 ```
 
 Notes:
-- The release `.wgt` is signed with a **throwaway developer certificate**. A TV
-  in developer mode accepts it, but if a KROMA build signed with a *different*
-  certificate is already installed, uninstall that one first (Apps > long-press
-  the KROMA tile > Delete), or the install fails with a signature error.
+- The release `.wgt` is signed with a **build certificate**, which is enough for
+  the emulator and refused by every retail set. Re-sign it with your own profile,
+  as above. If a KROMA signed with a *different* certificate is already on the
+  set, uninstall that one first (Apps > long-press the KROMA tile > Delete), or
+  the install fails with a signature error.
 - Developer mode survives reboots; the app stays installed like any other.
 - Community GUI installers that skip Tizen Studio exist (they speak the sdb
   protocol directly), but nothing official or maintained enough to recommend

--- a/README.md
+++ b/README.md
@@ -357,6 +357,10 @@ also ships a legacy tier (ES2015 + flattened CSS, runtime-gated) for
 Chromium 53–94 TVs (2018–2023), with a compat guard that fails the build on
 anything a legacy engine cannot parse. `bun run build:tv` builds all TV shells.
 
+`bun run tv` finds the televisions on your network and sideloads onto them
+(Samsung, LG, Android TV), toolchain included
+([tv-installer](packages/tv-installer/README.md)).
+
 **Installing on real devices** (TV developer mode, macOS quarantine, sideloading):
 see [INSTALL.md](INSTALL.md). **Joining the beta as a tester** (TestFlight,
 Firebase, sideloading on a beamer), written for non-technical users: see

--- a/bun.lock
+++ b/bun.lock
@@ -764,6 +764,25 @@
         "expo-video",
       ],
     },
+    "packages/tv-installer": {
+      "name": "@kroma/tv-installer",
+      "version": "0.0.0",
+      "bin": {
+        "kroma-tv": "./src/cli.ts",
+      },
+      "dependencies": {
+        "@clack/core": "1.4.3",
+        "@clack/prompts": "1.7.0",
+        "citty": "0.2.2",
+        "zod": "^4.4.3",
+      },
+      "devDependencies": {
+        "@types/node": "^22.20.1",
+        "bun-types": "^1.4.0",
+        "typescript": "^7.0.2",
+        "vitest": "^4.1.10",
+      },
+    },
     "packages/ui": {
       "name": "@kroma/ui",
       "version": "0.0.0",
@@ -1105,6 +1124,10 @@
 
     "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
 
+    "@clack/core": ["@clack/core@1.4.3", "", { "dependencies": { "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ=="],
+
+    "@clack/prompts": ["@clack/prompts@1.7.0", "", { "dependencies": { "@clack/core": "1.4.3", "fast-string-width": "^3.0.2", "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A=="],
+
     "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
 
     "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.1", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": ">1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw=="],
@@ -1420,6 +1443,8 @@
     "@kroma/tv": ["@kroma/tv@workspace:packages/tv"],
 
     "@kroma/tv-bench": ["@kroma/tv-bench@workspace:clients/bench"],
+
+    "@kroma/tv-installer": ["@kroma/tv-installer@workspace:packages/tv-installer"],
 
     "@kroma/tv-native": ["@kroma/tv-native@workspace:clients/tv-native"],
 
@@ -2055,6 +2080,8 @@
 
     "ci-info": ["ci-info@3.9.0", "", {}, "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="],
 
+    "citty": ["citty@0.2.2", "", {}, "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w=="],
+
     "cli-cursor": ["cli-cursor@2.1.0", "", { "dependencies": { "restore-cursor": "^2.0.0" } }, "sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw=="],
 
     "cli-spinners": ["cli-spinners@2.9.2", "", {}, "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg=="],
@@ -2306,6 +2333,12 @@
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
+
+    "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
+
+    "fast-wrap-ansi": ["fast-wrap-ansi@0.2.2", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q=="],
 
     "fault": ["fault@2.0.1", "", { "dependencies": { "format": "^0.2.0" } }, "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ=="],
 

--- a/docs/tizen-sdb-protocol.md
+++ b/docs/tizen-sdb-protocol.md
@@ -1,0 +1,342 @@
+# Talking to a Samsung television without Tizen Studio
+
+A Samsung set in developer mode listens on tcp/26101 and speaks sdb, which is
+adb's wire protocol with a handful of Samsung differences. `sdb install` is a
+few hundred bytes of framing over that socket, so `packages/tv-installer` does
+not need the 260 MB SDK to sideload a `.wgt`.
+
+Everything below is either **confirmed** (bytes captured, or read out of a
+binary's own code) or **unconfirmed** (read out of a string table, or inferred).
+The line between the two is the point of this document, so it is marked on every
+claim. The captures were taken by pointing the real `sdb` 4.2.36 client at a
+listener on 127.0.0.1:26101 that answered as a device, and reading what it sent.
+
+## Framing
+
+**Confirmed.** A packet is a 24-byte header, little-endian throughout, followed
+by `data_length` bytes of payload:
+
+| offset | field |
+| --- | --- |
+| 0 | command |
+| 4 | arg0 |
+| 8 | arg1 |
+| 12 | data_length |
+| 16 | data_checksum |
+| 20 | magic |
+
+`data_checksum` is the sum of every payload byte modulo 2^32, not a CRC.
+`magic` is `command ^ 0xffffffff`. A header failing either check means the
+stream is desynced, and every frame after it is noise.
+
+The commands are adb's four-letter codes read little-endian:
+
+| name | value | meaning |
+| --- | --- | --- |
+| `CNXN` | `0x4e584e43` | handshake |
+| `OPEN` | `0x4e45504f` | open a service |
+| `OKAY` | `0x59414b4f` | accept, and acknowledge one write |
+| `WRTE` | `0x45545257` | stream payload |
+| `CLSE` | `0x45534c43` | close a stream |
+| `AUTH` | `0x48545541` | adb's RSA challenge |
+
+Every packet after the handshake carries **`arg0` = the sender's stream id and
+`arg1` = the receiver's**. Reading a `WRTE` by the wrong one is the mistake that
+looks like the device going quiet: it stops being acknowledged and the peer
+never writes again.
+
+## Handshake
+
+**Confirmed.** The host opens the socket and sends
+
+```
+CNXN arg0=0x00100000 arg1=0x00040000 "host::\0"
+```
+
+`arg0` is the protocol version. Samsung's is **`0x00100000`**, not adb's
+`0x01000000`. `arg1` is the largest payload the host will accept, 256 KiB.
+
+The device answers with its own `CNXN`, whose `arg1` caps what the host may put
+in one `WRTE`, and whose payload is a banner beginning `device::`. A bare
+`device::\0` is enough for `sdb devices` to list the set as online, so nothing
+in the banner is load-bearing for the client. The name in the third column comes
+from somewhere else: feeding a name through the banner in four shapes never
+moved it off `<unknown>`, so read `device_name` out of `capability:` instead.
+
+**Unconfirmed:** that a real television never sends `AUTH`. Tizen gates on the
+Host PC list in the Developer Mode panel rather than on an RSA key, and no Tizen
+tool here carries key-generation code, but nothing was captured from a set. The
+client treats an `AUTH` as a hard error naming the cause.
+
+## Streams
+
+**Confirmed.**
+
+```
+host   OPEN  <local> 0        "<service>\0"
+device OKAY  <remote> <local>                 accepted
+device CLSE  0        <local>                 refused
+host   WRTE  <local> <remote> <payload>
+device OKAY  <remote> <local>                 one per WRTE, the flow-control gate
+device WRTE  <remote> <local> <payload>
+host   OKAY  <local> <remote>
+either CLSE                                   echoed back by the other side
+```
+
+One unacknowledged `WRTE` per stream. Several services may be open at once on
+the one socket.
+
+`host:*` services (`host:devices`, `host:connect:…`) belong to the local sdb
+**server** on 26099 and do not exist on a device. There is no device-side
+listing service: enumerating televisions means connecting to each candidate's
+26101 yourself, which is what `devices()` does.
+
+## `capability:`
+
+**Confirmed**, and it is the detail most likely to be got wrong. The payload is
+a **uint16 little-endian byte count** followed by that many bytes of
+`key:value\n` lines. It is not bare text.
+
+The evidence is `sdb`'s own `is_support_secure_protocol`, which does
+`readx(fd, &len, 2)` then `readx(fd, buf, len)` and clamps `len` to `0xfff`.
+Behaviour follows: a listener answering with unframed text has its first two
+bytes eaten, so the first key silently never matches, while later keys still do.
+Adding the prefix flipped `sdb` from `pkgcmd` to `0 appuninstall` on the next
+run.
+
+Keys that decide behaviour: `sdk_toolpath` (where to push a package),
+`secure_protocol`, `appcmd_support`, `profile_name`, `device_name`,
+`platform_version`, `cpu_arch`.
+
+## `sync:`
+
+**Confirmed.** The sync service is adb's, unchanged. Requests are an 8-byte
+header, four ASCII letters and a uint32 little-endian, optionally followed by
+that many payload bytes.
+
+A push captured off the real client:
+
+```
+SEND  len=47  "/home/owner/share/tmp/sdk_tools/Kroma.wgt,33261"
+DATA  len=n   <bytes>          repeated
+DONE  mtime                    seconds since the epoch, in the length field
+OKAY  0                        from the device, or FAIL + len + message
+QUIT  0
+```
+
+`33261` is `0o100755` in decimal: sdb forces that mode regardless of the local
+file's. `sdb` sends a `STAT` for the destination first, to notice a directory;
+the client here skips it, and the push works without it.
+
+## Installing a `.wgt`
+
+**Confirmed** as the sequence stock `sdb install` performs:
+
+1. `capability:` for `sdk_toolpath`. When it is missing, `shell:/usr/bin/pkgcmd
+   -a | head -1 | awk '{print $5}'`. When that fails too, `sdb` gives up with
+   "failed to get package temporary path".
+2. `sync:` the file to `<sdk_toolpath>/<basename>`.
+3. `capability:` again, plus `shell:/usr/bin/profile_command getversion`.
+4. The install command.
+5. `shell:0 rmfile "<path>"` when the set advertises the secure protocol, else
+   `shell:/bin/rm -f "<path>"`.
+
+Which install command is chosen is decided in `sdb`'s `install()`, and reading
+the disassembly settles a question the string table only hints at: **stock `sdb`
+never uses `0 appinstall` for a `.wgt`.** The `0 appinstall` branch is taken only
+when the package type is `tpk` or `rpk` *and* `secure_protocol` is `enabled`.
+For a widget it always lands on
+
+```
+shell:/usr/bin/pkgcmd -i -t wgt -p "<path>" -q
+```
+
+with `-S` added when the skip option is set and `-G` when `-g` is. The
+`0 appinstall` format string takes the package **type** first and the path
+second, the same order as `pkgcmd`, not a package id:
+
+```
+shell:0 appinstall <type> <path>
+shell:0 appuninstall <pkgid>
+```
+
+**Unconfirmed, and this is the one that matters for a television.** Samsung's TV
+extension SDK is not installed on the reference machine, so no capture contains
+`vd_appinstall`. Its existence and spelling come from the `tizen-core` binary
+(`tools/tizen-core/tz`), which carries `vd_appinstall`, `vd_appuninstall` and
+`vd_applist` in its string table and these format strings in
+`device.createInstallCommand` / `createUninstallCommand`, resolved from the
+disassembly:
+
+```
+shell 0 vd_appuninstall %s
+shell 0 vd_appuninstall %s.%s
+shell 0 appuninstall %s
+shell 0 execute %s.%s
+shell 0 debug %s.%s
+```
+
+The argument order of `vd_appinstall` itself was **not** recovered: `tz` shells
+out to `sdb install` for the install path, so no format string for it exists in
+any binary here. `0 vd_appinstall <pkgid> <path>` is what the Samsung TV
+documentation describes, and it is what the client sends first, but a set has to
+confirm it.
+
+The client therefore tries three shapes in order and stops at the first that
+reports success:
+
+```
+0 vd_appinstall <pkgid> <path>
+0 appinstall <type> <path>
+/usr/bin/pkgcmd -i -t <type> -p "<path>" -q
+```
+
+Uninstall and launch work the same way. Launch leads with `0 was_execute
+<appid>`, which is what this repository already sends through `sdb` today and
+which appears in no binary here, then `0 execute <appid>`, then
+`/usr/bin/app_launcher -s <appid>`.
+
+The `0` prefix is not a shell escape. It is the first argument to sdbd's own
+command dispatcher, which is why `0 rmfile` and `/bin/rm -f` are alternatives
+for the same job. A restricted sdbd accepts only the dispatcher forms.
+
+## Reading the result
+
+**Confirmed** shapes:
+
+- The sync service says `OKAY` or `FAIL` + length + message.
+- `pkgcmd` prints `processing result : OK [0] succeeded` or
+  `processing result : FAIL [n] …`, alongside a `spend time for pkgcmd is …`
+  line that says nothing about success.
+- A refused `OPEN` is a `CLSE` where an `OKAY` was expected.
+
+**Confirmed from the Tizen sdblib jar, not captured:** where the set advertises
+`appcmd_support:enabled`, there is a cleaner API that carries an exit code.
+`ApplicationCmdService` opens `appcmd:<verb>` and reads `appcmd_exitcode:<n>`
+and `appcmd_returnstr:<…>` back:
+
+```
+appcmd:install:<type>:<remotePath>
+appcmd:uninstall:<pkgid>
+appcmd:runapp:<appid>
+appcmd:killapp:<appid>
+appcmd:packageinfo:<pkgid>
+appcmd:appinstallpath:
+appcmd:debugwebapp:<appid>
+```
+
+The client reads `appcmd_exitcode` when it is present, because it is the only
+unambiguous answer, but it does not open `appcmd:` yet: no television here has
+confirmed it answers.
+
+**Unconfirmed:** what `0 vd_appinstall` prints. The parser returns one of three
+verdicts, `success`, `failure` and **`unknown`**, and `unknown` means "this set
+said nothing I recognise", which is a reason to try the next command shape
+rather than to declare a failure. Silence from a set that actually installed the
+package would otherwise read as a broken install.
+
+## What still needs a television
+
+In rough order of how much a wrong guess costs:
+
+1. **The `vd_appinstall` argument order.** `<pkgid> <path>` versus
+   `<type> <path>`. If the first shape is wrong the client falls through to
+   `pkgcmd`, so the cost is a confusing log line rather than a failure, but it
+   should be settled.
+2. **What a successful `0 vd_appinstall` prints**, so `unknown` stops being a
+   possible outcome of a good install.
+3. **Whether a television's sdbd offers `sync:` at all.** Every capture here is
+   against stock sdb's own idea of a device. A restricted TV sdbd could refuse
+   it, in which case the fallback is streaming the bytes through a shell service,
+   which is not implemented because there is nothing yet to say it is needed.
+4. **Whether `AUTH` ever arrives.**
+5. **Whether `capability:` is offered.** The client falls back to
+   `/home/owner/share/tmp/sdk_tools` when it is not, which is the path every
+   capture produced anyway.
+6. **`0 was_execute` versus `0 execute`** for launching, and what either prints.
+
+## Signing
+
+A `.wgt` carries two XML digital signatures at its root, and both are present in
+what CI ships:
+
+- `author-signature.xml`, `Id="AuthorSignature"`, signed by the author key.
+- `signature1.xml`, `Id="DistributorSignature"`, signed by a distributor key,
+  and it also references `author-signature.xml`.
+
+`.github/workflows/_release-tv.yml` generates a throwaway author certificate per
+run, so the comment there calling it "a throwaway author certificate" is right
+about the author half. It is **not** the whole story: `tizen security-profiles
+add` fills the distributor slot automatically from the certificate that ships
+inside Tizen Studio, which is why the workflow patches the well-known password
+`tizenpkcs12passfordsigner` into `profiles.xml`. The `.wgt` KROMA releases is
+therefore signed by a self-signed author certificate **and** by Tizen's public
+distributor signer.
+
+Producing both files on the reference machine and reading them confirms the
+shape:
+
+| | |
+| --- | --- |
+| canonicalisation | `http://www.w3.org/2001/10/xml-exc-c14n#` |
+| signature method | `http://www.w3.org/2001/04/xmldsig-more#rsa-sha512` |
+| digest method | `http://www.w3.org/2001/04/xmlenc#sha512` |
+| references | one per file in the package, URI-encoded relative paths |
+| `#prop` reference | transformed by `http://www.w3.org/2006/12/xml-c14n11` |
+| `Object Id="prop"` | `dsp:Profile`, `dsp:Role` (`role-author` or `role-distributor`), `dsp:Identifier` |
+| `KeyInfo` | `X509Data` carrying the signer and its CA, base64 wrapped at 76 columns |
+
+`signature1.xml` differs only in its `Id`, its role URI and in listing
+`author-signature.xml` as its first reference.
+
+**Does a developer-mode set accept a `.wgt` with no distributor signature, or a
+self-signed one?** Unconfirmed, and the release notes claiming a dev-mode TV
+accepts what CI signs are describing a package that has a real distributor
+signature, so they are not evidence either way. Tizen's signature validator is
+specified to require both files and derives the app's privilege level from the
+distributor certificate's root, which argues that author-only is refused. That
+has to be tested on a set.
+
+There is a third distributor key in play that neither CI nor this document uses:
+the Samsung Certificate Extension issues a distributor certificate bound to a
+particular set's DUID, and that is what Samsung's own instructions have you sign
+with before sideloading. A machine that has ever paired with a real television
+through Tizen Studio has one, under `~/SamsungCertificate/<profile>/`. Whether a
+developer-mode set insists on it, accepts Tizen's public distributor signer, or
+accepts neither is the same open question as above, and one set answers all
+three at once.
+
+Writing a signer from scratch is a day's work, not a research project: build the
+reference list by walking the package, SHA-512 each file, serialise the two XML
+documents, exclusive-c14n the `SignedInfo` element, RSA-SHA512 it. The awkward
+part is exclusive canonicalisation, which is fussy about namespace inheritance
+and attribute ordering and where a hand-rolled implementation quietly produces a
+signature that verifies nowhere.
+
+If it turns out to be needed, the design is a key pair generated on first use
+into `~/.kroma` and signed there. Neither a private key nor Samsung's or Tizen's
+distributor key belongs in this repository, and copying
+`tizen-distributor-signer.p12` out of Tizen Studio would put the SDK back in the
+dependency list by the back door.
+
+## Where the code is
+
+`packages/tv-installer/src/modules/tizen/sdb/`, dependency-free apart from `node:net`
+and `node:fs`:
+
+| file | what it owns |
+| --- | --- |
+| `packet.ts` | the header, the checksum, and reassembly out of a byte stream |
+| `stream.ts` | one multiplexed service, its flow control and its timeouts |
+| `connection.ts` | the socket, the handshake, and the stream table |
+| `capability.ts` | the length-prefixed `key:value` payload |
+| `sync.ts` | the file push |
+| `shell.ts` | one command, bounded output |
+| `commands.ts` | every command shape, as pure strings |
+| `result.ts` | success, failure or unknown |
+| `device.ts` | `connect()`, `devices()`, and the fallback chains |
+
+The tests beside them cover the pure halves, which is everything except the
+socket: header round trips, the checksum, reassembly across chunk boundaries,
+the capability framing, the sync requests, the command strings and the result
+parser. Nothing in the suite needs a television.

--- a/docs/tizen-sdb-protocol.md
+++ b/docs/tizen-sdb-protocol.md
@@ -141,6 +141,13 @@ the client here skips it, and the push works without it.
 5. `shell:0 rmfile "<path>"` when the set advertises the secure protocol, else
    `shell:/bin/rm -f "<path>"`.
 
+This tool's client differs from that sequence twice, and the tests pin both.
+It reads `capability:` once per connection and caches it, so there is no step 3,
+and it never runs `profile_command`. And it does not read `secure_protocol` to
+choose how to delete the pushed file: it tries `0 rmfile` and falls back to
+`/bin/rm -f` only when the first reports a failure, which reaches the same end
+on a restricted sdbd by a different route.
+
 Which install command is chosen is decided in `sdb`'s `install()`, and reading
 the disassembly settles a question the string table only hints at: **stock `sdb`
 never uses `0 appinstall` for a `.wgt`.** The `0 appinstall` branch is taken only

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "modules:test": "bun run modules cargo test",
     "modules:clippy": "bun run modules cargo clippy --all-targets",
     "modules:check": "bun run modules:validate && bun run modules:gen && git diff --exit-code -- modules server/crates/kroma-modules-generated packages/modules-generated",
+    "tv": "bun packages/tv-installer/src/cli.ts",
+    "build:tv-cli": "bun run --filter '@kroma/tv-installer' compile",
     "spec:index": "bun docs/spec/scripts/spec-index.ts",
     "spec:check": "bun docs/spec/scripts/spec-index.ts --check",
     "shots": "bun run --filter '@kroma/ui' shots",

--- a/packages/tv-installer/README.md
+++ b/packages/tv-installer/README.md
@@ -1,0 +1,240 @@
+# @kroma/tv-installer
+
+Finds the televisions on this network, installs the toolchain each platform
+needs, then sideloads KROMA onto the sets you pick.
+
+```bash
+bun run tv
+```
+
+With no argument the picker opens straight away and fills itself as the scan
+finds sets. Arrow keys move, space ticks, enter stops the scan and installs onto
+whatever is ticked. It installs the toolchain a set needs before touching it.
+
+Three platforms take a sideloaded package: Samsung (Tizen, `.wgt`), LG (webOS,
+`.ipk`) and Android TV (`.apk`, which covers Philips, Sony, TCL, Shield and
+Chromecast with Google TV). An Apple TV never appears in the list. Install one
+with `bun run --filter '@kroma/tv-native' ios`.
+
+## What the scan probes
+
+Three things at once:
+
+- An SSDP `M-SEARCH` for `urn:dial-multiscreen-org:service:dial:1`, LG's
+  second-screen target and `upnp:rootdevice`, over a 2.5 second window. Whatever
+  replies has its UPnP description fetched, which is where a set's friendly name
+  and manufacturer come from.
+- A TCP sweep of every `/24` this machine sits on, minus its own address, on four
+  ports: **8001** (Samsung's REST API), **9922** (LG's Dev Mode key server),
+  **1925** (JointSpace on a Philips) and **5555** (adb). A port has 700 ms to
+  accept.
+- CoreDevice, for the Apple TVs this Mac is paired with. They answer no probe at
+  all, so they are asked for rather than swept for, and a Mac with no Xcode is
+  told nothing rather than failed.
+
+A host that answered anything is then asked three more ports (26101 for sdb, 3000
+for the webOS app, 1926 for JointSpace over TLS) and identified:
+
+| What answers | Verdict |
+| --- | --- |
+| `GET http://<ip>:8001/api/v2/` parses as Samsung's device info | Tizen. Developer mode counts as on when the set reports `developerMode: "1"` or 26101 is open |
+| 9922 is open, or UPnP says LG Electronics or webOS | webOS. Dev Mode is running only when 9922 is open |
+| JointSpace answers `/6/system` or `/1/system` on 1925, or `/6/system` on 1926 over TLS | Philips. Its `os_type` decides whether the set takes an app at all |
+| 5555 is open and nothing above matched | Android TV, with whatever name UPnP gave it |
+
+Nothing else counts as a television.
+
+### What a set runs
+
+Every set listed says which platform version and browser engine it runs, and
+where that came from. The `scan` line carries it under the set, `--json` as
+`runtime`.
+
+- **Read off the set.** An Android TV that has accepted this computer over adb
+  answers `ro.build.version.release`, and the engine comes from
+  `dumpsys package com.google.android.webview`. An Apple TV reports its tvOS
+  version to CoreDevice and names React Native where the others name a browser,
+  because the app is compiled and no browser runs it.
+- **Worked out from the model**, printed with a trailing `by model` and marked
+  `"learned": "derived"` under `--json`. Samsung and LG each freeze a Chromium
+  per OS major and an OS major per model year, so `24_PTM_FTV_T09`,
+  `OLED55C16LA` and `55UR78006LK` date the set and its engine both. A Philips
+  adb cannot reach is floored by the year in its `os_type`, and
+  `MSAF_2019_ANDROID_TV` shipped Android 9.
+
+The tables live in `src/modules/*/runtime.ts` and follow the shells built for
+those engines (`clients/tizen/tv.target.ts`, `clients/webos/README.md`). A set
+no table dates carries no version rather than a guess.
+
+### Why a set may not answer
+
+- **It is off.**
+- **Its platform's port is still shut.** An LG without the Dev Mode app running
+  only turns up if it replied to SSDP; an Android TV with network debugging off
+  and no JointSpace answers nothing at all. A Samsung answers 8001 either way and
+  is listed with the step it needs.
+- **It is on another subnet.** The sweep walks the `/24`s of this machine's own
+  interfaces and no further. Anything beyond them has to be named as an explicit
+  host address.
+
+### macOS wants the Local Network permission
+
+The first sweep makes macOS ask whether the terminal may talk to the local
+network. Miss the prompt or deny it and every connection fails without an error:
+the scan finds nothing and says nothing is wrong. Grant it under **System
+Settings > Privacy & Security > Local Network** for the terminal app you run
+`bun run tv` from, then scan again.
+
+## The one-time step on the television
+
+None of these can be switched on over the network.
+
+**Samsung (Tizen).** Open the **Apps** panel and type **1 2 3 4 5** on the
+remote. In the popup that appears, switch **Developer mode ON**, enter the IP of
+this computer as the host PC, and reboot the set. Port 26101 only opens after
+that reboot, and the scan says so.
+
+**LG (webOS).** Install the **Dev Mode** app from the LG Content Store, sign in
+with a free developer.lge.com account, switch **Dev Mode ON** (the TV restarts),
+then switch **Key Server ON**. The app shows a passphrase, which the TUI asks
+for once per LG set. A session lasts **50 hours**, and when it runs out the
+sideloaded app goes with it, so extend it from the same app.
+
+**Android TV, Philips included.** **Settings > System > About**, then click the
+build 7 times until it tells you that you are a developer. **Developer options**
+appears in the same menu: turn **Network debugging** on. The name varies by
+brand, and on a Chromecast with Google TV the switch called USB debugging is the
+one that opens the network port. The first `adb connect` raises a prompt on
+screen: accept it, tick "always allow", and run the install again.
+
+A Philips is only an Android TV if it says so. On one running **Saphi** or
+**Titan OS** the scan lists the set and names the OS as the reason it takes no
+sideloaded app, only what its own store offers. There is nothing to enable there.
+
+## Toolchain
+
+No toolchain has to be installed by hand. An install fetches whatever the sets
+it is about to touch need, and the `doctor` and `tools` commands below report or
+fetch it without going near a television. Anything already on `PATH` is used as
+it is.
+
+| Platform | Tools | Source | Lands in |
+| --- | --- | --- | --- |
+| Samsung | `tizen`, `sdb` | the Tizen Studio 6.0 CLI installer from download.tizen.org, around 260 MB | `$TIZEN_HOME`, default `~/tizen-studio` |
+| LG | the `ares-*` commands | `bun add -g @webos-tools/cli` | `~/.bun/bin` |
+| Android TV | `adb` | Google's `platform-tools-latest` zip | `~/.kroma/tools/platform-tools` |
+
+An existing Android SDK is picked up first, from `$ANDROID_HOME`,
+`$ANDROID_SDK_ROOT` or `~/Library/Android/sdk`.
+
+Tizen Studio is the awkward one. It needs a JDK (`brew install --cask temurin`,
+or `apt install default-jdk`) and on Apple silicon it is an x86_64 binary, so
+Rosetta has to be there first
+(`softwareupdate --install-rosetta --agree-to-license`). Both are checked before
+the download starts. The headless installer exists for macOS and Linux only;
+anywhere else the tool stops and tells you to install it by hand.
+
+## Where the package comes from
+
+In order:
+
+1. The path given on the command line, used as it is.
+2. The newest matching build in this checkout: `clients/tizen/out|dist/*.wgt`,
+   `clients/webos/out|build/*.ipk`, `out/*.apk` or the tv-native release output.
+   For Tizen the every-tier `KROMA-tizen-<n>` build is preferred over the
+   per-generation slices.
+3. `gh release download --pattern '*.wgt'` (or `.ipk`, `.apk`) from the latest
+   release, into `~/.kroma/downloads/<platform>`. This needs `gh` on `PATH` and
+   logged in.
+
+With none of the three it stops and prints the `gh run download` line for the
+matching Build & Release artifact.
+
+The id the app is launched by is read from the shell that ships it
+(`clients/tizen/public/config.xml`, `clients/webos/public/appinfo.json`,
+`clients/tv-native/app.json`), so renaming one there is enough.
+
+## Commands
+
+Generated from the command definitions by `bun run tv docs`. Nothing between the
+markers is written by hand.
+
+<!-- usage:start -->
+
+| command | what it does |
+| --- | --- |
+| `bun run tv` | Find the televisions on this network and put KROMA on them. With no command it opens the picker. |
+| `bun run tv scan` | List what answered and stop, the picker without the picking. |
+| `bun run tv install <target>` | Put KROMA on one set, or on all of them, without the picker. |
+| `bun run tv probe <host>` | Ask a Samsung set what it is over sdb, installing nothing. |
+| `bun run tv certificate` | Generate a Samsung author certificate and the profile the tools sign with. |
+| `bun run tv tools <platform>` | Install the toolchain a platform needs, which the picker does on its own. |
+| `bun run tv doctor` | Show which toolchains this computer already has. |
+| `bun run tv docs` | Write this command tree into the package README, where nothing is typed by hand. |
+
+| option | what it does |
+| --- | --- |
+| `--host <ip>` | Probe this address instead of sweeping the network, repeatable |
+| `--package <path>` | The .wgt, .ipk, .apk or .app to install, instead of the newest built here |
+| `--source <local|stable|canary|build>` | Where the package comes from, instead of the newest build in this checkout |
+| `--launch`, `--no-launch` | Start the app once it is installed |
+| `--json` | Print what answered as JSON |
+
+<!-- usage:end -->
+
+## Downloading it, rather than building it
+
+Every release carries the installer as one executable, and every Build & Release
+run uploads the same three as run artifacts:
+
+```bash
+gh release download --pattern 'kroma-tv-*-darwin-arm64'   # or darwin-x64, linux-x64
+gh run download -n kroma-tv-bun-darwin-arm64              # from a run, no release needed
+chmod +x kroma-tv-*
+xattr -d com.apple.quarantine kroma-tv-*                  # macOS, once
+./kroma-tv-* scan
+```
+
+The binary is signed ad-hoc, not with a Developer ID, so macOS quarantines it
+until that attribute is cleared. Windows is not built: the installer drives sdb,
+adb, ares and devicectl and reads an ARP table, a keychain and a Settings pane.
+
+Run from outside a checkout it finds televisions and installs toolchains, but
+the package has to come from `--package`: looking for the newest build, and
+asking `gh` for a release asset, both need the repository.
+
+## As a single binary
+
+```bash
+bun run build:tv-cli                      # dist/kroma-tv, ~64 MB, no Bun needed to run it
+bun run build:tv-cli --target=bun-linux-x64
+```
+
+Targets: `bun-darwin-arm64`, `bun-darwin-x64`, `bun-linux-x64`,
+`bun-windows-x64`. On macOS the binary is re-signed after the build, because the
+signature `bun build --compile` leaves behind is one the system kills on sight.
+
+## When it goes wrong
+
+- **The scan finds nothing on macOS.** The Local Network permission, above. Check
+  it first, because a denied permission looks exactly like an empty network.
+- **"the TV refused the connection" on a Samsung.** Developer mode has to name
+  this computer as the host PC, and the set has to have been rebooted since. The
+  scan prints the IP the TV currently trusts.
+- **A Samsung install fails on a signature.** A KROMA signed with a different
+  certificate is already installed: delete its tile from the Apps panel
+  (long-press > Delete) and install again.
+- **`INSTALL_FAILED_UPDATE_INCOMPATIBLE`.** The Android version of the same
+  thing: `adb uninstall tv.kroma.tv`, then install again.
+- **`INSTALL_FAILED_VERSION_DOWNGRADE`.** The set already has a newer build.
+  Uninstall it, or install a newer `.apk`.
+- **adb sees the TV as `unauthorized`.** The prompt is on the television. Accept
+  it and run the install again.
+- **The LG install cannot get a key.** `ares` needs the passphrase from the Dev
+  Mode app, and a session past its 50 hours needs that app opened again first.
+- **`no .wgt found`, and the same for the other two.** Nothing is built here and
+  `gh` found no release asset. Build the shell, or download the artifact from a
+  Build & Release run.
+
+The manual path for each platform, and every device that is not a television, is
+in [INSTALL.md](../../INSTALL.md).

--- a/packages/tv-installer/package.json
+++ b/packages/tv-installer/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@kroma/tv-installer",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Finds the televisions on this network, installs the toolchain each platform needs, then sideloads KROMA onto them: a Samsung .wgt, an LG .ipk, an Android TV .apk.",
+  "author": "Maxime Scharwath <maxscharwath@gmail.com>",
+  "license": "GPL-2.0-or-later",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "directory": "packages/tv-installer"
+  },
+  "exports": {
+    ".": "./src/cli.ts"
+  },
+  "bin": {
+    "kroma-tv": "./src/cli.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "compile": "bun scripts/compile.ts"
+  },
+  "dependencies": {
+    "@clack/core": "1.4.3",
+    "@clack/prompts": "1.7.0",
+    "citty": "0.2.2",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.20.1",
+    "bun-types": "^1.4.0",
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.10"
+  }
+}

--- a/packages/tv-installer/scripts/compile.ts
+++ b/packages/tv-installer/scripts/compile.ts
@@ -1,0 +1,23 @@
+import { $ } from 'bun';
+
+const TARGETS = ['bun-darwin-arm64', 'bun-darwin-x64', 'bun-linux-x64', 'bun-windows-x64'];
+
+const target = process.argv.find((arg) => arg.startsWith('--target='))?.slice('--target='.length);
+if (target && !TARGETS.includes(target)) {
+  console.error(`unknown target '${target}'\ntargets: ${TARGETS.join(', ')}`);
+  process.exit(1);
+}
+
+const name = `kroma-tv${target ? `-${target.replace('bun-', '')}` : ''}`;
+const out = `dist/${name}${target?.includes('windows') ? '.exe' : ''}`;
+
+await $`bun build --compile ${target ? ['--target', target] : []} ./src/cli.ts --outfile ${out}`;
+
+// macOS kills a compiled binary whose ad-hoc signature it cannot validate, and
+// the one `bun build` leaves behind is not one it accepts.
+if (process.platform === 'darwin' && (target ?? 'bun-darwin').includes('darwin')) {
+  await $`codesign --force --sign - ${out}`.quiet();
+}
+
+const { size } = await Bun.file(out).stat();
+console.log(`${out}  ${(size / 1e6).toFixed(0)} MB`);

--- a/packages/tv-installer/scripts/compile.ts
+++ b/packages/tv-installer/scripts/compile.ts
@@ -8,7 +8,8 @@ if (target && !TARGETS.includes(target)) {
   process.exit(1);
 }
 
-const name = `kroma-tv${target ? `-${target.replace('bun-', '')}` : ''}`;
+const suffix = target ? `-${target.replace('bun-', '')}` : '';
+const name = `kroma-tv${suffix}`;
 const out = `dist/${name}${target?.includes('windows') ? '.exe' : ''}`;
 
 await $`bun build --compile ${target ? ['--target', target] : []} ./src/cli.ts --outfile ${out}`;

--- a/packages/tv-installer/src/cli.test.ts
+++ b/packages/tv-installer/src/cli.test.ts
@@ -1,0 +1,174 @@
+import { runCommand } from 'citty';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { tv } from './cli';
+import { docsCommand, doctorCommand, installCommand, scanCommand, toolsCommand } from './commands';
+import { runTui } from './tui/app';
+
+vi.mock('./commands', () => ({
+  docsCommand: vi.fn(),
+  doctorCommand: vi.fn(),
+  installCommand: vi.fn(),
+  scanCommand: vi.fn(),
+  toolsCommand: vi.fn(),
+}));
+vi.mock('./exit-after', () => ({ exitAfter: vi.fn() }));
+vi.mock('./tui/app', () => ({ runTui: vi.fn() }));
+
+const argv = process.argv;
+const isTTY = process.stdout.isTTY;
+
+const run = (rawArgs: readonly string[]) => {
+  process.argv = ['bun', 'tv', ...rawArgs];
+  return runCommand(tv, { rawArgs: [...rawArgs] });
+};
+
+beforeEach(() => {
+  process.stdout.isTTY = false;
+});
+
+afterEach(() => {
+  process.argv = argv;
+  process.stdout.isTTY = isTTY;
+  vi.clearAllMocks();
+});
+
+describe('tv scan', () => {
+  it('scans the network and prints what answered', async () => {
+    await run(['scan']);
+
+    expect(vi.mocked(scanCommand)).toHaveBeenCalledWith({
+      hosts: undefined,
+      json: false,
+      launch: true,
+    });
+  });
+
+  it('asks for machine output when the command line does', async () => {
+    await run(['scan', '--json']);
+
+    expect(vi.mocked(scanCommand).mock.calls[0]?.[0]?.json).toBe(true);
+  });
+
+  it('keeps every address the command line repeats, not only the last', async () => {
+    await run(['scan', '--host', '192.168.1.31', '--host', '192.168.1.44']);
+
+    expect(vi.mocked(scanCommand).mock.calls[0]?.[0]?.hosts).toEqual([
+      '192.168.1.31',
+      '192.168.1.44',
+    ]);
+  });
+
+  it('reads an address spelled onto the flag with an equals sign', async () => {
+    await run(['scan', '--host=192.168.1.31']);
+
+    expect(vi.mocked(scanCommand).mock.calls[0]?.[0]?.hosts).toEqual(['192.168.1.31']);
+  });
+
+  it('sweeps the network when the flag was given no address at all', async () => {
+    await run(['scan', '--host', '--json']);
+
+    expect(vi.mocked(scanCommand).mock.calls[0]?.[0]?.hosts).toBeUndefined();
+  });
+});
+
+describe('tv install', () => {
+  it('installs onto the target it was given', async () => {
+    await run(['install', '192.168.1.31']);
+
+    expect(vi.mocked(installCommand)).toHaveBeenCalledWith('192.168.1.31', {
+      hosts: undefined,
+      artifact: undefined,
+      source: undefined,
+      moduleOptions: { native: false },
+      launch: true,
+      json: false,
+    });
+  });
+
+  it('hands the package, the channel and the platform flags on', async () => {
+    await run([
+      'install',
+      'all',
+      '--package',
+      '/out/KROMA.wgt',
+      '--source',
+      'canary',
+      '--profile',
+      'kroma',
+      '--native',
+      '--no-launch',
+    ]);
+
+    expect(vi.mocked(installCommand)).toHaveBeenCalledWith('all', {
+      hosts: undefined,
+      artifact: '/out/KROMA.wgt',
+      source: 'canary',
+      moduleOptions: { profile: 'kroma', native: true },
+      launch: false,
+      json: false,
+    });
+  });
+
+  it('refuses a channel no release answers to', async () => {
+    await expect(run(['install', 'all', '--source', 'ftp'])).rejects.toThrow(
+      '--source takes local, stable, canary, build',
+    );
+  });
+});
+
+describe('tv tools', () => {
+  it('installs the toolchain of every platform named', async () => {
+    await run(['tools', 'tizen', 'webos']);
+
+    expect(vi.mocked(toolsCommand)).toHaveBeenCalledWith(['tizen', 'webos']);
+  });
+});
+
+describe('tv doctor', () => {
+  it('reports what this computer already has', async () => {
+    await run(['doctor']);
+
+    expect(vi.mocked(doctorCommand)).toHaveBeenCalledOnce();
+  });
+});
+
+describe('tv docs', () => {
+  it('writes the command tree into the README', async () => {
+    await run(['docs']);
+
+    expect(vi.mocked(docsCommand)).toHaveBeenCalledWith(tv, false);
+  });
+
+  it('checks the README instead of writing it when asked to', async () => {
+    await run(['docs', '--check']);
+
+    expect(vi.mocked(docsCommand)).toHaveBeenCalledWith(tv, true);
+  });
+});
+
+describe('tv', () => {
+  it('opens the picker when it was started from a terminal', async () => {
+    process.stdout.isTTY = true;
+
+    await run(['--package', '/out/KROMA.wgt']);
+
+    expect(vi.mocked(runTui)).toHaveBeenCalledWith({
+      hosts: undefined,
+      artifact: '/out/KROMA.wgt',
+      source: undefined,
+      launch: true,
+    });
+    expect(vi.mocked(scanCommand)).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a scan where there is no terminal to draw a picker in', async () => {
+    await run(['--json']);
+
+    expect(vi.mocked(runTui)).not.toHaveBeenCalled();
+    expect(vi.mocked(scanCommand)).toHaveBeenCalledWith({
+      hosts: undefined,
+      json: true,
+      launch: true,
+    });
+  });
+});

--- a/packages/tv-installer/src/cli.ts
+++ b/packages/tv-installer/src/cli.ts
@@ -1,0 +1,169 @@
+#!/usr/bin/env bun
+import { defineCommand, runMain } from 'citty';
+import { docsCommand, doctorCommand, installCommand, scanCommand, toolsCommand } from './commands';
+import { exitAfter } from './exit-after';
+import type { Source } from './install/artifact';
+import { moduleArgs, moduleCommands, moduleOptions, modules } from './modules/registry';
+import { runTui } from './tui/app';
+
+const SOURCES: readonly Source[] = ['local', 'stable', 'canary', 'build'];
+
+const hostArg = {
+  type: 'string',
+  valueHint: 'ip',
+  description: 'Probe this address instead of sweeping the network, repeatable',
+} as const;
+
+const packageArg = {
+  type: 'string',
+  valueHint: 'path',
+  description: `The ${packageKinds()} to install, instead of the newest built here`,
+} as const;
+
+const launchArg = {
+  type: 'boolean',
+  default: true,
+  description: 'Start the app once it is installed',
+  negativeDescription: 'Install without starting the app',
+} as const;
+
+const sourceArg = {
+  type: 'string',
+  valueHint: 'local|stable|canary|build',
+  description: 'Where the package comes from, instead of the newest build in this checkout',
+} as const;
+
+const jsonArg = {
+  type: 'boolean',
+  default: false,
+  description: 'Print what answered as JSON',
+} as const;
+
+const scan = defineCommand({
+  meta: {
+    name: 'scan',
+    description: 'List what answered and stop, the picker without the picking.',
+  },
+  args: { host: hostArg, json: jsonArg },
+  run: ({ args }) => exitAfter(scanCommand({ hosts: hostList(), json: args.json, launch: true })),
+});
+
+const install = defineCommand({
+  meta: {
+    name: 'install',
+    description: 'Put KROMA on one set, or on all of them, without the picker.',
+  },
+  args: {
+    target: {
+      type: 'positional',
+      required: true,
+      description: "The address of a set, or 'all' for every set that answered",
+    },
+    host: hostArg,
+    package: packageArg,
+    source: sourceArg,
+    launch: launchArg,
+    ...moduleArgs(),
+  },
+  run: ({ args }) =>
+    exitAfter(
+      installCommand(String(args.target), {
+        hosts: hostList(),
+        artifact: text(args.package),
+        source: asSource(text(args.source)),
+        moduleOptions: moduleOptions(args),
+        launch: args.launch !== false,
+        json: false,
+      }),
+    ),
+});
+
+const tools = defineCommand({
+  meta: {
+    name: 'tools',
+    description: 'Install the toolchain a platform needs, which the picker does on its own.',
+  },
+  args: {
+    platform: {
+      type: 'positional',
+      required: true,
+      description: `${withTools().join(', ')}, and more than one is allowed`,
+    },
+  },
+  run: ({ args }) => exitAfter(toolsCommand(args._)),
+});
+
+const doctor = defineCommand({
+  meta: { name: 'doctor', description: 'Show which toolchains this computer already has.' },
+  run: () => exitAfter(doctorCommand()),
+});
+
+const docs = defineCommand({
+  meta: {
+    name: 'docs',
+    description: 'Write this command tree into the package README, where nothing is typed by hand.',
+  },
+  args: {
+    check: {
+      type: 'boolean',
+      default: false,
+      description: 'Fail when the README is out of date instead of rewriting it',
+    },
+  },
+  run: ({ args }) => exitAfter(docsCommand(tv, args.check)),
+});
+
+export const tv = defineCommand({
+  meta: {
+    name: 'tv',
+    description:
+      'Find the televisions on this network and put KROMA on them. With no command it opens the picker.',
+  },
+  args: { host: hostArg, package: packageArg, source: sourceArg, launch: launchArg, json: jsonArg },
+  subCommands: { scan, install, ...moduleCommands(), tools, doctor, docs },
+  run: ({ args }) => {
+    const hosts = hostList();
+    if (!process.stdout.isTTY) {
+      return exitAfter(scanCommand({ hosts, json: args.json, launch: args.launch }));
+    }
+    return exitAfter(
+      runTui({ hosts, artifact: args.package, source: asSource(args.source), launch: args.launch }),
+    );
+  },
+});
+
+function withTools(): string[] {
+  return modules()
+    .filter((module) => module.tools().length > 0)
+    .map((module) => module.id);
+}
+
+function packageKinds(): string {
+  const kinds = modules().map((module) => module.package);
+  const last = kinds.at(-1) ?? '';
+  return kinds.length > 1 ? `${kinds.slice(0, -1).join(', ')} or ${last}` : last;
+}
+
+function text(value: unknown): string | undefined {
+  return typeof value === 'string' && value !== '' ? value : undefined;
+}
+
+function asSource(value: string | undefined): Source | undefined {
+  if (value === undefined) return undefined;
+  if (!SOURCES.includes(value as Source)) throw new Error(`--source takes ${SOURCES.join(', ')}`);
+  return value as Source;
+}
+
+// citty keeps only the last --host, so every repeat is read from argv instead.
+function hostList(): string[] | undefined {
+  const argv = process.argv.slice(2);
+  const hosts = argv.flatMap((arg, index) => {
+    if (arg.startsWith('--host=')) return [arg.slice('--host='.length)];
+    if (arg !== '--host') return [];
+    const value = argv[index + 1];
+    return value === undefined || value.startsWith('-') ? [] : [value];
+  });
+  return hosts.length > 0 ? hosts : undefined;
+}
+
+if (import.meta.main) await runMain(tv);

--- a/packages/tv-installer/src/commands.test.ts
+++ b/packages/tv-installer/src/commands.test.ts
@@ -310,6 +310,14 @@ describe('toolsCommand', () => {
     expect(installTool.mock.calls.map(([tool]) => (tool as Tool).id)).toEqual(['ares', 'adb']);
   });
 
+  it('says so about a platform that needs nothing this tool can install', async () => {
+    const code = await toolsCommand(['appletv']);
+
+    expect(code).toBe(0);
+    expect(printed.join('\n')).toContain('Apple TV needs nothing this tool can install');
+    expect(installTool).not.toHaveBeenCalled();
+  });
+
   it('refuses a platform no module answers for, and names the ones that do', async () => {
     const code = await toolsCommand(['sony']);
 

--- a/packages/tv-installer/src/commands.test.ts
+++ b/packages/tv-installer/src/commands.test.ts
@@ -1,0 +1,345 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { docsCommand, doctorCommand, installCommand, scanCommand, toolsCommand } from './commands';
+import type { DeployOptions } from './install/deploy';
+import type { Television } from './television';
+import type { Tool } from './toolchain/detect';
+import { injectUsage, renderUsage, type UsageCommand } from './usage';
+
+const { checkout, scan, deployTo, askForLocalNetwork, diagnoseEmptyScan, locate, installTool } =
+  await vi.hoisted(async () => {
+    const { mkdtempSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    return {
+      checkout: mkdtempSync(join(tmpdir(), 'kroma-tv-commands-')),
+      scan: vi.fn(async (_options: unknown): Promise<unknown[]> => []),
+      deployTo: vi.fn(async (_tv: unknown, _options: unknown) => {}),
+      askForLocalNetwork: vi.fn(async () => {}),
+      diagnoseEmptyScan: vi.fn(async () => ({
+        blocked: false,
+        hints: ['a set answers when it is on'],
+      })),
+      locate: vi.fn((_tool: unknown): string | null => null),
+      installTool: vi.fn(async (_tool: unknown, _log: unknown) => '/usr/bin/adb'),
+    };
+  });
+vi.mock('./discovery/scan', () => ({ scan }));
+vi.mock('./install/deploy', () => ({ deployTo }));
+vi.mock('./local-network', () => ({ askForLocalNetwork }));
+vi.mock('./hints', () => ({ diagnoseEmptyScan }));
+vi.mock('./root', () => ({ root: checkout }));
+vi.mock('./toolchain/detect', async (original) => ({
+  ...(await original<Record<string, unknown>>()),
+  locate,
+}));
+vi.mock('./toolchain/install', async (original) => ({
+  ...(await original<Record<string, unknown>>()),
+  installTool,
+}));
+
+const readme = join(checkout, 'packages', 'tv-installer', 'README.md');
+vi.stubGlobal('Bun', {
+  file: (path: string) => ({ text: async () => readFileSync(path, 'utf8') }),
+  write: async (path: string, content: string) => writeFileSync(path, content),
+});
+
+const salon: Television = {
+  host: '192.168.1.31',
+  platform: 'tizen',
+  vendor: 'Samsung',
+  name: '[TV] Salon',
+  model: 'UE50AU7172',
+  developerMode: 'on',
+  sideloadable: true,
+  note: 'developer mode off',
+  runtime: null,
+};
+
+const cuisine: Television = {
+  ...salon,
+  host: '192.168.1.42',
+  platform: 'webos',
+  vendor: 'LG',
+  name: 'Cuisine',
+  model: 'OLED55C16LA',
+  developerMode: 'off',
+  runtime: {
+    name: 'webOS',
+    version: '6.0',
+    engine: { name: 'Chromium', version: '79' },
+    learned: 'reported',
+  },
+};
+
+const printed: string[] = [];
+const failed: string[] = [];
+
+beforeEach(() => {
+  printed.length = 0;
+  failed.length = 0;
+  vi.spyOn(console, 'log').mockImplementation((line: string) => void printed.push(line));
+  vi.spyOn(console, 'error').mockImplementation((line: string) => void failed.push(line));
+  scan.mockReset();
+  deployTo.mockReset();
+  locate.mockReset();
+  installTool.mockClear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const options = { launch: true, json: false } as const;
+
+describe('scanCommand', () => {
+  it('prints the address, the package and the name of every set that answered', async () => {
+    scan.mockResolvedValue([salon, cuisine]);
+
+    const code = await scanCommand(options);
+
+    expect(code).toBe(0);
+    expect(printed[0]).toContain('192.168.1.31');
+    expect(printed[0]).toContain('Samsung .wgt');
+    expect(printed[0]).toContain('[TV] Salon');
+  });
+
+  it('prints what a set runs under its own line', async () => {
+    scan.mockResolvedValue([cuisine]);
+
+    await scanCommand(options);
+
+    expect(printed[0]).toContain('\n');
+    expect(printed[0]).toContain('webOS 6.0, Chromium 79');
+  });
+
+  it('cuts a name too long for its column rather than pushing the row over', async () => {
+    scan.mockResolvedValue([{ ...salon, name: 'The Television In The Living Room' }]);
+
+    await scanCommand(options);
+
+    expect(printed[0]).toContain('The Television In The Li… ');
+  });
+
+  it('falls back to the model of a set that carries no name', async () => {
+    scan.mockResolvedValue([{ ...salon, name: '' }]);
+
+    await scanCommand(options);
+
+    expect(printed[0]).toContain('UE50AU7172');
+  });
+
+  it('prints the sets as JSON when asked, and nothing else', async () => {
+    scan.mockResolvedValue([salon]);
+
+    const code = await scanCommand({ ...options, json: true });
+
+    expect(code).toBe(0);
+    expect(JSON.parse(printed.join(''))).toEqual([salon]);
+  });
+
+  it('explains an empty scan and answers a failure', async () => {
+    const code = await scanCommand(options);
+
+    expect(code).toBe(1);
+    expect(printed).toEqual([
+      'no television answered on this network',
+      'a set answers when it is on',
+    ]);
+  });
+
+  it('asks macOS for the local network before it probes anything', async () => {
+    await scanCommand(options);
+
+    expect(askForLocalNetwork).toHaveBeenCalled();
+  });
+});
+
+describe('installCommand', () => {
+  it('installs on every set that answered when the target is all', async () => {
+    scan.mockResolvedValue([salon, cuisine]);
+
+    const code = await installCommand('all', options);
+
+    expect(code).toBe(0);
+    expect(deployTo).toHaveBeenCalledTimes(2);
+  });
+
+  it('probes only the address it was given, and installs on that set alone', async () => {
+    scan.mockResolvedValue([salon, cuisine]);
+
+    await installCommand('192.168.1.42', options);
+
+    expect(scan).toHaveBeenCalledWith({ hosts: ['192.168.1.42'] });
+    expect(deployTo).toHaveBeenCalledOnce();
+    expect(deployTo.mock.calls[0]?.[0]).toBe(cuisine);
+  });
+
+  it('hands the package, the source and the module flags down to the install', async () => {
+    scan.mockResolvedValue([salon]);
+
+    await installCommand('all', {
+      ...options,
+      artifact: '/out/KROMA.wgt',
+      source: 'canary',
+      moduleOptions: { profile: 'LUMA' },
+      launch: false,
+    });
+
+    expect(deployTo.mock.calls[0]?.[1]).toMatchObject({
+      artifact: '/out/KROMA.wgt',
+      source: 'canary',
+      moduleOptions: { profile: 'LUMA' },
+      launch: false,
+    });
+  });
+
+  it('refuses an address no television answered at', async () => {
+    scan.mockResolvedValue([salon]);
+
+    const code = await installCommand('192.168.1.99', options);
+
+    expect(code).toBe(1);
+    expect(failed).toEqual(['192.168.1.99 is not a television this tool can install onto']);
+  });
+
+  it('says nothing answered when a sweep for every set came back empty', async () => {
+    const code = await installCommand('all', options);
+
+    expect(code).toBe(1);
+    expect(failed).toEqual(['no television answered']);
+  });
+
+  it('answers a failure when a set refused the install', async () => {
+    scan.mockResolvedValue([salon]);
+    deployTo.mockRejectedValue(new Error('the TV refused the connection'));
+
+    const code = await installCommand('all', options);
+
+    expect(code).toBe(1);
+    expect(failed[0]).toContain('the TV refused the connection');
+  });
+
+  it('keeps going to the next set after one refused the install', async () => {
+    scan.mockResolvedValue([salon, cuisine]);
+    deployTo.mockRejectedValueOnce(new Error('the TV refused the connection'));
+
+    const code = await installCommand('all', options);
+
+    expect(code).toBe(1);
+    expect(printed.join('\n')).toContain('installed on Cuisine');
+  });
+
+  it('indents what the install says under the set it is talking to', async () => {
+    scan.mockResolvedValue([salon]);
+    deployTo.mockImplementation(async (_tv, given) => {
+      (given as DeployOptions).log('pushing KROMA.wgt, 40%');
+    });
+
+    await installCommand('all', options);
+
+    expect(printed).toContain('  pushing KROMA.wgt, 40%');
+  });
+
+  it('quotes whatever a module threw that was not an error', async () => {
+    scan.mockResolvedValue([salon]);
+    deployTo.mockRejectedValue('sdb died');
+
+    await installCommand('all', options);
+
+    expect(failed[0]).toContain('sdb died');
+  });
+});
+
+const tizenCli = (path: string | null) => (tool: unknown) =>
+  (tool as Tool).id === 'tizen' ? path : null;
+
+describe('doctorCommand', () => {
+  it('lists every platform this tool installs onto', async () => {
+    doctorCommand();
+
+    expect(printed.join('\n')).toContain('Samsung  .wgt');
+    expect(printed.join('\n')).toContain('Apple TV  .app');
+  });
+
+  it('shows where a toolchain this machine already has lives', async () => {
+    locate.mockImplementation(tizenCli('/home/tizen-studio/tools/ide/bin/tizen'));
+
+    doctorCommand();
+
+    expect(printed.join('\n')).toContain(
+      'Tizen Studio CLI      /home/tizen-studio/tools/ide/bin/tizen',
+    );
+  });
+
+  it('says where a missing toolchain comes from', async () => {
+    doctorCommand();
+
+    expect(printed.join('\n')).toContain(
+      'Android Debug Bridge  missing, from dl.google.com platform-tools',
+    );
+  });
+});
+
+describe('toolsCommand', () => {
+  it('installs every tool the named platform needs', async () => {
+    const code = await toolsCommand(['tizen']);
+
+    expect(code).toBe(0);
+    expect(installTool.mock.calls.map(([tool]) => (tool as Tool).id)).toEqual(['tizen', 'sdb']);
+  });
+
+  it('installs the tools of each platform that was named', async () => {
+    await toolsCommand(['webos', 'androidtv']);
+
+    expect(installTool.mock.calls.map(([tool]) => (tool as Tool).id)).toEqual(['ares', 'adb']);
+  });
+
+  it('refuses a platform no module answers for, and names the ones that do', async () => {
+    const code = await toolsCommand(['sony']);
+
+    expect(code).toBe(1);
+    expect(failed).toEqual(['usage: tools <tizen|webos|androidtv|appletv>']);
+    expect(installTool).not.toHaveBeenCalled();
+  });
+});
+
+const tv: UsageCommand = {
+  meta: { name: 'tv', description: 'find televisions and install KROMA' },
+  args: { json: { type: 'boolean', description: 'machine readable output' } },
+  subCommands: { scan: { meta: { description: 'list what answered' } } },
+};
+
+const TEMPLATE = '# tv\n\n<!-- usage:start -->\n\n<!-- usage:end -->\n\ntail\n';
+
+describe('docsCommand', () => {
+  beforeEach(() => {
+    mkdirSync(join(checkout, 'packages', 'tv-installer'), { recursive: true });
+    writeFileSync(readme, TEMPLATE);
+  });
+
+  it('writes the command tree into the README', async () => {
+    const code = await docsCommand(tv, false);
+
+    expect(code).toBe(0);
+    expect(readFileSync(readme, 'utf8')).toContain('| `bun run tv scan` | list what answered |');
+  });
+
+  it('leaves a README that already carries the current tree alone', async () => {
+    writeFileSync(readme, injectUsage(TEMPLATE, await renderUsage(tv, 'bun run tv')));
+
+    const code = await docsCommand(tv, true);
+
+    expect(code).toBe(0);
+    expect(printed).toEqual(['packages/tv-installer/README.md is current']);
+  });
+
+  it('fails a stale README under a check instead of rewriting it', async () => {
+    const code = await docsCommand(tv, true);
+
+    expect(code).toBe(1);
+    expect(failed).toEqual(['packages/tv-installer/README.md is out of date: run bun run tv docs']);
+    expect(readFileSync(readme, 'utf8')).toBe(TEMPLATE);
+  });
+});

--- a/packages/tv-installer/src/commands.test.ts
+++ b/packages/tv-installer/src/commands.test.ts
@@ -1,6 +1,6 @@
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { docsCommand, doctorCommand, installCommand, scanCommand, toolsCommand } from './commands';
 import type { DeployOptions } from './install/deploy';
 import type { Television } from './television';
@@ -89,6 +89,10 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+});
+
+afterAll(() => {
+  rmSync(checkout, { recursive: true, force: true });
 });
 
 const options = { launch: true, json: false } as const;
@@ -201,14 +205,24 @@ describe('installCommand', () => {
     const code = await installCommand('192.168.1.99', options);
 
     expect(code).toBe(1);
-    expect(failed).toEqual(['192.168.1.99 is not a television this tool can install onto']);
+    expect(failed[0]).toBe('192.168.1.99 is not a television this tool can install onto');
   });
 
   it('says nothing answered when a sweep for every set came back empty', async () => {
     const code = await installCommand('all', options);
 
     expect(code).toBe(1);
-    expect(failed).toEqual(['no television answered']);
+    expect(failed[0]).toBe('no television to install onto');
+  });
+
+  it('passes over a set whose platform takes no sideloaded app, and says why', async () => {
+    scan.mockResolvedValue([{ ...salon, sideloadable: false, note: 'SAPHI: takes no app' }]);
+
+    const code = await installCommand('all', options);
+
+    expect(code).toBe(1);
+    expect(failed[0]).toContain('SAPHI: takes no app');
+    expect(deployTo).not.toHaveBeenCalled();
   });
 
   it('answers a failure when a set refused the install', async () => {

--- a/packages/tv-installer/src/commands.ts
+++ b/packages/tv-installer/src/commands.ts
@@ -42,13 +42,19 @@ export async function installCommand(target: string, options: CommandOptions): P
   const hosts = target === 'all' ? options.hosts : [target];
   await askForLocalNetwork();
   const found = await scan({ hosts });
-  const chosen = target === 'all' ? found : found.filter((tv) => tv.host === target);
+  const matched = target === 'all' ? found : found.filter((tv) => tv.host === target);
+  for (const tv of matched.filter((candidate) => !candidate.sideloadable)) {
+    console.error(style.yellow(`skipping ${tv.name} (${tv.host}): ${tv.note}`));
+  }
+
+  const chosen = matched.filter((tv) => tv.sideloadable);
   if (chosen.length === 0) {
     console.error(
       target === 'all'
-        ? 'no television answered'
+        ? 'no television to install onto'
         : `${target} is not a television this tool can install onto`,
     );
+    for (const hint of (await diagnoseEmptyScan()).hints) console.error(style.dim(hint));
     return 1;
   }
 
@@ -97,6 +103,10 @@ export async function toolsCommand(names: readonly string[]): Promise<number> {
     );
     return 1;
   }
+  for (const module of chosen.filter((candidate) => candidate.tools().length === 0)) {
+    console.log(style.dim(`${module.label} needs nothing this tool can install`));
+  }
+
   const wanted = new Set(chosen.flatMap((module) => [...module.tools()]));
   for (const tool of wanted) await installTool(tool, (line) => console.log(style.dim(`  ${line}`)));
   return 0;

--- a/packages/tv-installer/src/commands.ts
+++ b/packages/tv-installer/src/commands.ts
@@ -1,0 +1,145 @@
+import { join } from 'node:path';
+import { scan } from './discovery/scan';
+import { diagnoseEmptyScan } from './hints';
+import type { Source } from './install/artifact';
+import { deployTo } from './install/deploy';
+import { askForLocalNetwork } from './local-network';
+import type { ModuleOptions } from './modules/module';
+import { findModule, moduleFor, modules } from './modules/registry';
+import { root } from './root';
+import { runtimeLabel, type Television } from './television';
+import { locate } from './toolchain/detect';
+import { installTool } from './toolchain/install';
+import { style } from './tui/ansi';
+import { injectUsage, renderUsage, type UsageCommand } from './usage';
+
+export interface CommandOptions {
+  hosts?: string[];
+  artifact?: string;
+  source?: Source;
+  moduleOptions?: ModuleOptions;
+  launch: boolean;
+  json: boolean;
+}
+
+export async function scanCommand(options: CommandOptions): Promise<number> {
+  await askForLocalNetwork();
+  const found = await scan({ hosts: options.hosts });
+  if (options.json) {
+    console.log(JSON.stringify(found, null, 2));
+    return 0;
+  }
+  if (found.length === 0) {
+    console.log('no television answered on this network');
+    for (const hint of (await diagnoseEmptyScan()).hints) console.log(style.dim(hint));
+    return 1;
+  }
+  for (const tv of found) console.log(describe(tv));
+  return 0;
+}
+
+export async function installCommand(target: string, options: CommandOptions): Promise<number> {
+  const hosts = target === 'all' ? options.hosts : [target];
+  await askForLocalNetwork();
+  const found = await scan({ hosts });
+  const chosen = target === 'all' ? found : found.filter((tv) => tv.host === target);
+  if (chosen.length === 0) {
+    console.error(
+      target === 'all'
+        ? 'no television answered'
+        : `${target} is not a television this tool can install onto`,
+    );
+    return 1;
+  }
+
+  let failures = 0;
+  for (const tv of chosen) {
+    console.log(describe(tv));
+    try {
+      await deployTo(tv, {
+        log: (line) => console.log(style.dim(`  ${line}`)),
+        artifact: options.artifact,
+        launch: options.launch,
+        source: options.source,
+        moduleOptions: options.moduleOptions,
+      });
+      console.log(style.green(`  installed on ${tv.name}`));
+    } catch (error) {
+      failures++;
+      console.error(style.red(`  ${error instanceof Error ? error.message : String(error)}`));
+    }
+  }
+  return failures === 0 ? 0 : 1;
+}
+
+export function doctorCommand(): number {
+  for (const module of modules()) {
+    console.log(`${module.label}  ${style.dim(module.package)}`);
+    for (const tool of module.tools()) {
+      const path = locate(tool);
+      const status = path ? style.green(path) : style.yellow(`missing, from ${tool.source}`);
+      console.log(`  ${tool.label.padEnd(22)}${status}`);
+    }
+  }
+  return 0;
+}
+
+export async function toolsCommand(names: readonly string[]): Promise<number> {
+  const chosen = names.flatMap((name) => {
+    const module = findModule(name);
+    return module ? [module] : [];
+  });
+  if (chosen.length !== names.length) {
+    console.error(
+      `usage: tools <${modules()
+        .map((module) => module.id)
+        .join('|')}>`,
+    );
+    return 1;
+  }
+  const wanted = new Set(chosen.flatMap((module) => [...module.tools()]));
+  for (const tool of wanted) await installTool(tool, (line) => console.log(style.dim(`  ${line}`)));
+  return 0;
+}
+
+const HOST_WIDTH = 24;
+const VENDOR_WIDTH = 16;
+const NAME_WIDTH = 26;
+
+function describe(tv: Television): string {
+  const platform = `${tv.vendor} ${moduleFor(tv.platform).package}`;
+  const state = tv.developerMode === 'on' ? style.green('ready') : style.yellow(tv.note);
+  const runs = runtimeLabel(tv.runtime);
+  const head = [
+    style.bold(cell(tv.host, HOST_WIDTH)),
+    cell(platform, VENDOR_WIDTH),
+    cell(tv.name || tv.model, NAME_WIDTH),
+    state,
+  ].join('');
+  return runs ? `${head}\n${' '.repeat(HOST_WIDTH)}${style.dim(runs)}` : head;
+}
+
+function cell(text: string, width: number): string {
+  return text.length >= width ? `${text.slice(0, width - 2)}… ` : text.padEnd(width);
+}
+
+const README = 'packages/tv-installer/README.md';
+
+/** Renders the command tree into the README, so no usage line is typed by hand. */
+export async function docsCommand(command: UsageCommand, check: boolean): Promise<number> {
+  const path = join(root, README);
+  const current = await Bun.file(path).text();
+  const written = injectUsage(current, await renderUsage(command, 'bun run tv'));
+
+  if (written === current) {
+    console.log(`${README} is current`);
+    return 0;
+  }
+  if (check) {
+    console.error(`${README} is out of date: run bun run tv docs`);
+    return 1;
+  }
+  await Bun.write(path, written);
+  console.log(`wrote the usage block into ${README}`);
+  return 0;
+}

--- a/packages/tv-installer/src/discovery/arp.test.ts
+++ b/packages/tv-installer/src/discovery/arp.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from 'vitest';
-import { parseArpTable } from './arp';
+import { describe, expect, it, vi } from 'vitest';
+import { run } from '../run';
+import { arpHosts, parseArpTable } from './arp';
+
+vi.mock('../run', () => ({ run: vi.fn() }));
 
 const table = [
   '? (192.168.1.1) at dc:f5:1b:75:c6:c0 on en0 ifscope [ethernet]',
@@ -25,5 +28,19 @@ describe('parseArpTable', () => {
 
   it('answers nothing for an empty table', () => {
     expect(parseArpTable('')).toEqual([]);
+  });
+});
+
+describe('arpHosts', () => {
+  it('answers every address the system table already knows', async () => {
+    vi.mocked(run).mockResolvedValue({ code: 0, output: table });
+
+    expect(await arpHosts()).toEqual(['192.168.1.1', '192.168.1.107', '224.0.0.251']);
+  });
+
+  it('answers nothing when arp refuses to print its table', async () => {
+    vi.mocked(run).mockResolvedValue({ code: 1, output: table });
+
+    expect(await arpHosts()).toEqual([]);
   });
 });

--- a/packages/tv-installer/src/discovery/arp.test.ts
+++ b/packages/tv-installer/src/discovery/arp.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { parseArpTable } from './arp';
+
+const table = [
+  '? (192.168.1.1) at dc:f5:1b:75:c6:c0 on en0 ifscope [ethernet]',
+  '? (192.168.1.107) at 4:e4:b6:5d:38:a0 on en0 ifscope [ethernet]',
+  '? (192.168.1.200) at (incomplete) on en0 ifscope [ethernet]',
+  '? (192.168.1.107) at 4:e4:b6:5d:38:a0 on en1 ifscope [ethernet]',
+  '? (224.0.0.251) at 1:0:5e:0:0:fb on en0 ifscope permanent [ethernet]',
+].join('\n');
+
+describe('parseArpTable', () => {
+  it('reads the address out of every resolved entry', () => {
+    expect(parseArpTable(table)).toContain('192.168.1.1');
+    expect(parseArpTable(table)).toContain('192.168.1.107');
+  });
+
+  it('leaves out an entry whose lookup never completed', () => {
+    expect(parseArpTable(table)).not.toContain('192.168.1.200');
+  });
+
+  it('names a host once even when two interfaces know it', () => {
+    expect(parseArpTable(table).filter((host) => host === '192.168.1.107')).toHaveLength(1);
+  });
+
+  it('answers nothing for an empty table', () => {
+    expect(parseArpTable('')).toEqual([]);
+  });
+});

--- a/packages/tv-installer/src/discovery/arp.ts
+++ b/packages/tv-installer/src/discovery/arp.ts
@@ -1,0 +1,22 @@
+import { run } from '../run';
+
+const ADDRESS = /\((\d+\.\d+\.\d+\.\d+)\)/;
+
+export function parseArpTable(output: string): string[] {
+  const hosts: string[] = [];
+  for (const line of output.split('\n')) {
+    if (line.includes('incomplete')) continue;
+    const address = ADDRESS.exec(line)?.[1];
+    if (address && !hosts.includes(address)) hosts.push(address);
+  }
+  return hosts;
+}
+
+/**
+ * The addresses this machine has already talked to. Probing those first puts a
+ * television on screen in the time one connect takes, rather than one sweep.
+ */
+export async function arpHosts(): Promise<string[]> {
+  const { code, output } = await run(['arp', '-an'], { timeoutMs: 3000 });
+  return code === 0 ? parseArpTable(output) : [];
+}

--- a/packages/tv-installer/src/discovery/http.test.ts
+++ b/packages/tv-installer/src/discovery/http.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
-import { fetchJson } from './http';
+import { fetchJson, fetchText } from './http';
 
 const System = z.object({ name: z.string() });
 const url = 'http://192.168.1.34:1925/6/system';
@@ -33,5 +33,49 @@ describe('fetchJson', () => {
     answering(JSON.stringify({ name: 'x'.repeat(4096) }));
 
     expect(await fetchJson(url, System, { maxBytes: 512 })).toBeNull();
+  });
+
+  it('answers nothing when the body is not JSON at all', async () => {
+    answering('<html>404 Not Found</html>');
+
+    expect(await fetchJson(url, System)).toBeNull();
+  });
+});
+
+describe('fetchText', () => {
+  it('answers the body the television sent back', async () => {
+    answering('<root><device /></root>');
+
+    expect(await fetchText(url)).toBe('<root><device /></root>');
+  });
+
+  it('answers nothing when the television is unreachable', async () => {
+    vi.stubGlobal('fetch', () => Promise.reject(new Error('ECONNREFUSED')));
+
+    expect(await fetchText(url)).toBeNull();
+  });
+
+  it('answers nothing when the television announces a body past the ceiling', async () => {
+    answering('<root />', { headers: { 'content-length': '99999' } });
+
+    expect(await fetchText(url, { maxBytes: 512 })).toBeNull();
+  });
+
+  it('answers nothing when the answer carries no body at all', async () => {
+    vi.stubGlobal('fetch', () => Promise.resolve(new Response(null, { status: 204 })));
+
+    expect(await fetchText(url)).toBeNull();
+  });
+
+  it('accepts the certificate a television signed for itself when asked to', async () => {
+    const asked: unknown[] = [];
+    vi.stubGlobal('fetch', (_url: string, init: unknown) => {
+      asked.push(init);
+      return Promise.resolve(new Response('<root />'));
+    });
+
+    await fetchText(url, { insecureTls: true });
+
+    expect(asked[0]).toMatchObject({ tls: { rejectUnauthorized: false } });
   });
 });

--- a/packages/tv-installer/src/discovery/http.test.ts
+++ b/packages/tv-installer/src/discovery/http.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { fetchJson } from './http';
+
+const System = z.object({ name: z.string() });
+const url = 'http://192.168.1.34:1925/6/system';
+
+const answering = (body: string, init?: ResponseInit) =>
+  vi.stubGlobal('fetch', () => Promise.resolve(new Response(body, init)));
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('fetchJson', () => {
+  it('parses a body the television answered and the schema accepts', async () => {
+    answering('{"name":"55PUS7304/12"}');
+
+    expect(await fetchJson(url, System)).toEqual({ name: '55PUS7304/12' });
+  });
+
+  it('answers nothing when the television refuses the request', async () => {
+    answering('{"name":"55PUS7304/12"}', { status: 403 });
+
+    expect(await fetchJson(url, System)).toBeNull();
+  });
+
+  it('answers nothing when the body is not the shape that was asked for', async () => {
+    answering('{"name":42}');
+
+    expect(await fetchJson(url, System)).toBeNull();
+  });
+
+  it('answers nothing when the body runs past the byte ceiling', async () => {
+    answering(JSON.stringify({ name: 'x'.repeat(4096) }));
+
+    expect(await fetchJson(url, System, { maxBytes: 512 })).toBeNull();
+  });
+});

--- a/packages/tv-installer/src/discovery/http.ts
+++ b/packages/tv-installer/src/discovery/http.ts
@@ -1,0 +1,65 @@
+import type { ZodType } from 'zod';
+
+const DEFAULT_TIMEOUT_MS = 1500;
+const DEFAULT_MAX_BYTES = 64 * 1024;
+
+export interface FetchOptions {
+  timeoutMs?: number;
+  maxBytes?: number;
+  /** For a television that signs its own certificate, which is all of them. */
+  insecureTls?: boolean;
+}
+
+/** The body as text, or null for any refusal: unreachable, not ok, or too big. */
+export async function fetchText(url: string, options: FetchOptions = {}): Promise<string | null> {
+  const { timeoutMs = DEFAULT_TIMEOUT_MS, maxBytes = DEFAULT_MAX_BYTES } = options;
+  try {
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(timeoutMs),
+      tls: options.insecureTls ? { rejectUnauthorized: false } : undefined,
+    });
+    if (!response.ok) return null;
+    return await readBounded(response, maxBytes);
+  } catch {
+    return null;
+  }
+}
+
+/** As `fetchText`, held to a schema: anything on the link can answer a probe. */
+export async function fetchJson<T>(
+  url: string,
+  schema: ZodType<T>,
+  options: FetchOptions = {},
+): Promise<T | null> {
+  const text = await fetchText(url, options);
+  if (text === null) return null;
+  try {
+    const parsed = schema.safeParse(JSON.parse(text));
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}
+
+async function readBounded(response: Response, maxBytes: number): Promise<string | null> {
+  if (Number(response.headers.get('content-length') ?? '0') > maxBytes) return null;
+  const reader = response.body?.getReader();
+  if (!reader) return null;
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  for (let chunk = await reader.read(); !chunk.done; chunk = await reader.read()) {
+    size += chunk.value.byteLength;
+    if (size > maxBytes) {
+      await reader.cancel();
+      return null;
+    }
+    chunks.push(chunk.value);
+  }
+  const body = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(body);
+}

--- a/packages/tv-installer/src/discovery/lan.test.ts
+++ b/packages/tv-installer/src/discovery/lan.test.ts
@@ -1,5 +1,27 @@
-import { describe, expect, it } from 'vitest';
-import { compareHosts, prefixOf, subnetHosts } from './lan';
+import { networkInterfaces } from 'node:os';
+import { describe, expect, it, vi } from 'vitest';
+import { compareHosts, localSubnets, prefixOf, subnetHosts } from './lan';
+
+vi.mock('node:os', () => ({ networkInterfaces: vi.fn() }));
+
+const ipv4 = (address: string, internal = false) => ({
+  address,
+  netmask: '255.255.255.0',
+  family: 'IPv4' as const,
+  mac: '3c:22:fb:1a:2b:3c',
+  internal,
+  cidr: `${address}/24`,
+});
+
+const ipv6 = (address: string) => ({
+  address,
+  netmask: 'ffff:ffff:ffff:ffff::',
+  family: 'IPv6' as const,
+  mac: '3c:22:fb:1a:2b:3c',
+  internal: false,
+  cidr: `${address}/64`,
+  scopeid: 6,
+});
 
 describe('prefixOf', () => {
   it('keeps the first three octets of a dotted-quad address', () => {
@@ -48,6 +70,16 @@ describe('compareHosts', () => {
     expect([...hosts].sort(compareHosts)).toEqual(['192.168.1.31', 'Salon.coredevice.local']);
   });
 
+  it('orders an address before a named set whichever way round it is asked', () => {
+    expect(compareHosts('192.168.1.31', 'Salon.coredevice.local')).toBeLessThan(0);
+    expect(compareHosts('Salon.coredevice.local', '192.168.1.31')).toBeGreaterThan(0);
+  });
+
+  it('puts the named set last whichever way round the two are handed over', () => {
+    expect(compareHosts('Salon.coredevice.local', '192.168.1.31')).toBeGreaterThan(0);
+    expect(compareHosts('192.168.1.31', 'Salon.coredevice.local')).toBeLessThan(0);
+  });
+
   it('orders two named sets against each other by name', () => {
     const hosts = ['Salon.coredevice.local', 'Chambre.coredevice.local'];
 
@@ -55,5 +87,44 @@ describe('compareHosts', () => {
       'Chambre.coredevice.local',
       'Salon.coredevice.local',
     ]);
+  });
+});
+
+describe('localSubnets', () => {
+  it('answers the IPv4 network an interface sits on', () => {
+    vi.mocked(networkInterfaces).mockReturnValue({
+      en0: [ipv6('fe80::1c2b:4aff:fe6d:1a30'), ipv4('192.168.1.10')],
+      lo0: [ipv4('127.0.0.1', true)],
+    });
+
+    expect(localSubnets()).toEqual([
+      { iface: 'en0', address: '192.168.1.10', prefix: '192.168.1' },
+    ]);
+  });
+
+  it('leaves out the virtual interfaces sitting beside the real one', () => {
+    vi.mocked(networkInterfaces).mockReturnValue({
+      awdl0: [ipv4('169.254.7.7')],
+      bridge100: [ipv4('192.168.64.1')],
+      en0: [ipv4('192.168.1.10')],
+      utun4: [ipv4('10.8.0.2')],
+    });
+
+    expect(localSubnets().map((subnet) => subnet.iface)).toEqual(['en0']);
+  });
+
+  it('names a network once even when two interfaces sit on it', () => {
+    vi.mocked(networkInterfaces).mockReturnValue({
+      en0: [ipv4('192.168.1.10')],
+      en1: [ipv4('192.168.1.11')],
+    });
+
+    expect(localSubnets()).toHaveLength(1);
+  });
+
+  it('answers nothing on a machine that is on no network', () => {
+    vi.mocked(networkInterfaces).mockReturnValue({ en0: undefined });
+
+    expect(localSubnets()).toEqual([]);
   });
 });

--- a/packages/tv-installer/src/discovery/lan.test.ts
+++ b/packages/tv-installer/src/discovery/lan.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { compareHosts, prefixOf, subnetHosts } from './lan';
+
+describe('prefixOf', () => {
+  it('keeps the first three octets of a dotted-quad address', () => {
+    expect(prefixOf('192.168.1.42')).toBe('192.168.1');
+  });
+
+  it('answers nothing for an address that is not dotted-quad IPv4', () => {
+    expect(prefixOf('fe80::1c2b:4aff:fe6d:1a30')).toBeNull();
+    expect(prefixOf('192.168.1')).toBeNull();
+    expect(prefixOf('192.168.1.42.7')).toBeNull();
+  });
+
+  it('answers nothing for an octet past 255', () => {
+    expect(prefixOf('192.168.1.256')).toBeNull();
+    expect(prefixOf('999.1.1.1')).toBeNull();
+  });
+});
+
+describe('subnetHosts', () => {
+  it('covers every addressable host of a /24', () => {
+    const hosts = subnetHosts('192.168.1');
+
+    expect(hosts).toHaveLength(254);
+    expect(hosts[0]).toBe('192.168.1.1');
+    expect(hosts.at(-1)).toBe('192.168.1.254');
+  });
+
+  it('leaves out the address this machine already holds', () => {
+    const hosts = subnetHosts('192.168.1', '192.168.1.42');
+
+    expect(hosts).toHaveLength(253);
+    expect(hosts).not.toContain('192.168.1.42');
+  });
+});
+
+describe('compareHosts', () => {
+  it('orders addresses by octet rather than by digit', () => {
+    const hosts = ['192.168.1.31', '192.168.1.5', '192.168.1.107'];
+
+    expect([...hosts].sort(compareHosts)).toEqual(['192.168.1.5', '192.168.1.31', '192.168.1.107']);
+  });
+
+  it('puts a set named rather than addressed after every address', () => {
+    const hosts = ['Salon.coredevice.local', '192.168.1.31'];
+
+    expect([...hosts].sort(compareHosts)).toEqual(['192.168.1.31', 'Salon.coredevice.local']);
+  });
+
+  it('orders two named sets against each other by name', () => {
+    const hosts = ['Salon.coredevice.local', 'Chambre.coredevice.local'];
+
+    expect([...hosts].sort(compareHosts)).toEqual([
+      'Chambre.coredevice.local',
+      'Salon.coredevice.local',
+    ]);
+  });
+});

--- a/packages/tv-installer/src/discovery/lan.ts
+++ b/packages/tv-installer/src/discovery/lan.ts
@@ -1,0 +1,62 @@
+import { networkInterfaces } from 'node:os';
+
+// A television sits on the network the router hands out, and sweeping the
+// virtual bridges beside it triples how long a scan takes for nothing.
+const VIRTUAL = /^(bridge|utun|awdl|llw|anpi|ap\d|docker|virbr|br-|tun|tap|veth|zt|wg)/;
+
+export interface Subnet {
+  iface: string;
+  address: string;
+  prefix: string;
+}
+
+/** Every IPv4 network this machine sits on, one entry per interface. */
+export function localSubnets(): Subnet[] {
+  const out: Subnet[] = [];
+  for (const [iface, entries] of Object.entries(networkInterfaces())) {
+    for (const entry of entries ?? []) {
+      if (entry.family !== 'IPv4' || entry.internal || VIRTUAL.test(iface)) continue;
+      const prefix = prefixOf(entry.address);
+      if (!prefix || out.some((s) => s.prefix === prefix)) continue;
+      out.push({ iface, address: entry.address, prefix });
+    }
+  }
+  return out;
+}
+
+/** `192.168.1.42` -> `192.168.1`, or null for anything that is not dotted-quad IPv4. */
+export function prefixOf(address: string): string | null {
+  const octets = address.split('.');
+  if (octets.length !== 4) return null;
+  if (!octets.every((o) => /^\d{1,3}$/.test(o) && Number(o) <= 255)) return null;
+  return octets.slice(0, 3).join('.');
+}
+
+/** Addresses in numeric order, then the sets named rather than addressed. */
+export function compareHosts(a: string, b: string): number {
+  const left = hostKey(a);
+  const right = hostKey(b);
+  if (Number.isNaN(left) && Number.isNaN(right)) return a.localeCompare(b);
+  if (Number.isNaN(left)) return 1;
+  if (Number.isNaN(right)) return -1;
+  return left - right;
+}
+
+function hostKey(host: string): number {
+  if (prefixOf(host) === null) return Number.NaN;
+  return host.split('.').reduce((key, octet) => key * 256 + Number(octet), 0);
+}
+
+/**
+ * The addressable hosts of a `/24`, minus this machine's own. A television
+ * answers on a home network, and a network wider than a `/24` is a sweep long
+ * enough that nobody waits for it.
+ */
+export function subnetHosts(prefix: string, self?: string): string[] {
+  const hosts: string[] = [];
+  for (let last = 1; last <= 254; last++) {
+    const host = `${prefix}.${last}`;
+    if (host !== self) hosts.push(host);
+  }
+  return hosts;
+}

--- a/packages/tv-installer/src/discovery/pool.test.ts
+++ b/packages/tv-installer/src/discovery/pool.test.ts
@@ -38,4 +38,14 @@ describe('mapPool', () => {
 
     expect(results).toEqual([]);
   });
+
+  it('skips a hole in the list rather than working on nothing', async () => {
+    const items = [1, undefined, 3];
+
+    const results = await mapPool(items, 2, (item) => Promise.resolve(String(item)));
+
+    expect(results).toHaveLength(3);
+    expect(results[1]).toBeUndefined();
+    expect([results[0], results[2]]).toEqual(['1', '3']);
+  });
 });

--- a/packages/tv-installer/src/discovery/pool.test.ts
+++ b/packages/tv-installer/src/discovery/pool.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { mapPool } from './pool';
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe('mapPool', () => {
+  it('answers in the order it was given, not the order the work finished', async () => {
+    const delaysMs = [30, 0, 10];
+
+    const results = await mapPool(delaysMs, 3, async (delayMs, index) => {
+      await sleep(delayMs);
+      return index;
+    });
+
+    expect(results).toEqual([0, 1, 2]);
+  });
+
+  it('never has more than the limit in flight at once', async () => {
+    const hosts = Array.from({ length: 8 }, (_, index) => `192.168.1.${index + 1}`);
+    let inFlight = 0;
+    let peak = 0;
+
+    await mapPool(hosts, 3, async (host) => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await sleep(1);
+      inFlight -= 1;
+      return host;
+    });
+
+    expect(peak).toBe(3);
+  });
+
+  it('runs nothing and answers nothing for an empty list', async () => {
+    const hosts: string[] = [];
+
+    const results = await mapPool(hosts, 4, () => Promise.reject(new Error('called')));
+
+    expect(results).toEqual([]);
+  });
+});

--- a/packages/tv-installer/src/discovery/pool.ts
+++ b/packages/tv-installer/src/discovery/pool.ts
@@ -1,0 +1,19 @@
+/** Runs `fn` over every item at most `limit` at a time, results in input order. */
+export async function mapPool<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let next = 0;
+  const worker = async () => {
+    while (next < items.length) {
+      const index = next++;
+      const item = items[index];
+      if (item === undefined) continue;
+      results[index] = await fn(item, index);
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return results;
+}

--- a/packages/tv-installer/src/discovery/scan.test.ts
+++ b/packages/tv-installer/src/discovery/scan.test.ts
@@ -171,6 +171,13 @@ describe('scan', () => {
     expect(vi.mocked(identify).mock.calls[0]?.[2]).toEqual(device);
   });
 
+  it('leaves out a host whose description says nothing any module recognises', async () => {
+    vi.mocked(ssdpSearch).mockResolvedValue([reply('10.0.0.7')]);
+    vi.mocked(fetchDeviceDescription).mockResolvedValue(device);
+
+    expect(await scan({ hosts: ['10.0.0.5'] })).toEqual([]);
+  });
+
   it('asks a set that answered every search target for its description once', async () => {
     vi.mocked(ssdpSearch).mockResolvedValue([reply('10.0.0.7'), reply('10.0.0.7')]);
 

--- a/packages/tv-installer/src/discovery/scan.test.ts
+++ b/packages/tv-installer/src/discovery/scan.test.ts
@@ -1,0 +1,275 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { identify } from '../modules/identify';
+import type { TvModule } from '../modules/module';
+import { detailPorts, modules, searchTargets, sweepPorts } from '../modules/registry';
+import type { Television } from '../television';
+import { arpHosts } from './arp';
+import { localSubnets } from './lan';
+import { scan, sweepTargets, watch } from './scan';
+import { ssdpSearch } from './ssdp';
+import { tcpOpen } from './tcp';
+import { fetchDeviceDescription } from './upnp';
+
+vi.mock('./arp', () => ({ arpHosts: vi.fn() }));
+vi.mock('./ssdp', () => ({ ssdpSearch: vi.fn() }));
+vi.mock('./tcp', () => ({ tcpOpen: vi.fn() }));
+vi.mock('./upnp', () => ({ fetchDeviceDescription: vi.fn() }));
+vi.mock('../modules/identify', () => ({ identify: vi.fn() }));
+vi.mock('../modules/registry', () => ({
+  detailPorts: vi.fn(),
+  modules: vi.fn(),
+  searchTargets: vi.fn(),
+  sweepPorts: vi.fn(),
+}));
+vi.mock('./lan', async (original) => ({
+  ...(await original<typeof import('./lan')>()),
+  localSubnets: vi.fn(),
+}));
+
+const television = (host: string, name = 'Salon'): Television => ({
+  host,
+  platform: 'webos',
+  vendor: 'LG',
+  name,
+  model: 'OLED55C1',
+  developerMode: 'on',
+  sideloadable: true,
+  note: '',
+  runtime: null,
+});
+
+const tvModule = (sets?: readonly Television[]): TvModule => ({
+  id: 'appletv',
+  label: 'Apple TV',
+  brands: 'Apple',
+  package: 'tv.kroma.appletv',
+  notReadyHint: '',
+  discover: sets ? () => Promise.resolve([...sets]) : undefined,
+  tools: () => [],
+  sources: () => [],
+  resolve: () => Promise.resolve(''),
+  install: () => Promise.resolve(),
+});
+
+const reply = (host: string) => ({
+  host,
+  location: `http://${host}:1754/`,
+  server: 'WebOS/1.4',
+  searchTarget: 'upnp:rootdevice',
+});
+
+const device = {
+  friendlyName: '[LG] webOS TV',
+  manufacturer: 'LG Electronics',
+  modelName: 'LG TV',
+  modelNumber: 'OLED55C1',
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(arpHosts).mockResolvedValue([]);
+  vi.mocked(ssdpSearch).mockResolvedValue([]);
+  vi.mocked(tcpOpen).mockResolvedValue(false);
+  vi.mocked(identify).mockResolvedValue(null);
+  vi.mocked(fetchDeviceDescription).mockResolvedValue(null);
+  vi.mocked(localSubnets).mockReturnValue([]);
+  vi.mocked(modules).mockReturnValue([]);
+  vi.mocked(searchTargets).mockReturnValue([]);
+  vi.mocked(sweepPorts).mockReturnValue([8001]);
+  vi.mocked(detailPorts).mockReturnValue([1926]);
+});
+
+afterEach(() => vi.useRealTimers());
+
+describe('scan', () => {
+  it('reports a set the moment a host answers on a swept port', async () => {
+    const salon = television('10.0.0.5');
+    vi.mocked(tcpOpen).mockImplementation((host) => Promise.resolve(host === '10.0.0.5'));
+    vi.mocked(identify).mockResolvedValue(salon);
+    const found: Television[] = [];
+
+    const sets = await scan({ hosts: ['10.0.0.5', '10.0.0.6'], onFound: (tv) => found.push(tv) });
+
+    expect(sets).toEqual([salon]);
+    expect(found).toEqual([salon]);
+  });
+
+  it('asks nothing about a host that answered on no port at all', async () => {
+    const sets = await scan({ hosts: ['10.0.0.5'] });
+
+    expect(sets).toEqual([]);
+    expect(identify).not.toHaveBeenCalled();
+  });
+
+  it('adds the detail ports to what it knows about a host that answered', async () => {
+    vi.mocked(tcpOpen).mockResolvedValue(true);
+    vi.mocked(identify).mockResolvedValue(television('10.0.0.5'));
+
+    await scan({ hosts: ['10.0.0.5'] });
+
+    expect(vi.mocked(identify).mock.calls[0]?.[1]).toEqual(new Set([8001, 1926]));
+  });
+
+  it('counts every host it visited as it goes', async () => {
+    const progress: number[][] = [];
+
+    await scan({
+      hosts: ['10.0.0.5', '10.0.0.6'],
+      onProgress: (done, total) => progress.push([done, total]),
+    });
+
+    expect(progress).toEqual([
+      [1, 2],
+      [2, 2],
+    ]);
+  });
+
+  it('visits no host once the signal has aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const sets = await scan({ hosts: ['10.0.0.5'], signal: controller.signal });
+
+    expect(sets).toEqual([]);
+    expect(tcpOpen).not.toHaveBeenCalled();
+  });
+
+  it('drops a host that answered after the scan was called off', async () => {
+    const controller = new AbortController();
+    vi.mocked(tcpOpen).mockImplementation(() => {
+      controller.abort();
+      return Promise.resolve(true);
+    });
+
+    const sets = await scan({ hosts: ['10.0.0.5'], signal: controller.signal });
+
+    expect(sets).toEqual([]);
+    expect(identify).not.toHaveBeenCalled();
+  });
+
+  it('takes a set a module found on its own without probing for it', async () => {
+    const salon = television('Salon.coredevice.local');
+    vi.mocked(modules).mockReturnValue([tvModule(), tvModule([salon])]);
+
+    expect(await scan()).toEqual([salon]);
+    expect(tcpOpen).not.toHaveBeenCalled();
+  });
+
+  it('leaves out a set a module found that is not among the hosts asked about', async () => {
+    vi.mocked(modules).mockReturnValue([tvModule([television('Salon.coredevice.local')])]);
+
+    expect(await scan({ hosts: ['10.0.0.5'] })).toEqual([]);
+  });
+
+  it('identifies a set that answered the SSDP search but no probe', async () => {
+    const chambre = television('10.0.0.7', 'Chambre');
+    vi.mocked(ssdpSearch).mockResolvedValue([reply('10.0.0.7')]);
+    vi.mocked(fetchDeviceDescription).mockResolvedValue(device);
+    vi.mocked(identify).mockResolvedValue(chambre);
+
+    expect(await scan({ hosts: ['10.0.0.5'] })).toEqual([chambre]);
+    expect(vi.mocked(identify).mock.calls[0]?.[2]).toEqual(device);
+  });
+
+  it('asks a set that answered every search target for its description once', async () => {
+    vi.mocked(ssdpSearch).mockResolvedValue([reply('10.0.0.7'), reply('10.0.0.7')]);
+
+    await scan({ hosts: ['10.0.0.5'] });
+
+    expect(fetchDeviceDescription).toHaveBeenCalledTimes(1);
+  });
+
+  it('asks a set again once its description arrives, and keeps one entry for it', async () => {
+    vi.mocked(tcpOpen).mockResolvedValue(true);
+    vi.mocked(identify)
+      .mockResolvedValueOnce(television('10.0.0.7'))
+      .mockResolvedValueOnce({ ...television('10.0.0.7'), name: '[LG] OLED55C1' });
+    vi.mocked(ssdpSearch).mockResolvedValue([reply('10.0.0.7')]);
+    vi.mocked(fetchDeviceDescription).mockResolvedValue(device);
+
+    const sets = await scan({ hosts: ['10.0.0.7'] });
+
+    expect(identify).toHaveBeenLastCalledWith('10.0.0.7', expect.anything(), device);
+    expect(sets).toHaveLength(1);
+    expect(sets[0]?.name).toBe('[LG] OLED55C1');
+  });
+
+  it('orders what it found by address rather than by who answered first', async () => {
+    vi.mocked(tcpOpen).mockResolvedValue(true);
+    vi.mocked(identify).mockImplementation((host) => Promise.resolve(television(host)));
+
+    const sets = await scan({ hosts: ['10.0.0.30', '10.0.0.5'] });
+
+    expect(sets.map((tv) => tv.host)).toEqual(['10.0.0.5', '10.0.0.30']);
+  });
+});
+
+describe('watch', () => {
+  it('stops as soon as the signal aborts', async () => {
+    const controller = new AbortController();
+    const rounds: number[] = [];
+
+    await watch({
+      hosts: ['10.0.0.5'],
+      signal: controller.signal,
+      onRound: (round) => {
+        rounds.push(round);
+        controller.abort();
+      },
+    });
+
+    expect(rounds).toEqual([1]);
+  });
+
+  it('reports a set once, then again only when what it says about itself changed', async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const salon = television('10.0.0.5');
+    const renamed = television('10.0.0.5', 'Cuisine');
+    const seen: string[] = [];
+    vi.mocked(tcpOpen).mockResolvedValue(true);
+    vi.mocked(identify)
+      .mockResolvedValueOnce(salon)
+      .mockResolvedValueOnce(salon)
+      .mockResolvedValueOnce(renamed);
+
+    const watching = watch({
+      hosts: ['10.0.0.5'],
+      signal: controller.signal,
+      onFound: (tv) => seen.push(tv.name),
+    });
+    await vi.advanceTimersByTimeAsync(1500);
+    await vi.advanceTimersByTimeAsync(1500);
+    controller.abort();
+
+    expect(seen).toEqual(['Salon', 'Cuisine']);
+    expect(await watching).toEqual([renamed]);
+  });
+});
+
+describe('sweepTargets', () => {
+  it('puts the hosts this machine already talked to before the rest of the subnet', async () => {
+    vi.mocked(localSubnets).mockReturnValue([
+      { iface: 'en0', address: '192.168.1.10', prefix: '192.168.1' },
+    ]);
+    vi.mocked(arpHosts).mockResolvedValue(['192.168.1.5']);
+
+    const targets = await sweepTargets();
+
+    expect(targets[0]).toBe('192.168.1.5');
+    expect(targets).toHaveLength(253);
+    expect(new Set(targets).size).toBe(targets.length);
+  });
+
+  it('leaves out this machine and any address no local subnet holds', async () => {
+    vi.mocked(localSubnets).mockReturnValue([
+      { iface: 'en0', address: '192.168.1.10', prefix: '192.168.1' },
+    ]);
+    vi.mocked(arpHosts).mockResolvedValue(['10.0.0.9', '192.168.1.5']);
+
+    const targets = await sweepTargets();
+
+    expect(targets).not.toContain('10.0.0.9');
+    expect(targets).not.toContain('192.168.1.10');
+  });
+});

--- a/packages/tv-installer/src/discovery/scan.ts
+++ b/packages/tv-installer/src/discovery/scan.ts
@@ -51,9 +51,17 @@ export async function scan(options: ScanOptions = {}): Promise<Television[]> {
     options.signal?.aborted ? Promise.resolve() : visit(host),
   );
 
+  // A set that answered a port was identified before its description arrived,
+  // so it is asked again once there is a name and a model to give it.
   for (const [host, device] of await describe(await announced)) {
     upnp.set(host, device);
-    if (!found.some((television) => television.host === host)) await visit(host);
+    const television = await examine(host, device, options.signal);
+    if (!television) continue;
+
+    const at = found.findIndex((seen) => seen.host === host);
+    if (at === -1) found.push(television);
+    else found[at] = television;
+    options.onFound?.(television);
   }
   return found.sort(byHost);
 }

--- a/packages/tv-installer/src/discovery/scan.ts
+++ b/packages/tv-installer/src/discovery/scan.ts
@@ -1,0 +1,150 @@
+import { identify } from '../modules/identify';
+import { detailPorts, modules, searchTargets, sweepPorts } from '../modules/registry';
+import type { Television } from '../television';
+import { arpHosts } from './arp';
+import { compareHosts, localSubnets, prefixOf, subnetHosts } from './lan';
+import { mapPool } from './pool';
+import { ssdpSearch } from './ssdp';
+import { tcpOpen } from './tcp';
+import { fetchDeviceDescription, type UpnpDevice } from './upnp';
+
+const CONNECT_TIMEOUT_MS = 500;
+const HOST_CONCURRENCY = 64;
+const SSDP_WINDOW_MS = 2000;
+const BETWEEN_ROUNDS_MS = 1500;
+
+export interface ScanOptions {
+  hosts?: readonly string[];
+  signal?: AbortSignal;
+  onProgress?: (done: number, total: number) => void;
+  /** Called the moment a set is identified, before the sweep finishes. */
+  onFound?: (tv: Television) => void;
+}
+
+export interface WatchOptions extends ScanOptions {
+  onRound?: (round: number) => void;
+}
+
+/** One pass over the network. */
+export async function scan(options: ScanOptions = {}): Promise<Television[]> {
+  const found: Television[] = [];
+  const discovered = Promise.all(modules().map((module) => module.discover?.() ?? []));
+  const announced = ssdpSearch(SSDP_WINDOW_MS, options.signal, searchTargets());
+  const targets = options.hosts?.length ? [...options.hosts] : await sweepTargets();
+
+  for (const television of (await discovered).flat()) {
+    if (options.hosts?.length && !options.hosts.includes(television.host)) continue;
+    found.push(television);
+    options.onFound?.(television);
+  }
+
+  const upnp = new Map<string, UpnpDevice>();
+  let done = 0;
+  const visit = async (host: string) => {
+    const television = await examine(host, upnp.get(host), options.signal);
+    options.onProgress?.(Math.min(++done, targets.length), targets.length);
+    if (!television) return;
+    found.push(television);
+    options.onFound?.(television);
+  };
+
+  await mapPool(targets, HOST_CONCURRENCY, (host) =>
+    options.signal?.aborted ? Promise.resolve() : visit(host),
+  );
+
+  for (const [host, device] of await describe(await announced)) {
+    upnp.set(host, device);
+    if (!found.some((television) => television.host === host)) await visit(host);
+  }
+  return found.sort(byHost);
+}
+
+/**
+ * Scans again and again until the signal aborts, reporting a set the first time
+ * it answers and every time what it says about itself changes.
+ */
+export async function watch(options: WatchOptions): Promise<Television[]> {
+  const seen = new Map<string, Television>();
+  for (let round = 1; !options.signal?.aborted; round++) {
+    options.onRound?.(round);
+    await scan({
+      ...options,
+      onFound: (tv) => {
+        const before = seen.get(tv.host);
+        seen.set(tv.host, tv);
+        if (!before || before.developerMode !== tv.developerMode || before.name !== tv.name) {
+          options.onFound?.(tv);
+        }
+      },
+    });
+    if (options.signal?.aborted) break;
+    await rest(BETWEEN_ROUNDS_MS, options.signal);
+  }
+  return [...seen.values()].sort(byHost);
+}
+
+/** The hosts this machine already knows first, then the rest of its own /24s. */
+export async function sweepTargets(): Promise<string[]> {
+  const subnets = localSubnets();
+  const prefixes = new Set(subnets.map((subnet) => subnet.prefix));
+  const known = (await arpHosts()).filter((host) => {
+    const prefix = prefixOf(host);
+    return prefix !== null && prefixes.has(prefix);
+  });
+
+  const rest = subnets.flatMap((subnet) =>
+    subnetHosts(subnet.prefix, subnet.address).filter((host) => !known.includes(host)),
+  );
+  return [...known, ...rest];
+}
+
+async function examine(
+  host: string,
+  upnp: UpnpDevice | undefined,
+  signal?: AbortSignal,
+): Promise<Television | null> {
+  const ports = await openOf(host, sweepPorts());
+  if (ports.size === 0 && !upnp) return null;
+  if (signal?.aborted) return null;
+
+  for (const port of await openOf(host, detailPorts())) ports.add(port);
+  return identify(host, ports, upnp);
+}
+
+async function openOf(host: string, ports: readonly number[]): Promise<Set<number>> {
+  const reachable = await Promise.all(
+    ports.map(async (port) => ((await tcpOpen(host, port, CONNECT_TIMEOUT_MS)) ? port : null)),
+  );
+  return new Set(reachable.filter((port): port is number => port !== null));
+}
+
+async function describe(replies: Awaited<ReturnType<typeof ssdpSearch>>) {
+  const byHost = new Map<string, UpnpDevice>();
+  const seen = new Set<string>();
+  const first = replies.filter((reply) => {
+    if (seen.has(reply.host)) return false;
+    seen.add(reply.host);
+    return true;
+  });
+  await mapPool(first, 8, async (reply) => {
+    const device = await fetchDeviceDescription(reply.location);
+    if (device) byHost.set(reply.host, device);
+  });
+  return byHost;
+}
+
+function rest(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    const done = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener('abort', done);
+      resolve();
+    };
+    const timer = setTimeout(done, ms);
+    signal?.addEventListener('abort', done, { once: true });
+  });
+}
+
+function byHost(a: Television, b: Television): number {
+  return compareHosts(a.host, b.host);
+}

--- a/packages/tv-installer/src/discovery/scan.ts
+++ b/packages/tv-installer/src/discovery/scan.ts
@@ -17,7 +17,6 @@ export interface ScanOptions {
   hosts?: readonly string[];
   signal?: AbortSignal;
   onProgress?: (done: number, total: number) => void;
-  /** Called the moment a set is identified, before the sweep finishes. */
   onFound?: (tv: Television) => void;
 }
 
@@ -28,7 +27,7 @@ export interface WatchOptions extends ScanOptions {
 /** One pass over the network. */
 export async function scan(options: ScanOptions = {}): Promise<Television[]> {
   const found: Television[] = [];
-  const discovered = Promise.all(modules().map((module) => module.discover?.() ?? []));
+  const discovered = Promise.all(modules().map(async (module) => module.discover?.() ?? []));
   const announced = ssdpSearch(SSDP_WINDOW_MS, options.signal, searchTargets());
   const targets = options.hosts?.length ? [...options.hosts] : await sweepTargets();
 
@@ -65,14 +64,16 @@ export async function scan(options: ScanOptions = {}): Promise<Television[]> {
  */
 export async function watch(options: WatchOptions): Promise<Television[]> {
   const seen = new Map<string, Television>();
-  for (let round = 1; !options.signal?.aborted; round++) {
+  let round = 0;
+  while (!options.signal?.aborted) {
+    round += 1;
     options.onRound?.(round);
     await scan({
       ...options,
       onFound: (tv) => {
         const before = seen.get(tv.host);
         seen.set(tv.host, tv);
-        if (!before || before.developerMode !== tv.developerMode || before.name !== tv.name) {
+        if (before?.developerMode !== tv.developerMode || before?.name !== tv.name) {
           options.onFound?.(tv);
         }
       },

--- a/packages/tv-installer/src/discovery/ssdp.test.ts
+++ b/packages/tv-installer/src/discovery/ssdp.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { parseSsdpReply } from './ssdp';
+
+const reply = (...headers: string[]) => ['HTTP/1.1 200 OK', ...headers, '', ''].join('\r\n');
+
+const webosReply = reply(
+  'CACHE-CONTROL: max-age=1800',
+  'DATE: Sat, 22 Aug 2026 09:12:44 GMT',
+  'EXT:',
+  'Location: http://192.168.1.32:1754/',
+  'SERVER: WebOS/1.4 UPnP/1.0 Linux/4.19',
+  'st: urn:lge-com:service:webos-second-screen:1',
+  'USN: uuid:8e3cf1a4-7c2f-4b19-9a3d-6f0b1f5f5c11::urn:lge-com:service:webos-second-screen:1',
+);
+
+describe('parseSsdpReply', () => {
+  it('reads the description URL, the server and the target out of a webOS reply', () => {
+    expect(parseSsdpReply(webosReply, '192.168.1.32')).toEqual({
+      host: '192.168.1.32',
+      location: 'http://192.168.1.32:1754/',
+      server: 'WebOS/1.4 UPnP/1.0 Linux/4.19',
+      searchTarget: 'urn:lge-com:service:webos-second-screen:1',
+    });
+  });
+
+  it('answers nothing for a reply that points at no description', () => {
+    const noLocation = reply(
+      'CACHE-CONTROL: max-age=1800',
+      'EXT:',
+      'ST: upnp:rootdevice',
+      'USN: uuid:8e3cf1a4-7c2f-4b19-9a3d-6f0b1f5f5c11::upnp:rootdevice',
+    );
+
+    expect(parseSsdpReply(noLocation, '192.168.1.32')).toBeNull();
+  });
+});

--- a/packages/tv-installer/src/discovery/ssdp.test.ts
+++ b/packages/tv-installer/src/discovery/ssdp.test.ts
@@ -1,5 +1,20 @@
-import { describe, expect, it } from 'vitest';
-import { parseSsdpReply } from './ssdp';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { parseSsdpReply, ssdpSearch } from './ssdp';
+
+const socket = vi.hoisted(() => {
+  const listeners = new Map<string, (...args: never[]) => void>();
+  return {
+    listeners,
+    on: vi.fn((event: string, listener: (...args: never[]) => void) => {
+      listeners.set(event, listener);
+    }),
+    bind: vi.fn((ready: () => void) => ready()),
+    send: vi.fn((_probe: Buffer, _port: number, _group: string) => undefined),
+    close: vi.fn(),
+  };
+});
+
+vi.mock('node:dgram', () => ({ createSocket: vi.fn(() => socket) }));
 
 const reply = (...headers: string[]) => ['HTTP/1.1 200 OK', ...headers, '', ''].join('\r\n');
 
@@ -32,5 +47,72 @@ describe('parseSsdpReply', () => {
     );
 
     expect(parseSsdpReply(noLocation, '192.168.1.32')).toBeNull();
+  });
+});
+
+const deliver = (message: string, host: string) => {
+  const listener = socket.listeners.get('message') as
+    | ((buffer: Buffer, from: { address: string }) => void)
+    | undefined;
+  listener?.(Buffer.from(message), { address: host });
+};
+
+const targetOf = (probe: Buffer) => /\r\nST: (.+)\r\n/.exec(probe.toString('utf8'))?.[1];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  socket.listeners.clear();
+});
+
+describe('ssdpSearch', () => {
+  it('asks the targets it always asks, and the extra ones it was given', async () => {
+    await ssdpSearch(10, undefined, ['urn:lge-com:service:webos-second-screen:1']);
+
+    expect(socket.send.mock.calls.map(([probe]) => targetOf(probe))).toEqual([
+      'urn:dial-multiscreen-org:service:dial:1',
+      'upnp:rootdevice',
+      'urn:lge-com:service:webos-second-screen:1',
+    ]);
+  });
+
+  it('keeps one reply per host and description, however often it heard it', async () => {
+    const searching = ssdpSearch(10);
+
+    deliver(webosReply, '192.168.1.32');
+    deliver(webosReply, '192.168.1.32');
+    deliver(reply('LOCATION: http://192.168.1.44:1754/'), '192.168.1.44');
+
+    expect((await searching).map((answer) => answer.host)).toEqual([
+      '192.168.1.32',
+      '192.168.1.44',
+    ]);
+  });
+
+  it('drops a reply that points at no description', async () => {
+    const searching = ssdpSearch(10);
+
+    deliver(reply('ST: upnp:rootdevice'), '192.168.1.44');
+
+    expect(await searching).toEqual([]);
+  });
+
+  it('stops listening as soon as the signal aborts', async () => {
+    const controller = new AbortController();
+
+    const searching = ssdpSearch(60_000, controller.signal);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    controller.abort();
+
+    expect(await searching).toEqual([]);
+    expect(socket.close).toHaveBeenCalled();
+  });
+
+  it('closes the socket on an error as well as at the end of the window', async () => {
+    const searching = ssdpSearch(10);
+
+    socket.listeners.get('error')?.();
+
+    await searching;
+    expect(socket.close).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/tv-installer/src/discovery/ssdp.test.ts
+++ b/packages/tv-installer/src/discovery/ssdp.test.ts
@@ -107,12 +107,12 @@ describe('ssdpSearch', () => {
     expect(socket.close).toHaveBeenCalled();
   });
 
-  it('closes the socket on an error as well as at the end of the window', async () => {
+  it('closes the socket once, whether the error or the window gets there first', async () => {
     const searching = ssdpSearch(10);
 
     socket.listeners.get('error')?.();
 
-    await searching;
-    expect(socket.close).toHaveBeenCalledTimes(2);
+    expect(await searching).toEqual([]);
+    expect(socket.close).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/tv-installer/src/discovery/ssdp.ts
+++ b/packages/tv-installer/src/discovery/ssdp.ts
@@ -1,6 +1,6 @@
 import { createSocket } from 'node:dgram';
 
-const SSDP_ADDRESS = '239.255.255.250';
+const SSDP_MULTICAST_GROUP = '239.255.255.250';
 const SSDP_PORT = 1900;
 const MAX_WAIT_SECONDS = 2;
 
@@ -52,10 +52,10 @@ export async function ssdpSearch(
   await new Promise<void>((resolve) => socket.bind(resolve));
   for (const target of [...SEARCH_TARGETS, ...extraTargets]) {
     const probe = Buffer.from(
-      `M-SEARCH * HTTP/1.1\r\nHOST: ${SSDP_ADDRESS}:${SSDP_PORT}\r\n` +
+      `M-SEARCH * HTTP/1.1\r\nHOST: ${SSDP_MULTICAST_GROUP}:${SSDP_PORT}\r\n` +
         `MAN: "ssdp:discover"\r\nMX: ${MAX_WAIT_SECONDS}\r\nST: ${target}\r\n\r\n`,
     );
-    socket.send(probe, SSDP_PORT, SSDP_ADDRESS);
+    socket.send(probe, SSDP_PORT, SSDP_MULTICAST_GROUP);
   }
 
   await listenFor(durationMs, signal);

--- a/packages/tv-installer/src/discovery/ssdp.ts
+++ b/packages/tv-installer/src/discovery/ssdp.ts
@@ -1,0 +1,76 @@
+import { createSocket } from 'node:dgram';
+
+const SSDP_ADDRESS = '239.255.255.250';
+const SSDP_PORT = 1900;
+const MAX_WAIT_SECONDS = 2;
+
+/** What every television answers to, `dial` being the screen-casting service they all publish. */
+export const SEARCH_TARGETS = [
+  'urn:dial-multiscreen-org:service:dial:1',
+  'upnp:rootdevice',
+] as const;
+
+export interface SsdpReply {
+  host: string;
+  location: string;
+  server: string;
+  searchTarget: string;
+}
+
+export function parseSsdpReply(message: string, host: string): SsdpReply | null {
+  const headers = new Map<string, string>();
+  for (const line of message.split(/\r?\n/).slice(1)) {
+    const at = line.indexOf(':');
+    if (at < 1) continue;
+    headers.set(line.slice(0, at).trim().toLowerCase(), line.slice(at + 1).trim());
+  }
+  const location = headers.get('location');
+  if (!location) return null;
+  return {
+    host,
+    location,
+    server: headers.get('server') ?? '',
+    searchTarget: headers.get('st') ?? '',
+  };
+}
+
+/** Broadcasts one M-SEARCH per target and collects replies until the window closes. */
+export async function ssdpSearch(
+  durationMs: number,
+  signal?: AbortSignal,
+  extraTargets: readonly string[] = [],
+): Promise<SsdpReply[]> {
+  const replies = new Map<string, SsdpReply>();
+  const socket = createSocket({ type: 'udp4', reuseAddr: true });
+
+  socket.on('message', (buffer, from) => {
+    const reply = parseSsdpReply(buffer.toString('utf8'), from.address);
+    if (reply) replies.set(`${reply.host}|${reply.location}`, reply);
+  });
+  socket.on('error', () => socket.close());
+
+  await new Promise<void>((resolve) => socket.bind(resolve));
+  for (const target of [...SEARCH_TARGETS, ...extraTargets]) {
+    const probe = Buffer.from(
+      `M-SEARCH * HTTP/1.1\r\nHOST: ${SSDP_ADDRESS}:${SSDP_PORT}\r\n` +
+        `MAN: "ssdp:discover"\r\nMX: ${MAX_WAIT_SECONDS}\r\nST: ${target}\r\n\r\n`,
+    );
+    socket.send(probe, SSDP_PORT, SSDP_ADDRESS);
+  }
+
+  await listenFor(durationMs, signal);
+  socket.close();
+  return [...replies.values()];
+}
+
+function listenFor(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    const done = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener('abort', done);
+      resolve();
+    };
+    const timer = setTimeout(done, ms);
+    signal?.addEventListener('abort', done, { once: true });
+  });
+}

--- a/packages/tv-installer/src/discovery/ssdp.ts
+++ b/packages/tv-installer/src/discovery/ssdp.ts
@@ -47,7 +47,15 @@ export async function ssdpSearch(
     const reply = parseSsdpReply(buffer.toString('utf8'), from.address);
     if (reply) replies.set(`${reply.host}|${reply.location}`, reply);
   });
-  socket.on('error', () => socket.close());
+  // Closing twice throws, and a multicast send fails outright when the link is
+  // down, so a scan on a sleeping interface must come back empty rather than die.
+  let closed = false;
+  const close = () => {
+    if (closed) return;
+    closed = true;
+    socket.close();
+  };
+  socket.on('error', close);
 
   await new Promise<void>((resolve) => socket.bind(resolve));
   for (const target of [...SEARCH_TARGETS, ...extraTargets]) {
@@ -59,7 +67,7 @@ export async function ssdpSearch(
   }
 
   await listenFor(durationMs, signal);
-  socket.close();
+  close();
   return [...replies.values()];
 }
 

--- a/packages/tv-installer/src/discovery/tcp.test.ts
+++ b/packages/tv-installer/src/discovery/tcp.test.ts
@@ -1,0 +1,90 @@
+import { createServer, type Server } from 'node:net';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { connect, tcpOpen } from './tcp';
+
+const silent = vi.hoisted(() => ({
+  host: 'nothing-answers.invalid',
+  socket: () => {
+    const handlers = new Map<string, () => void>();
+    return {
+      setTimeout: (ms: number) => setTimeout(() => handlers.get('timeout')?.(), ms),
+      once: (event: string, handler: () => void) => handlers.set(event, handler),
+      destroy: () => undefined,
+    };
+  },
+}));
+
+vi.mock('node:net', async (importOriginal) => {
+  const net = await importOriginal<typeof import('node:net')>();
+  return {
+    ...net,
+    createConnection: (options: { host: string; port: number }) =>
+      options.host === silent.host ? silent.socket() : net.createConnection(options),
+  };
+});
+
+const servers: Server[] = [];
+
+const portOf = (server: Server): number => {
+  const address = server.address();
+  if (address === null || typeof address === 'string') throw new Error('the server took no port');
+  return address.port;
+};
+
+const listeningPort = async (): Promise<number> => {
+  const server = createServer((socket) => socket.end());
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  return portOf(server);
+};
+
+const closedPort = async (): Promise<number> => {
+  const port = await listeningPort();
+  await new Promise<void>((resolve) => servers.pop()?.close(() => resolve()));
+  return port;
+};
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => new Promise((done) => server.close(done))));
+});
+
+describe('connect', () => {
+  it('answers open when something accepts the connection', async () => {
+    const port = await listeningPort();
+
+    expect(await connect('127.0.0.1', port, 250)).toMatchObject({ outcome: 'open' });
+  });
+
+  it('answers refused when nothing listens on that port', async () => {
+    const port = await closedPort();
+
+    expect(await connect('127.0.0.1', port, 250)).toMatchObject({ outcome: 'refused' });
+  });
+
+  it('answers timeout when the host never answers the handshake', async () => {
+    expect(await connect(silent.host, 8001, 50)).toMatchObject({ outcome: 'timeout' });
+  });
+
+  it('answers how long the attempt took', async () => {
+    const port = await listeningPort();
+
+    const { ms } = await connect('127.0.0.1', port, 250);
+
+    expect(ms).toBeGreaterThanOrEqual(0);
+    expect(ms).toBeLessThan(250);
+  });
+});
+
+describe('tcpOpen', () => {
+  it('is true for a port something answers on', async () => {
+    const port = await listeningPort();
+
+    expect(await tcpOpen('127.0.0.1', port, 250)).toBe(true);
+  });
+
+  it('is false for a port nothing answers on', async () => {
+    const port = await closedPort();
+
+    expect(await tcpOpen('127.0.0.1', port, 250)).toBe(false);
+  });
+});

--- a/packages/tv-installer/src/discovery/tcp.ts
+++ b/packages/tv-installer/src/discovery/tcp.ts
@@ -1,0 +1,28 @@
+import { createConnection } from 'node:net';
+
+export type ConnectOutcome = 'open' | 'refused' | 'timeout';
+
+export interface ConnectResult {
+  outcome: ConnectOutcome;
+  ms: number;
+}
+
+export function connect(host: string, port: number, timeoutMs: number): Promise<ConnectResult> {
+  const started = performance.now();
+  return new Promise((resolve) => {
+    const socket = createConnection({ host, port });
+    const settle = (outcome: ConnectOutcome) => {
+      socket.destroy();
+      resolve({ outcome, ms: performance.now() - started });
+    };
+    socket.setTimeout(timeoutMs);
+    socket.once('connect', () => settle('open'));
+    socket.once('timeout', () => settle('timeout'));
+    socket.once('error', () => settle('refused'));
+  });
+}
+
+/** True when something accepts a TCP connection there within `timeoutMs`. */
+export async function tcpOpen(host: string, port: number, timeoutMs: number): Promise<boolean> {
+  return (await connect(host, port, timeoutMs)).outcome === 'open';
+}

--- a/packages/tv-installer/src/discovery/upnp.test.ts
+++ b/packages/tv-installer/src/discovery/upnp.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { parseDeviceDescription } from './upnp';
+
+const description = `<?xml version="1.0" encoding="utf-8"?>
+<root xmlns="urn:schemas-upnp-org:device-1-0" xmlns:dlna="urn:schemas-dlna-org:device-1-0">
+  <specVersion><major>1</major><minor>0</minor></specVersion>
+  <device>
+    <deviceType>urn:schemas-upnp-org:device:MediaRenderer:1</deviceType>
+    <friendlyName xml:lang="fr">[LG] webOS TV OLED55C16LA</friendlyName>
+    <manufacturer>LG Electronics</manufacturer>
+    <manufacturerURL>http://www.lge.com</manufacturerURL>
+    <modelName>
+      LG TV
+    </modelName>
+    <modelNumber>OLED55C16LA</modelNumber>
+    <UDN>uuid:8e3cf1a4-7c2f-4b19-9a3d-6f0b1f5f5c11</UDN>
+    <dlna:X_DLNADOC>DMR-1.50</dlna:X_DLNADOC>
+  </device>
+</root>`;
+
+describe('parseDeviceDescription', () => {
+  it('reads the names a television publishes about itself', () => {
+    expect(parseDeviceDescription(description)).toEqual({
+      friendlyName: '[LG] webOS TV OLED55C16LA',
+      manufacturer: 'LG Electronics',
+      modelName: 'LG TV',
+      modelNumber: 'OLED55C16LA',
+    });
+  });
+
+  it('answers empty names for a description that carries none', () => {
+    const bare = '<root><device><UDN>uuid:8e3cf1a4</UDN></device></root>';
+
+    expect(parseDeviceDescription(bare)).toEqual({
+      friendlyName: '',
+      manufacturer: '',
+      modelName: '',
+      modelNumber: '',
+    });
+  });
+});

--- a/packages/tv-installer/src/discovery/upnp.test.ts
+++ b/packages/tv-installer/src/discovery/upnp.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from 'vitest';
-import { parseDeviceDescription } from './upnp';
+import { describe, expect, it, vi } from 'vitest';
+import { fetchText } from './http';
+import { fetchDeviceDescription, parseDeviceDescription } from './upnp';
+
+vi.mock('./http', () => ({ fetchText: vi.fn() }));
 
 const description = `<?xml version="1.0" encoding="utf-8"?>
 <root xmlns="urn:schemas-upnp-org:device-1-0" xmlns:dlna="urn:schemas-dlna-org:device-1-0">
@@ -37,5 +40,28 @@ describe('parseDeviceDescription', () => {
       modelName: '',
       modelNumber: '',
     });
+  });
+});
+
+describe('fetchDeviceDescription', () => {
+  it('answers the names the description at that location carries', async () => {
+    vi.mocked(fetchText).mockResolvedValue(description);
+
+    expect(await fetchDeviceDescription('http://192.168.1.32:1754/')).toMatchObject({
+      friendlyName: '[LG] webOS TV OLED55C16LA',
+      manufacturer: 'LG Electronics',
+    });
+  });
+
+  it('answers nothing when the location answers nothing', async () => {
+    vi.mocked(fetchText).mockResolvedValue(null);
+
+    expect(await fetchDeviceDescription('http://192.168.1.32:1754/')).toBeNull();
+  });
+
+  it('answers nothing for a description that names neither a set nor a maker', async () => {
+    vi.mocked(fetchText).mockResolvedValue('<root><device><UDN>uuid:8e3</UDN></device></root>');
+
+    expect(await fetchDeviceDescription('http://192.168.1.32:1754/')).toBeNull();
   });
 });

--- a/packages/tv-installer/src/discovery/upnp.ts
+++ b/packages/tv-installer/src/discovery/upnp.ts
@@ -1,0 +1,32 @@
+import { fetchText } from './http';
+
+export interface UpnpDevice {
+  friendlyName: string;
+  manufacturer: string;
+  modelName: string;
+  modelNumber: string;
+}
+
+const MAX_DESCRIPTION_BYTES = 32 * 1024;
+
+export function parseDeviceDescription(xml: string): UpnpDevice {
+  return {
+    friendlyName: tagText(xml, 'friendlyName'),
+    manufacturer: tagText(xml, 'manufacturer'),
+    modelName: tagText(xml, 'modelName'),
+    modelNumber: tagText(xml, 'modelNumber'),
+  };
+}
+
+/** The UPnP description a television's SSDP reply points at, or null if it lies. */
+export async function fetchDeviceDescription(location: string): Promise<UpnpDevice | null> {
+  const xml = await fetchText(location, { maxBytes: MAX_DESCRIPTION_BYTES });
+  if (!xml) return null;
+  const device = parseDeviceDescription(xml);
+  return device.friendlyName || device.manufacturer ? device : null;
+}
+
+function tagText(xml: string, tag: string): string {
+  const match = new RegExp(`<${tag}[^>]*>([^<]*)</${tag}>`, 'i').exec(xml);
+  return match?.[1]?.trim() ?? '';
+}

--- a/packages/tv-installer/src/exit-after.test.ts
+++ b/packages/tv-installer/src/exit-after.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { exitAfter } from './exit-after';
+
+let exit: ReturnType<typeof vi.spyOn>;
+let errors: string[];
+
+beforeEach(() => {
+  errors = [];
+  exit = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
+  vi.spyOn(console, 'error').mockImplementation((...parts) => errors.push(parts.join(' ')));
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('exitAfter', () => {
+  it('exits with the code the work answered', async () => {
+    await exitAfter(Promise.resolve(3));
+
+    expect(exit).toHaveBeenCalledWith(3);
+  });
+
+  it('exits with a code that was handed over rather than awaited', async () => {
+    await exitAfter(0);
+
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  it('prints what went wrong and exits one', async () => {
+    await exitAfter(Promise.reject(new Error('sdb refused the connection')));
+
+    expect(errors).toEqual(['sdb refused the connection']);
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it('prints a rejection that is not an error as it reads', async () => {
+    await exitAfter(Promise.reject('no device'));
+
+    expect(errors).toEqual(['no device']);
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/tv-installer/src/exit-after.ts
+++ b/packages/tv-installer/src/exit-after.ts
@@ -1,0 +1,8 @@
+export async function exitAfter(work: number | Promise<number>): Promise<never> {
+  try {
+    return process.exit(await work);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return process.exit(1);
+  }
+}

--- a/packages/tv-installer/src/hints.test.ts
+++ b/packages/tv-installer/src/hints.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { diagnoseEmptyScan } from './hints';
+import { localNetworkBlocked, responsibleApp } from './local-network';
+import type { TvModule } from './modules/module';
+import { modules } from './modules/registry';
+
+vi.mock('./local-network', () => ({ localNetworkBlocked: vi.fn(), responsibleApp: vi.fn() }));
+vi.mock('./modules/registry', () => ({ modules: vi.fn() }));
+
+const module = (label: string, enableSteps?: string): TvModule => ({
+  id: label.toLowerCase(),
+  label,
+  brands: label,
+  package: `tv.kroma.${label.toLowerCase()}`,
+  notReadyHint: '',
+  enableSteps,
+  tools: () => [],
+  sources: () => [],
+  resolve: () => Promise.resolve(''),
+  install: () => Promise.resolve(),
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(localNetworkBlocked).mockResolvedValue(false);
+  vi.mocked(responsibleApp).mockResolvedValue(null);
+  vi.mocked(modules).mockReturnValue([
+    module('Samsung', 'Apps panel, 12345, Developer mode on'),
+    module('LG', 'install Developer Mode and sign in'),
+    module('Apple TV'),
+  ]);
+});
+
+describe('diagnoseEmptyScan', () => {
+  it('blames the permission when macOS is refusing the local network', async () => {
+    vi.mocked(localNetworkBlocked).mockResolvedValue(true);
+    vi.mocked(responsibleApp).mockResolvedValue('Ghostty');
+
+    const { blocked, hints } = await diagnoseEmptyScan();
+
+    expect(blocked).toBe(true);
+    expect(hints[0]).toContain('Ghostty');
+  });
+
+  it('blames the terminal itself when no application owns the process', async () => {
+    vi.mocked(localNetworkBlocked).mockResolvedValue(true);
+
+    const { hints } = await diagnoseEmptyScan();
+
+    expect(hints[0]).toContain('this terminal');
+  });
+
+  it('says how to turn developer mode on when nothing is blocking', async () => {
+    const { blocked, hints } = await diagnoseEmptyScan();
+
+    expect(blocked).toBe(false);
+    expect(hints.join(' ')).toContain('Samsung: Apps panel, 12345, Developer mode on');
+  });
+
+  it('leaves out a platform that asks for nothing to be turned on', async () => {
+    const { hints } = await diagnoseEmptyScan();
+
+    expect(hints.join(' ')).not.toContain('Apple TV');
+  });
+
+  it('still says how to turn developer mode on when the permission is denied', async () => {
+    vi.mocked(localNetworkBlocked).mockResolvedValue(true);
+
+    const { hints } = await diagnoseEmptyScan();
+
+    expect(hints.join(' ')).toContain('LG: install Developer Mode and sign in');
+  });
+});

--- a/packages/tv-installer/src/hints.ts
+++ b/packages/tv-installer/src/hints.ts
@@ -1,0 +1,33 @@
+import { localNetworkBlocked, responsibleApp } from './local-network';
+import { modules } from './modules/registry';
+
+function blocked(app: string): string[] {
+  return [
+    `macOS is refusing ${app} the local network, so no probe can land.`,
+    `Allow ${app} under System Settings, Privacy & Security, Local Network, then restart it.`,
+    `That list takes no entry by hand: the request just sent on ${app}'s behalf is what lists it.`,
+  ];
+}
+
+function quiet(): string[] {
+  const enabling = modules()
+    .flatMap((module) => (module.enableSteps ? [`${module.label}: ${module.enableSteps}`] : []))
+    .join('. ');
+  return [
+    'A set answers only when it is on, and only once its developer mode is enabled.',
+    `${enabling}.`,
+  ];
+}
+
+export interface EmptyScan {
+  blocked: boolean;
+  hints: string[];
+}
+
+/** Why a scan came back empty, most likely cause first. */
+export async function diagnoseEmptyScan(): Promise<EmptyScan> {
+  if (!(await localNetworkBlocked())) return { blocked: false, hints: quiet() };
+
+  const app = (await responsibleApp()) ?? 'this terminal';
+  return { blocked: true, hints: [...blocked(app), ...quiet()] };
+}

--- a/packages/tv-installer/src/install/artifact.test.ts
+++ b/packages/tv-installer/src/install/artifact.test.ts
@@ -1,8 +1,206 @@
-import { describe, expect, it } from 'vitest';
-import { rankArtifacts } from './artifact';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { run } from '../run';
+import type { Television } from '../television';
+import {
+  availableSources,
+  localArtifact,
+  type PackageKind,
+  rankArtifacts,
+  resolveArtifact,
+} from './artifact';
+
+const { mtimes, globbed } = vi.hoisted(() => ({
+  mtimes: new Map<string, number>(),
+  globbed: new Map<string, string[]>(),
+}));
+
+vi.mock('node:fs', () => ({
+  existsSync: () => true,
+  statSync: (path: string) => ({ mtimeMs: mtimes.get(path) ?? 0 }),
+}));
+vi.mock('node:fs/promises', () => ({ mkdir: vi.fn() }));
+vi.mock('../root', () => ({ root: '/kroma' }));
+vi.mock('../run', () => ({ run: vi.fn() }));
+
+const which = vi.fn<(binary: string) => string | null>();
+
+class FakeGlob {
+  constructor(private readonly pattern: string) {}
+
+  scanSync({ cwd, absolute }: { cwd: string; absolute?: boolean }): string[] {
+    const names = globbed.get(this.pattern) ?? [];
+    return names.map((name) => (absolute ? join(cwd, name) : name));
+  }
+}
+
+vi.stubGlobal('Bun', { which, Glob: FakeGlob });
+
+const wgt: PackageKind = {
+  extension: '.wgt',
+  globs: ['clients/tizen/out/*.wgt', 'clients/tizen/dist/*.wgt'],
+  pattern: 'KROMA-tizen-*.wgt',
+  runArtifact: 'kroma-tizen-wgt',
+  preferred: /KROMA-tizen-\d/,
+};
+
+const samsung: Television = {
+  host: '192.168.1.31',
+  platform: 'tizen',
+  vendor: 'Samsung',
+  name: 'Salon',
+  model: 'UE50AU7172',
+  developerMode: 'on',
+  sideloadable: true,
+  note: '',
+  runtime: null,
+};
+
+const downloads = join(homedir(), '.kroma', 'downloads');
+const lines: string[] = [];
+const log = (line: string) => lines.push(line);
+
+beforeEach(() => {
+  globbed.clear();
+  mtimes.clear();
+  lines.length = 0;
+  which.mockReturnValue('/usr/local/bin/gh');
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
 
 describe('rankArtifacts', () => {
   it('answers an empty list when nothing has been built', () => {
     expect(rankArtifacts([])).toEqual([]);
+  });
+
+  it('separates two packages of the same age by their name', () => {
+    const built = [
+      { path: '/out/KROMA-b.wgt', mtimeMs: 1_000 },
+      { path: '/out/KROMA-a.wgt', mtimeMs: 1_000 },
+    ];
+
+    expect(rankArtifacts(built)).toEqual(['/out/KROMA-b.wgt', '/out/KROMA-a.wgt']);
+  });
+});
+
+describe('localArtifact', () => {
+  it('takes the newest package of every place a build leaves one', () => {
+    globbed.set('clients/tizen/out/*.wgt', ['clients/tizen/out/KROMA-tizen-0.1.32.wgt']);
+    globbed.set('clients/tizen/dist/*.wgt', ['clients/tizen/dist/KROMA-tizen-0.1.33.wgt']);
+    mtimes.set('/kroma/clients/tizen/out/KROMA-tizen-0.1.32.wgt', 1_000);
+    mtimes.set('/kroma/clients/tizen/dist/KROMA-tizen-0.1.33.wgt', 5_000);
+
+    expect(localArtifact(wgt)).toBe('/kroma/clients/tizen/dist/KROMA-tizen-0.1.33.wgt');
+  });
+
+  it('answers nothing when this checkout has built none', () => {
+    expect(localArtifact(wgt)).toBeNull();
+  });
+});
+
+describe('availableSources', () => {
+  it('offers what is built here, both release channels and a build from source', () => {
+    globbed.set('clients/tizen/out/*.wgt', ['clients/tizen/out/KROMA-tizen-0.1.33.wgt']);
+
+    expect(availableSources(wgt, true)).toEqual(['local', 'stable', 'canary', 'build']);
+  });
+
+  it('offers no release channel on a machine with no gh to fetch one', () => {
+    which.mockReturnValue(null);
+
+    expect(availableSources(wgt, true)).toEqual(['build']);
+  });
+
+  it('offers no build for a shell whose sources are not here', () => {
+    which.mockReturnValue(null);
+
+    expect(availableSources(wgt, false)).toEqual([]);
+  });
+});
+
+describe('resolveArtifact', () => {
+  const from = { id: 'tizen', kind: wgt, build: vi.fn() };
+
+  it('takes the package it was given over anything else', async () => {
+    const path = await resolveArtifact(from, { tv: samsung, given: '/tmp/KROMA.wgt', log });
+
+    expect(path).toBe('/tmp/KROMA.wgt');
+    expect(from.build).not.toHaveBeenCalled();
+    expect(vi.mocked(run)).not.toHaveBeenCalled();
+  });
+
+  it('builds from source when that is the source asked for', async () => {
+    from.build.mockResolvedValue('/kroma/clients/tizen/dist');
+
+    const path = await resolveArtifact(from, { tv: samsung, source: 'build', log });
+
+    expect(path).toBe('/kroma/clients/tizen/dist');
+  });
+
+  it('names the package it found in this checkout, relative to the checkout', async () => {
+    globbed.set('clients/tizen/out/*.wgt', ['clients/tizen/out/KROMA-tizen-0.1.33.wgt']);
+
+    const path = await resolveArtifact(from, { tv: samsung, log });
+
+    expect(path).toBe('/kroma/clients/tizen/out/KROMA-tizen-0.1.33.wgt');
+    expect(lines).toEqual(['package: clients/tizen/out/KROMA-tizen-0.1.33.wgt']);
+  });
+
+  it('pulls the stable release when this checkout has built nothing', async () => {
+    vi.mocked(run).mockResolvedValue({ code: 0, output: '' });
+    globbed.set('*.wgt', ['KROMA-tizen-0.1.33.wgt']);
+
+    const path = await resolveArtifact(from, { tv: samsung, log });
+
+    expect(vi.mocked(run).mock.calls[0]?.[0]).toEqual([
+      'gh',
+      'release',
+      'download',
+      '--pattern',
+      'KROMA-tizen-*.wgt',
+      '--dir',
+      join(downloads, 'stable', 'tizen'),
+      '--clobber',
+    ]);
+    expect(path).toBe(join(downloads, 'stable', 'tizen', 'KROMA-tizen-0.1.33.wgt'));
+  });
+
+  it('names the canary tag when the canary channel is the one asked for', async () => {
+    vi.mocked(run).mockResolvedValue({ code: 0, output: '' });
+    globbed.set('*.wgt', ['KROMA-tizen-0.1.34.wgt']);
+
+    await resolveArtifact(from, { tv: samsung, source: 'canary', log });
+
+    expect(vi.mocked(run).mock.calls[0]?.[0]).toEqual([
+      'gh',
+      'release',
+      'download',
+      'canary',
+      '--pattern',
+      'KROMA-tizen-*.wgt',
+      '--dir',
+      join(downloads, 'canary', 'tizen'),
+      '--clobber',
+    ]);
+  });
+
+  it('says what to run by hand on a machine with no gh', async () => {
+    which.mockReturnValue(null);
+
+    await expect(resolveArtifact(from, { tv: samsung, source: 'stable', log })).rejects.toThrow(
+      'no .wgt here and no gh to fetch one: gh run download -n kroma-tizen-wgt',
+    );
+  });
+
+  it('refuses a release that carried no package of that kind', async () => {
+    vi.mocked(run).mockResolvedValue({ code: 0, output: '' });
+
+    await expect(resolveArtifact(from, { tv: samsung, source: 'stable', log })).rejects.toThrow(
+      'the stable release carries no KROMA-tizen-*.wgt',
+    );
   });
 });

--- a/packages/tv-installer/src/install/artifact.test.ts
+++ b/packages/tv-installer/src/install/artifact.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { rankArtifacts } from './artifact';
+
+describe('rankArtifacts', () => {
+  it('answers an empty list when nothing has been built', () => {
+    expect(rankArtifacts([])).toEqual([]);
+  });
+});

--- a/packages/tv-installer/src/install/artifact.ts
+++ b/packages/tv-installer/src/install/artifact.ts
@@ -1,0 +1,116 @@
+import { existsSync, statSync } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { basename, join } from 'node:path';
+import { root } from '../root';
+import { type LogLine, run } from '../run';
+import type { Television } from '../television';
+
+export type Source = 'local' | 'stable' | 'canary' | 'build';
+
+export interface PackageKind {
+  extension: string;
+  globs: readonly string[];
+  pattern: string;
+  runArtifact: string;
+  preferred?: RegExp;
+}
+
+export interface ArtifactRequest {
+  tv: Television;
+  given?: string;
+  source?: Source;
+  log: LogLine;
+}
+
+export interface ArtifactSource {
+  id: string;
+  kind: PackageKind;
+  build?: (log: LogLine) => Promise<string>;
+}
+
+const DOWNLOADS = join(homedir(), '.kroma', 'downloads');
+const DOWNLOAD_TIMEOUT_MS = 600_000;
+
+export interface Candidate {
+  path: string;
+  mtimeMs: number;
+}
+
+/** Newest first, with the build `preferred` matches ahead of every other one. */
+export function rankArtifacts(candidates: readonly Candidate[], preferred?: RegExp): string[] {
+  const rank = (path: string) => Number(preferred?.test(basename(path)) ?? false);
+  return [...candidates]
+    .sort((a, b) => {
+      const byKind = rank(b.path) - rank(a.path);
+      if (byKind !== 0) return byKind;
+      const byAge = b.mtimeMs - a.mtimeMs;
+      return byAge !== 0 ? byAge : basename(b.path).localeCompare(basename(a.path));
+    })
+    .map((candidate) => candidate.path);
+}
+
+export function localArtifact(kind: PackageKind): string | null {
+  const candidates: Candidate[] = [];
+  for (const pattern of kind.globs) {
+    for (const path of new Bun.Glob(pattern).scanSync({ cwd: root, absolute: true })) {
+      candidates.push({ path, mtimeMs: statSync(path).mtimeMs });
+    }
+  }
+  return rankArtifacts(candidates, kind.preferred)[0] ?? null;
+}
+
+export function availableSources(kind: PackageKind, buildable: boolean): Source[] {
+  const sources: Source[] = [];
+  if (localArtifact(kind)) sources.push('local');
+  if (Bun.which('gh')) sources.push('stable', 'canary');
+  if (buildable) sources.push('build');
+  return sources;
+}
+
+export async function resolveArtifact(
+  from: ArtifactSource,
+  { given, source, log }: ArtifactRequest,
+): Promise<string> {
+  if (given) return given;
+  if (source === 'build' && from.build) return from.build(log);
+  if (source === 'stable' || source === 'canary') return fromRelease(from, source, log);
+
+  const local = localArtifact(from.kind);
+  if (local) {
+    log(`package: ${local.replace(`${root}/`, '')}`);
+    return local;
+  }
+  return fromRelease(from, 'stable', log);
+}
+
+async function fromRelease(from: ArtifactSource, source: Source, log: LogLine): Promise<string> {
+  const { extension, pattern, runArtifact } = from.kind;
+  if (!Bun.which('gh')) {
+    throw new Error(
+      `no ${extension} here and no gh to fetch one: gh run download -n ${runArtifact}`,
+    );
+  }
+
+  const dir = join(DOWNLOADS, source, from.id);
+  await mkdir(dir, { recursive: true });
+  log(`pulling the ${source} ${extension} with gh`);
+
+  const tag = source === 'canary' ? ['canary'] : [];
+  const { code } = await run(
+    ['gh', 'release', 'download', ...tag, '--pattern', pattern, '--dir', dir, '--clobber'],
+    { log, cwd: root, timeoutMs: DOWNLOAD_TIMEOUT_MS },
+  );
+  const downloaded = existsSync(dir) ? newest(dir, from.kind) : null;
+  if (code !== 0 || !downloaded) {
+    throw new Error(`the ${source} release carries no ${pattern}`);
+  }
+  return downloaded;
+}
+
+function newest(dir: string, kind: PackageKind): string | null {
+  const candidates = [
+    ...new Bun.Glob(`*${kind.extension}`).scanSync({ cwd: dir, absolute: true }),
+  ].map((path) => ({ path, mtimeMs: statSync(path).mtimeMs }));
+  return rankArtifacts(candidates, kind.preferred)[0] ?? null;
+}

--- a/packages/tv-installer/src/install/artifact.ts
+++ b/packages/tv-installer/src/install/artifact.ts
@@ -78,7 +78,8 @@ export async function resolveArtifact(
 
   const local = localArtifact(from.kind);
   if (local) {
-    log(`package: ${local.replace(`${root}/`, '')}`);
+    const relative = local.replace(`${root}/`, '');
+    log(`package: ${relative}`);
     return local;
   }
   return fromRelease(from, 'stable', log);

--- a/packages/tv-installer/src/install/build.test.ts
+++ b/packages/tv-installer/src/install/build.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { buildable } from './build';
+
+describe('buildable', () => {
+  it('builds a shell whose sources are in this checkout', () => {
+    expect(buildable('clients/tizen')).toBe(true);
+  });
+
+  it('refuses a shell this checkout carries no sources for', () => {
+    expect(buildable('clients/betamax')).toBe(false);
+  });
+});

--- a/packages/tv-installer/src/install/build.ts
+++ b/packages/tv-installer/src/install/build.ts
@@ -1,0 +1,7 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { root } from '../root';
+
+export function buildable(shell: string): boolean {
+  return existsSync(join(root, shell, 'package.json'));
+}

--- a/packages/tv-installer/src/install/deploy.test.ts
+++ b/packages/tv-installer/src/install/deploy.test.ts
@@ -34,12 +34,17 @@ const steps: string[] = [];
 const resolve = vi.fn(async () => '/out/KROMA.apk');
 const install = vi.fn(async (_context: unknown) => {});
 
-const androidtv = {
+const androidtv: TvModule = {
   id: 'androidtv',
+  label: 'Android TV',
+  brands: 'Philips, Sony, TCL, Shield, Chromecast',
+  package: '.apk',
+  notReadyHint: 'network debugging off',
   tools: () => [adb],
+  sources: () => [],
   resolve,
   install,
-} as unknown as TvModule;
+};
 
 const log = () => {};
 

--- a/packages/tv-installer/src/install/deploy.test.ts
+++ b/packages/tv-installer/src/install/deploy.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TvModule } from '../modules/module';
+import type { Television } from '../television';
+import type { Tool } from '../toolchain/detect';
+import { deployTo } from './deploy';
+
+const { moduleFor, installTool } = vi.hoisted(() => ({
+  moduleFor: vi.fn((_platform: string): unknown => undefined),
+  installTool: vi.fn(async (_tool: unknown, _log: unknown) => '/usr/bin/adb'),
+}));
+vi.mock('../modules/registry', () => ({ moduleFor }));
+vi.mock('../toolchain/install', () => ({ installTool }));
+
+const adb: Tool = {
+  id: 'adb',
+  label: 'Android Debug Bridge',
+  binary: 'adb',
+  source: 'dl.google.com platform-tools',
+};
+
+const shield: Television = {
+  host: '192.168.1.36',
+  platform: 'androidtv',
+  vendor: 'Nvidia',
+  name: 'Shield',
+  model: 'SHIELD Android TV',
+  developerMode: 'on',
+  sideloadable: true,
+  note: 'network debugging open on 5555',
+  runtime: null,
+};
+
+const steps: string[] = [];
+const resolve = vi.fn(async () => '/out/KROMA.apk');
+const install = vi.fn(async (_context: unknown) => {});
+
+const androidtv = {
+  id: 'androidtv',
+  tools: () => [adb],
+  resolve,
+  install,
+} as unknown as TvModule;
+
+const log = () => {};
+
+beforeEach(() => {
+  steps.length = 0;
+  resolve.mockClear();
+  install.mockClear();
+  installTool.mockReset();
+  installTool.mockImplementation(async () => {
+    steps.push('tool');
+    return '/usr/bin/adb';
+  });
+  resolve.mockImplementation(async () => {
+    steps.push('resolve');
+    return '/out/KROMA.apk';
+  });
+  install.mockImplementation(async () => void steps.push('install'));
+  moduleFor.mockReturnValue(androidtv);
+});
+
+describe('deployTo', () => {
+  it('installs the toolchain the platform needs before it looks for a package', async () => {
+    await deployTo(shield, { log });
+
+    expect(installTool).toHaveBeenCalledWith(adb, log);
+    expect(steps).toEqual(['tool', 'resolve', 'install']);
+  });
+
+  it('hands the module the package it resolved, and starts the app', async () => {
+    await deployTo(shield, { log });
+
+    expect(install).toHaveBeenCalledWith({
+      tv: shield,
+      artifact: '/out/KROMA.apk',
+      log,
+      launch: true,
+      options: {},
+    });
+  });
+
+  it('passes the package that was named and where it should come from', async () => {
+    await deployTo(shield, { log, artifact: '/out/other.apk', source: 'canary' });
+
+    expect(resolve).toHaveBeenCalledWith({
+      tv: shield,
+      given: '/out/other.apk',
+      source: 'canary',
+      log,
+    });
+  });
+
+  it('installs without starting the app when told not to launch', async () => {
+    await deployTo(shield, { log, launch: false, moduleOptions: { native: true } });
+
+    expect(install.mock.calls[0]?.[0]).toMatchObject({ launch: false, options: { native: true } });
+  });
+});

--- a/packages/tv-installer/src/install/deploy.ts
+++ b/packages/tv-installer/src/install/deploy.ts
@@ -1,0 +1,34 @@
+import type { ModuleOptions } from '../modules/module';
+import { moduleFor } from '../modules/registry';
+import type { LogLine } from '../run';
+import type { Television } from '../television';
+import { installTool } from '../toolchain/install';
+import type { Source } from './artifact';
+
+export interface DeployOptions {
+  log: LogLine;
+  artifact?: string;
+  launch?: boolean;
+  source?: Source;
+  moduleOptions?: ModuleOptions;
+}
+
+/** Installs the toolchain the set's platform needs, then puts KROMA on it. */
+export async function deployTo(tv: Television, options: DeployOptions): Promise<void> {
+  const module = moduleFor(tv.platform);
+  for (const tool of module.tools()) await installTool(tool, options.log);
+
+  const artifact = await module.resolve({
+    tv,
+    given: options.artifact,
+    source: options.source,
+    log: options.log,
+  });
+  await module.install({
+    tv,
+    artifact,
+    log: options.log,
+    launch: options.launch ?? true,
+    options: options.moduleOptions ?? {},
+  });
+}

--- a/packages/tv-installer/src/local-network.test.ts
+++ b/packages/tv-installer/src/local-network.test.ts
@@ -1,0 +1,267 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { arpHosts } from './discovery/arp';
+import { localSubnets } from './discovery/lan';
+import { connect } from './discovery/tcp';
+import {
+  askForLocalNetwork,
+  localNetworkBlocked,
+  mdnsQuery,
+  openPrivacySettings,
+  PRIVACY_PANE,
+  responsibleApp,
+} from './local-network';
+import { run } from './run';
+
+vi.mock('./discovery/arp', () => ({ arpHosts: vi.fn() }));
+vi.mock('./discovery/tcp', () => ({ connect: vi.fn() }));
+vi.mock('./run', () => ({ run: vi.fn() }));
+vi.mock('./discovery/lan', async (original) => ({
+  ...(await original<typeof import('./discovery/lan')>()),
+  localSubnets: vi.fn(),
+}));
+
+const socket = vi.hoisted(() => ({
+  bind: vi.fn(),
+  on: vi.fn(),
+  setMulticastInterface: vi.fn(),
+  send: vi.fn(),
+  close: vi.fn(),
+}));
+
+vi.mock('node:dgram', () => ({ createSocket: vi.fn(() => socket) }));
+
+const realPlatform = process.platform;
+
+const onPlatform = (platform: NodeJS.Platform) => {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+};
+
+const home = { iface: 'en0', address: '192.168.1.10', prefix: '192.168.1' };
+
+const labelsOf = (query: Buffer): string[] => {
+  const labels: string[] = [];
+  for (let at = 12; query[at]; ) {
+    const length = Number(query[at]);
+    labels.push(query.subarray(at + 1, at + 1 + length).toString('ascii'));
+    at += length + 1;
+  }
+  return labels;
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  onPlatform('darwin');
+  socket.bind.mockImplementation((ready: () => void) => ready());
+  socket.send.mockImplementation((_query, _port, _group, sent?: () => void) => sent?.());
+  vi.mocked(arpHosts).mockResolvedValue([]);
+  vi.mocked(localSubnets).mockReturnValue([home]);
+  vi.mocked(connect).mockResolvedValue({ outcome: 'timeout', ms: 600 });
+  vi.mocked(run).mockResolvedValue({ code: 0, output: '' });
+});
+
+afterEach(() => {
+  onPlatform(realPlatform);
+  vi.useRealTimers();
+});
+
+describe('localNetworkBlocked', () => {
+  it('reads a refusal too fast to be the network as the permission being denied', async () => {
+    vi.mocked(connect).mockResolvedValue({ outcome: 'refused', ms: 3 });
+
+    expect(await localNetworkBlocked()).toBe(true);
+  });
+
+  it('reads a refusal at network speed as a set that really refused', async () => {
+    vi.mocked(connect).mockResolvedValue({ outcome: 'refused', ms: 250 });
+
+    expect(await localNetworkBlocked()).toBe(false);
+  });
+
+  it('reads silence at the probed address as nobody home', async () => {
+    expect(await localNetworkBlocked()).toBe(false);
+  });
+
+  it('probes only addresses this machine has never talked to', async () => {
+    vi.mocked(arpHosts).mockResolvedValue(['192.168.1.253']);
+
+    await localNetworkBlocked();
+
+    expect(vi.mocked(connect).mock.calls.map(([host]) => host)).toEqual([
+      '192.168.1.252',
+      '192.168.1.251',
+    ]);
+  });
+
+  it('answers no when the machine sits on no network to be refused', async () => {
+    vi.mocked(localSubnets).mockReturnValue([]);
+
+    expect(await localNetworkBlocked()).toBe(false);
+    expect(connect).not.toHaveBeenCalled();
+  });
+
+  it('answers no anywhere the permission does not exist', async () => {
+    onPlatform('linux');
+
+    expect(await localNetworkBlocked()).toBe(false);
+    expect(connect).not.toHaveBeenCalled();
+  });
+});
+
+describe('responsibleApp', () => {
+  it('names the application bundle this process runs under', async () => {
+    vi.mocked(run).mockResolvedValue({
+      code: 0,
+      output: '  501 /Applications/Ghostty.app/Contents/MacOS/ghostty',
+    });
+
+    expect(await responsibleApp()).toBe('Ghostty');
+  });
+
+  it('walks up the process tree until it reaches an application', async () => {
+    vi.mocked(run)
+      .mockResolvedValueOnce({ code: 0, output: '  501 /bin/zsh' })
+      .mockResolvedValueOnce({
+        code: 0,
+        output: '  1 /Applications/iTerm.app/Contents/MacOS/iTerm2',
+      });
+
+    expect(await responsibleApp()).toBe('iTerm');
+  });
+
+  it('answers nothing when ps prints a line it cannot read', async () => {
+    vi.mocked(run).mockResolvedValue({ code: 0, output: 'ps: no such process' });
+
+    expect(await responsibleApp()).toBeNull();
+  });
+
+  it('answers nothing when ps refuses to answer', async () => {
+    vi.mocked(run).mockResolvedValue({ code: 1, output: '' });
+
+    expect(await responsibleApp()).toBeNull();
+  });
+
+  it('gives up after twelve generations of shells', async () => {
+    vi.mocked(run).mockResolvedValue({ code: 0, output: '  99 /bin/zsh' });
+
+    expect(await responsibleApp()).toBeNull();
+    expect(run).toHaveBeenCalledTimes(12);
+  });
+
+  it('answers nothing anywhere macOS is not what owns the process', async () => {
+    onPlatform('linux');
+
+    expect(await responsibleApp()).toBeNull();
+    expect(run).not.toHaveBeenCalled();
+  });
+});
+
+describe('openPrivacySettings', () => {
+  it('opens the Local Network pane and says the system took it', async () => {
+    expect(await openPrivacySettings()).toBe(true);
+    expect(vi.mocked(run).mock.calls[0]?.[0]).toEqual(['open', PRIVACY_PANE]);
+  });
+
+  it('says nothing opened when the system refuses', async () => {
+    vi.mocked(run).mockResolvedValue({ code: 1, output: '' });
+
+    expect(await openPrivacySettings()).toBe(false);
+  });
+});
+
+describe('mdnsQuery', () => {
+  it('encodes the name as one length-prefixed label per dotted part', () => {
+    expect(labelsOf(mdnsQuery('_services._dns-sd._udp.local'))).toEqual([
+      '_services',
+      '_dns-sd',
+      '_udp',
+      'local',
+    ]);
+  });
+
+  it('asks one PTR question of the internet class', () => {
+    const query = mdnsQuery('_services._dns-sd._udp.local');
+
+    expect(query.readUInt16BE(4)).toBe(1);
+    expect(query.readUInt16BE(query.length - 4)).toBe(12);
+    expect(query.readUInt16BE(query.length - 2)).toBe(1);
+  });
+
+  it('carries no id, no flags and no answers of its own', () => {
+    const query = mdnsQuery('local');
+
+    expect([...query.subarray(0, 4)]).toEqual([0, 0, 0, 0]);
+    expect([...query.subarray(6, 12)]).toEqual([0, 0, 0, 0, 0, 0]);
+  });
+});
+
+describe('askForLocalNetwork', () => {
+  it('multicasts the query out of every interface, then closes the socket', async () => {
+    vi.useFakeTimers();
+    vi.mocked(localSubnets).mockReturnValue([
+      home,
+      { iface: 'en1', address: '10.0.0.2', prefix: '10.0.0' },
+    ]);
+
+    const asking = askForLocalNetwork();
+    await vi.advanceTimersByTimeAsync(300);
+    await asking;
+
+    expect(socket.setMulticastInterface.mock.calls.flat()).toEqual(['192.168.1.10', '10.0.0.2']);
+    expect(socket.send.mock.calls.map(([, port, group]) => [port, group])).toEqual([
+      [5353, '224.0.0.251'],
+      [5353, '224.0.0.251'],
+    ]);
+    expect(socket.close).toHaveBeenCalled();
+  });
+
+  it('sends the same question it encodes for the link', async () => {
+    vi.useFakeTimers();
+
+    const asking = askForLocalNetwork();
+    await vi.advanceTimersByTimeAsync(300);
+    await asking;
+
+    expect(socket.send.mock.calls[0]?.[0]).toEqual(mdnsQuery('_services._dns-sd._udp.local'));
+  });
+
+  it('skips an interface the socket refuses to multicast on', async () => {
+    vi.useFakeTimers();
+    socket.setMulticastInterface.mockImplementation(() => {
+      throw new Error('EADDRNOTAVAIL');
+    });
+
+    const asking = askForLocalNetwork();
+    await vi.advanceTimersByTimeAsync(300);
+    await asking;
+
+    expect(socket.send).not.toHaveBeenCalled();
+    expect(socket.close).toHaveBeenCalled();
+  });
+
+  it('swallows an error the socket raises rather than letting it throw', async () => {
+    vi.useFakeTimers();
+
+    const asking = askForLocalNetwork();
+    await vi.advanceTimersByTimeAsync(300);
+    await asking;
+    const raised = socket.on.mock.calls.find(([event]) => event === 'error')?.[1];
+
+    expect(() => raised(new Error('ENETUNREACH'))).not.toThrow();
+  });
+
+  it('opens no socket when the machine sits on no network', async () => {
+    vi.mocked(localSubnets).mockReturnValue([]);
+
+    await askForLocalNetwork();
+
+    expect(socket.bind).not.toHaveBeenCalled();
+  });
+
+  it('asks nothing anywhere the permission does not exist', async () => {
+    onPlatform('linux');
+
+    await askForLocalNetwork();
+
+    expect(socket.bind).not.toHaveBeenCalled();
+  });
+});

--- a/packages/tv-installer/src/local-network.ts
+++ b/packages/tv-installer/src/local-network.ts
@@ -35,7 +35,7 @@ export async function localNetworkBlocked(): Promise<boolean> {
 }
 
 const APP_BUNDLE = /\/([^/]+)\.app\/Contents\/MacOS\//;
-const PROCESS_LINE = /^\s*(\d+)\s+(.*)$/;
+const PROCESS_LINE = /^[ \t]*(\d+)[ \t]+(\S.*)$/;
 const MAX_DEPTH = 12;
 
 /**
@@ -65,7 +65,7 @@ export async function openPrivacySettings(): Promise<boolean> {
   return code === 0;
 }
 
-const MDNS_ADDRESS = '224.0.0.251';
+const MDNS_MULTICAST_GROUP = '224.0.0.251';
 const MDNS_PORT = 5353;
 const SETTLE_MS = 300;
 
@@ -85,7 +85,7 @@ export function mdnsQuery(name: string): Buffer {
 function queryOn(socket: Socket, address: string, query: Buffer): void {
   try {
     socket.setMulticastInterface(address);
-    socket.send(query, MDNS_PORT, MDNS_ADDRESS, () => undefined);
+    socket.send(query, MDNS_PORT, MDNS_MULTICAST_GROUP, () => undefined);
   } catch {
     return;
   }

--- a/packages/tv-installer/src/local-network.ts
+++ b/packages/tv-installer/src/local-network.ts
@@ -1,0 +1,113 @@
+import { createSocket, type Socket } from 'node:dgram';
+import { arpHosts } from './discovery/arp';
+import { localSubnets } from './discovery/lan';
+import { connect } from './discovery/tcp';
+import { run } from './run';
+
+export const PRIVACY_PANE =
+  'x-apple.systempreferences:com.apple.preference.security?Privacy_LocalNetwork';
+
+const DISCARD_PORT = 9;
+const PROBE_TIMEOUT_MS = 600;
+// An address nobody answers at cannot refuse a connection: the packet goes out
+// and nothing comes back, which is a timeout. A refusal that fast is the system
+// answering on its behalf, which is what a denied Local Network permission does.
+const TOO_FAST_TO_BE_THE_NETWORK_MS = 100;
+const NOBODY_HOME = [253, 252, 251];
+
+/** macOS only: whether this process is being refused the local network outright. */
+export async function localNetworkBlocked(): Promise<boolean> {
+  if (process.platform !== 'darwin') return false;
+
+  const known = new Set(await arpHosts());
+  const targets = localSubnets()
+    .flatMap((subnet) => NOBODY_HOME.map((last) => `${subnet.prefix}.${last}`))
+    .filter((host) => !known.has(host))
+    .slice(0, 2);
+  if (targets.length === 0) return false;
+
+  const results = await Promise.all(
+    targets.map((host) => connect(host, DISCARD_PORT, PROBE_TIMEOUT_MS)),
+  );
+  return results.every(
+    (result) => result.outcome === 'refused' && result.ms < TOO_FAST_TO_BE_THE_NETWORK_MS,
+  );
+}
+
+const APP_BUNDLE = /\/([^/]+)\.app\/Contents\/MacOS\//;
+const PROCESS_LINE = /^\s*(\d+)\s+(.*)$/;
+const MAX_DEPTH = 12;
+
+/**
+ * The application macOS holds responsible for what this process does, which is
+ * the entry to allow in the Local Network list: a terminal, an editor, an IDE.
+ */
+export async function responsibleApp(): Promise<string | null> {
+  if (process.platform !== 'darwin') return null;
+
+  let pid = process.pid;
+  for (let depth = 0; depth < MAX_DEPTH && pid > 1; depth++) {
+    const { code, output } = await run(['ps', '-o', 'ppid=,comm=', '-p', String(pid)], {
+      timeoutMs: 2000,
+    });
+    const [, parent, command] = PROCESS_LINE.exec(output.trim()) ?? [];
+    if (code !== 0 || !parent || !command) return null;
+
+    const app = APP_BUNDLE.exec(command)?.[1];
+    if (app) return app;
+    pid = Number(parent);
+  }
+  return null;
+}
+
+export async function openPrivacySettings(): Promise<boolean> {
+  const { code } = await run(['open', PRIVACY_PANE], { timeoutMs: 5000 });
+  return code === 0;
+}
+
+const MDNS_ADDRESS = '224.0.0.251';
+const MDNS_PORT = 5353;
+const SETTLE_MS = 300;
+
+export function mdnsQuery(name: string): Buffer {
+  const header = Buffer.alloc(12);
+  header.writeUInt16BE(1, 4);
+  const labels = name.split('.').map((label) => {
+    const bytes = Buffer.from(label, 'ascii');
+    return Buffer.concat([Buffer.from([bytes.length]), bytes]);
+  });
+  const question = Buffer.alloc(5);
+  question.writeUInt16BE(12, 1);
+  question.writeUInt16BE(1, 3);
+  return Buffer.concat([header, ...labels, question]);
+}
+
+function queryOn(socket: Socket, address: string, query: Buffer): void {
+  try {
+    socket.setMulticastInterface(address);
+    socket.send(query, MDNS_PORT, MDNS_ADDRESS, () => undefined);
+  } catch {
+    return;
+  }
+}
+
+/**
+ * Multicasts one mDNS query per interface. macOS lists an app under Local
+ * Network only once it has asked, and the list cannot be added to by hand, so
+ * this is what puts the responsible app there for the switch to be flipped.
+ */
+export async function askForLocalNetwork(): Promise<void> {
+  if (process.platform !== 'darwin') return;
+  const subnets = localSubnets();
+  if (subnets.length === 0) return;
+
+  const socket = createSocket({ type: 'udp4', reuseAddr: true });
+  socket.on('error', () => undefined);
+  await new Promise<void>((resolve) => socket.bind(resolve));
+
+  const query = mdnsQuery('_services._dns-sd._udp.local');
+  for (const subnet of subnets) queryOn(socket, subnet.address, query);
+
+  await new Promise((resolve) => setTimeout(resolve, SETTLE_MS));
+  socket.close();
+}

--- a/packages/tv-installer/src/modules/androidtv/adb.test.ts
+++ b/packages/tv-installer/src/modules/androidtv/adb.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { adbDevice } from './adb';
+
+const { run, locate } = vi.hoisted(() => ({
+  run: vi.fn(async (_command: readonly string[], _options?: unknown) => ({ code: 0, output: '' })),
+  locate: vi.fn((): string | null => '/usr/bin/adb'),
+}));
+vi.mock('../../run', () => ({ run }));
+vi.mock('../../toolchain/detect', async (original) => ({
+  ...(await original<Record<string, unknown>>()),
+  locate,
+}));
+
+const props = [
+  '[ro.build.version.release]: [12]',
+  '[ro.product.model]: [SHIELD Android TV]',
+  '[ro.product.manufacturer]: [NVIDIA]',
+].join('\n');
+
+const webview = 'Package [com.google.android.webview]\n    versionName=108.0.5359.128';
+
+const answer = (command: readonly string[]) => {
+  if (command.includes('connect')) return { code: 0, output: 'connected to 192.168.1.34:5555' };
+  if (command.includes('getprop')) return { code: 0, output: props };
+  return { code: 0, output: webview };
+};
+
+beforeEach(() => {
+  run.mockReset();
+  run.mockImplementation(async (command) => answer(command));
+  locate.mockReset();
+  locate.mockReturnValue('/usr/bin/adb');
+});
+
+describe('adbDevice', () => {
+  it('reads the model and the maker off the set', async () => {
+    const device = await adbDevice('192.168.1.34', 5555);
+
+    expect(device).toMatchObject({ model: 'SHIELD Android TV', vendor: 'NVIDIA' });
+  });
+
+  it('names the system WebView as the engine the set renders with', async () => {
+    const device = await adbDevice('192.168.1.34', 5555);
+
+    expect(device?.runtime).toEqual({
+      name: 'Android',
+      version: '12',
+      engine: { name: 'WebView', version: '108' },
+      learned: 'reported',
+    });
+  });
+
+  it('still answers when the set would not say which WebView it carries', async () => {
+    run.mockImplementation(async (command) =>
+      command.includes('dumpsys') ? { code: 1, output: '' } : answer(command),
+    );
+
+    const device = await adbDevice('192.168.1.34', 5555);
+
+    expect(device?.runtime?.engine).toBeNull();
+  });
+
+  it('answers nothing on a machine with no adb, without running anything', async () => {
+    locate.mockReturnValue(null);
+
+    const device = await adbDevice('192.168.1.34', 5555);
+
+    expect(device).toBeNull();
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('answers nothing when the set refused the connection', async () => {
+    run.mockImplementation(async () => ({ code: 1, output: 'failed to connect to 192.168.1.34' }));
+
+    expect(await adbDevice('192.168.1.34', 5555)).toBeNull();
+  });
+
+  it('answers nothing when nobody has accepted the prompt on the screen', async () => {
+    run.mockImplementation(async (command) =>
+      command.includes('getprop') ? { code: 1, output: 'device unauthorized' } : answer(command),
+    );
+
+    expect(await adbDevice('192.168.1.34', 5555)).toBeNull();
+  });
+
+  it('answers nothing rather than failing the scan when adb throws', async () => {
+    run.mockRejectedValue(new Error('spawn adb ENOENT'));
+
+    expect(await adbDevice('192.168.1.34', 5555)).toBeNull();
+  });
+});

--- a/packages/tv-installer/src/modules/androidtv/adb.ts
+++ b/packages/tv-installer/src/modules/androidtv/adb.ts
@@ -1,0 +1,48 @@
+import { run } from '../../run';
+import type { Runtime } from '../../television';
+import { locate } from '../../toolchain/detect';
+import { androidProps, androidRuntime } from './runtime';
+import { ADB } from './tools';
+
+const CONNECT_TIMEOUT_MS = 5000;
+const SHELL_TIMEOUT_MS = 5000;
+const WEBVIEW_PACKAGE = 'com.google.android.webview';
+
+export interface AdbDevice {
+  runtime: Runtime | null;
+  model: string;
+  vendor: string;
+}
+
+/**
+ * What a set answers over adb, or null when adb is not installed, the set
+ * refused the connection, or nobody has accepted the prompt on its screen. A
+ * scan never fails over any of the three.
+ */
+export async function adbDevice(host: string, port: number): Promise<AdbDevice | null> {
+  const adb = locate(ADB);
+  if (!adb) return null;
+
+  const serial = `${host}:${port}`;
+  try {
+    const connected = await run([adb, 'connect', serial], { timeoutMs: CONNECT_TIMEOUT_MS });
+    if (!connected.output.includes('connected')) return null;
+
+    const props = await run([adb, '-s', serial, 'shell', 'getprop'], {
+      timeoutMs: SHELL_TIMEOUT_MS,
+    });
+    if (props.code !== 0) return null;
+
+    const printed = androidProps(props.output);
+    const webview = await run([adb, '-s', serial, 'shell', 'dumpsys', 'package', WEBVIEW_PACKAGE], {
+      timeoutMs: SHELL_TIMEOUT_MS,
+    });
+    return {
+      runtime: androidRuntime(printed, webview.code === 0 ? webview.output : ''),
+      model: printed['ro.product.model'] ?? '',
+      vendor: printed['ro.product.manufacturer'] ?? '',
+    };
+  } catch {
+    return null;
+  }
+}

--- a/packages/tv-installer/src/modules/androidtv/app-id.test.ts
+++ b/packages/tv-installer/src/modules/androidtv/app-id.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { androidAppId } from './app-id';
+
+const appJson = vi.hoisted(() => ({ json: '' }));
+vi.mock('node:fs', () => ({
+  readFileSync: () => {
+    if (appJson.json === '') throw new Error('ENOENT');
+    return appJson.json;
+  },
+}));
+vi.mock('../../root', () => ({ root: '/kroma' }));
+
+beforeEach(() => {
+  appJson.json = '';
+});
+
+describe('androidAppId', () => {
+  it('reads the package the Expo config declares', () => {
+    appJson.json = JSON.stringify({ expo: { android: { package: 'tv.kroma.tv' } } });
+
+    expect(androidAppId()).toBe('tv.kroma.tv');
+  });
+
+  it('falls back to the published package on a checkout with no shell in it', () => {
+    expect(androidAppId()).toBe('tv.kroma.tv');
+  });
+
+  it('falls back to the published package when the config names none', () => {
+    appJson.json = JSON.stringify({ expo: { ios: { bundleIdentifier: 'tv.kroma.mobile' } } });
+
+    expect(androidAppId()).toBe('tv.kroma.tv');
+  });
+});

--- a/packages/tv-installer/src/modules/androidtv/app-id.ts
+++ b/packages/tv-installer/src/modules/androidtv/app-id.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { z } from 'zod';
+import { root } from '../../root';
+
+const APP_JSON = 'clients/tv-native/app.json';
+const FALLBACK = 'tv.kroma.tv';
+
+const ExpoConfig = z.object({
+  expo: z.object({ android: z.object({ package: z.string().min(1).max(128) }) }),
+});
+
+export function androidAppId(): string {
+  try {
+    const json = readFileSync(join(root, APP_JSON), 'utf8');
+    return ExpoConfig.parse(JSON.parse(json)).expo.android.package;
+  } catch {
+    return FALLBACK;
+  }
+}

--- a/packages/tv-installer/src/modules/androidtv/artifact.test.ts
+++ b/packages/tv-installer/src/modules/androidtv/artifact.test.ts
@@ -1,6 +1,31 @@
-import { describe, expect, it } from 'vitest';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resolveArtifact } from '../../install/artifact';
 import type { Television } from '../../television';
-import { resolveAndroidArtifact } from './artifact';
+import { ANDROID_PACKAGE, androidSources, resolveAndroidArtifact } from './artifact';
+
+const { globbed, which } = vi.hoisted(() => ({
+  globbed: new Map<string, string[]>(),
+  which: vi.fn((_binary: string): string | null => null),
+}));
+
+vi.mock('../../install/artifact', async (original) => ({
+  ...(await original<typeof import('../../install/artifact')>()),
+  resolveArtifact: vi.fn(),
+}));
+vi.mock('node:fs', () => ({ statSync: () => ({ mtimeMs: 0 }) }));
+vi.mock('../../root', () => ({ root: '/kroma' }));
+
+class FakeGlob {
+  constructor(private readonly pattern: string) {}
+
+  scanSync({ cwd, absolute }: { cwd: string; absolute?: boolean }): string[] {
+    const names = globbed.get(this.pattern) ?? [];
+    return names.map((name) => (absolute ? join(cwd, name) : name));
+  }
+}
+
+vi.stubGlobal('Bun', { Glob: FakeGlob, which });
 
 const shield: Television = {
   host: '192.168.1.36',
@@ -14,10 +39,43 @@ const shield: Television = {
   runtime: null,
 };
 
+beforeEach(() => {
+  globbed.clear();
+  which.mockReturnValue(null);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('androidSources', () => {
+  it('offers the package built here and the two releases gh can reach', () => {
+    globbed.set('out/*.apk', ['KROMA-androidtv-0.1.33.apk']);
+    which.mockReturnValue('/opt/homebrew/bin/gh');
+
+    expect(androidSources()).toEqual(['local', 'stable', 'canary']);
+  });
+
+  it('offers the releases alone when nothing has been built here', () => {
+    which.mockReturnValue('/opt/homebrew/bin/gh');
+
+    expect(androidSources()).toEqual(['stable', 'canary']);
+  });
+});
+
 describe('resolveAndroidArtifact', () => {
   it('leaves the Android TV package to the release workflow', async () => {
     const request = { tv: shield, source: 'build', log: () => {} } as const;
 
     await expect(resolveAndroidArtifact(request)).rejects.toThrow(/release workflow/);
+  });
+
+  it('looks for the package under the id the downloads are kept by', async () => {
+    await resolveAndroidArtifact({ tv: shield, log: () => {} });
+
+    expect(vi.mocked(resolveArtifact).mock.calls[0]?.[0]).toEqual({
+      id: 'androidtv',
+      kind: ANDROID_PACKAGE,
+    });
   });
 });

--- a/packages/tv-installer/src/modules/androidtv/artifact.test.ts
+++ b/packages/tv-installer/src/modules/androidtv/artifact.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import type { Television } from '../../television';
+import { resolveAndroidArtifact } from './artifact';
+
+const shield: Television = {
+  host: '192.168.1.36',
+  platform: 'androidtv',
+  vendor: 'Nvidia',
+  name: 'Shield',
+  model: 'SHIELD Android TV',
+  developerMode: 'on',
+  sideloadable: true,
+  note: 'network debugging open on 5555',
+  runtime: null,
+};
+
+describe('resolveAndroidArtifact', () => {
+  it('leaves the Android TV package to the release workflow', async () => {
+    const request = { tv: shield, source: 'build', log: () => {} } as const;
+
+    await expect(resolveAndroidArtifact(request)).rejects.toThrow(/release workflow/);
+  });
+});

--- a/packages/tv-installer/src/modules/androidtv/artifact.ts
+++ b/packages/tv-installer/src/modules/androidtv/artifact.ts
@@ -1,0 +1,26 @@
+import {
+  type ArtifactRequest,
+  availableSources,
+  type PackageKind,
+  resolveArtifact,
+  type Source,
+} from '../../install/artifact';
+
+export const ANDROID_PACKAGE: PackageKind = {
+  extension: '.apk',
+  globs: ['out/*.apk', 'clients/tv-native/android/app/build/outputs/apk/release/*.apk'],
+  // The phone build sits in the same release and is not this app.
+  pattern: 'KROMA-androidtv-*.apk',
+  runArtifact: 'kroma-androidtv-apk',
+};
+
+export function androidSources(): Source[] {
+  return availableSources(ANDROID_PACKAGE, false);
+}
+
+export async function resolveAndroidArtifact(request: ArtifactRequest): Promise<string> {
+  if (request.source === 'build') {
+    throw new Error('the Android TV .apk is built by the release workflow, not from here');
+  }
+  return resolveArtifact({ id: 'androidtv', kind: ANDROID_PACKAGE }, request);
+}

--- a/packages/tv-installer/src/modules/androidtv/identify.ts
+++ b/packages/tv-installer/src/modules/androidtv/identify.ts
@@ -1,0 +1,81 @@
+import type { UpnpDevice } from '../../discovery/upnp';
+import type { Television } from '../../television';
+import { adbDevice } from './adb';
+import { isAndroid, philipsSystem } from './philips';
+import { philipsAndroid } from './runtime';
+import type { PhilipsSystem } from './schemas';
+
+const ADB_PORT = 5555;
+const PHILIPS_API_PORT = 1925;
+const PHILIPS_TLS_PORT = 1926;
+
+export const ANDROID_PORTS = {
+  sweep: [PHILIPS_API_PORT, ADB_PORT],
+  detail: [PHILIPS_TLS_PORT],
+} as const;
+
+export async function identifyAndroidTv(
+  host: string,
+  openPorts: ReadonlySet<number>,
+  upnp?: UpnpDevice,
+): Promise<Television | null> {
+  const adbPort = openPorts.has(ADB_PORT) ? ADB_PORT : null;
+
+  const philips = await philipsSystem(host, openPorts, {
+    plain: PHILIPS_API_PORT,
+    tls: PHILIPS_TLS_PORT,
+  });
+  if (philips) return identifyPhilips(host, philips, adbPort);
+
+  return adbPort === null ? null : identifyAndroid(host, adbPort, upnp);
+}
+
+async function identifyPhilips(
+  host: string,
+  system: PhilipsSystem,
+  adbPort: number | null,
+): Promise<Television> {
+  const android = isAndroid(system);
+  const debugging = adbPort !== null;
+  const device = adbPort === null ? null : await adbDevice(host, adbPort);
+  const runtime = device?.runtime ?? philipsAndroid(system.os_type);
+  return {
+    host,
+    platform: 'androidtv',
+    vendor: 'Philips',
+    name: system.name || 'Philips TV',
+    model: system.model ?? '',
+    developerMode: debugging ? 'on' : 'off',
+    sideloadable: android || debugging,
+    note: philipsNote(android, debugging, system.os_type),
+    runtime,
+  };
+}
+
+async function identifyAndroid(
+  host: string,
+  adbPort: number,
+  upnp?: UpnpDevice,
+): Promise<Television> {
+  const device = await adbDevice(host, adbPort);
+  const runtime = device?.runtime ?? null;
+  return {
+    host,
+    platform: 'androidtv',
+    vendor: device?.vendor || upnp?.manufacturer || 'Android TV',
+    name: upnp?.friendlyName || device?.model || 'Android TV',
+    model: device?.model || upnp?.modelName || '',
+    developerMode: 'on',
+    sideloadable: true,
+    note: 'network debugging open on 5555',
+    runtime,
+  };
+}
+
+function philipsNote(android: boolean, debugging: boolean, osType: string | undefined): string {
+  if (debugging) return 'Android TV, network debugging open on 5555';
+  if (!android) {
+    return `${osType ?? 'not Android'}: this Philips takes no sideloaded app, only its own store`;
+  }
+  return 'Android TV: About, click the build 7 times, then Developer options, Network debugging ON';
+}

--- a/packages/tv-installer/src/modules/androidtv/install.test.ts
+++ b/packages/tv-installer/src/modules/androidtv/install.test.ts
@@ -140,7 +140,7 @@ describe('installAndroid', () => {
     await expect(installAndroid(context())).rejects.toThrow('adb sees the TV as absent');
   });
 
-  it('quotes what adb said when the install did not take', async () => {
+  it('answers the advice for the failure adb reported', async () => {
     run.mockResolvedValue({ code: 1, output: failure('INSTALL_FAILED_VERSION_DOWNGRADE') });
 
     await expect(installAndroid(context())).rejects.toThrow('the TV already has a newer build');

--- a/packages/tv-installer/src/modules/androidtv/install.test.ts
+++ b/packages/tv-installer/src/modules/androidtv/install.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { installFailure, parseAdbState } from './install';
+
+const devices = [
+  'List of devices attached',
+  '192.168.1.34:5555\tdevice',
+  '192.168.1.44:5555\tunauthorized',
+  'emulator-5554\toffline',
+].join('\n');
+
+const failure = (reason: string) =>
+  [
+    'Performing Streamed Install',
+    `adb: failed to install /out/KROMA.apk: Failure [${reason}]`,
+    '',
+  ].join('\n');
+
+describe('parseAdbState', () => {
+  it('reads the state adb holds the television in', () => {
+    expect(parseAdbState(devices, '192.168.1.34:5555')).toBe('device');
+  });
+
+  it('reads the state of a set that is still asking to trust this computer', () => {
+    expect(parseAdbState(devices, '192.168.1.44:5555')).toBe('unauthorized');
+  });
+
+  it('answers nothing for a serial adb does not list', () => {
+    expect(parseAdbState(devices, '192.168.1.99:5555')).toBeNull();
+  });
+});
+
+describe('installFailure', () => {
+  it('tells the owner to remove a KROMA that was signed with another key', () => {
+    const output = failure('INSTALL_FAILED_UPDATE_INCOMPATIBLE: Existing package tv.kroma.tv');
+
+    expect(installFailure(output)).toContain('adb uninstall tv.kroma.tv');
+  });
+
+  it('tells the owner the set already has a newer build than the package', () => {
+    const output = failure('INSTALL_FAILED_VERSION_DOWNGRADE');
+
+    expect(installFailure(output)).toContain('uninstall it first, or install a newer .apk');
+  });
+
+  it('quotes what adb said when the failure is one it has no advice for', () => {
+    const output = failure('INSTALL_FAILED_INSUFFICIENT_STORAGE');
+
+    expect(installFailure(output)).toBe(
+      'adb install failed: Performing Streamed Install / ' +
+        'adb: failed to install /out/KROMA.apk: Failure [INSTALL_FAILED_INSUFFICIENT_STORAGE]',
+    );
+  });
+});

--- a/packages/tv-installer/src/modules/androidtv/install.test.ts
+++ b/packages/tv-installer/src/modules/androidtv/install.test.ts
@@ -1,5 +1,19 @@
-import { describe, expect, it } from 'vitest';
-import { installFailure, parseAdbState } from './install';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Television } from '../../television';
+import type { InstallContext } from '../module';
+import { installAndroid, installFailure, parseAdbState } from './install';
+
+const { run, runOk, requireTool } = vi.hoisted(() => ({
+  run: vi.fn(async (_command: readonly string[], _options?: unknown) => ({ code: 0, output: '' })),
+  runOk: vi.fn(async (_command: readonly string[], _options?: unknown) => ''),
+  requireTool: vi.fn(() => '/usr/bin/adb'),
+}));
+vi.mock('../../run', () => ({ run, runOk }));
+vi.mock('../../toolchain/detect', async (original) => ({
+  ...(await original<Record<string, unknown>>()),
+  requireTool,
+}));
+vi.mock('./app-id', () => ({ androidAppId: () => 'tv.kroma.tv' }));
 
 const devices = [
   'List of devices attached',
@@ -15,6 +29,38 @@ const failure = (reason: string) =>
     '',
   ].join('\n');
 
+const shield: Television = {
+  host: '192.168.1.34',
+  platform: 'androidtv',
+  vendor: 'Nvidia',
+  name: 'Shield',
+  model: 'SHIELD Android TV',
+  developerMode: 'on',
+  sideloadable: true,
+  note: 'network debugging open on 5555',
+  runtime: null,
+};
+
+const context = (overrides: Partial<InstallContext> = {}): InstallContext => ({
+  tv: shield,
+  artifact: '/out/KROMA.apk',
+  log: () => {},
+  launch: true,
+  options: {},
+  ...overrides,
+});
+
+const argv = () => [
+  ...runOk.mock.calls.map(([command]) => command),
+  ...run.mock.calls.map(([command]) => command),
+];
+
+beforeEach(() => {
+  run.mockReset();
+  runOk.mockReset();
+  runOk.mockImplementation(async (command) => (command.includes('devices') ? devices : ''));
+});
+
 describe('parseAdbState', () => {
   it('reads the state adb holds the television in', () => {
     expect(parseAdbState(devices, '192.168.1.34:5555')).toBe('device');
@@ -26,6 +72,78 @@ describe('parseAdbState', () => {
 
   it('answers nothing for a serial adb does not list', () => {
     expect(parseAdbState(devices, '192.168.1.99:5555')).toBeNull();
+  });
+});
+
+describe('installAndroid', () => {
+  it('connects to the set on the network debugging port', async () => {
+    await installAndroid(context());
+
+    expect(argv()).toContainEqual(['/usr/bin/adb', 'connect', '192.168.1.34:5555']);
+  });
+
+  it('installs over whatever build the set already carries', async () => {
+    await installAndroid(context());
+
+    expect(argv()).toContainEqual([
+      '/usr/bin/adb',
+      '-s',
+      '192.168.1.34:5555',
+      'install',
+      '-r',
+      '/out/KROMA.apk',
+    ]);
+  });
+
+  it('starts the app through the launcher a television has', async () => {
+    await installAndroid(context());
+
+    expect(argv()).toContainEqual([
+      '/usr/bin/adb',
+      '-s',
+      '192.168.1.34:5555',
+      'shell',
+      'monkey',
+      '-p',
+      'tv.kroma.tv',
+      '-c',
+      'android.intent.category.LEANBACK_LAUNCHER',
+      '1',
+    ]);
+  });
+
+  it('leaves the app alone when the install was told not to launch', async () => {
+    await installAndroid(context({ launch: false }));
+
+    expect(argv().flat()).not.toContain('monkey');
+  });
+
+  it('tells the owner to accept the prompt a set is still showing', async () => {
+    await expect(
+      installAndroid(context({ tv: { ...shield, host: '192.168.1.44' } })),
+    ).rejects.toThrow(
+      'the TV is asking to allow this computer: accept the prompt on screen, then run this again',
+    );
+  });
+
+  it('refuses a set adb holds in any other state', async () => {
+    runOk.mockImplementation(async () => 'List of devices attached\n192.168.1.34:5555\toffline');
+
+    await expect(installAndroid(context())).rejects.toThrow(
+      'adb sees the TV as offline: turn Network debugging on in Developer options',
+    );
+  });
+
+  it('refuses a set adb never listed at all', async () => {
+    runOk.mockImplementation(async () => 'List of devices attached');
+
+    await expect(installAndroid(context())).rejects.toThrow('adb sees the TV as absent');
+  });
+
+  it('quotes what adb said when the install did not take', async () => {
+    run.mockResolvedValue({ code: 1, output: failure('INSTALL_FAILED_VERSION_DOWNGRADE') });
+
+    await expect(installAndroid(context())).rejects.toThrow('the TV already has a newer build');
   });
 });
 

--- a/packages/tv-installer/src/modules/androidtv/install.ts
+++ b/packages/tv-installer/src/modules/androidtv/install.ts
@@ -1,0 +1,58 @@
+import { run, runOk } from '../../run';
+import { requireTool } from '../../toolchain/detect';
+import type { InstallContext } from '../module';
+import { androidAppId } from './app-id';
+import { ADB } from './tools';
+
+const ADB_PORT = 5555;
+const INSTALL_TIMEOUT_MS = 600_000;
+const LEANBACK = 'android.intent.category.LEANBACK_LAUNCHER';
+
+export function parseAdbState(devices: string, serial: string): string | null {
+  for (const line of devices.split('\n')) {
+    const [found = '', state = ''] = line.trim().split(/\s+/);
+    if (found === serial) return state;
+  }
+  return null;
+}
+
+export async function installAndroid({ tv, artifact, log, launch }: InstallContext): Promise<void> {
+  const adb = requireTool(ADB);
+  const serial = `${tv.host}:${ADB_PORT}`;
+
+  await runOk([adb, 'connect', serial], { log, timeoutMs: 25_000 });
+  const state = parseAdbState(await runOk([adb, 'devices'], { log }), serial);
+  if (state === 'unauthorized') {
+    throw new Error(
+      'the TV is asking to allow this computer: accept the prompt on screen, then run this again',
+    );
+  }
+  if (state !== 'device') {
+    throw new Error(
+      `adb sees the TV as ${state ?? 'absent'}: turn Network debugging on in Developer options`,
+    );
+  }
+
+  const installed = await run([adb, '-s', serial, 'install', '-r', artifact], {
+    log,
+    timeoutMs: INSTALL_TIMEOUT_MS,
+  });
+  if (installed.code !== 0) throw new Error(installFailure(installed.output));
+  if (!launch) return;
+
+  const application = androidAppId();
+  await run([adb, '-s', serial, 'shell', 'monkey', '-p', application, '-c', LEANBACK, '1'], {
+    log,
+  });
+}
+
+export function installFailure(output: string): string {
+  if (output.includes('INSTALL_FAILED_UPDATE_INCOMPATIBLE')) {
+    return 'a KROMA signed with another key is already there: adb uninstall tv.kroma.tv, then install again';
+  }
+  if (output.includes('INSTALL_FAILED_VERSION_DOWNGRADE')) {
+    return 'the TV already has a newer build: uninstall it first, or install a newer .apk';
+  }
+  const tail = output.split('\n').filter(Boolean).slice(-2).join(' / ');
+  return `adb install failed${tail ? `: ${tail}` : ''}`;
+}

--- a/packages/tv-installer/src/modules/androidtv/install.ts
+++ b/packages/tv-installer/src/modules/androidtv/install.ts
@@ -46,9 +46,9 @@ export async function installAndroid({ tv, artifact, log, launch }: InstallConte
   });
 }
 
-export function installFailure(output: string): string {
+export function installFailure(output: string, application = androidAppId()): string {
   if (output.includes('INSTALL_FAILED_UPDATE_INCOMPATIBLE')) {
-    return 'a KROMA signed with another key is already there: adb uninstall tv.kroma.tv, then install again';
+    return `a KROMA signed with another key is already there: adb uninstall ${application}, then install again`;
   }
   if (output.includes('INSTALL_FAILED_VERSION_DOWNGRADE')) {
     return 'the TV already has a newer build: uninstall it first, or install a newer .apk';

--- a/packages/tv-installer/src/modules/androidtv/install.ts
+++ b/packages/tv-installer/src/modules/androidtv/install.ts
@@ -54,5 +54,6 @@ export function installFailure(output: string): string {
     return 'the TV already has a newer build: uninstall it first, or install a newer .apk';
   }
   const tail = output.split('\n').filter(Boolean).slice(-2).join(' / ');
-  return `adb install failed${tail ? `: ${tail}` : ''}`;
+  const said = tail ? `: ${tail}` : '';
+  return `adb install failed${said}`;
 }

--- a/packages/tv-installer/src/modules/androidtv/module.ts
+++ b/packages/tv-installer/src/modules/androidtv/module.ts
@@ -1,0 +1,20 @@
+import type { TvModule } from '../module';
+import { androidSources, resolveAndroidArtifact } from './artifact';
+import { ANDROID_PORTS, identifyAndroidTv } from './identify';
+import { installAndroid } from './install';
+import { ADB } from './tools';
+
+export const androidtv: TvModule = {
+  id: 'androidtv',
+  label: 'Android TV',
+  brands: 'Philips, Sony, TCL, Shield, Chromecast',
+  package: '.apk',
+  notReadyHint: 'network debugging off',
+  enableSteps: 'network debugging',
+  ports: ANDROID_PORTS,
+  identify: identifyAndroidTv,
+  tools: () => [ADB],
+  sources: androidSources,
+  resolve: resolveAndroidArtifact,
+  install: installAndroid,
+};

--- a/packages/tv-installer/src/modules/androidtv/philips.ts
+++ b/packages/tv-installer/src/modules/androidtv/philips.ts
@@ -1,0 +1,35 @@
+import { fetchJson } from '../../discovery/http';
+import { PhilipsSystem } from './schemas';
+
+/**
+ * Philips answers JointSpace on 1925 in the clear and, from the 2016 sets, only
+ * on 1926 over TLS with a certificate signed by nobody. The API version is part
+ * of the path and a set answers exactly one of them.
+ */
+export async function philipsSystem(
+  host: string,
+  openPorts: ReadonlySet<number>,
+  ports: { plain: number; tls: number },
+): Promise<PhilipsSystem | null> {
+  const endpoints: string[] = [];
+  if (openPorts.has(ports.plain)) {
+    endpoints.push(
+      `http://${host}:${ports.plain}/6/system`,
+      `http://${host}:${ports.plain}/1/system`,
+    );
+  }
+  if (openPorts.has(ports.tls)) endpoints.push(`https://${host}:${ports.tls}/6/system`);
+
+  for (const endpoint of endpoints) {
+    const system = await fetchJson(endpoint, PhilipsSystem, {
+      insecureTls: endpoint.startsWith('https:'),
+    });
+    if (system?.name || system?.model) return system;
+  }
+  return null;
+}
+
+/** A Philips only takes an .apk when its OS is Android; Saphi and Titan take nothing. */
+export function isAndroid(system: PhilipsSystem): boolean {
+  return (system.os_type ?? '').toUpperCase().includes('ANDROID');
+}

--- a/packages/tv-installer/src/modules/androidtv/runtime.test.ts
+++ b/packages/tv-installer/src/modules/androidtv/runtime.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { androidProps, androidRuntime, philipsAndroid } from './runtime';
+
+const getprop = `[net.bt.name]: [Android]
+[ro.build.version.release]: [12]
+[ro.build.version.sdk]: [31]
+[ro.product.manufacturer]: [Sony]
+[ro.product.model]: [BRAVIA 4K VH2]`;
+
+const dumpsys = `Packages:
+  Package [com.google.android.webview] (9f3c1a2):
+    userId=10091
+    versionCode=560308833 minSdk=29 targetSdk=33
+    versionName=108.0.5359.128`;
+
+describe('androidProps', () => {
+  it('keeps only the properties this tool reads out of everything getprop printed', () => {
+    expect(androidProps(getprop)).toEqual({
+      'ro.build.version.release': '12',
+      'ro.product.manufacturer': 'Sony',
+      'ro.product.model': 'BRAVIA 4K VH2',
+    });
+  });
+
+  it('answers no properties for output in no shape getprop ever prints', () => {
+    expect(androidProps('error: device unauthorized.')).toEqual({});
+  });
+});
+
+describe('androidRuntime', () => {
+  it('names the Android a set reports and the WebView it has installed', () => {
+    expect(androidRuntime(androidProps(getprop), dumpsys)).toEqual({
+      name: 'Android',
+      version: '12',
+      engine: { name: 'WebView', version: '108' },
+      learned: 'reported',
+    });
+  });
+
+  it('leaves the engine out when the WebView package answered nothing', () => {
+    expect(androidRuntime(androidProps(getprop), '')).toMatchObject({
+      version: '12',
+      engine: null,
+    });
+  });
+
+  it('answers nothing when the set named no Android version', () => {
+    expect(androidRuntime({}, dumpsys)).toBeNull();
+  });
+});
+
+describe('philipsAndroid', () => {
+  it('floors a Philips at the Android its build year shipped with', () => {
+    expect(philipsAndroid('MSAF_2019_ANDROID_TV')).toEqual({
+      name: 'Android',
+      version: '9',
+      engine: null,
+      learned: 'derived',
+    });
+  });
+
+  it('answers nothing for a Philips whose build names no Android', () => {
+    expect(philipsAndroid('SAPHI')).toBeNull();
+  });
+
+  it('answers nothing for a build year no Philips shipped Android in', () => {
+    expect(philipsAndroid('MSAF_2035_ANDROID_TV')).toBeNull();
+  });
+});

--- a/packages/tv-installer/src/modules/androidtv/runtime.ts
+++ b/packages/tv-installer/src/modules/androidtv/runtime.ts
@@ -1,0 +1,58 @@
+import type { Runtime } from '../../television';
+import { AndroidProps } from './schemas';
+
+const MAX_OUTPUT_CHARS = 256 * 1024;
+
+const PHILIPS_ANDROID_FLOOR: Readonly<Record<number, string>> = {
+  2016: '5',
+  2017: '6',
+  2018: '8',
+  2019: '9',
+  2020: '9',
+  2021: '10',
+  2022: '11',
+  2023: '11',
+};
+
+/** The `[key]: [value]` lines `adb shell getprop` prints, cut to the ones this tool reads. */
+export function androidProps(output: string): AndroidProps {
+  const printed: Record<string, string> = {};
+  for (const line of output.slice(0, MAX_OUTPUT_CHARS).split('\n')) {
+    const [, key, value] = /^\[([^\]]+)]: \[(.*)]$/.exec(line.trim()) ?? [];
+    if (key !== undefined) printed[key] = value ?? '';
+  }
+  const parsed = AndroidProps.safeParse(printed);
+  return parsed.success ? parsed.data : {};
+}
+
+/**
+ * What an Android set says it runs, with the system WebView as its engine: the
+ * major of the `versionName` that `dumpsys package com.google.android.webview`
+ * prints. Null for a set that named no Android version.
+ */
+export function androidRuntime(props: AndroidProps, webview: string): Runtime | null {
+  const version = props['ro.build.version.release'];
+  if (!version) return null;
+  const major = /versionName=(\d+)/.exec(webview.slice(0, MAX_OUTPUT_CHARS))?.[1];
+  return {
+    name: 'Android',
+    version,
+    engine: major === undefined ? null : { name: 'WebView', version: major },
+    learned: 'reported',
+  };
+}
+
+/**
+ * The oldest Android a Philips build tag dates a set to, for the sets adb
+ * cannot reach: `MSAF_2019_ANDROID_TV` shipped Android 9. Null unless the tag
+ * names Android and carries a year the table holds.
+ */
+export function philipsAndroid(osType: string | undefined): Runtime | null {
+  const tag = (osType ?? '').toUpperCase();
+  if (!tag.includes('ANDROID')) return null;
+  const year = /(?:^|_)(20\d{2})(?:_|$)/.exec(tag)?.[1];
+  const version = year === undefined ? undefined : PHILIPS_ANDROID_FLOOR[Number(year)];
+  return version === undefined
+    ? null
+    : { name: 'Android', version, engine: null, learned: 'derived' };
+}

--- a/packages/tv-installer/src/modules/androidtv/schemas.ts
+++ b/packages/tv-installer/src/modules/androidtv/schemas.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+const Short = z.string().max(200);
+
+export const AndroidProps = z.object({
+  'ro.build.version.release': Short.optional(),
+  'ro.product.model': Short.optional(),
+  'ro.product.manufacturer': Short.optional(),
+});
+export type AndroidProps = z.infer<typeof AndroidProps>;
+
+export const PhilipsSystem = z.object({
+  name: Short.optional(),
+  model: Short.optional(),
+  os_type: z.string().max(64).optional(),
+});
+export type PhilipsSystem = z.infer<typeof PhilipsSystem>;

--- a/packages/tv-installer/src/modules/androidtv/tools.test.ts
+++ b/packages/tv-installer/src/modules/androidtv/tools.test.ts
@@ -1,0 +1,71 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { KROMA_TOOLS } from '../../toolchain/detect';
+import { ADB } from './tools';
+
+const { runOk, download, mkdir } = vi.hoisted(() => ({
+  runOk: vi.fn(async (_command: readonly string[], _options?: unknown) => ''),
+  download: vi.fn(async (_url: string, _dest: string, _log: unknown) => {}),
+  mkdir: vi.fn(async (_path: string, _options?: unknown) => undefined),
+}));
+vi.mock('../../run', () => ({ runOk }));
+vi.mock('../../toolchain/install', () => ({ download }));
+vi.mock('node:fs/promises', () => ({ mkdir }));
+
+const running = process.platform;
+const on = (platform: string) =>
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+
+beforeEach(() => {
+  runOk.mockReset();
+  download.mockReset();
+});
+
+afterEach(() => {
+  on(running);
+});
+
+describe('ADB', () => {
+  it('looks where each Android SDK layout keeps adb, and where this tool would put it', () => {
+    expect(ADB.candidates?.()).toEqual([
+      join(process.env.ANDROID_HOME ?? '', 'platform-tools', 'adb'),
+      join(process.env.ANDROID_SDK_ROOT ?? '', 'platform-tools', 'adb'),
+      join(homedir(), 'Library', 'Android', 'sdk', 'platform-tools', 'adb'),
+      join(homedir(), 'Android', 'Sdk', 'platform-tools', 'adb'),
+      join(KROMA_TOOLS, 'platform-tools', 'adb'),
+    ]);
+  });
+
+  it('downloads the platform-tools Google builds for this system', async () => {
+    on('linux');
+
+    await ADB.install?.(() => {});
+
+    expect(download.mock.calls[0]?.slice(0, 2)).toEqual([
+      'https://dl.google.com/android/repository/platform-tools-latest-linux.zip',
+      join(KROMA_TOOLS, 'platform-tools.zip'),
+    ]);
+  });
+
+  it('unpacks them where the other tools this installs live', async () => {
+    await ADB.install?.(() => {});
+
+    expect(runOk.mock.calls[0]?.[0]).toEqual([
+      'unzip',
+      '-q',
+      '-o',
+      join(KROMA_TOOLS, 'platform-tools.zip'),
+      '-d',
+      KROMA_TOOLS,
+    ]);
+  });
+
+  it('refuses a system Google ships no platform-tools for', async () => {
+    on('freebsd');
+
+    await expect(ADB.install?.(() => {})).rejects.toThrow(
+      'no Android platform-tools build for freebsd',
+    );
+  });
+});

--- a/packages/tv-installer/src/modules/androidtv/tools.ts
+++ b/packages/tv-installer/src/modules/androidtv/tools.ts
@@ -1,0 +1,38 @@
+import { mkdir } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { type LogLine, runOk } from '../../run';
+import { KROMA_TOOLS, type Tool } from '../../toolchain/detect';
+import { download } from '../../toolchain/install';
+
+const PLATFORM_TOOLS_URL = 'https://dl.google.com/android/repository/platform-tools-latest';
+const PLATFORM_TOOLS_BUILD: Record<string, string> = {
+  darwin: 'darwin',
+  linux: 'linux',
+  win32: 'windows',
+};
+
+export const ADB: Tool = {
+  id: 'adb',
+  label: 'Android Debug Bridge',
+  binary: 'adb',
+  source: 'dl.google.com platform-tools',
+  candidates: () => [
+    join(process.env.ANDROID_HOME ?? '', 'platform-tools', 'adb'),
+    join(process.env.ANDROID_SDK_ROOT ?? '', 'platform-tools', 'adb'),
+    join(homedir(), 'Library', 'Android', 'sdk', 'platform-tools', 'adb'),
+    join(homedir(), 'Android', 'Sdk', 'platform-tools', 'adb'),
+    join(KROMA_TOOLS, 'platform-tools', 'adb'),
+  ],
+  install: installPlatformTools,
+};
+
+async function installPlatformTools(log: LogLine): Promise<void> {
+  const build = PLATFORM_TOOLS_BUILD[process.platform];
+  if (!build) throw new Error(`no Android platform-tools build for ${process.platform}`);
+
+  await mkdir(KROMA_TOOLS, { recursive: true });
+  const zip = join(KROMA_TOOLS, 'platform-tools.zip');
+  await download(`${PLATFORM_TOOLS_URL}-${build}.zip`, zip, log);
+  await runOk(['unzip', '-q', '-o', zip, '-d', KROMA_TOOLS], { log });
+}

--- a/packages/tv-installer/src/modules/appletv/build.test.ts
+++ b/packages/tv-installer/src/modules/appletv/build.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { runOk } from '../../run';
+import {
+  appleTvSources,
+  buildAppleTvApp,
+  buildableAppleTv,
+  localAppleTvApp,
+  resolveAppleTvApp,
+} from './build';
+import { missingAppleTvTools } from './toolchain';
+
+const { mtimes, globbed, present } = vi.hoisted(() => ({
+  mtimes: new Map<string, number>(),
+  globbed: new Map<string, string[]>(),
+  present: new Set<string>(),
+}));
+
+vi.mock('node:fs', () => ({
+  existsSync: (path: string) => present.has(path),
+  statSync: (path: string) => ({ mtimeMs: mtimes.get(path) ?? 0 }),
+}));
+vi.mock('../../root', () => ({ root: '/kroma' }));
+vi.mock('../../run', () => ({ runOk: vi.fn() }));
+vi.mock('./toolchain', async (original) => ({
+  ...(await original<typeof import('./toolchain')>()),
+  missingAppleTvTools: vi.fn(() => []),
+}));
+
+class FakeGlob {
+  constructor(private readonly pattern: string) {}
+
+  scanSync({ cwd, absolute }: { cwd: string; absolute?: boolean }): string[] {
+    const names = globbed.get(this.pattern) ?? [];
+    return names.map((name) => (absolute ? `${cwd}/${name}` : name));
+  }
+}
+
+vi.stubGlobal('Bun', { Glob: FakeGlob });
+
+const BUILT = 'clients/tv-native/ios/build/**/Products/*-appletvos/*.app';
+const older = 'clients/tv-native/ios/build/Debug/Products/Debug-appletvos/KROMA.app';
+const newer = 'clients/tv-native/ios/build/Release/Products/Release-appletvos/KROMA.app';
+
+const lines: string[] = [];
+const log = (line: string) => lines.push(line);
+
+beforeEach(() => {
+  globbed.clear();
+  mtimes.clear();
+  present.clear();
+  lines.length = 0;
+  vi.mocked(missingAppleTvTools).mockReturnValue([]);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('localAppleTvApp', () => {
+  it('takes the newest app that was built for a real set', () => {
+    globbed.set(BUILT, [older, newer]);
+    mtimes.set(`/kroma/${older}`, 1_000);
+    mtimes.set(`/kroma/${newer}`, 5_000);
+
+    expect(localAppleTvApp()).toBe(`/kroma/${newer}`);
+  });
+
+  it('answers nothing when this checkout has built none', () => {
+    expect(localAppleTvApp()).toBeNull();
+  });
+});
+
+describe('buildableAppleTv', () => {
+  it('builds from source when the shell is in this checkout', () => {
+    present.add('/kroma/clients/tv-native/package.json');
+
+    expect(buildableAppleTv()).toBe(true);
+  });
+
+  it('refuses a checkout the shell is not in', () => {
+    expect(buildableAppleTv()).toBe(false);
+  });
+});
+
+describe('appleTvSources', () => {
+  it('offers what was built here and a build from source', () => {
+    globbed.set(BUILT, [newer]);
+    present.add('/kroma/clients/tv-native/package.json');
+
+    expect(appleTvSources()).toEqual(['local', 'build']);
+  });
+
+  it('offers nothing on a machine with neither an app nor the sources', () => {
+    expect(appleTvSources()).toEqual([]);
+  });
+});
+
+describe('resolveAppleTvApp', () => {
+  it('takes the app it was given over anything else', async () => {
+    const app = await resolveAppleTvApp({ udid: '0000-1111', log, given: '/tmp/KROMA.app' });
+
+    expect(app).toBe('/tmp/KROMA.app');
+    expect(vi.mocked(runOk)).not.toHaveBeenCalled();
+  });
+
+  it('names the app it found in this checkout, relative to the checkout', async () => {
+    globbed.set(BUILT, [newer]);
+
+    const app = await resolveAppleTvApp({ udid: '0000-1111', log });
+
+    expect(app).toBe(`/kroma/${newer}`);
+    expect(lines).toEqual([`app: ${newer}`]);
+  });
+
+  it('builds against the set even with an app already built here', async () => {
+    globbed.set(BUILT, [newer]);
+    vi.mocked(runOk).mockResolvedValue('');
+
+    await resolveAppleTvApp({ udid: '0000-1111', log, source: 'build' });
+
+    expect(vi.mocked(runOk)).toHaveBeenCalledOnce();
+  });
+});
+
+describe('buildAppleTvApp', () => {
+  it('builds the app for the set it was given, from the checkout', async () => {
+    globbed.set(BUILT, [newer]);
+    vi.mocked(runOk).mockResolvedValue('');
+
+    const app = await buildAppleTvApp('0000-1111', log);
+
+    expect(vi.mocked(runOk).mock.calls[0]?.[0]).toEqual([
+      'bun',
+      'run',
+      '--filter',
+      '@kroma/tv-native',
+      'ios',
+      '--device',
+      '0000-1111',
+    ]);
+    expect(vi.mocked(runOk).mock.calls[0]?.[1]?.cwd).toBe('/kroma');
+    expect(app).toBe(`/kroma/${newer}`);
+  });
+
+  it('names every tool a build from source is still missing', async () => {
+    vi.mocked(missingAppleTvTools).mockReturnValue(['cocoapods', 'prebuild']);
+
+    await expect(buildAppleTvApp('0000-1111', log)).rejects.toThrow(
+      'a build from source still needs CocoaPods (brew install cocoapods), ' +
+        "the Expo prebuild (bun run --filter '@kroma/tv-native' prebuild)",
+    );
+    expect(vi.mocked(runOk)).not.toHaveBeenCalled();
+  });
+
+  it('refuses a build that left no app for a real set behind', async () => {
+    vi.mocked(runOk).mockResolvedValue('');
+
+    await expect(buildAppleTvApp('0000-1111', log)).rejects.toThrow(
+      'the build left no appletvos .app under clients/tv-native/ios/build',
+    );
+  });
+});

--- a/packages/tv-installer/src/modules/appletv/build.ts
+++ b/packages/tv-installer/src/modules/appletv/build.ts
@@ -48,7 +48,8 @@ export async function resolveAppleTvApp({
 
   const local = source === 'build' ? null : localAppleTvApp();
   if (local) {
-    log(`app: ${local.replace(`${root}/`, '')}`);
+    const relative = local.replace(`${root}/`, '');
+    log(`app: ${relative}`);
     return local;
   }
   return buildAppleTvApp(udid, log);

--- a/packages/tv-installer/src/modules/appletv/build.ts
+++ b/packages/tv-installer/src/modules/appletv/build.ts
@@ -1,0 +1,77 @@
+import { existsSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { root } from '../../root';
+import { type LogLine, runOk } from '../../run';
+import { APPLETV_TOOLS, missingAppleTvTools } from './toolchain';
+
+const BUILD_TIMEOUT_MS = 3_600_000;
+const SHELL = 'clients/tv-native';
+const BUILT_APPS = `${SHELL}/ios/build/**/Products/*-appletvos/*.app`;
+
+export type AppleTvSource = 'local' | 'build';
+
+export interface AppleTvAppRequest {
+  udid: string;
+  log: LogLine;
+  given?: string;
+  source?: AppleTvSource;
+}
+
+/** The newest `.app` built for a real set. */
+export function localAppleTvApp(): string | null {
+  const built = [
+    ...new Bun.Glob(BUILT_APPS).scanSync({ cwd: root, absolute: true, onlyFiles: false }),
+  ]
+    .map((path) => ({ path, mtimeMs: statSync(path).mtimeMs }))
+    .sort((a, b) => b.mtimeMs - a.mtimeMs);
+  return built[0]?.path ?? null;
+}
+
+export function buildableAppleTv(): boolean {
+  return existsSync(join(root, SHELL, 'package.json'));
+}
+
+export function appleTvSources(): AppleTvSource[] {
+  const sources: AppleTvSource[] = [];
+  if (localAppleTvApp()) sources.push('local');
+  if (buildableAppleTv()) sources.push('build');
+  return sources;
+}
+
+export async function resolveAppleTvApp({
+  given,
+  source,
+  udid,
+  log,
+}: AppleTvAppRequest): Promise<string> {
+  if (given) return given;
+
+  const local = source === 'build' ? null : localAppleTvApp();
+  if (local) {
+    log(`app: ${local.replace(`${root}/`, '')}`);
+    return local;
+  }
+  return buildAppleTvApp(udid, log);
+}
+
+export async function buildAppleTvApp(udid: string, log: LogLine): Promise<string> {
+  const missing = missingAppleTvTools('build');
+  if (missing.length > 0) {
+    const wanted = missing.map(
+      (tool) => `${APPLETV_TOOLS[tool].label} (${APPLETV_TOOLS[tool].source})`,
+    );
+    throw new Error(`a build from source still needs ${wanted.join(', ')}`);
+  }
+
+  log('building the tvOS app with Xcode, which takes tens of minutes on a cold checkout');
+  log('Xcode signs it as it builds, so this set must already be in one of your profiles');
+  await runOk(['bun', 'run', '--filter', '@kroma/tv-native', 'ios', '--device', udid], {
+    log,
+    cwd: root,
+    timeoutMs: BUILD_TIMEOUT_MS,
+  });
+
+  const built = localAppleTvApp();
+  if (!built) throw new Error(`the build left no appletvos .app under ${SHELL}/ios/build`);
+  return built;
+}

--- a/packages/tv-installer/src/modules/appletv/devicectl.test.ts
+++ b/packages/tv-installer/src/modules/appletv/devicectl.test.ts
@@ -1,5 +1,25 @@
-import { describe, expect, it } from 'vitest';
-import { devicectlAdvice, failureText } from './devicectl';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { devicectl, devicectlAdvice, failureText } from './devicectl';
+
+const { run, requireAppleTvTool, unlink, wrote } = vi.hoisted(() => ({
+  run: vi.fn(async (_command: readonly string[], _options?: unknown) => ({ code: 0, output: '' })),
+  requireAppleTvTool: vi.fn(() => '/usr/bin/devicectl'),
+  unlink: vi.fn(async (_path: string) => {}),
+  wrote: { text: '', exists: true, size: 0 },
+}));
+vi.mock('../../run', () => ({ run }));
+vi.mock('./toolchain', async (original) => ({
+  ...(await original<Record<string, unknown>>()),
+  requireAppleTvTool,
+}));
+vi.mock('node:fs/promises', () => ({ unlink }));
+vi.stubGlobal('Bun', {
+  file: () => ({
+    exists: async () => wrote.exists,
+    size: wrote.size,
+    text: async () => wrote.text,
+  }),
+});
 
 const report = (description: string) => ({
   error: {
@@ -73,6 +93,60 @@ describe('devicectlAdvice', () => {
 
     expect(devicectlAdvice(said)).toBe(
       'devicectl failed: The operation failed since the device is out of storage.',
+    );
+  });
+});
+
+describe('devicectl', () => {
+  beforeEach(() => {
+    run.mockReset();
+    unlink.mockReset();
+    run.mockResolvedValue({ code: 0, output: '' });
+    wrote.exists = true;
+    wrote.text = JSON.stringify(report('The specified device was not found.'));
+    wrote.size = wrote.text.length;
+  });
+
+  it('tells devicectl where to write the report, and hands back what it wrote', async () => {
+    const outcome = await devicectl(['list', 'devices']);
+
+    const [binary, list, devices, flag, path] = run.mock.calls[0]?.[0] ?? [];
+    expect([binary, list, devices, flag]).toEqual([
+      '/usr/bin/devicectl',
+      'list',
+      'devices',
+      '--json-output',
+    ]);
+    expect(path).toMatch(/kroma-devicectl-[0-9a-f-]+\.json$/);
+    expect(failureText(outcome.report)).toBe('The specified device was not found.');
+  });
+
+  it('deletes the report it asked for, whatever devicectl did', async () => {
+    run.mockResolvedValue({ code: 1, output: 'failed' });
+
+    await devicectl(['list', 'devices']);
+
+    expect(unlink).toHaveBeenCalledOnce();
+  });
+
+  it('answers no report when devicectl wrote none', async () => {
+    wrote.exists = false;
+
+    expect((await devicectl(['list', 'devices'])).report).toBeNull();
+  });
+
+  it('answers no report when what devicectl wrote is not JSON', async () => {
+    wrote.text = 'not json at all';
+    wrote.size = wrote.text.length;
+
+    expect((await devicectl(['list', 'devices'])).report).toBeNull();
+  });
+
+  it('refuses a report too big to read into memory', async () => {
+    wrote.size = 4_000_001;
+
+    await expect(devicectl(['list', 'devices'])).rejects.toThrow(
+      'devicectl wrote a 4000001 byte report, past the 4000000 read',
     );
   });
 });

--- a/packages/tv-installer/src/modules/appletv/devicectl.test.ts
+++ b/packages/tv-installer/src/modules/appletv/devicectl.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { devicectlAdvice, failureText } from './devicectl';
+
+const report = (description: string) => ({
+  error: {
+    code: 1000,
+    domain: 'com.apple.dt.CoreDeviceError',
+    userInfo: {
+      DeviceName: { string: 'Salon' },
+      NSLocalizedDescription: { string: description },
+    },
+  },
+  info: { commandType: 'devicectl.device.install.app', jsonVersion: 3, outcome: 'failed' },
+});
+
+describe('failureText', () => {
+  it('reads the sentence devicectl wrote into its report', () => {
+    const written = report('The specified device was not found. (Name: Salon)');
+
+    expect(failureText(written)).toBe('The specified device was not found. (Name: Salon)');
+  });
+
+  it('answers nothing for the report of a command that worked', () => {
+    const written = { info: { jsonVersion: 3, outcome: 'success' }, result: {} };
+
+    expect(failureText(written)).toBeNull();
+  });
+
+  it('answers nothing when devicectl wrote no report at all', () => {
+    expect(failureText(null)).toBeNull();
+  });
+});
+
+describe('devicectlAdvice', () => {
+  it('sends the owner back to Xcode when CoreDevice has forgotten the set', () => {
+    const said = 'The specified device was not found. (Name: Salon)';
+
+    expect(devicectlAdvice(said)).toContain('pair it again');
+  });
+
+  it('tells the owner to wake a set that stopped answering mid-install', () => {
+    const said = 'There was a problem communicating with the device.';
+
+    expect(devicectlAdvice(said)).toContain('wake it');
+  });
+
+  it('names the setting to change when the set refuses developer commands', () => {
+    const said = 'The operation failed since Developer Mode is disabled on the device.';
+
+    expect(devicectlAdvice(said)).toContain('Developer Mode');
+  });
+
+  it('blames the signing profile when the set will not verify the bundle', () => {
+    const said = 'Failed to install the app on the device. ApplicationVerificationFailed';
+
+    expect(devicectlAdvice(said)).toContain('signing profile');
+  });
+
+  it('says which SDK to build against when a simulator bundle is pushed at a real set', () => {
+    const said = 'The bundle at the provided URL was built for AppleTVSimulator.';
+
+    expect(devicectlAdvice(said)).toContain('appletvos');
+  });
+
+  it('sends the owner to a newer Xcode when the disk image will not mount', () => {
+    const said = 'The developer disk image could not be mounted on this device.';
+
+    expect(devicectlAdvice(said)).toContain('update Xcode');
+  });
+
+  it('quotes devicectl when the failure is one it has no advice for', () => {
+    const said = 'The operation failed since the device is out of storage.';
+
+    expect(devicectlAdvice(said)).toBe(
+      'devicectl failed: The operation failed since the device is out of storage.',
+    );
+  });
+});

--- a/packages/tv-installer/src/modules/appletv/devicectl.ts
+++ b/packages/tv-installer/src/modules/appletv/devicectl.ts
@@ -1,0 +1,82 @@
+import { unlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { type RunOptions, run } from '../../run';
+import { CommandReport } from './schemas';
+import { requireAppleTvTool } from './toolchain';
+
+const MAX_REPORT_BYTES = 4_000_000;
+
+const ADVICE: readonly (readonly [RegExp, string])[] = [
+  [
+    /specified device was not found/i,
+    'CoreDevice no longer knows that set: pair it again in Xcode, Window then Devices and Simulators',
+  ],
+  [
+    /problem communicating|network socket|connection to the device was lost|unable to connect/i,
+    'the set stopped answering: wake it and check it is still on this network',
+  ],
+  [
+    /developer mode is disabled/i,
+    'Developer Mode is off on the set: turn it on under Settings, Privacy and Security, then restart it',
+  ],
+  [
+    /applicationverificationfailed|provisioning profile|code ?signature|codesign/i,
+    'the set is not in the signing profile this build was signed with: add it in Xcode and build again',
+  ],
+  [
+    /appletvsimulator|minimumosversion|wrong platform|not supported on this device/i,
+    'that .app was built for the simulator: build it against the appletvos SDK',
+  ],
+  [
+    /developer disk image/i,
+    'Xcode carries no developer disk image for that tvOS: update Xcode and try again',
+  ],
+];
+
+export interface DevicectlRun {
+  code: number;
+  output: string;
+  report: unknown;
+}
+
+/** Runs one devicectl subcommand and hands back the JSON report it was told to write. */
+export async function devicectl(
+  args: readonly string[],
+  options: RunOptions = {},
+): Promise<DevicectlRun> {
+  const binary = requireAppleTvTool('devicectl');
+  const path = join(tmpdir(), `kroma-devicectl-${crypto.randomUUID()}.json`);
+  try {
+    const { code, output } = await run([binary, ...args, '--json-output', path], options);
+    return { code, output, report: await readReport(path) };
+  } finally {
+    await unlink(path).catch(() => {});
+  }
+}
+
+export function failureText(report: unknown): string | null {
+  const parsed = CommandReport.safeParse(report);
+  if (!parsed.success) return null;
+  return parsed.data.error?.userInfo?.NSLocalizedDescription?.string ?? null;
+}
+
+export function devicectlAdvice(message: string): string {
+  for (const [pattern, advice] of ADVICE) if (pattern.test(message)) return advice;
+  return `devicectl failed: ${message}`;
+}
+
+async function readReport(path: string): Promise<unknown> {
+  const file = Bun.file(path);
+  if (!(await file.exists())) return null;
+  if (file.size > MAX_REPORT_BYTES) {
+    throw new Error(
+      `devicectl wrote a ${file.size} byte report, past the ${MAX_REPORT_BYTES} read`,
+    );
+  }
+  try {
+    return JSON.parse(await file.text());
+  } catch {
+    return null;
+  }
+}

--- a/packages/tv-installer/src/modules/appletv/devices.test.ts
+++ b/packages/tv-installer/src/modules/appletv/devices.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from 'vitest';
-import { readAppleTvs } from './devices';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { devicectl } from './devicectl';
+import { listAppleTvs, readAppleTvs } from './devices';
+
+vi.mock('./devicectl', () => ({ devicectl: vi.fn() }));
 
 const salon = {
   identifier: '54519807-3629-5FCC-9B92-0FE3B890595A',
@@ -102,5 +105,32 @@ describe('readAppleTvs', () => {
 
   it('refuses a document that is not the one devicectl writes', () => {
     expect(() => readAppleTvs({ result: {} })).toThrow();
+  });
+});
+
+describe('listAppleTvs', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('asks CoreDevice for every device it is paired with', async () => {
+    vi.mocked(devicectl).mockResolvedValue({ code: 0, output: '', report: listing([salon]) });
+
+    const paired = await listAppleTvs();
+
+    expect(vi.mocked(devicectl).mock.calls[0]?.[0]).toEqual(['list', 'devices']);
+    expect(paired.map((tv) => tv.identifier)).toEqual([salon.identifier]);
+  });
+
+  it('quotes what devicectl said when it could not list anything', async () => {
+    vi.mocked(devicectl).mockResolvedValue({
+      code: 1,
+      output: '  ERROR: Xcode is not installed\n',
+      report: null,
+    });
+
+    await expect(listAppleTvs()).rejects.toThrow(
+      'devicectl could not list the paired devices: ERROR: Xcode is not installed',
+    );
   });
 });

--- a/packages/tv-installer/src/modules/appletv/devices.test.ts
+++ b/packages/tv-installer/src/modules/appletv/devices.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { readAppleTvs } from './devices';
+
+const salon = {
+  identifier: '54519807-3629-5FCC-9B92-0FE3B890595A',
+  connectionProperties: {
+    authenticationType: 'manualPairing',
+    pairingState: 'paired',
+    potentialHostnames: [
+      'Salon.coredevice.local',
+      '54519807-3629-5FCC-9B92-0FE3B890595A.coredevice.local',
+    ],
+    transportType: 'localNetwork',
+    tunnelState: 'disconnected',
+  },
+  deviceProperties: { developerModeStatus: 'enabled', name: 'Salon', osVersionNumber: '27.0' },
+  hardwareProperties: {
+    deviceType: 'appleTV',
+    marketingName: 'Apple TV 4K (2nd generation)',
+    platform: 'tvOS',
+    productType: 'AppleTV11,1',
+    udid: 'bdbf82b2ced94649fea4fcdb41e52cafb560362b',
+  },
+};
+
+const iphone = {
+  identifier: '1B794ECF-D4DB-587C-A039-199E0D69F76B',
+  connectionProperties: {
+    pairingState: 'paired',
+    transportType: 'localNetwork',
+    tunnelState: 'disconnected',
+  },
+  deviceProperties: { name: 'Maxime', osVersionNumber: '27.0' },
+  hardwareProperties: {
+    marketingName: 'iPhone 14 Pro Max',
+    platform: 'iOS',
+    productType: 'iPhone15,3',
+  },
+};
+
+const listing = (devices: readonly unknown[]) => ({
+  info: { commandType: 'devicectl.list.devices', jsonVersion: 3, outcome: 'success' },
+  result: { devices },
+});
+
+describe('readAppleTvs', () => {
+  it('keeps the televisions and leaves every other paired device out', () => {
+    expect(readAppleTvs(listing([iphone, salon])).map((tv) => tv.name)).toEqual(['Salon']);
+  });
+
+  it('reads a paired set under both of the ids its tools ask for', () => {
+    const [tv] = readAppleTvs(listing([salon]));
+
+    expect(tv).toEqual({
+      identifier: '54519807-3629-5FCC-9B92-0FE3B890595A',
+      udid: 'bdbf82b2ced94649fea4fcdb41e52cafb560362b',
+      hostname: 'Salon.coredevice.local',
+      name: 'Salon',
+      model: 'Apple TV 4K (2nd generation)',
+      osVersion: '27.0',
+      reachable: true,
+      note: 'reachable over localNetwork',
+    });
+  });
+
+  it('still reaches a set whose tunnel is down, because devicectl opens one per command', () => {
+    const [tv] = readAppleTvs(listing([salon]));
+
+    expect(tv?.reachable).toBe(true);
+  });
+
+  it('reports a set that has gone off the network rather than dropping it', () => {
+    const asleep = {
+      ...salon,
+      connectionProperties: { pairingState: 'paired', tunnelState: 'unavailable' },
+    };
+
+    const [tv] = readAppleTvs(listing([asleep]));
+
+    expect(tv).toMatchObject({
+      name: 'Salon',
+      reachable: false,
+      note: expect.stringContaining('wake it'),
+    });
+  });
+
+  it('reports a set this Mac was never paired with', () => {
+    const stranger = { ...salon, connectionProperties: { pairingState: 'unpaired' } };
+
+    const [tv] = readAppleTvs(listing([stranger]));
+
+    expect(tv).toMatchObject({ reachable: false, note: expect.stringContaining('pair it') });
+  });
+
+  it('falls back to the product type for a set with no marketing name', () => {
+    const bare = { ...salon, hardwareProperties: { platform: 'tvOS', productType: 'AppleTV14,1' } };
+
+    const [tv] = readAppleTvs(listing([bare]));
+
+    expect(tv).toMatchObject({ model: 'AppleTV14,1', udid: '' });
+  });
+
+  it('refuses a document that is not the one devicectl writes', () => {
+    expect(() => readAppleTvs({ result: {} })).toThrow();
+  });
+});

--- a/packages/tv-installer/src/modules/appletv/devices.ts
+++ b/packages/tv-installer/src/modules/appletv/devices.ts
@@ -1,0 +1,63 @@
+import { devicectl } from './devicectl';
+import { type Device, DeviceList } from './schemas';
+
+const LIST_TIMEOUT_MS = 30_000;
+const TVOS = 'tvOS';
+
+/**
+ * `identifier` is what `devicectl --device` takes; `udid` is the hardware id
+ * `xcodebuild` and `expo run:ios --device` take.
+ */
+export interface AppleTv {
+  identifier: string;
+  udid: string;
+  hostname: string;
+  name: string;
+  model: string;
+  osVersion: string;
+  reachable: boolean;
+  note: string;
+}
+
+/** The Apple TVs in a `devicectl list devices --json-output` document. */
+export function readAppleTvs(report: unknown): AppleTv[] {
+  return DeviceList.parse(report)
+    .result.devices.filter((device) => device.hardwareProperties?.platform === TVOS)
+    .map(describe);
+}
+
+/** Every Apple TV this Mac is paired with, the ones it cannot reach right now included. */
+export async function listAppleTvs(): Promise<AppleTv[]> {
+  const { code, output, report } = await devicectl(['list', 'devices'], {
+    timeoutMs: LIST_TIMEOUT_MS,
+  });
+  if (code !== 0) throw new Error(`devicectl could not list the paired devices: ${output.trim()}`);
+  return readAppleTvs(report);
+}
+
+function describe(device: Device): AppleTv {
+  const connection = device.connectionProperties;
+  const hardware = device.hardwareProperties;
+  return {
+    identifier: device.identifier,
+    udid: hardware?.udid ?? '',
+    hostname: connection?.potentialHostnames?.[0] ?? '',
+    name: device.deviceProperties?.name ?? '',
+    model: hardware?.marketingName ?? hardware?.productType ?? '',
+    osVersion: device.deviceProperties?.osVersionNumber ?? '',
+    ...reach(connection),
+  };
+}
+
+function reach(connection: Device['connectionProperties']): { reachable: boolean; note: string } {
+  if (connection?.pairingState !== 'paired') {
+    return {
+      reachable: false,
+      note: 'not paired with this Mac: pair it again in Xcode, Window then Devices and Simulators',
+    };
+  }
+  if (!connection.transportType || connection.tunnelState === 'unavailable') {
+    return { reachable: false, note: 'off the network: wake it and put it back on this Wi-Fi' };
+  }
+  return { reachable: true, note: `reachable over ${connection.transportType}` };
+}

--- a/packages/tv-installer/src/modules/appletv/index.ts
+++ b/packages/tv-installer/src/modules/appletv/index.ts
@@ -1,0 +1,21 @@
+export {
+  type AppleTvAppRequest,
+  type AppleTvSource,
+  appleTvSources,
+  buildAppleTvApp,
+  buildableAppleTv,
+  localAppleTvApp,
+  resolveAppleTvApp,
+} from './build';
+export { type DevicectlRun, devicectl, devicectlAdvice, failureText } from './devicectl';
+export { type AppleTv, listAppleTvs, readAppleTvs } from './devices';
+export { type AppleTvInstall, installAppleTv } from './install';
+export {
+  APPLETV_TOOLS,
+  APPLETV_TOOLS_FOR,
+  type AppleTvIntent,
+  type AppleTvToolId,
+  locateAppleTvTool,
+  missingAppleTvTools,
+  requireAppleTvTool,
+} from './toolchain';

--- a/packages/tv-installer/src/modules/appletv/install.test.ts
+++ b/packages/tv-installer/src/modules/appletv/install.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { runOk } from '../../run';
+import { devicectl } from './devicectl';
+import { installAppleTv } from './install';
+
+vi.mock('../../run', () => ({ runOk: vi.fn() }));
+vi.mock('./devicectl', async (original) => ({
+  ...(await original<typeof import('./devicectl')>()),
+  devicectl: vi.fn(),
+}));
+
+const plist = JSON.stringify({
+  CFBundleIdentifier: 'tv.kroma.mobile',
+  DTPlatformName: 'appletvos',
+});
+
+const salon = {
+  identifier: '00008110-000A1B2C3D4E5F6G',
+  app: '/kroma/clients/tv-native/ios/build/Products/Release-appletvos/KROMA.app',
+  log: () => {},
+  launch: true,
+};
+
+const args = () => vi.mocked(devicectl).mock.calls.map(([given]) => [...given]);
+
+beforeEach(() => {
+  vi.mocked(runOk).mockResolvedValue(plist);
+  vi.mocked(devicectl).mockResolvedValue({ code: 0, output: '', report: null });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('installAppleTv', () => {
+  it('reads the bundle id out of the app it is about to install', async () => {
+    await installAppleTv(salon);
+
+    expect(vi.mocked(runOk).mock.calls[0]?.[0]).toEqual([
+      'plutil',
+      '-convert',
+      'json',
+      '-o',
+      '-',
+      `${salon.app}/Info.plist`,
+    ]);
+  });
+
+  it('installs the app on the set CoreDevice knows under that identifier', async () => {
+    await installAppleTv(salon);
+
+    expect(args()[0]).toEqual([
+      'device',
+      'install',
+      'app',
+      '--device',
+      '00008110-000A1B2C3D4E5F6G',
+      salon.app,
+    ]);
+  });
+
+  it('starts the app it installed, over any copy the set is already running', async () => {
+    await installAppleTv(salon);
+
+    expect(args()[1]).toEqual([
+      'device',
+      'process',
+      'launch',
+      '--device',
+      '00008110-000A1B2C3D4E5F6G',
+      '--terminate-existing',
+      'tv.kroma.mobile',
+    ]);
+  });
+
+  it('leaves the app alone when it was told to install without starting it', async () => {
+    await installAppleTv({ ...salon, launch: false });
+
+    expect(args()).toHaveLength(1);
+  });
+
+  it('refuses an app that was built for the simulator', async () => {
+    vi.mocked(runOk).mockResolvedValue(
+      JSON.stringify({ CFBundleIdentifier: 'tv.kroma.mobile', DTPlatformName: 'appletvsimulator' }),
+    );
+
+    await expect(installAppleTv(salon)).rejects.toThrow(
+      'KROMA.app was built for appletvsimulator: a real set takes an appletvos build, not a simulator one',
+    );
+  });
+
+  it('refuses an app whose plist names no SDK at all', async () => {
+    vi.mocked(runOk).mockResolvedValue(JSON.stringify({ CFBundleIdentifier: 'tv.kroma.mobile' }));
+
+    await expect(installAppleTv(salon)).rejects.toThrow('built for an unnamed SDK');
+  });
+
+  it('refuses a plist too big to be one', async () => {
+    vi.mocked(runOk).mockResolvedValue(`${plist}${' '.repeat(200_000)}`);
+
+    await expect(installAppleTv(salon)).rejects.toThrow('KROMA.app carries an unreadable plist');
+  });
+
+  it('turns what devicectl reported into advice the owner can act on', async () => {
+    vi.mocked(devicectl).mockResolvedValue({
+      code: 1,
+      output: '',
+      report: {
+        error: {
+          userInfo: { NSLocalizedDescription: { string: 'The specified device was not found.' } },
+        },
+      },
+    });
+
+    await expect(installAppleTv(salon)).rejects.toThrow(
+      'CoreDevice no longer knows that set: pair it again in Xcode, Window then Devices and Simulators',
+    );
+  });
+
+  it('quotes the last of the output when devicectl wrote no report', async () => {
+    vi.mocked(devicectl).mockResolvedValue({
+      code: 1,
+      output: 'ERROR: something\nERROR: else entirely\n',
+      report: null,
+    });
+
+    await expect(installAppleTv(salon)).rejects.toThrow(
+      'devicectl failed: ERROR: something / ERROR: else entirely',
+    );
+  });
+});

--- a/packages/tv-installer/src/modules/appletv/install.ts
+++ b/packages/tv-installer/src/modules/appletv/install.ts
@@ -1,0 +1,61 @@
+import { basename, join } from 'node:path';
+import { type LogLine, runOk } from '../../run';
+import { devicectl, devicectlAdvice, failureText } from './devicectl';
+import { AppBundleInfo } from './schemas';
+
+const INSTALL_TIMEOUT_MS = 900_000;
+const LAUNCH_TIMEOUT_MS = 120_000;
+const PLIST_TIMEOUT_MS = 15_000;
+const MAX_PLIST_BYTES = 200_000;
+const TVOS_DEVICE_SDK = 'appletvos';
+
+export interface AppleTvInstall {
+  identifier: string;
+  app: string;
+  log: LogLine;
+  launch: boolean;
+}
+
+export async function installAppleTv({
+  identifier,
+  app,
+  log,
+  launch,
+}: AppleTvInstall): Promise<void> {
+  const bundleId = await readBundleId(app);
+
+  log(`installing ${basename(app)} on ${identifier}`);
+  await command(['device', 'install', 'app', '--device', identifier, app], log, INSTALL_TIMEOUT_MS);
+  if (!launch) return;
+
+  log(`launching ${bundleId}`);
+  const args = ['device', 'process', 'launch', '--device', identifier, '--terminate-existing'];
+  await command([...args, bundleId], log, LAUNCH_TIMEOUT_MS);
+}
+
+async function command(args: readonly string[], log: LogLine, timeoutMs: number): Promise<void> {
+  const { code, output, report } = await devicectl(args, { log, timeoutMs });
+  if (code === 0) return;
+  throw new Error(devicectlAdvice(failureText(report) ?? lastLines(output)));
+}
+
+async function readBundleId(app: string): Promise<string> {
+  const plist = join(app, 'Info.plist');
+  const json = await runOk(['plutil', '-convert', 'json', '-o', '-', plist], {
+    timeoutMs: PLIST_TIMEOUT_MS,
+  });
+  if (json.length > MAX_PLIST_BYTES)
+    throw new Error(`${basename(app)} carries an unreadable plist`);
+
+  const info = AppBundleInfo.parse(JSON.parse(json));
+  if (info.DTPlatformName !== TVOS_DEVICE_SDK) {
+    throw new Error(
+      `${basename(app)} was built for ${info.DTPlatformName ?? 'an unnamed SDK'}: a real set takes an ${TVOS_DEVICE_SDK} build, not a simulator one`,
+    );
+  }
+  return info.CFBundleIdentifier;
+}
+
+function lastLines(output: string): string {
+  return output.split('\n').filter(Boolean).slice(-2).join(' / ');
+}

--- a/packages/tv-installer/src/modules/appletv/module.test.ts
+++ b/packages/tv-installer/src/modules/appletv/module.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Television } from '../../television';
+import type { AppleTv } from './index';
+import { appletv } from './module';
+
+const { listAppleTvs, resolveAppleTvApp, installAppleTv } = vi.hoisted(() => ({
+  listAppleTvs: vi.fn(async (): Promise<AppleTv[]> => []),
+  resolveAppleTvApp: vi.fn(async (_request: unknown) => '/kroma/KROMA.app'),
+  installAppleTv: vi.fn(async (_install: unknown) => {}),
+}));
+vi.mock('./index', () => ({
+  appleTvSources: () => ['local'],
+  installAppleTv,
+  listAppleTvs,
+  locateAppleTvTool: () => '/usr/bin/devicectl',
+  resolveAppleTvApp,
+}));
+
+const salon: AppleTv = {
+  identifier: '54519807-3629-5FCC-9B92-0FE3B890595A',
+  udid: 'bdbf82b2ced94649fea4fcdb41e52cafb560362b',
+  hostname: 'Salon.coredevice.local',
+  name: 'Salon',
+  model: 'Apple TV 4K (2nd generation)',
+  osVersion: '27.0',
+  reachable: true,
+  note: 'reachable over localNetwork',
+};
+
+const tv: Television = {
+  host: 'Salon.coredevice.local',
+  platform: 'appletv',
+  vendor: 'Apple',
+  name: 'Salon',
+  model: 'Apple TV 4K (2nd generation)',
+  developerMode: 'on',
+  sideloadable: true,
+  note: 'reachable over localNetwork',
+  runtime: null,
+  identifier: '54519807-3629-5FCC-9B92-0FE3B890595A',
+};
+
+const log = () => {};
+
+beforeEach(() => {
+  listAppleTvs.mockReset();
+  resolveAppleTvApp.mockReset();
+  installAppleTv.mockReset();
+  listAppleTvs.mockResolvedValue([salon]);
+  resolveAppleTvApp.mockResolvedValue('/kroma/KROMA.app');
+});
+
+describe('appletv.install', () => {
+  it('installs on the set CoreDevice still knows by that identifier', async () => {
+    await appletv.install({ tv, artifact: '/kroma/KROMA.app', log, launch: true, options: {} });
+
+    expect(installAppleTv).toHaveBeenCalledWith({
+      identifier: '54519807-3629-5FCC-9B92-0FE3B890595A',
+      app: '/kroma/KROMA.app',
+      log,
+      launch: true,
+    });
+  });
+
+  it('refuses a set this Mac is no longer paired with', async () => {
+    listAppleTvs.mockResolvedValue([]);
+
+    await expect(
+      appletv.install({ tv, artifact: '/kroma/KROMA.app', log, launch: true, options: {} }),
+    ).rejects.toThrow('Salon is no longer paired with this Mac: pair it again in Xcode');
+  });
+});
+
+describe('appletv.resolve', () => {
+  it('asks the build for the hardware udid, which is not the identifier it installs by', async () => {
+    await appletv.resolve({ tv, log });
+
+    expect(resolveAppleTvApp).toHaveBeenCalledWith({
+      given: undefined,
+      source: undefined,
+      udid: 'bdbf82b2ced94649fea4fcdb41e52cafb560362b',
+      log,
+    });
+  });
+
+  it('builds from source only when that is the source that was named', async () => {
+    await appletv.resolve({ tv, log, source: 'build' });
+
+    expect(resolveAppleTvApp.mock.calls[0]?.[0]).toMatchObject({ source: 'build' });
+  });
+
+  it('has no release to pull from, so any other source falls back to a local app', async () => {
+    await appletv.resolve({ tv, log, source: 'canary' });
+
+    expect(resolveAppleTvApp.mock.calls[0]?.[0]).toMatchObject({ source: undefined });
+  });
+
+  it('finds the set again by name when CoreDevice gave it another identifier', async () => {
+    await appletv.resolve({ tv: { ...tv, identifier: undefined }, log });
+
+    expect(resolveAppleTvApp.mock.calls[0]?.[0]).toMatchObject({ udid: salon.udid });
+  });
+
+  it('refuses a set this Mac is no longer paired with', async () => {
+    listAppleTvs.mockResolvedValue([]);
+
+    await expect(appletv.resolve({ tv, log })).rejects.toThrow('is no longer paired with this Mac');
+  });
+});

--- a/packages/tv-installer/src/modules/appletv/module.test.ts
+++ b/packages/tv-installer/src/modules/appletv/module.test.ts
@@ -95,7 +95,7 @@ describe('appletv.resolve', () => {
     expect(resolveAppleTvApp.mock.calls[0]?.[0]).toMatchObject({ source: undefined });
   });
 
-  it('finds the set again by name when CoreDevice gave it another identifier', async () => {
+  it('finds the set by name when the scan recorded no identifier for it', async () => {
     await appletv.resolve({ tv: { ...tv, identifier: undefined }, log });
 
     expect(resolveAppleTvApp.mock.calls[0]?.[0]).toMatchObject({ udid: salon.udid });

--- a/packages/tv-installer/src/modules/appletv/module.ts
+++ b/packages/tv-installer/src/modules/appletv/module.ts
@@ -1,0 +1,47 @@
+import type { ArtifactRequest } from '../../install/artifact';
+import type { InstallContext, TvModule } from '../module';
+import {
+  type AppleTv,
+  appleTvSources,
+  installAppleTv,
+  listAppleTvs,
+  resolveAppleTvApp,
+} from './index';
+import { pairedTelevisions } from './paired';
+
+export const appletv: TvModule = {
+  id: 'appletv',
+  label: 'Apple TV',
+  brands: 'Apple',
+  package: '.app',
+  notReadyHint: 'not paired',
+  discover: pairedTelevisions,
+  tools: () => [],
+  sources: appleTvSources,
+  resolve: resolveApp,
+  install: deploy,
+};
+
+async function pairedWith(name: string, identifier: string | undefined): Promise<AppleTv> {
+  const paired = await listAppleTvs();
+  const set = paired.find(
+    (candidate) => candidate.identifier === identifier || candidate.name === name,
+  );
+  if (!set) throw new Error(`${name} is no longer paired with this Mac: pair it again in Xcode`);
+  return set;
+}
+
+async function resolveApp({ tv, given, source, log }: ArtifactRequest): Promise<string> {
+  const set = await pairedWith(tv.name, tv.identifier);
+  return resolveAppleTvApp({
+    given,
+    source: source === 'build' ? 'build' : undefined,
+    udid: set.udid,
+    log,
+  });
+}
+
+async function deploy({ tv, artifact, log, launch }: InstallContext): Promise<void> {
+  const set = await pairedWith(tv.name, tv.identifier);
+  await installAppleTv({ identifier: set.identifier, app: artifact, log, launch });
+}

--- a/packages/tv-installer/src/modules/appletv/paired.test.ts
+++ b/packages/tv-installer/src/modules/appletv/paired.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { AppleTv } from './index';
+import { pairedTelevisions } from './paired';
+
+const salon: AppleTv = {
+  identifier: '54519807-3629-5FCC-9B92-0FE3B890595A',
+  udid: 'bdbf82b2ced94649fea4fcdb41e52cafb560362b',
+  hostname: 'Salon.coredevice.local',
+  name: 'Salon',
+  model: 'Apple TV 4K (2nd generation)',
+  osVersion: '27.0',
+  reachable: true,
+  note: 'reachable over localNetwork',
+};
+
+const { listAppleTvs, locateAppleTvTool } = vi.hoisted(() => ({
+  listAppleTvs: vi.fn(async (): Promise<AppleTv[]> => []),
+  locateAppleTvTool: vi.fn((): string | null => '/usr/bin/devicectl'),
+}));
+vi.mock('./index', () => ({ listAppleTvs, locateAppleTvTool }));
+
+describe('pairedTelevisions', () => {
+  it('lists a paired set under the hostname its tools address it by', async () => {
+    listAppleTvs.mockResolvedValueOnce([salon]);
+
+    const [tv] = await pairedTelevisions();
+
+    expect(tv).toMatchObject({
+      host: 'Salon.coredevice.local',
+      platform: 'appletv',
+      vendor: 'Apple',
+      name: 'Salon',
+      model: 'Apple TV 4K (2nd generation)',
+      developerMode: 'on',
+      sideloadable: true,
+      note: 'reachable over localNetwork',
+      identifier: '54519807-3629-5FCC-9B92-0FE3B890595A',
+    });
+  });
+
+  it('takes the tvOS version off the set, and names no browser engine', async () => {
+    listAppleTvs.mockResolvedValueOnce([salon]);
+
+    const [tv] = await pairedTelevisions();
+
+    expect(tv?.runtime).toEqual({
+      name: 'tvOS',
+      version: '27.0',
+      engine: { name: 'React Native', version: null },
+      learned: 'reported',
+    });
+  });
+
+  it('marks a set that has gone off the network as not ready', async () => {
+    listAppleTvs.mockResolvedValueOnce([{ ...salon, reachable: false, note: 'off the network' }]);
+
+    const [tv] = await pairedTelevisions();
+
+    expect(tv).toMatchObject({ developerMode: 'off', note: 'off the network' });
+  });
+
+  it('falls back to the CoreDevice identifier for a set that published no hostname', async () => {
+    listAppleTvs.mockResolvedValueOnce([{ ...salon, hostname: '' }]);
+
+    const [tv] = await pairedTelevisions();
+
+    expect(tv?.host).toBe('54519807-3629-5FCC-9B92-0FE3B890595A');
+  });
+
+  it('leaves the runtime out for a set that named no tvOS version', async () => {
+    listAppleTvs.mockResolvedValueOnce([{ ...salon, osVersion: '' }]);
+
+    const [tv] = await pairedTelevisions();
+
+    expect(tv?.runtime).toBeNull();
+  });
+
+  it('answers nothing on a machine with no Xcode to ask', async () => {
+    locateAppleTvTool.mockReturnValueOnce(null);
+    listAppleTvs.mockClear();
+
+    const sets = await pairedTelevisions();
+
+    expect(sets).toEqual([]);
+    expect(listAppleTvs).not.toHaveBeenCalled();
+  });
+
+  it('answers nothing rather than failing the scan when CoreDevice refuses', async () => {
+    listAppleTvs.mockRejectedValueOnce(new Error('devicectl could not list the paired devices'));
+
+    const sets = await pairedTelevisions();
+
+    expect(sets).toEqual([]);
+  });
+});

--- a/packages/tv-installer/src/modules/appletv/paired.ts
+++ b/packages/tv-installer/src/modules/appletv/paired.ts
@@ -1,0 +1,42 @@
+import type { Runtime, Television } from '../../television';
+import { type AppleTv, listAppleTvs, locateAppleTvTool } from './index';
+
+/**
+ * The sets this Mac is paired with rather than the ones on the network: an
+ * Apple TV answers no probe, it is reached through CoreDevice. Empty on a
+ * machine with no Xcode to ask, and on any refusal, because neither is a reason
+ * for a scan to fail.
+ */
+export async function pairedTelevisions(): Promise<Television[]> {
+  if (locateAppleTvTool('devicectl') === null) return [];
+  try {
+    return (await listAppleTvs()).map(asTelevision);
+  } catch {
+    return [];
+  }
+}
+
+function asTelevision(set: AppleTv): Television {
+  return {
+    host: set.hostname || set.identifier,
+    platform: 'appletv',
+    vendor: 'Apple',
+    name: set.name,
+    model: set.model,
+    developerMode: set.reachable ? 'on' : 'off',
+    sideloadable: true,
+    note: set.note,
+    runtime: tvosRuntime(set.osVersion),
+    identifier: set.identifier,
+  };
+}
+
+function tvosRuntime(osVersion: string): Runtime | null {
+  if (!osVersion) return null;
+  return {
+    name: 'tvOS',
+    version: osVersion,
+    engine: { name: 'React Native', version: null },
+    learned: 'reported',
+  };
+}

--- a/packages/tv-installer/src/modules/appletv/schemas.ts
+++ b/packages/tv-installer/src/modules/appletv/schemas.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+
+const Short = z.string().max(200);
+const Sentence = z.string().max(4000);
+
+const Device = z.object({
+  identifier: Short,
+  connectionProperties: z
+    .object({
+      pairingState: Short.optional(),
+      transportType: Short.optional(),
+      tunnelState: Short.optional(),
+      potentialHostnames: z.array(Short).max(16).optional(),
+    })
+    .optional(),
+  deviceProperties: z
+    .object({ name: Short.optional(), osVersionNumber: Short.optional() })
+    .optional(),
+  hardwareProperties: z
+    .object({
+      platform: Short.optional(),
+      marketingName: Short.optional(),
+      productType: Short.optional(),
+      udid: Short.optional(),
+    })
+    .optional(),
+});
+export type Device = z.infer<typeof Device>;
+
+export const DeviceList = z.object({
+  result: z.object({ devices: z.array(Device).max(256) }),
+});
+
+export const CommandReport = z.object({
+  error: z
+    .object({
+      userInfo: z
+        .object({ NSLocalizedDescription: z.object({ string: Sentence }).optional() })
+        .optional(),
+    })
+    .optional(),
+});
+
+export const AppBundleInfo = z.object({
+  CFBundleIdentifier: Short,
+  DTPlatformName: Short.optional(),
+});

--- a/packages/tv-installer/src/modules/appletv/toolchain.test.ts
+++ b/packages/tv-installer/src/modules/appletv/toolchain.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { locateAppleTvTool, missingAppleTvTools, requireAppleTvTool } from './toolchain';
+
+const { present, spawnSync, which } = vi.hoisted(() => ({
+  present: new Set<string>(),
+  spawnSync: vi.fn((_command: readonly string[], _options?: unknown) => ({
+    exitCode: 0,
+    stdout: Buffer.from(''),
+  })),
+  which: vi.fn((_binary: string): string | null => null),
+}));
+vi.mock('node:fs', () => ({ existsSync: (path: string) => present.has(path) }));
+vi.mock('../../root', () => ({ root: '/kroma' }));
+vi.stubGlobal('Bun', { spawnSync, which });
+
+const DEVELOPER = '/Applications/Xcode.app/Contents/Developer';
+const DEVICECTL = `${DEVELOPER}/usr/bin/devicectl`;
+const WORKSPACE = '/kroma/clients/tv-native/ios/KROMA.xcworkspace';
+
+const running = process.platform;
+const on = (platform: string) =>
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+
+const answers = new Map<string, string>();
+
+beforeEach(() => {
+  present.clear();
+  answers.clear();
+  which.mockReset();
+  spawnSync.mockReset();
+  spawnSync.mockImplementation((command) => {
+    const answer = answers.get(command[0] ?? '');
+    return answer === undefined
+      ? { exitCode: 1, stdout: Buffer.from('') }
+      : { exitCode: 0, stdout: Buffer.from(answer) };
+  });
+  on('darwin');
+});
+
+afterEach(() => {
+  on(running);
+});
+
+describe('locateAppleTvTool', () => {
+  it('finds nothing at all on a machine that is not a Mac', () => {
+    on('linux');
+    answers.set('xcode-select', DEVELOPER);
+    present.add(DEVELOPER).add(`${DEVELOPER}/usr/bin`);
+
+    expect(locateAppleTvTool('xcode')).toBeNull();
+  });
+
+  it('answers the developer directory xcode-select points at', () => {
+    answers.set('xcode-select', DEVELOPER);
+    present.add(DEVELOPER).add(`${DEVELOPER}/usr/bin`);
+
+    expect(locateAppleTvTool('xcode')).toBe(DEVELOPER);
+  });
+
+  it('refuses a developer directory that carries none of the tools', () => {
+    answers.set('xcode-select', DEVELOPER);
+    present.add(DEVELOPER);
+
+    expect(locateAppleTvTool('xcode')).toBeNull();
+  });
+
+  it('answers nothing when no Xcode has been selected', () => {
+    expect(locateAppleTvTool('xcode')).toBeNull();
+  });
+
+  it('finds devicectl through xcrun', () => {
+    answers.set('xcrun', DEVICECTL);
+    present.add(DEVICECTL);
+
+    expect(locateAppleTvTool('devicectl')).toBe(DEVICECTL);
+  });
+
+  it('finds CocoaPods on PATH', () => {
+    which.mockReturnValue('/opt/homebrew/bin/pod');
+
+    expect(locateAppleTvTool('cocoapods')).toBe('/opt/homebrew/bin/pod');
+  });
+
+  it('counts the prebuild as done once the workspace is in the checkout', () => {
+    present.add(WORKSPACE);
+
+    expect(locateAppleTvTool('prebuild')).toBe(WORKSPACE);
+  });
+
+  it('counts the prebuild as still to run when the workspace is not there', () => {
+    expect(locateAppleTvTool('prebuild')).toBeNull();
+  });
+});
+
+describe('missingAppleTvTools', () => {
+  it('asks a build for more than an install needs', () => {
+    answers.set('xcode-select', DEVELOPER);
+    answers.set('xcrun', DEVICECTL);
+    present.add(DEVELOPER).add(`${DEVELOPER}/usr/bin`).add(DEVICECTL);
+
+    expect(missingAppleTvTools('install')).toEqual([]);
+    expect(missingAppleTvTools('build')).toEqual(['cocoapods', 'prebuild']);
+  });
+});
+
+describe('requireAppleTvTool', () => {
+  it('answers the path of a tool this Mac has', () => {
+    answers.set('xcrun', DEVICECTL);
+    present.add(DEVICECTL);
+
+    expect(requireAppleTvTool('devicectl')).toBe(DEVICECTL);
+  });
+
+  it('says which Xcode a missing devicectl comes with', () => {
+    expect(() => requireAppleTvTool('devicectl')).toThrow(
+      'Xcode device tools is missing: the full Xcode: the standalone command line tools do not carry devicectl',
+    );
+  });
+});

--- a/packages/tv-installer/src/modules/appletv/toolchain.ts
+++ b/packages/tv-installer/src/modules/appletv/toolchain.ts
@@ -1,0 +1,60 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { root } from '../../root';
+
+export type AppleTvToolId = 'xcode' | 'devicectl' | 'cocoapods' | 'prebuild';
+
+export type AppleTvIntent = 'install' | 'build';
+
+export const APPLETV_TOOLS: Record<AppleTvToolId, { label: string; source: string }> = {
+  xcode: { label: 'Xcode', source: 'the Mac App Store, then xcode-select --switch' },
+  devicectl: {
+    label: 'Xcode device tools',
+    source: 'the full Xcode: the standalone command line tools do not carry devicectl',
+  },
+  cocoapods: { label: 'CocoaPods', source: 'brew install cocoapods' },
+  prebuild: {
+    label: 'the Expo prebuild',
+    source: "bun run --filter '@kroma/tv-native' prebuild",
+  },
+};
+
+export const APPLETV_TOOLS_FOR: Record<AppleTvIntent, readonly AppleTvToolId[]> = {
+  install: ['xcode', 'devicectl'],
+  build: ['xcode', 'devicectl', 'cocoapods', 'prebuild'],
+};
+
+const WORKSPACE = 'clients/tv-native/ios/KROMA.xcworkspace';
+
+export function locateAppleTvTool(tool: AppleTvToolId): string | null {
+  if (process.platform !== 'darwin') return null;
+  if (tool === 'xcode') return developerDirectory();
+  if (tool === 'devicectl') return found(['xcrun', '--find', 'devicectl']);
+  if (tool === 'cocoapods') return Bun.which('pod');
+  return existing(join(root, WORKSPACE));
+}
+
+export function missingAppleTvTools(intent: AppleTvIntent): AppleTvToolId[] {
+  return APPLETV_TOOLS_FOR[intent].filter((tool) => locateAppleTvTool(tool) === null);
+}
+
+export function requireAppleTvTool(tool: AppleTvToolId): string {
+  const path = locateAppleTvTool(tool);
+  if (path) return path;
+  throw new Error(`${APPLETV_TOOLS[tool].label} is missing: ${APPLETV_TOOLS[tool].source}`);
+}
+
+function developerDirectory(): string | null {
+  const selected = found(['xcode-select', '-p']);
+  return selected && existsSync(join(selected, 'usr', 'bin')) ? selected : null;
+}
+
+function found(command: readonly string[]): string | null {
+  const [file = '', ...args] = command;
+  const { exitCode, stdout } = Bun.spawnSync([file, ...args], { stderr: 'ignore' });
+  return exitCode === 0 ? existing(stdout.toString().trim()) : null;
+}
+
+function existing(path: string): string | null {
+  return path && existsSync(path) ? path : null;
+}

--- a/packages/tv-installer/src/modules/identify.test.ts
+++ b/packages/tv-installer/src/modules/identify.test.ts
@@ -114,6 +114,40 @@ describe('identify', () => {
     });
   });
 
+  it('falls back to a plain name for a Philips that answered with only a model', async () => {
+    answering({ 'http://192.168.1.37:1925/6/system': { model: '50PUS6704/12' } });
+
+    const tv = await identify('192.168.1.37', new Set([1925]));
+
+    expect(tv?.name).toBe('Philips TV');
+    expect(tv?.note).toContain('not Android');
+  });
+
+  it('carries no model for a Philips that answered with only a name', async () => {
+    answering({
+      'http://192.168.1.38:1925/6/system': { name: '43PUS7406/12', os_type: 'SAPHI' },
+    });
+
+    const tv = await identify('192.168.1.38', new Set([1925]));
+
+    expect(tv?.model).toBe('');
+  });
+
+  it('tells a Philips Android owner where the debugging switch is', async () => {
+    answering({
+      'http://192.168.1.34:1925/6/system': {
+        name: '55PUS7304/12',
+        model: '55PUS7304/12',
+        os_type: 'MSAF_2019_ANDROID_TV',
+      },
+    });
+
+    const tv = await identify('192.168.1.34', new Set([1925]));
+
+    expect(tv?.developerMode).toBe('off');
+    expect(tv?.note).toContain('Developer options, Network debugging ON');
+  });
+
   it('marks a Philips that runs Saphi as taking no sideloaded package', async () => {
     answering({
       'http://192.168.1.35:1925/6/system': {

--- a/packages/tv-installer/src/modules/identify.test.ts
+++ b/packages/tv-installer/src/modules/identify.test.ts
@@ -1,0 +1,254 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { AdbDevice } from './androidtv/adb';
+import { identify } from './identify';
+
+const adb = vi.hoisted(() => vi.fn(async (): Promise<AdbDevice | null> => null));
+vi.mock('./androidtv/adb', () => ({ adbDevice: adb }));
+
+const answering = (routes: Record<string, unknown>) =>
+  vi.stubGlobal('fetch', (url: string) => {
+    const body = routes[url];
+    if (body === undefined) return Promise.resolve(new Response('', { status: 404 }));
+    return Promise.resolve(new Response(JSON.stringify(body)));
+  });
+
+const samsungInfo = (developerMode: string) => ({
+  device: {
+    name: '[TV] Salon',
+    modelName: 'UE50AU7172',
+    developerMode,
+    developerIP: '192.168.1.20',
+    OS: 'Tizen',
+  },
+});
+
+const lgUpnp = {
+  friendlyName: '[LG] webOS TV OLED55C16LA',
+  manufacturer: 'LG Electronics',
+  modelName: 'OLED55C16LA',
+  modelNumber: 'OLED55C16LA',
+};
+
+const theFrame = {
+  device: {
+    name: '75&quot; The Frame',
+    model: '24_PTM_FTV_T09',
+    modelName: 'GQ75LS03DAUXZG',
+    developerMode: '1',
+    developerIP: '192.168.1.124',
+    OS: 'Tizen',
+  },
+};
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('identify', () => {
+  it('names a Samsung set that answers its own API', async () => {
+    answering({ 'http://192.168.1.31:8001/api/v2/': samsungInfo('1') });
+
+    const tv = await identify('192.168.1.31', new Set([8001, 26101]));
+
+    expect(tv).toMatchObject({
+      platform: 'tizen',
+      vendor: 'Samsung',
+      name: '[TV] Salon',
+      model: 'UE50AU7172',
+      developerMode: 'on',
+      sideloadable: true,
+    });
+  });
+
+  it('tells a Samsung owner the code that turns developer mode on', async () => {
+    answering({ 'http://192.168.1.31:8001/api/v2/': samsungInfo('0') });
+
+    const tv = await identify('192.168.1.31', new Set([8001]));
+
+    expect(tv?.developerMode).toBe('off');
+    expect(tv?.note).toContain('1 2 3 4 5');
+  });
+
+  it('names an LG set by the key server it left open', async () => {
+    answering({});
+
+    const tv = await identify('192.168.1.32', new Set([9922, 3000]));
+
+    expect(tv).toMatchObject({
+      platform: 'webos',
+      vendor: 'LG',
+      developerMode: 'on',
+      sideloadable: true,
+    });
+  });
+
+  it('names an LG set that only spoke over UPnP, with its Dev Mode app asleep', async () => {
+    answering({});
+
+    const tv = await identify('192.168.1.32', new Set([3000]), lgUpnp);
+
+    expect(tv).toMatchObject({
+      platform: 'webos',
+      vendor: 'LG',
+      name: '[LG] webOS TV OLED55C16LA',
+      model: 'OLED55C16LA',
+      developerMode: 'off',
+    });
+  });
+
+  it('names a Philips that runs Android TV with network debugging open', async () => {
+    answering({
+      'http://192.168.1.34:1925/6/system': {
+        name: '55PUS7304/12',
+        model: '55PUS7304/12',
+        os_type: 'MSAF_2019_ANDROID_TV',
+      },
+    });
+
+    const tv = await identify('192.168.1.34', new Set([1925, 5555]));
+
+    expect(tv).toMatchObject({
+      platform: 'androidtv',
+      vendor: 'Philips',
+      name: '55PUS7304/12',
+      developerMode: 'on',
+      sideloadable: true,
+    });
+  });
+
+  it('marks a Philips that runs Saphi as taking no sideloaded package', async () => {
+    answering({
+      'http://192.168.1.35:1925/6/system': {
+        name: '50PUS6704/12',
+        model: '50PUS6704/12',
+        os_type: 'SAPHI',
+      },
+    });
+
+    const tv = await identify('192.168.1.35', new Set([1925]));
+
+    expect(tv?.sideloadable).toBe(false);
+    expect(tv?.note).toContain('SAPHI');
+  });
+
+  it('takes an open debugging port alone as an Android TV', async () => {
+    answering({});
+
+    const tv = await identify('192.168.1.36', new Set([5555]));
+
+    expect(tv).toMatchObject({
+      platform: 'androidtv',
+      vendor: 'Android TV',
+      developerMode: 'on',
+      sideloadable: true,
+    });
+  });
+
+  it('reads back the name its owner typed, escaped as the set reports it', async () => {
+    answering({ 'http://192.168.1.107:8001/api/v2/': theFrame });
+
+    const tv = await identify('192.168.1.107', new Set([8001, 26101]));
+
+    expect(tv?.name).toBe('75" The Frame');
+    expect(tv?.note).toContain('192.168.1.124');
+  });
+
+  it('dates what a Samsung runs from the model year it opens with', async () => {
+    answering({ 'http://192.168.1.107:8001/api/v2/': theFrame });
+
+    const tv = await identify('192.168.1.107', new Set([8001, 26101]));
+
+    expect(tv?.runtime).toEqual({
+      name: 'Tizen',
+      version: '8.0',
+      engine: { name: 'Chromium', version: '108' },
+      learned: 'derived',
+    });
+    expect(tv?.note).toBe('sdb open, host PC 192.168.1.124');
+  });
+
+  it('dates what an LG runs from the model UPnP named it by', async () => {
+    answering({});
+
+    const tv = await identify('192.168.1.32', new Set([3000]), lgUpnp);
+
+    expect(tv?.runtime).toEqual({
+      name: 'webOS',
+      version: '6.0',
+      engine: { name: 'Chromium', version: '79' },
+      learned: 'derived',
+    });
+  });
+
+  it('leaves a set no name dated without a runtime rather than guessing one', async () => {
+    answering({});
+
+    const tv = await identify('192.168.1.32', new Set([9922, 3000]));
+
+    expect(tv?.runtime).toBeNull();
+    expect(tv?.note).toBe('Dev Mode running, key server on 9922');
+  });
+
+  it('reads what an Android TV runs off the set when adb answers', async () => {
+    answering({});
+    adb.mockResolvedValueOnce({
+      runtime: {
+        name: 'Android',
+        version: '12',
+        engine: { name: 'WebView', version: '108' },
+        learned: 'reported',
+      },
+      model: 'BRAVIA 4K VH2',
+      vendor: 'Sony',
+    });
+
+    const tv = await identify('192.168.1.36', new Set([5555]));
+
+    expect(tv).toMatchObject({
+      vendor: 'Sony',
+      model: 'BRAVIA 4K VH2',
+      runtime: { version: '12', engine: { name: 'WebView', version: '108' } },
+    });
+    expect(tv?.note).toBe('network debugging open on 5555');
+  });
+
+  it('falls back to the year a Philips build tag carries when adb says nothing', async () => {
+    answering({
+      'http://192.168.1.34:1925/6/system': {
+        name: '55PUS7304/12',
+        model: '55PUS7304/12',
+        os_type: 'MSAF_2019_ANDROID_TV',
+      },
+    });
+
+    const tv = await identify('192.168.1.34', new Set([1925, 5555]));
+
+    expect(tv?.runtime).toEqual({
+      name: 'Android',
+      version: '9',
+      engine: null,
+      learned: 'derived',
+    });
+  });
+
+  it('passes over a Samsung soundbar, which answers the same API as a set', async () => {
+    answering({
+      'http://192.168.1.105:8001/api/v2/': {
+        device: {
+          name: 'Soundbar Salon',
+          model: '25_MT8532_AISPK',
+          modelName: '',
+          ModelNumber: 'HW-QS700F',
+          developerMode: '0',
+          OS: 'Tizen',
+        },
+      },
+    });
+
+    expect(await identify('192.168.1.105', new Set([8001]))).toBeNull();
+  });
+
+  it('answers nothing for a host that is not a television', async () => {
+    answering({});
+
+    expect(await identify('192.168.1.37', new Set([22, 80]))).toBeNull();
+  });
+});

--- a/packages/tv-installer/src/modules/identify.ts
+++ b/packages/tv-installer/src/modules/identify.ts
@@ -1,0 +1,15 @@
+import type { UpnpDevice } from '../discovery/upnp';
+import type { Television } from '../television';
+import { modules } from './registry';
+
+export async function identify(
+  host: string,
+  openPorts: ReadonlySet<number>,
+  upnp?: UpnpDevice,
+): Promise<Television | null> {
+  for (const module of modules()) {
+    const television = await module.identify?.(host, openPorts, upnp);
+    if (television) return television;
+  }
+  return null;
+}

--- a/packages/tv-installer/src/modules/module.test.ts
+++ b/packages/tv-installer/src/modules/module.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { booleanOption, stringOption } from './module';
+
+describe('stringOption', () => {
+  it('reads a flag that was given a value', () => {
+    expect(stringOption({ profile: 'LUMA' }, 'profile')).toBe('LUMA');
+  });
+
+  it('treats a flag left empty as one nobody gave', () => {
+    expect(stringOption({ profile: '' }, 'profile')).toBeUndefined();
+  });
+
+  it('answers nothing for a flag that was never typed', () => {
+    expect(stringOption({}, 'profile')).toBeUndefined();
+  });
+
+  it('answers nothing when the flag is a switch rather than a value', () => {
+    expect(stringOption({ native: true }, 'native')).toBeUndefined();
+  });
+});
+
+describe('booleanOption', () => {
+  it('reads a switch that was turned on', () => {
+    expect(booleanOption({ native: true }, 'native')).toBe(true);
+  });
+
+  it('reads a switch that was turned off', () => {
+    expect(booleanOption({ native: false }, 'native')).toBe(false);
+  });
+
+  it('answers nothing for a switch that was never typed', () => {
+    expect(booleanOption({}, 'native')).toBeUndefined();
+  });
+
+  it('answers nothing when the flag carries a value rather than a switch', () => {
+    expect(booleanOption({ profile: 'LUMA' }, 'profile')).toBeUndefined();
+  });
+});

--- a/packages/tv-installer/src/modules/module.ts
+++ b/packages/tv-installer/src/modules/module.ts
@@ -1,0 +1,55 @@
+import type { ArgsDef, SubCommandsDef } from 'citty';
+import type { UpnpDevice } from '../discovery/upnp';
+import type { ArtifactRequest, Source } from '../install/artifact';
+import type { LogLine } from '../run';
+import type { Platform, Television } from '../television';
+import type { Tool } from '../toolchain/detect';
+
+export type ModuleOptions = Readonly<Record<string, string | boolean | undefined>>;
+
+export interface InstallContext {
+  tv: Television;
+  artifact: string;
+  log: LogLine;
+  launch: boolean;
+  options: ModuleOptions;
+}
+
+export interface ModulePorts {
+  sweep: readonly number[];
+  detail: readonly number[];
+}
+
+export interface TvModule {
+  id: Platform;
+  label: string;
+  brands: string;
+  package: string;
+  notReadyHint: string;
+  enableSteps?: string;
+  ports?: ModulePorts;
+  searchTargets?: readonly string[];
+  flags?: ArgsDef;
+  commands?: SubCommandsDef;
+  identify?(
+    host: string,
+    openPorts: ReadonlySet<number>,
+    upnp?: UpnpDevice,
+  ): Promise<Television | null>;
+  discover?(): Promise<Television[]>;
+  prompt?(sets: readonly Television[]): Promise<Map<string, ModuleOptions> | null>;
+  tools(): readonly Tool[];
+  sources(): readonly Source[];
+  resolve(request: ArtifactRequest): Promise<string>;
+  install(context: InstallContext): Promise<void>;
+}
+
+export function stringOption(options: ModuleOptions, name: string): string | undefined {
+  const value = options[name];
+  return typeof value === 'string' && value !== '' ? value : undefined;
+}
+
+export function booleanOption(options: ModuleOptions, name: string): boolean | undefined {
+  const value = options[name];
+  return typeof value === 'boolean' ? value : undefined;
+}

--- a/packages/tv-installer/src/modules/registry.test.ts
+++ b/packages/tv-installer/src/modules/registry.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import {
+  detailPorts,
+  findModule,
+  moduleArgs,
+  moduleCommands,
+  moduleFor,
+  moduleOptions,
+  modules,
+  searchTargets,
+  sweepPorts,
+} from './registry';
+
+describe('modules', () => {
+  it('answers for the four platforms this tool installs onto', () => {
+    expect(modules().map((module) => module.id)).toEqual([
+      'tizen',
+      'webos',
+      'androidtv',
+      'appletv',
+    ]);
+  });
+});
+
+describe('moduleFor', () => {
+  it('answers the module that installs onto that platform', () => {
+    expect(moduleFor('webos').package).toBe('.ipk');
+  });
+
+  it('refuses a platform no module answers for', () => {
+    expect(() => moduleFor('roku')).toThrow('no module answers for roku');
+  });
+});
+
+describe('findModule', () => {
+  it('answers nothing for a platform no module answers for', () => {
+    expect(findModule('roku')).toBeUndefined();
+  });
+});
+
+describe('sweepPorts', () => {
+  it('gathers the port every module opens its sweep with', () => {
+    expect(sweepPorts()).toEqual([8001, 9922, 1925, 5555]);
+  });
+});
+
+describe('detailPorts', () => {
+  it('gathers the ports a set is asked about only once it answered', () => {
+    expect(detailPorts()).toEqual([26101, 3000, 1926]);
+  });
+});
+
+describe('searchTargets', () => {
+  it('lists the SSDP target the LG sets answer with their own name', () => {
+    expect(searchTargets()).toEqual(['urn:lge-com:service:webos-second-screen:1']);
+  });
+});
+
+describe('moduleArgs', () => {
+  it('merges the flags every module adds to the install command', () => {
+    expect(Object.keys(moduleArgs())).toEqual(['profile', 'native', 'passphrase']);
+  });
+});
+
+describe('moduleCommands', () => {
+  it('merges the subcommands every module adds to the CLI', () => {
+    expect(Object.keys(moduleCommands())).toEqual(['probe', 'certificate']);
+  });
+});
+
+describe('moduleOptions', () => {
+  it('keeps the flags a module declared, whatever else was typed', () => {
+    const args = { profile: 'LUMA', native: true, target: 'all', _: ['install'] };
+
+    expect(moduleOptions(args)).toEqual({ profile: 'LUMA', native: true });
+  });
+
+  it('drops a flag whose value is neither text nor a switch', () => {
+    expect(moduleOptions({ passphrase: 12 })).toEqual({});
+  });
+});

--- a/packages/tv-installer/src/modules/registry.ts
+++ b/packages/tv-installer/src/modules/registry.ts
@@ -1,0 +1,56 @@
+import type { ArgsDef, SubCommandsDef } from 'citty';
+import type { Platform } from '../television';
+import { androidtv } from './androidtv/module';
+import { appletv } from './appletv/module';
+import type { ModuleOptions, TvModule } from './module';
+import { tizen } from './tizen/module';
+import { webos } from './webos/module';
+
+const REGISTRY: readonly TvModule[] = [tizen, webos, androidtv, appletv];
+
+export function modules(): readonly TvModule[] {
+  return REGISTRY;
+}
+
+export function findModule(platform: Platform): TvModule | undefined {
+  return REGISTRY.find((module) => module.id === platform);
+}
+
+export function moduleFor(platform: Platform): TvModule {
+  const module = findModule(platform);
+  if (!module) throw new Error(`no module answers for ${platform}`);
+  return module;
+}
+
+export function sweepPorts(): number[] {
+  return REGISTRY.flatMap((module) => [...(module.ports?.sweep ?? [])]);
+}
+
+export function detailPorts(): number[] {
+  return REGISTRY.flatMap((module) => [...(module.ports?.detail ?? [])]);
+}
+
+export function searchTargets(): string[] {
+  return REGISTRY.flatMap((module) => [...(module.searchTargets ?? [])]);
+}
+
+export function moduleArgs(): ArgsDef {
+  const args: ArgsDef = {};
+  for (const module of REGISTRY) Object.assign(args, module.flags);
+  return args;
+}
+
+export function moduleCommands(): SubCommandsDef {
+  const commands: SubCommandsDef = {};
+  for (const module of REGISTRY) Object.assign(commands, module.commands);
+  return commands;
+}
+
+export function moduleOptions(args: Record<string, unknown>): ModuleOptions {
+  const options: Record<string, string | boolean> = {};
+  for (const name of Object.keys(moduleArgs())) {
+    const value = args[name];
+    if (typeof value === 'string' || typeof value === 'boolean') options[name] = value;
+  }
+  return options;
+}

--- a/packages/tv-installer/src/modules/tizen/app-id.test.ts
+++ b/packages/tv-installer/src/modules/tizen/app-id.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { tizenAppId } from './app-id';
+
+vi.mock('node:fs', () => ({ readFileSync: vi.fn() }));
+vi.mock('../../root', () => ({ root: '/kroma' }));
+
+const config = [
+  '<?xml version="1.0" encoding="UTF-8"?>',
+  '<widget xmlns="http://www.w3.org/ns/widgets" id="http://kroma.tv/tizen">',
+  '  <tizen:application id="KromaTV001.KROMA" package="KromaTV001" required_version="4.0"/>',
+  '</widget>',
+].join('\n');
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('tizenAppId', () => {
+  it('reads the id the shell declares in its own config', () => {
+    vi.mocked(readFileSync).mockReturnValue(config);
+
+    expect(tizenAppId()).toBe('KromaTV001.KROMA');
+    expect(vi.mocked(readFileSync)).toHaveBeenCalledWith(
+      '/kroma/clients/tizen/public/config.xml',
+      'utf8',
+    );
+  });
+
+  it('falls back to the shipped id when the config is not in this checkout', () => {
+    vi.mocked(readFileSync).mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+
+    expect(tizenAppId()).toBe('KromaTV001.KROMA');
+  });
+
+  it('falls back to the shipped id when the config declares no application', () => {
+    vi.mocked(readFileSync).mockReturnValue('<widget></widget>');
+
+    expect(tizenAppId()).toBe('KromaTV001.KROMA');
+  });
+});

--- a/packages/tv-installer/src/modules/tizen/app-id.ts
+++ b/packages/tv-installer/src/modules/tizen/app-id.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { root } from '../../root';
+
+const CONFIG = 'clients/tizen/public/config.xml';
+const FALLBACK = 'KromaTV001.KROMA';
+
+export function tizenAppId(): string {
+  try {
+    const config = readFileSync(join(root, CONFIG), 'utf8');
+    return /<tizen:application[^>]*\sid="([^"]+)"/.exec(config)?.[1] ?? FALLBACK;
+  } catch {
+    return FALLBACK;
+  }
+}

--- a/packages/tv-installer/src/modules/tizen/artifact.test.ts
+++ b/packages/tv-installer/src/modules/tizen/artifact.test.ts
@@ -1,9 +1,35 @@
-import { describe, expect, it } from 'vitest';
-import { rankArtifacts } from '../../install/artifact';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { rankArtifacts, resolveArtifact } from '../../install/artifact';
 import { buildable } from '../../install/build';
-import { TIZEN_PACKAGE, TIZEN_SHELL } from './artifact';
+import { root } from '../../root';
+import { runOk } from '../../run';
+import type { Television } from '../../television';
+import { resolveTizenArtifact, TIZEN_PACKAGE, TIZEN_SHELL } from './artifact';
+
+vi.mock('../../install/artifact', async (original) => ({
+  ...(await original<typeof import('../../install/artifact')>()),
+  resolveArtifact: vi.fn(),
+}));
+vi.mock('../../run', () => ({ runOk: vi.fn() }));
 
 const tizenOut = '/kroma/clients/tizen/out';
+
+const salon: Television = {
+  host: '192.168.1.31',
+  platform: 'tizen',
+  vendor: 'Samsung',
+  name: 'Salon',
+  model: 'UE50AU7172',
+  developerMode: 'on',
+  sideloadable: true,
+  note: '',
+  runtime: null,
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
 
 describe('rankArtifacts', () => {
   it('puts the every-tier Samsung build ahead of the newer per-tier slices', () => {
@@ -24,5 +50,31 @@ describe('rankArtifacts', () => {
 describe('buildable', () => {
   it('builds the shell whose sources live in this checkout', () => {
     expect(buildable(TIZEN_SHELL)).toBe(true);
+  });
+});
+
+describe('resolveTizenArtifact', () => {
+  const buildOf = () => {
+    const build = vi.mocked(resolveArtifact).mock.calls[0]?.[0].build;
+    if (!build) throw new Error('the Samsung package named no way to build one');
+    return build;
+  };
+
+  it('looks for a Samsung package under the id the downloads are kept by', async () => {
+    await resolveTizenArtifact({ tv: salon, log: () => {} });
+
+    expect(vi.mocked(resolveArtifact).mock.calls[0]?.[0]).toMatchObject({
+      id: 'tizen',
+      kind: TIZEN_PACKAGE,
+    });
+  });
+
+  it('builds the bundle from this checkout and leaves it unsigned', async () => {
+    await resolveTizenArtifact({ tv: salon, source: 'build', log: () => {} });
+    const built = await buildOf()(() => {});
+
+    expect(vi.mocked(runOk).mock.calls[0]?.[0]).toEqual(['bun', 'run', 'build:tizen']);
+    expect(vi.mocked(runOk).mock.calls[0]?.[1]?.cwd).toBe(root);
+    expect(built).toBe(join(root, 'clients/tizen/dist'));
   });
 });

--- a/packages/tv-installer/src/modules/tizen/artifact.test.ts
+++ b/packages/tv-installer/src/modules/tizen/artifact.test.ts
@@ -5,13 +5,21 @@ import { buildable } from '../../install/build';
 import { root } from '../../root';
 import { runOk } from '../../run';
 import type { Television } from '../../television';
-import { resolveTizenArtifact, TIZEN_PACKAGE, TIZEN_SHELL } from './artifact';
+import { resolveTizenArtifact, TIZEN_PACKAGE, TIZEN_SHELL, tizenSources } from './artifact';
 
 vi.mock('../../install/artifact', async (original) => ({
   ...(await original<typeof import('../../install/artifact')>()),
   resolveArtifact: vi.fn(),
 }));
 vi.mock('../../run', () => ({ runOk: vi.fn() }));
+
+class EmptyGlob {
+  scanSync(): string[] {
+    return [];
+  }
+}
+
+vi.stubGlobal('Bun', { which: () => null, Glob: EmptyGlob });
 
 const tizenOut = '/kroma/clients/tizen/out';
 
@@ -50,6 +58,12 @@ describe('rankArtifacts', () => {
 describe('buildable', () => {
   it('builds the shell whose sources live in this checkout', () => {
     expect(buildable(TIZEN_SHELL)).toBe(true);
+  });
+});
+
+describe('tizenSources', () => {
+  it('offers a build from source on a machine with nothing built and no gh', () => {
+    expect(tizenSources()).toEqual(['build']);
   });
 });
 

--- a/packages/tv-installer/src/modules/tizen/artifact.test.ts
+++ b/packages/tv-installer/src/modules/tizen/artifact.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { rankArtifacts } from '../../install/artifact';
+import { buildable } from '../../install/build';
+import { TIZEN_PACKAGE, TIZEN_SHELL } from './artifact';
+
+const tizenOut = '/kroma/clients/tizen/out';
+
+describe('rankArtifacts', () => {
+  it('puts the every-tier Samsung build ahead of the newer per-tier slices', () => {
+    const built = [
+      { path: `${tizenOut}/KROMA-tizen8-0.1.33.wgt`, mtimeMs: 3_000 },
+      { path: `${tizenOut}/KROMA-tizen4to7-0.1.33.wgt`, mtimeMs: 2_000 },
+      { path: `${tizenOut}/KROMA-tizen-0.1.33.wgt`, mtimeMs: 1_000 },
+    ];
+
+    expect(rankArtifacts(built, TIZEN_PACKAGE.preferred)).toEqual([
+      `${tizenOut}/KROMA-tizen-0.1.33.wgt`,
+      `${tizenOut}/KROMA-tizen8-0.1.33.wgt`,
+      `${tizenOut}/KROMA-tizen4to7-0.1.33.wgt`,
+    ]);
+  });
+});
+
+describe('buildable', () => {
+  it('builds the shell whose sources live in this checkout', () => {
+    expect(buildable(TIZEN_SHELL)).toBe(true);
+  });
+});

--- a/packages/tv-installer/src/modules/tizen/artifact.ts
+++ b/packages/tv-installer/src/modules/tizen/artifact.ts
@@ -1,0 +1,39 @@
+import { join } from 'node:path';
+import {
+  type ArtifactRequest,
+  availableSources,
+  type PackageKind,
+  resolveArtifact,
+  type Source,
+} from '../../install/artifact';
+import { buildable } from '../../install/build';
+import { root } from '../../root';
+import { type LogLine, runOk } from '../../run';
+
+export const TIZEN_SHELL = 'clients/tizen';
+const BUILD_TIMEOUT_MS = 900_000;
+
+export const TIZEN_PACKAGE: PackageKind = {
+  extension: '.wgt',
+  globs: [`${TIZEN_SHELL}/out/*.wgt`, `${TIZEN_SHELL}/dist/*.wgt`],
+  pattern: 'KROMA-tizen-*.wgt',
+  runArtifact: 'kroma-tizen-wgt',
+  // The every-tier build, not one of the KROMA-tizen8- / tizen4to7- slices.
+  preferred: /KROMA-tizen-\d/,
+};
+
+export function tizenSources(): Source[] {
+  return availableSources(TIZEN_PACKAGE, buildable(TIZEN_SHELL));
+}
+
+export function resolveTizenArtifact(request: ArtifactRequest): Promise<string> {
+  return resolveArtifact({ id: 'tizen', kind: TIZEN_PACKAGE, build: buildTizen }, request);
+}
+
+async function buildTizen(log: LogLine): Promise<string> {
+  log('building the Tizen bundle');
+  await runOk(['bun', 'run', 'build:tizen'], { log, cwd: root, timeoutMs: BUILD_TIMEOUT_MS });
+  // Left unsigned on purpose: installTizen signs with this machine's profile,
+  // which is the only signature a retail set accepts.
+  return join(root, `${TIZEN_SHELL}/dist`);
+}

--- a/packages/tv-installer/src/modules/tizen/certificate-command.test.ts
+++ b/packages/tv-installer/src/modules/tizen/certificate-command.test.ts
@@ -82,6 +82,17 @@ describe('certificateCommand', () => {
     ]);
   });
 
+  it('passes on what the Tizen tools said while they added the profile', async () => {
+    run.mockImplementation(async (_command, options) => {
+      (options as { log: (line: string) => void }).log('Succeed to add a profile');
+      return { code: 0, output: '' };
+    });
+
+    await generate({ name: 'kroma', register: true });
+
+    expect(printed).toContain('Succeed to add a profile');
+  });
+
   it('answers a failure when the tools would not add the profile', async () => {
     run.mockResolvedValue({ code: 1, output: 'profile already exists' });
 

--- a/packages/tv-installer/src/modules/tizen/certificate-command.test.ts
+++ b/packages/tv-installer/src/modules/tizen/certificate-command.test.ts
@@ -1,0 +1,94 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { certificateCommand } from './certificate-command';
+
+const { run, requireTool, createAuthorCertificate, exitAfter } = vi.hoisted(() => ({
+  run: vi.fn(async (_command: readonly string[], _options?: unknown) => ({ code: 0, output: '' })),
+  requireTool: vi.fn(() => '/tizen-studio/tools/ide/bin/tizen'),
+  createAuthorCertificate: vi.fn(async (_options: unknown) => ({
+    certificate: '/certs/kroma/author.crt',
+    key: '/certs/kroma/author.key',
+    archive: '/certs/kroma/author.p12',
+    password: 'a-generated-password',
+    passwordFile: '/certs/kroma/author.pwd',
+  })),
+  exitAfter: vi.fn((work: number | Promise<number>) => work),
+}));
+vi.mock('../../run', () => ({ run }));
+vi.mock('../../toolchain/detect', async (original) => ({
+  ...(await original<Record<string, unknown>>()),
+  requireTool,
+}));
+vi.mock('./certificate/authority', () => ({ createAuthorCertificate }));
+vi.mock('./certificate/password', () => ({ randomPassword: () => 'a-generated-password' }));
+vi.mock('../../exit-after', () => ({ exitAfter }));
+
+const generate = (args: { name: string; register: boolean }) =>
+  (certificateCommand.run as (given: { args: typeof args }) => Promise<number>)({ args });
+
+const printed: string[] = [];
+
+beforeEach(() => {
+  printed.length = 0;
+  vi.spyOn(console, 'log').mockImplementation((line: string) => void printed.push(line));
+  run.mockReset();
+  createAuthorCertificate.mockClear();
+});
+
+describe('certificateCommand', () => {
+  it('generates the certificate under the name it was given', async () => {
+    await generate({ name: 'salon', register: false });
+
+    expect(createAuthorCertificate).toHaveBeenCalledWith({
+      directory: join(homedir(), '.kroma', 'certificates', 'salon'),
+      alias: 'salon',
+      password: 'a-generated-password',
+      subject: { commonName: 'KROMA', organization: 'KROMA' },
+    });
+  });
+
+  it('says where the certificate, the key, the archive and the password landed', async () => {
+    await generate({ name: 'kroma', register: false });
+
+    expect(printed.join('\n')).toContain('/certs/kroma/author.crt');
+    expect(printed.join('\n')).toContain('/certs/kroma/author.key');
+    expect(printed.join('\n')).toContain('/certs/kroma/author.p12');
+    expect(printed.join('\n')).toContain('/certs/kroma/author.pwd');
+  });
+
+  it('spells the registration out with the password read from its file, never printed', async () => {
+    await generate({ name: 'kroma', register: false });
+
+    expect(printed.at(-1)).toContain(
+      'tizen security-profiles add -n kroma -a /certs/kroma/author.p12 -p "$(cat /certs/kroma/author.pwd)"',
+    );
+    expect(printed.join('\n')).not.toContain('a-generated-password');
+  });
+
+  it('registers the profile with the Tizen tools when that was asked for', async () => {
+    await generate({ name: 'kroma', register: true });
+
+    expect(run.mock.calls[0]?.[0]).toEqual([
+      '/tizen-studio/tools/ide/bin/tizen',
+      'security-profiles',
+      'add',
+      '-n',
+      'kroma',
+      '-a',
+      '/certs/kroma/author.p12',
+      '-p',
+      'a-generated-password',
+    ]);
+  });
+
+  it('answers a failure when the tools would not add the profile', async () => {
+    run.mockResolvedValue({ code: 1, output: 'profile already exists' });
+
+    expect(await generate({ name: 'kroma', register: true })).toBe(1);
+  });
+
+  it('answers a success once the profile is registered', async () => {
+    expect(await generate({ name: 'kroma', register: true })).toBe(0);
+  });
+});

--- a/packages/tv-installer/src/modules/tizen/certificate-command.ts
+++ b/packages/tv-installer/src/modules/tizen/certificate-command.ts
@@ -58,8 +58,9 @@ async function certificate(options: CertificateOptions): Promise<number> {
 
   const add = ['security-profiles', 'add', '-n', options.name, '-a', author.archive, '-p'];
   if (!options.register) {
-    // The password is handed over as a file read rather than printed: a shell
-    // history and a CI log are both places it must not end up.
+    // Handed over as a file read rather than printed: a terminal and a shell
+    // history both keep what they are shown. The Tizen CLI takes the password
+    // only as an argument, so it is briefly in `ps` either way.
     const spelled = [...add, `"$(cat ${author.passwordFile})"`].join(' ');
     console.log(`\nregister it, which also makes it the active profile:\n  tizen ${spelled}`);
     return 0;

--- a/packages/tv-installer/src/modules/tizen/certificate-command.ts
+++ b/packages/tv-installer/src/modules/tizen/certificate-command.ts
@@ -6,10 +6,10 @@ import { run } from '../../run';
 import { requireTool } from '../../toolchain/detect';
 import { style } from '../../tui/ansi';
 import { createAuthorCertificate } from './certificate/authority';
+import { randomPassword } from './certificate/password';
 import { TIZEN_CLI } from './tools';
 
 const CERTIFICATES = join(homedir(), '.kroma', 'certificates');
-const PASSWORD = 'kroma-dev';
 
 export const certificateCommand = defineCommand({
   meta: {
@@ -42,35 +42,30 @@ async function certificate(options: CertificateOptions): Promise<number> {
   const author = await createAuthorCertificate({
     directory: join(CERTIFICATES, options.name),
     alias: options.name,
-    password: PASSWORD,
+    password: randomPassword(),
     subject: { commonName: 'KROMA', organization: 'KROMA' },
   });
 
   console.log(`${style.green('certificate')}  ${author.certificate}`);
   console.log(`${style.green('key')}          ${author.key}`);
-  console.log(`${style.green('archive')}      ${author.archive}  (password ${author.password})`);
+  console.log(`${style.green('archive')}      ${author.archive}`);
+  console.log(`${style.green('password')}     ${author.passwordFile}`);
   console.log(
     style.dim(
       'The author half only. A retail Samsung also wants a distributor certificate,\nwhich Samsung issues against the DUID of that one set: Tizen Studio, Certificate Manager.',
     ),
   );
 
-  const add = [
-    'security-profiles',
-    'add',
-    '-n',
-    options.name,
-    '-a',
-    author.archive,
-    '-p',
-    PASSWORD,
-  ];
+  const add = ['security-profiles', 'add', '-n', options.name, '-a', author.archive, '-p'];
   if (!options.register) {
-    console.log(`\nregister it, which also makes it the active profile:\n  tizen ${add.join(' ')}`);
+    // The password is handed over as a file read rather than printed: a shell
+    // history and a CI log are both places it must not end up.
+    const spelled = [...add, `"$(cat ${author.passwordFile})"`].join(' ');
+    console.log(`\nregister it, which also makes it the active profile:\n  tizen ${spelled}`);
     return 0;
   }
 
-  const { code } = await run([requireTool(TIZEN_CLI), ...add], {
+  const { code } = await run([requireTool(TIZEN_CLI), ...add, author.password], {
     log: (line) => console.log(line),
   });
   return code === 0 ? 0 : 1;

--- a/packages/tv-installer/src/modules/tizen/certificate-command.ts
+++ b/packages/tv-installer/src/modules/tizen/certificate-command.ts
@@ -1,0 +1,77 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { defineCommand } from 'citty';
+import { exitAfter } from '../../exit-after';
+import { run } from '../../run';
+import { requireTool } from '../../toolchain/detect';
+import { style } from '../../tui/ansi';
+import { createAuthorCertificate } from './certificate/authority';
+import { TIZEN_CLI } from './tools';
+
+const CERTIFICATES = join(homedir(), '.kroma', 'certificates');
+const PASSWORD = 'kroma-dev';
+
+export const certificateCommand = defineCommand({
+  meta: {
+    name: 'certificate',
+    description: 'Generate a Samsung author certificate and the profile the tools sign with.',
+  },
+  args: {
+    name: { type: 'string', default: 'kroma', description: 'The profile and alias name' },
+    register: {
+      type: 'boolean',
+      default: false,
+      description: 'Add it to the Tizen profiles, which makes it the active one',
+    },
+  },
+  run: ({ args }) => exitAfter(certificate({ name: args.name, register: args.register })),
+});
+
+interface CertificateOptions {
+  name: string;
+  register: boolean;
+}
+
+/**
+ * Generates an author certificate: an RSA key, a self-signed X.509 over it, and
+ * the PKCS#12 the Tizen tools sign with. Registering it is opt-in, because
+ * adding a profile makes it the active one and a machine that already signs for
+ * a retail set must keep signing with the certificate that set accepts.
+ */
+async function certificate(options: CertificateOptions): Promise<number> {
+  const author = await createAuthorCertificate({
+    directory: join(CERTIFICATES, options.name),
+    alias: options.name,
+    password: PASSWORD,
+    subject: { commonName: 'KROMA', organization: 'KROMA' },
+  });
+
+  console.log(`${style.green('certificate')}  ${author.certificate}`);
+  console.log(`${style.green('key')}          ${author.key}`);
+  console.log(`${style.green('archive')}      ${author.archive}  (password ${author.password})`);
+  console.log(
+    style.dim(
+      'The author half only. A retail Samsung also wants a distributor certificate,\nwhich Samsung issues against the DUID of that one set: Tizen Studio, Certificate Manager.',
+    ),
+  );
+
+  const add = [
+    'security-profiles',
+    'add',
+    '-n',
+    options.name,
+    '-a',
+    author.archive,
+    '-p',
+    PASSWORD,
+  ];
+  if (!options.register) {
+    console.log(`\nregister it, which also makes it the active profile:\n  tizen ${add.join(' ')}`);
+    return 0;
+  }
+
+  const { code } = await run([requireTool(TIZEN_CLI), ...add], {
+    log: (line) => console.log(line),
+  });
+  return code === 0 ? 0 : 1;
+}

--- a/packages/tv-installer/src/modules/tizen/certificate/asn1.ts
+++ b/packages/tv-installer/src/modules/tizen/certificate/asn1.ts
@@ -1,0 +1,90 @@
+const CLASS_CONTEXT = 0xa0;
+
+export const TAG = {
+  boolean: 0x01,
+  integer: 0x02,
+  bitString: 0x03,
+  octetString: 0x04,
+  null: 0x05,
+  oid: 0x06,
+  utf8String: 0x0c,
+  printableString: 0x13,
+  utcTime: 0x17,
+  sequence: 0x30,
+  set: 0x31,
+} as const;
+
+/** A DER value: one tag byte, a length, and the contents. */
+export function encode(tag: number, contents: Buffer): Buffer {
+  return Buffer.concat([Buffer.from([tag]), length(contents.length), contents]);
+}
+
+export const sequence = (...parts: Buffer[]) => encode(TAG.sequence, Buffer.concat(parts));
+export const set = (...parts: Buffer[]) => encode(TAG.set, Buffer.concat(parts));
+export const nul = () => encode(TAG.null, Buffer.alloc(0));
+export const utf8 = (text: string) => encode(TAG.utf8String, Buffer.from(text, 'utf8'));
+export const printable = (text: string) => encode(TAG.printableString, Buffer.from(text, 'ascii'));
+export const boolean = (value: boolean) => encode(TAG.boolean, Buffer.from([value ? 0xff : 0x00]));
+export const octets = (contents: Buffer) => encode(TAG.octetString, contents);
+
+/** Explicit `[n]` tagging, which X.509 uses for its version and extensions. */
+export const context = (index: number, contents: Buffer) => encode(CLASS_CONTEXT | index, contents);
+
+/** Two's complement, with a leading zero when the top bit would read as negative. */
+export function integer(value: Buffer | number): Buffer {
+  const bytes = typeof value === 'number' ? unsigned(value) : value;
+  const first = bytes[0] ?? 0;
+  return encode(TAG.integer, first & 0x80 ? Buffer.concat([Buffer.from([0]), bytes]) : bytes);
+}
+
+/** A BIT STRING, whose first byte counts the bits the last byte does not use. */
+export const bitString = (contents: Buffer, unused = 0) =>
+  encode(TAG.bitString, Buffer.concat([Buffer.from([unused]), contents]));
+
+export function oid(dotted: string): Buffer {
+  const parts = dotted.split('.').map(Number);
+  const [first = 0, second = 0, ...rest] = parts;
+  const bytes = [first * 40 + second];
+  for (const part of rest) bytes.push(...base128(part));
+  return encode(TAG.oid, Buffer.from(bytes));
+}
+
+/** `YYMMDDhhmmssZ`, which is what X.509 dates before 2050 are written as. */
+export function utcTime(date: Date): Buffer {
+  const pad = (value: number) => String(value).padStart(2, '0');
+  const stamp = [
+    pad(date.getUTCFullYear() % 100),
+    pad(date.getUTCMonth() + 1),
+    pad(date.getUTCDate()),
+    pad(date.getUTCHours()),
+    pad(date.getUTCMinutes()),
+    pad(date.getUTCSeconds()),
+  ].join('');
+  return encode(TAG.utcTime, Buffer.from(`${stamp}Z`, 'ascii'));
+}
+
+function length(size: number): Buffer {
+  if (size < 0x80) return Buffer.from([size]);
+  const bytes = unsigned(size);
+  return Buffer.concat([Buffer.from([0x80 | bytes.length]), bytes]);
+}
+
+function unsigned(value: number): Buffer {
+  const bytes: number[] = [];
+  let rest = value;
+  do {
+    bytes.unshift(rest & 0xff);
+    rest = Math.floor(rest / 256);
+  } while (rest > 0);
+  return Buffer.from(bytes);
+}
+
+function base128(value: number): number[] {
+  const bytes = [value & 0x7f];
+  let rest = Math.floor(value / 128);
+  while (rest > 0) {
+    bytes.unshift((rest & 0x7f) | 0x80);
+    rest = Math.floor(rest / 128);
+  }
+  return bytes;
+}

--- a/packages/tv-installer/src/modules/tizen/certificate/authority.test.ts
+++ b/packages/tv-installer/src/modules/tizen/certificate/authority.test.ts
@@ -1,0 +1,119 @@
+import { spawnSync } from 'node:child_process';
+import { createPrivateKey, randomInt, X509Certificate } from 'node:crypto';
+import { mkdtempSync, rmSync, statSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
+import { nodeSpawn } from '../../../run.fixture';
+import { type AuthorRequest, createAuthorCertificate } from './authority';
+import { OPENSSL } from './openssl';
+import { randomPassword } from './password';
+import { readPkcs12 } from './pkcs12';
+
+vi.stubGlobal('Bun', { spawn: nodeSpawn });
+
+const DAY_MS = 86_400_000;
+const bases: string[] = [];
+
+function request(over: Partial<AuthorRequest> = {}): AuthorRequest {
+  const base = mkdtempSync(join(tmpdir(), 'kroma-authority-'));
+  bases.push(base);
+  const name = `kroma-${randomInt(1000, 9999)}`;
+  return {
+    directory: join(base, 'certificates', name),
+    alias: name,
+    password: randomPassword(),
+    subject: { commonName: name.toUpperCase(), organization: 'KROMA', country: 'ch' },
+    ...over,
+  };
+}
+
+const lifetimeDays = (certificate: X509Certificate) =>
+  (Date.parse(certificate.validTo) - Date.parse(certificate.validFrom)) / DAY_MS;
+
+const asked = request();
+const author = await createAuthorCertificate(asked);
+const signed = new X509Certificate(await readFile(author.certificate));
+
+afterEach(() => {
+  vi.doUnmock('./openssl');
+  vi.resetModules();
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+  for (const base of bases) rmSync(base, { recursive: true, force: true });
+});
+
+describe('createAuthorCertificate', () => {
+  it('answers where each of the files it wrote landed', () => {
+    expect(author).toEqual({
+      directory: asked.directory,
+      certificate: join(asked.directory, 'author.crt'),
+      key: join(asked.directory, 'author.key'),
+      archive: join(asked.directory, 'author.p12'),
+      passwordFile: join(asked.directory, 'author.pwd'),
+      password: asked.password,
+    });
+  });
+
+  it('writes a certificate carrying the subject it was asked to sign', () => {
+    expect(signed.subject).toContain(`CN=${asked.subject.commonName}`);
+    expect(signed.subject).toContain('C=CH');
+  });
+
+  it('signs the certificate with the key it wrote beside it', async () => {
+    const key = createPrivateKey(await readFile(author.key, 'utf8'));
+
+    expect(signed.checkPrivateKey(key)).toBe(true);
+  });
+
+  it('signs the certificate with itself, so nothing above it has to be trusted', () => {
+    expect(signed.issuer).toBe(signed.subject);
+    expect(signed.verify(signed.publicKey)).toBe(true);
+  });
+
+  it('keeps the certificate good for five years when no lifetime was named', () => {
+    expect(lifetimeDays(signed)).toBe(1825);
+  });
+
+  it('honours a lifetime it was given', async () => {
+    const short = await createAuthorCertificate(request({ days: 30 }));
+
+    expect(lifetimeDays(new X509Certificate(await readFile(short.certificate)))).toBe(30);
+  });
+
+  it('keeps the key and the password readable only by the account that made them', () => {
+    expect(statSync(author.key).mode & 0o777).toBe(0o600);
+    expect(statSync(author.passwordFile).mode & 0o777).toBe(0o600);
+  });
+
+  it('packs an archive that opens under the password it wrote beside it', async () => {
+    const written = await readFile(author.passwordFile, 'utf8');
+
+    const { chain, key } = readPkcs12({ archive: author.archive, password: written });
+
+    expect(chain[0]?.checkPrivateKey(key)).toBe(true);
+    expect(chain[0]?.subject).toBe(signed.subject);
+  });
+
+  it('files the key in the archive under the alias the Tizen tools look it up by', () => {
+    const dumped = spawnSync(
+      OPENSSL,
+      ['pkcs12', '-in', author.archive, '-nokeys', '-info', '-passin', 'stdin'],
+      { input: `${asked.password}\n`, encoding: 'utf8' },
+    );
+
+    expect(dumped.stdout + dumped.stderr).toContain(`friendlyName: ${asked.alias}`);
+  });
+
+  it('says openssl is needed when this machine has none', async () => {
+    vi.resetModules();
+    vi.doMock('./openssl', () => ({ OPENSSL: join(tmpdir(), 'kroma-openssl-that-is-not-here') }));
+
+    const { createAuthorCertificate: withoutOpenssl } = await import('./authority');
+
+    await expect(withoutOpenssl(request())).rejects.toThrow('openssl is needed');
+  });
+});

--- a/packages/tv-installer/src/modules/tizen/certificate/authority.ts
+++ b/packages/tv-installer/src/modules/tizen/certificate/authority.ts
@@ -1,7 +1,9 @@
 import { generateKeyPairSync } from 'node:crypto';
+import { existsSync } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { runOk } from '../../../run';
+import { OPENSSL } from './openssl';
 import { type Subject, selfSignedCertificate, toPem } from './x509';
 
 const KEY_BITS = 2048;
@@ -16,7 +18,6 @@ export interface AuthorCertificate {
   key: string;
   archive: string;
   password: string;
-  /** Where the password is kept, so nothing has to print it to hand it over. */
   passwordFile: string;
 }
 
@@ -65,9 +66,9 @@ async function pack(
   alias: string,
   password: string,
 ): Promise<void> {
-  if (!Bun.which('openssl')) throw new Error('openssl is needed to write the .p12 and is not here');
+  if (!existsSync(OPENSSL)) throw new Error('openssl is needed to write the .p12 and is not here');
   await runOk([
-    'openssl',
+    OPENSSL,
     'pkcs12',
     '-export',
     '-inkey',

--- a/packages/tv-installer/src/modules/tizen/certificate/authority.ts
+++ b/packages/tv-installer/src/modules/tizen/certificate/authority.ts
@@ -1,0 +1,81 @@
+import { generateKeyPairSync } from 'node:crypto';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { runOk } from '../../../run';
+import { type Subject, selfSignedCertificate, toPem } from './x509';
+
+const KEY_BITS = 2048;
+const VALID_DAYS = 1825;
+// Java reads a PKCS#12 written this way without an argument. OpenSSL 3 defaults
+// to AES-256 with PBKDF2, which the JRE bundled with Tizen Studio refuses.
+const JAVA_READABLE = ['-certpbe', 'PBE-SHA1-3DES', '-keypbe', 'PBE-SHA1-3DES', '-macalg', 'sha1'];
+
+export interface AuthorCertificate {
+  directory: string;
+  certificate: string;
+  key: string;
+  archive: string;
+  password: string;
+}
+
+export interface AuthorRequest {
+  directory: string;
+  alias: string;
+  password: string;
+  subject: Subject;
+  days?: number;
+}
+
+/**
+ * An author certificate of this machine's own: an RSA key, a self-signed X.509
+ * over it, and the PKCS#12 the Tizen tools sign with. It is the whole chain for
+ * an emulator, and half of it for a retail set, whose distributor certificate
+ * only Samsung can issue.
+ */
+export async function createAuthorCertificate(request: AuthorRequest): Promise<AuthorCertificate> {
+  const { directory, alias, password, subject } = request;
+  await mkdir(directory, { recursive: true });
+
+  const { publicKey, privateKey } = generateKeyPairSync('rsa', { modulusLength: KEY_BITS });
+  const certificate = selfSignedCertificate({
+    subject,
+    publicKey,
+    privateKey,
+    days: request.days ?? VALID_DAYS,
+  });
+
+  const paths = {
+    certificate: join(directory, 'author.crt'),
+    key: join(directory, 'author.key'),
+    archive: join(directory, 'author.p12'),
+  };
+  await writeFile(paths.certificate, toPem(certificate, 'CERTIFICATE'));
+  await writeFile(paths.key, privateKey.export({ format: 'pem', type: 'pkcs8' }), { mode: 0o600 });
+  await pack(paths, alias, password);
+
+  return { directory, password, ...paths };
+}
+
+async function pack(
+  paths: { certificate: string; key: string; archive: string },
+  alias: string,
+  password: string,
+): Promise<void> {
+  if (!Bun.which('openssl')) throw new Error('openssl is needed to write the .p12 and is not here');
+  await runOk([
+    'openssl',
+    'pkcs12',
+    '-export',
+    '-inkey',
+    paths.key,
+    '-in',
+    paths.certificate,
+    '-out',
+    paths.archive,
+    '-name',
+    alias,
+    '-passout',
+    `pass:${password}`,
+    ...JAVA_READABLE,
+  ]);
+}

--- a/packages/tv-installer/src/modules/tizen/certificate/authority.ts
+++ b/packages/tv-installer/src/modules/tizen/certificate/authority.ts
@@ -16,6 +16,8 @@ export interface AuthorCertificate {
   key: string;
   archive: string;
   password: string;
+  /** Where the password is kept, so nothing has to print it to hand it over. */
+  passwordFile: string;
 }
 
 export interface AuthorRequest {
@@ -48,9 +50,11 @@ export async function createAuthorCertificate(request: AuthorRequest): Promise<A
     certificate: join(directory, 'author.crt'),
     key: join(directory, 'author.key'),
     archive: join(directory, 'author.p12'),
+    passwordFile: join(directory, 'author.pwd'),
   };
   await writeFile(paths.certificate, toPem(certificate, 'CERTIFICATE'));
   await writeFile(paths.key, privateKey.export({ format: 'pem', type: 'pkcs8' }), { mode: 0o600 });
+  await writeFile(paths.passwordFile, password, { mode: 0o600 });
   await pack(paths, alias, password);
 
   return { directory, password, ...paths };

--- a/packages/tv-installer/src/modules/tizen/certificate/openssl.test.ts
+++ b/packages/tv-installer/src/modules/tizen/certificate/openssl.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const present = vi.hoisted(() => new Set<string>());
+vi.mock('node:fs', () => ({ existsSync: (path: string) => present.has(path) }));
+
+async function resolvedWith(installed: string[], path: string | undefined): Promise<string> {
+  present.clear();
+  for (const candidate of installed) present.add(candidate);
+  vi.stubEnv('PATH', path);
+  vi.resetModules();
+  return (await import('./openssl')).OPENSSL;
+}
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe('OPENSSL', () => {
+  it('is the first of the fixed locations this machine has one at', async () => {
+    const found = await resolvedWith(
+      ['/opt/homebrew/bin/openssl', '/usr/local/bin/openssl'],
+      '/opt/homebrew/bin',
+    );
+
+    expect(found).toBe('/opt/homebrew/bin/openssl');
+  });
+
+  it('prefers a fixed location to whatever PATH would have found', async () => {
+    const found = await resolvedWith(
+      ['/usr/bin/openssl', '/opt/impostor/openssl'],
+      '/opt/impostor',
+    );
+
+    expect(found).toBe('/usr/bin/openssl');
+  });
+
+  it('falls back to the first entry on PATH holding one', async () => {
+    const found = await resolvedWith(['/opt/tools/openssl'], '/nothing/here:/opt/tools');
+
+    expect(found).toBe('/opt/tools/openssl');
+  });
+
+  it('passes over an empty PATH entry instead of the working directory', async () => {
+    const found = await resolvedWith(['openssl', '/opt/tools/openssl'], ':/opt/tools');
+
+    expect(found).toBe('/opt/tools/openssl');
+  });
+
+  it('answers the bare name when no entry on PATH holds one', async () => {
+    expect(await resolvedWith([], '/nothing/here:/nor/there')).toBe('openssl');
+  });
+
+  it('answers the bare name when there is no PATH to search', async () => {
+    expect(await resolvedWith([], undefined)).toBe('openssl');
+  });
+});

--- a/packages/tv-installer/src/modules/tizen/certificate/openssl.ts
+++ b/packages/tv-installer/src/modules/tizen/certificate/openssl.ts
@@ -1,0 +1,18 @@
+import { existsSync } from 'node:fs';
+import { delimiter, join } from 'node:path';
+
+const INSTALLED_AT = ['/usr/bin/openssl', '/opt/homebrew/bin/openssl', '/usr/local/bin/openssl'];
+
+/**
+ * The openssl to spawn, resolved once. An absolute path is preferred over a
+ * PATH lookup so that nothing earlier on PATH can stand in for it.
+ */
+export const OPENSSL = INSTALLED_AT.find((path) => existsSync(path)) ?? onPath() ?? 'openssl';
+
+function onPath(): string | null {
+  for (const directory of (process.env.PATH ?? '').split(delimiter)) {
+    const candidate = join(directory, 'openssl');
+    if (directory !== '' && existsSync(candidate)) return candidate;
+  }
+  return null;
+}

--- a/packages/tv-installer/src/modules/tizen/certificate/password.ts
+++ b/packages/tv-installer/src/modules/tizen/certificate/password.ts
@@ -1,0 +1,10 @@
+import { randomBytes } from 'node:crypto';
+
+const BYTES = 24;
+
+/**
+ * The password a generated PKCS#12 is locked with. It is written beside the
+ * archive rather than chosen by anyone, so nothing has to print it, type it or
+ * carry it in a shell history.
+ */
+export const randomPassword = () => randomBytes(BYTES).toString('base64url');

--- a/packages/tv-installer/src/modules/tizen/certificate/pkcs12.fixture.ts
+++ b/packages/tv-installer/src/modules/tizen/certificate/pkcs12.fixture.ts
@@ -1,0 +1,64 @@
+import { spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+import type { ProfileKey } from './profile';
+
+const PASSWORD = 'kroma-dev';
+const RSA = ['-newkey', 'rsa:2048', '-nodes'];
+const ONE_DAY = ['-days', '1'];
+const subject = (name: string) => ['-subj', `/CN=${name}/O=KROMA/C=CH`];
+
+function openssl(args: string[]): void {
+  const result = spawnSync('openssl', args, { encoding: 'utf8' });
+  if (result.status !== 0) throw new Error(`openssl ${args[0]}: ${result.stderr ?? result.error}`);
+}
+
+/**
+ * A PKCS#12 written under `directory`, holding a throwaway key and the throwaway
+ * authority that issued it, so the chain is two deep as a Samsung one is.
+ */
+export function writeArchive(directory: string, name: string): ProfileKey {
+  const at = (suffix: string) => join(directory, `${name}.${suffix}`);
+
+  openssl([
+    'req',
+    '-x509',
+    ...RSA,
+    ...ONE_DAY,
+    '-keyout',
+    at('ca.key'),
+    '-out',
+    at('ca.crt'),
+    ...subject(`${name} authority`),
+  ]);
+  openssl(['req', ...RSA, '-keyout', at('key'), '-out', at('csr'), ...subject(name)]);
+  openssl([
+    'x509',
+    '-req',
+    ...ONE_DAY,
+    '-in',
+    at('csr'),
+    '-CA',
+    at('ca.crt'),
+    '-CAkey',
+    at('ca.key'),
+    '-CAcreateserial',
+    '-out',
+    at('crt'),
+  ]);
+  openssl([
+    'pkcs12',
+    '-export',
+    '-inkey',
+    at('key'),
+    '-in',
+    at('crt'),
+    '-certfile',
+    at('ca.crt'),
+    '-out',
+    at('p12'),
+    '-passout',
+    `pass:${PASSWORD}`,
+  ]);
+
+  return { archive: at('p12'), password: PASSWORD };
+}

--- a/packages/tv-installer/src/modules/tizen/certificate/pkcs12.fixture.ts
+++ b/packages/tv-installer/src/modules/tizen/certificate/pkcs12.fixture.ts
@@ -1,14 +1,15 @@
 import { spawnSync } from 'node:child_process';
 import { join } from 'node:path';
+import { OPENSSL } from './openssl';
+import { randomPassword } from './password';
 import type { ProfileKey } from './profile';
 
-const PASSWORD = 'kroma-dev';
 const RSA = ['-newkey', 'rsa:2048', '-nodes'];
 const ONE_DAY = ['-days', '1'];
 const subject = (name: string) => ['-subj', `/CN=${name}/O=KROMA/C=CH`];
 
 function openssl(args: string[]): void {
-  const result = spawnSync('openssl', args, { encoding: 'utf8' });
+  const result = spawnSync(OPENSSL, args, { encoding: 'utf8' });
   if (result.status !== 0) throw new Error(`openssl ${args[0]}: ${result.stderr ?? result.error}`);
 }
 
@@ -18,6 +19,7 @@ function openssl(args: string[]): void {
  */
 export function writeArchive(directory: string, name: string): ProfileKey {
   const at = (suffix: string) => join(directory, `${name}.${suffix}`);
+  const password = randomPassword();
 
   openssl([
     'req',
@@ -57,8 +59,8 @@ export function writeArchive(directory: string, name: string): ProfileKey {
     '-out',
     at('p12'),
     '-passout',
-    `pass:${PASSWORD}`,
+    `pass:${password}`,
   ]);
 
-  return { archive: at('p12'), password: PASSWORD };
+  return { archive: at('p12'), password };
 }

--- a/packages/tv-installer/src/modules/tizen/certificate/pkcs12.test.ts
+++ b/packages/tv-installer/src/modules/tizen/certificate/pkcs12.test.ts
@@ -1,0 +1,32 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+import { readPkcs12 } from './pkcs12';
+import { writeArchive } from './pkcs12.fixture';
+
+const directory = mkdtempSync(join(tmpdir(), 'kroma-pkcs12-'));
+const issued = writeArchive(directory, 'leaf');
+
+afterAll(() => rmSync(directory, { recursive: true, force: true }));
+
+describe('readPkcs12', () => {
+  it('returns the chain leaf first, then the authority that issued it', () => {
+    const { chain } = readPkcs12(issued);
+
+    expect(chain.map((certificate) => certificate.subject)).toEqual([
+      expect.stringContaining('CN=leaf'),
+      expect.stringContaining('CN=leaf authority'),
+    ]);
+  });
+
+  it('returns the key the leaf certificate belongs to', () => {
+    const { chain, key } = readPkcs12(issued);
+
+    expect(chain[0]?.checkPrivateKey(key)).toBe(true);
+  });
+
+  it('names the archive the password did not open', () => {
+    expect(() => readPkcs12({ ...issued, password: 'wrong' })).toThrow(issued.archive);
+  });
+});

--- a/packages/tv-installer/src/modules/tizen/certificate/pkcs12.ts
+++ b/packages/tv-installer/src/modules/tizen/certificate/pkcs12.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from 'node:child_process';
 import { createPrivateKey, type KeyObject, X509Certificate } from 'node:crypto';
+import { OPENSSL } from './openssl';
 import type { ProfileKey } from './profile';
 
 const PEM_BLOCK = /-----BEGIN ([A-Z ]+)-----[^-]+-----END \1-----/g;
@@ -15,7 +16,7 @@ export interface Pkcs12 {
  * key comes back over a pipe, so neither reaches the process table or the disk.
  */
 export function readPkcs12({ archive, password }: ProfileKey): Pkcs12 {
-  const openssl = spawnSync('openssl', ['pkcs12', '-in', archive, '-passin', 'stdin', '-nodes'], {
+  const openssl = spawnSync(OPENSSL, ['pkcs12', '-in', archive, '-passin', 'stdin', '-nodes'], {
     input: `${password}\n`,
     encoding: 'utf8',
   });
@@ -42,7 +43,7 @@ function chainFrom(certificates: X509Certificate[], key: KeyObject): X509Certifi
   const chain = [leaf];
   const rest = certificates.filter((certificate) => certificate !== leaf);
   while (rest.length > 0) {
-    const issuer = chain[chain.length - 1]?.issuer;
+    const issuer = chain.at(-1)?.issuer;
     const next = rest.findIndex((certificate) => certificate.subject === issuer);
     if (next < 0) break;
     chain.push(...rest.splice(next, 1));

--- a/packages/tv-installer/src/modules/tizen/certificate/pkcs12.ts
+++ b/packages/tv-installer/src/modules/tizen/certificate/pkcs12.ts
@@ -1,0 +1,51 @@
+import { spawnSync } from 'node:child_process';
+import { createPrivateKey, type KeyObject, X509Certificate } from 'node:crypto';
+import type { ProfileKey } from './profile';
+
+const PEM_BLOCK = /-----BEGIN ([A-Z ]+)-----[^-]+-----END \1-----/g;
+
+export interface Pkcs12 {
+  key: KeyObject;
+  chain: X509Certificate[];
+}
+
+/**
+ * The signing key and its certificate chain, leaf first. `node:crypto` cannot
+ * open a PKCS#12, so openssl unpacks it; the password goes in over stdin and the
+ * key comes back over a pipe, so neither reaches the process table or the disk.
+ */
+export function readPkcs12({ archive, password }: ProfileKey): Pkcs12 {
+  const openssl = spawnSync('openssl', ['pkcs12', '-in', archive, '-passin', 'stdin', '-nodes'], {
+    input: `${password}\n`,
+    encoding: 'utf8',
+  });
+  if (openssl.error) throw new Error('openssl is needed to read a .p12 and is not here');
+  if (openssl.status !== 0) {
+    throw new Error(`openssl could not open ${archive}: ${openssl.stderr.trim()}`);
+  }
+
+  const blocks = [...openssl.stdout.matchAll(PEM_BLOCK)];
+  const keyBlock = blocks.find(([, label]) => label?.endsWith('PRIVATE KEY'));
+  if (!keyBlock) throw new Error(`${archive} holds no private key`);
+
+  const key = createPrivateKey(keyBlock[0]);
+  const certificates = blocks
+    .filter(([, label]) => label === 'CERTIFICATE')
+    .map(([block]) => new X509Certificate(block));
+  return { key, chain: chainFrom(certificates, key) };
+}
+
+function chainFrom(certificates: X509Certificate[], key: KeyObject): X509Certificate[] {
+  const leaf = certificates.find((certificate) => certificate.checkPrivateKey(key));
+  if (!leaf) throw new Error('no certificate in the .p12 belongs to its private key');
+
+  const chain = [leaf];
+  const rest = certificates.filter((certificate) => certificate !== leaf);
+  while (rest.length > 0) {
+    const issuer = chain[chain.length - 1]?.issuer;
+    const next = rest.findIndex((certificate) => certificate.subject === issuer);
+    if (next < 0) break;
+    chain.push(...rest.splice(next, 1));
+  }
+  return chain;
+}

--- a/packages/tv-installer/src/modules/tizen/certificate/profile.test.ts
+++ b/packages/tv-installer/src/modules/tizen/certificate/profile.test.ts
@@ -1,7 +1,34 @@
-import { describe, expect, it } from 'vitest';
+import { randomInt } from 'node:crypto';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
+import { homedir, tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
 import { profilesXml } from './profile';
 
 const author = { archive: '/home/max/.kroma/certificates/kroma/author.p12', password: 'kroma-dev' };
+
+const bases: string[] = [];
+
+function tizenData(): string {
+  const base = mkdtempSync(join(tmpdir(), 'kroma-profile-'));
+  bases.push(base);
+  return join(base, `tizen-studio-data-${randomInt(1000, 9999)}`);
+}
+
+const profileName = () => `kroma-${randomInt(1000, 9999)}`;
+
+async function writerUnder(data: string | undefined) {
+  vi.stubEnv('TIZEN_DATA', data);
+  vi.resetModules();
+  return await import('./profile');
+}
+
+afterEach(() => vi.unstubAllEnvs());
+
+afterAll(() => {
+  for (const base of bases) rmSync(base, { recursive: true, force: true });
+});
 
 describe('profilesXml', () => {
   it('makes the profile it writes the active one', () => {
@@ -36,5 +63,46 @@ describe('profilesXml', () => {
     const xml = profilesXml({ name: 'a"b&c', author });
 
     expect(xml).toContain('active="a&quot;b&amp;c"');
+  });
+});
+
+describe('writeProfile', () => {
+  it('writes the profile where the Tizen tools read theirs from', async () => {
+    const data = tizenData();
+    const request = { name: profileName(), author };
+    const { writeProfile } = await writerUnder(data);
+
+    const path = await writeProfile(request);
+
+    expect(path).toBe(join(data, 'profile', 'profiles.xml'));
+    expect(readFileSync(path, 'utf8')).toBe(profilesXml(request));
+  });
+
+  it('refuses a profiles.xml that already holds someone else, and names it', async () => {
+    const data = tizenData();
+    const registered = profileName();
+    const { writeProfile, PROFILES_XML } = await writerUnder(data);
+    await mkdir(dirname(PROFILES_XML), { recursive: true });
+    writeFileSync(PROFILES_XML, profilesXml({ name: registered, author }));
+
+    await expect(writeProfile({ name: profileName(), author })).rejects.toThrow(PROFILES_XML);
+
+    expect(readFileSync(PROFILES_XML, 'utf8')).toContain(`active="${registered}"`);
+  });
+});
+
+describe('PROFILES_XML', () => {
+  it('is the Tizen data directory the environment names', async () => {
+    const data = tizenData();
+
+    const { PROFILES_XML } = await writerUnder(data);
+
+    expect(PROFILES_XML).toBe(join(data, 'profile', 'profiles.xml'));
+  });
+
+  it('falls back to the studio data directory in the home when nothing names one', async () => {
+    const { PROFILES_XML } = await writerUnder(undefined);
+
+    expect(PROFILES_XML).toBe(join(homedir(), 'tizen-studio-data', 'profile', 'profiles.xml'));
   });
 });

--- a/packages/tv-installer/src/modules/tizen/certificate/profile.test.ts
+++ b/packages/tv-installer/src/modules/tizen/certificate/profile.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { profilesXml } from './profile';
+
+const author = { archive: '/home/max/.kroma/certificates/kroma/author.p12', password: 'kroma-dev' };
+
+describe('profilesXml', () => {
+  it('makes the profile it writes the active one', () => {
+    expect(profilesXml({ name: 'kroma', author })).toContain('<profiles active="kroma"');
+  });
+
+  it('puts the author key in the slot the tools read it from', () => {
+    const xml = profilesXml({ name: 'kroma', author });
+
+    expect(xml).toContain(`distributor="0" key="${author.archive}" password="kroma-dev"`);
+  });
+
+  it('leaves the distributor slots empty when Samsung issued nothing', () => {
+    const xml = profilesXml({ name: 'kroma', author });
+
+    expect(xml).toContain('distributor="1" key="" password=""');
+    expect(xml).toContain('distributor="2" key="" password=""');
+  });
+
+  it('carries a Samsung distributor certificate when there is one', () => {
+    const distributor = {
+      archive: '/home/max/SamsungCertificate/LUMA/distributor.p12',
+      password: 'x',
+    };
+
+    const xml = profilesXml({ name: 'LUMA', author, distributor });
+
+    expect(xml).toContain(`distributor="1" key="${distributor.archive}"`);
+  });
+
+  it('escapes what would otherwise close an attribute', () => {
+    const xml = profilesXml({ name: 'a"b&c', author });
+
+    expect(xml).toContain('active="a&quot;b&amp;c"');
+  });
+});

--- a/packages/tv-installer/src/modules/tizen/certificate/profile.ts
+++ b/packages/tv-installer/src/modules/tizen/certificate/profile.ts
@@ -1,0 +1,55 @@
+import { existsSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+export const PROFILES_XML = join(
+  process.env.TIZEN_DATA ?? join(homedir(), 'tizen-studio-data'),
+  'profile',
+  'profiles.xml',
+);
+
+export interface ProfileKey {
+  archive: string;
+  password: string;
+}
+
+export interface ProfileRequest {
+  name: string;
+  author: ProfileKey;
+  distributor?: ProfileKey;
+}
+
+const attribute = (value: string) =>
+  value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
+
+export function profilesXml(request: ProfileRequest): string {
+  const item = (index: number, key: ProfileKey | undefined) =>
+    `<profileitem ca="" distributor="${index}" key="${attribute(key?.archive ?? '')}" password="${attribute(key?.password ?? '')}" rootca=""/>`;
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8" standalone="no"?>',
+    `<profiles active="${attribute(request.name)}" version="3.1">`,
+    `<profile name="${attribute(request.name)}">`,
+    item(0, request.author),
+    item(1, request.distributor),
+    item(2, undefined),
+    '</profile>',
+    '</profiles>',
+    '',
+  ].join('\n');
+}
+
+/**
+ * Writes the profile the Tizen tools sign with. It refuses a file that already
+ * exists: the Tizen CLI merges into that one, and this writer would take the
+ * other profiles with it.
+ */
+export async function writeProfile(request: ProfileRequest): Promise<string> {
+  if (existsSync(PROFILES_XML)) {
+    throw new Error(`${PROFILES_XML} already holds profiles: add to it with the Tizen CLI`);
+  }
+  await mkdir(dirname(PROFILES_XML), { recursive: true });
+  await writeFile(PROFILES_XML, profilesXml(request));
+  return PROFILES_XML;
+}

--- a/packages/tv-installer/src/modules/tizen/certificate/profile.ts
+++ b/packages/tv-installer/src/modules/tizen/certificate/profile.ts
@@ -21,7 +21,7 @@ export interface ProfileRequest {
 }
 
 const attribute = (value: string) =>
-  value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
+  value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('"', '&quot;');
 
 export function profilesXml(request: ProfileRequest): string {
   const item = (index: number, key: ProfileKey | undefined) =>

--- a/packages/tv-installer/src/modules/tizen/certificate/widget-resources.test.ts
+++ b/packages/tv-installer/src/modules/tizen/certificate/widget-resources.test.ts
@@ -1,0 +1,60 @@
+import { rmSync } from 'node:fs';
+import { afterAll, describe, expect, it } from 'vitest';
+import { writeWidget } from './widget.fixture';
+import { widgetResources } from './widget-resources';
+
+const directory = writeWidget({
+  'config.xml': '',
+  'index.html': '',
+  '.manifest.tmp': '',
+  '.delta.lst': '',
+  'author-signature.xml': '',
+  'signature1.xml': '',
+  'signature12.xml': '',
+  'legacy!.txt': '',
+  'legacy.txt': '',
+  'legacy/index.js': '',
+  'legacy~.txt': '',
+  'assets/app main.js': '',
+  'accentué.txt': '',
+});
+
+const paths = (role: 'author' | 'distributor') =>
+  widgetResources(directory, role).map((resource) => resource.path);
+
+const uriOf = (path: string) =>
+  widgetResources(directory, 'author').find((resource) => resource.path === path)?.uri;
+
+afterAll(() => rmSync(directory, { recursive: true, force: true }));
+
+describe('widgetResources', () => {
+  it('orders by the path a slash still separates, not by the escaped form', () => {
+    expect(paths('author').filter((path) => path.startsWith('legacy'))).toEqual([
+      'legacy!.txt',
+      'legacy.txt',
+      'legacy/index.js',
+      'legacy~.txt',
+    ]);
+  });
+
+  it('escapes the separator and the space Tizen calls unsafe, in upper case', () => {
+    expect(uriOf('assets/app main.js')).toBe('assets%2Fapp%20main.js');
+    expect(uriOf('legacy~.txt')).toBe('legacy%7E.txt');
+  });
+
+  it('escapes a name outside ASCII as UTF-8', () => {
+    expect(uriOf('accentué.txt')).toBe('accentu%C3%A9.txt');
+  });
+
+  it('leaves out the packaging leftovers and every distributor signature', () => {
+    expect(paths('distributor')).not.toContain('.manifest.tmp');
+    expect(paths('distributor')).not.toContain('.delta.lst');
+    expect(paths('distributor')).not.toContain('signature1.xml');
+    expect(paths('distributor')).not.toContain('signature12.xml');
+  });
+
+  it('covers the author signature from the distributor and never from the author', () => {
+    expect(paths('author')).not.toContain('author-signature.xml');
+    expect(paths('distributor')).toContain('author-signature.xml');
+  });
+});

--- a/packages/tv-installer/src/modules/tizen/certificate/widget-resources.ts
+++ b/packages/tv-installer/src/modules/tizen/certificate/widget-resources.ts
@@ -1,0 +1,64 @@
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import type { SignatureRole } from './widget-signature';
+
+const BUILD_LEFTOVERS = ['.manifest.tmp', '.delta.lst'];
+const AUTHOR_SIGNATURE = 'author-signature.xml';
+const DISTRIBUTOR_SIGNATURE = /^signature[1-9]\d*\.xml$/;
+const UNSAFE = '% <>#{}|\\^~[]`;/?@=&$!*:+';
+const ATTRIBUTE: Record<string, string> = {
+  '"': '&quot;',
+  '\t': '&#x9;',
+  '\n': '&#xA;',
+  '\r': '&#xD;',
+};
+
+export interface WidgetResource {
+  path: string;
+  uri: string;
+}
+
+/**
+ * Every file a widget signature covers, in the order Tizen lists them: relative
+ * paths sorted by UTF-16 code unit, then percent-escaped. Signature files and
+ * packaging leftovers are left out wherever in the tree they sit, and an author
+ * signature also leaves out itself.
+ */
+export function widgetResources(directory: string, role: SignatureRole): WidgetResource[] {
+  return walk(directory, '')
+    .filter((path) => !excluded(path.split('/').at(-1) ?? path, role))
+    .sort((left, right) => (left < right ? -1 : 1))
+    .map((path) => ({ path, uri: escapeUri(path) }));
+}
+
+// A symlink is never followed: a widget carries none, and a tree that has one
+// pointing at an ancestor makes this walk run until the machine gives up.
+function walk(directory: string, prefix: string): string[] {
+  const found: string[] = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const relative = prefix ? `${prefix}/${entry.name}` : entry.name;
+    if (entry.isSymbolicLink()) continue;
+    if (entry.isDirectory()) found.push(...walk(join(directory, entry.name), relative));
+    else if (entry.isFile()) found.push(relative);
+  }
+  return found;
+}
+
+function excluded(name: string, role: SignatureRole): boolean {
+  if (BUILD_LEFTOVERS.includes(name) || DISTRIBUTOR_SIGNATURE.test(name)) return true;
+  return role === 'author' && name === AUTHOR_SIGNATURE;
+}
+
+function escapeUri(path: string): string {
+  let escaped = '';
+  for (const character of path) {
+    const code = character.codePointAt(0) ?? 0;
+    if (code > 127) escaped += percent(Buffer.from(character, 'utf8'));
+    else if (UNSAFE.includes(character)) escaped += percent(Buffer.from(character, 'ascii'));
+    else escaped += ATTRIBUTE[character] ?? character;
+  }
+  return escaped;
+}
+
+const percent = (bytes: Buffer) =>
+  [...bytes].map((byte) => `%${byte.toString(16).toUpperCase().padStart(2, '0')}`).join('');

--- a/packages/tv-installer/src/modules/tizen/certificate/widget-resources.ts
+++ b/packages/tv-installer/src/modules/tizen/certificate/widget-resources.ts
@@ -2,7 +2,7 @@ import { readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import type { SignatureRole } from './widget-signature';
 
-const BUILD_LEFTOVERS = ['.manifest.tmp', '.delta.lst'];
+const BUILD_LEFTOVERS = new Set(['.manifest.tmp', '.delta.lst']);
 const AUTHOR_SIGNATURE = 'author-signature.xml';
 const DISTRIBUTOR_SIGNATURE = /^signature[1-9]\d*\.xml$/;
 const UNSAFE = '% <>#{}|\\^~[]`;/?@=&$!*:+';
@@ -45,7 +45,7 @@ function walk(directory: string, prefix: string): string[] {
 }
 
 function excluded(name: string, role: SignatureRole): boolean {
-  if (BUILD_LEFTOVERS.includes(name) || DISTRIBUTOR_SIGNATURE.test(name)) return true;
+  if (BUILD_LEFTOVERS.has(name) || DISTRIBUTOR_SIGNATURE.test(name)) return true;
   return role === 'author' && name === AUTHOR_SIGNATURE;
 }
 

--- a/packages/tv-installer/src/modules/tizen/certificate/widget-signature.ts
+++ b/packages/tv-installer/src/modules/tizen/certificate/widget-signature.ts
@@ -1,0 +1,108 @@
+import { createHash, createSign, type KeyObject, type X509Certificate } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { WidgetResource } from './widget-resources';
+
+const DSIG = 'http://www.w3.org/2000/09/xmldsig#';
+const EXCLUSIVE_C14N = 'http://www.w3.org/2001/10/xml-exc-c14n#';
+const RSA_SHA512 = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha512';
+const SHA512 = 'http://www.w3.org/2001/04/xmlenc#sha512';
+const C14N11 = 'http://www.w3.org/2006/12/xml-c14n11';
+const PROPERTIES = 'http://www.w3.org/2009/xmldsig-properties';
+const DIGSIG = 'http://www.w3.org/ns/widgets-digsig';
+const BASE64_COLUMNS = 76;
+const CHAIN_LIMIT = 3;
+
+export type SignatureRole = 'author' | 'distributor';
+
+export interface WidgetSignatureRequest {
+  directory: string;
+  resources: readonly WidgetResource[];
+  role: SignatureRole;
+  key: KeyObject;
+  chain: readonly X509Certificate[];
+}
+
+/**
+ * One widget signature document, emitted already canonical: the bytes are what
+ * exclusive c14n would produce, so `SignedInfo` is signed as written rather than
+ * re-serialised. Identical to `tizen package -t wgt` down to the byte.
+ */
+export function widgetSignature(request: WidgetSignatureRequest): string {
+  const { chain, directory, key, resources, role } = request;
+  const id = role === 'author' ? 'AuthorSignature' : 'DistributorSignature';
+  const properties = signatureProperties(id, role);
+
+  const references = [
+    ...resources.map((resource) =>
+      fileReference(resource.uri, digest(readFileSync(join(directory, resource.path)))),
+    ),
+    propertyReference(digest(Buffer.from(objectElement(properties, ` xmlns="${DSIG}"`), 'utf8'))),
+  ];
+  const signedInfo = (open: string) =>
+    [
+      open,
+      `<CanonicalizationMethod Algorithm="${EXCLUSIVE_C14N}"></CanonicalizationMethod>`,
+      `<SignatureMethod Algorithm="${RSA_SHA512}"></SignatureMethod>`,
+      ...references,
+      '</SignedInfo>',
+    ].join('\n');
+  const signature = createSign('RSA-SHA512')
+    .update(signedInfo(`<SignedInfo xmlns="${DSIG}">`), 'utf8')
+    .sign(key);
+
+  return [
+    `<Signature xmlns="${DSIG}" Id="${id}">`,
+    signedInfo('<SignedInfo>'),
+    `<SignatureValue>\n${wrap(signature)}\n</SignatureValue>`,
+    '<KeyInfo>',
+    '<X509Data>',
+    ...chain
+      .slice(0, CHAIN_LIMIT)
+      .map((certificate) => `<X509Certificate>\n${wrap(certificate.raw)}\n</X509Certificate>`),
+    '</X509Data>',
+    '</KeyInfo>',
+    objectElement(properties, ''),
+    '</Signature>',
+  ].join('\n');
+}
+
+const objectElement = (properties: string, namespace: string) =>
+  `<Object${namespace} Id="prop">${properties}</Object>`;
+
+const signatureProperties = (target: string, role: SignatureRole) =>
+  [
+    `<SignatureProperties xmlns:dsp="${PROPERTIES}">`,
+    property('profile', target, `<dsp:Profile URI="${DIGSIG}#profile"></dsp:Profile>`),
+    property('role', target, `<dsp:Role URI="${DIGSIG}#role-${role}"></dsp:Role>`),
+    property('identifier', target, '<dsp:Identifier></dsp:Identifier>'),
+    '</SignatureProperties>',
+  ].join('');
+
+const property = (name: string, target: string, value: string) =>
+  `<SignatureProperty Id="${name}" Target="#${target}">${value}</SignatureProperty>`;
+
+const fileReference = (uri: string, value: string) =>
+  [
+    `<Reference URI="${uri}">`,
+    `<DigestMethod Algorithm="${SHA512}"></DigestMethod>`,
+    `<DigestValue>${value}</DigestValue>`,
+    '</Reference>',
+  ].join('\n');
+
+const propertyReference = (value: string) =>
+  [
+    '<Reference URI="#prop">',
+    '<Transforms>',
+    `<Transform Algorithm="${C14N11}"></Transform>`,
+    '</Transforms>',
+    `<DigestMethod Algorithm="${SHA512}"></DigestMethod>`,
+    `<DigestValue>${value}</DigestValue>`,
+    '</Reference>',
+  ].join('\n');
+
+const digest = (bytes: Buffer) => wrap(createHash('sha512').update(bytes).digest());
+
+const BASE64_LINE = new RegExp(`.{${BASE64_COLUMNS}}`, 'g');
+
+const wrap = (bytes: Buffer) => bytes.toString('base64').replace(BASE64_LINE, '$&\n').trimEnd();

--- a/packages/tv-installer/src/modules/tizen/certificate/widget.fixture.ts
+++ b/packages/tv-installer/src/modules/tizen/certificate/widget.fixture.ts
@@ -1,0 +1,102 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+export const WIDGET_FILES: Record<string, string> = {
+  'config.xml': `<?xml version="1.0" encoding="UTF-8"?>
+<widget xmlns="http://www.w3.org/ns/widgets" xmlns:tizen="http://tizen.org/ns/widgets" id="http://kroma.tv/fixture" version="1.0.0" viewmodes="maximized">
+  <tizen:application id="KromaTV001.FIXTURE" package="KromaTV001" required_version="6.0"/>
+  <content src="index.html"/>
+  <name>FIXTURE</name>
+  <tizen:profile name="tv"/>
+</widget>
+`,
+  'index.html': `<!doctype html>
+<title>fixture</title>
+`,
+  'assets/app main.js': `export const kroma = 1;
+`,
+};
+
+export const AUTHOR_SIGNATURE = `<Signature xmlns="http://www.w3.org/2000/09/xmldsig#" Id="AuthorSignature">
+<SignedInfo>
+<CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"></CanonicalizationMethod>
+<SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha512"></SignatureMethod>
+<Reference URI="assets%2Fapp%20main.js">
+<DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></DigestMethod>
+<DigestValue>ghTRLHaKyWpXopaRzqX0gVvYYGh7KgDXzz5qlyPsCZxuJ/p0tGgb1gKmxPoJNZDBgKxNIiHETqxu
+Kv8z8lOAaA==</DigestValue>
+</Reference>
+<Reference URI="config.xml">
+<DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></DigestMethod>
+<DigestValue>E9IieFtveRQ9PQK+bopWRxrrd911oq/yw+VT8OVCZOH/Gm6dhK9hhKmdXHncV6W6M/gMekWYXAaN
+5owExF6WyQ==</DigestValue>
+</Reference>
+<Reference URI="index.html">
+<DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></DigestMethod>
+<DigestValue>DbDCOYg9U+gHT4ohlUF28q+iWQCcj1LpGGq7SHUcXexKuKQq8N7tqqE//oyLgIfkUkpgACPLv978
+llyC80222w==</DigestValue>
+</Reference>
+<Reference URI="#prop">
+<Transforms>
+<Transform Algorithm="http://www.w3.org/2006/12/xml-c14n11"></Transform>
+</Transforms>
+<DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></DigestMethod>
+<DigestValue>aXbSAVgmAz0GsBUeZ1UmNDRrxkWhDUVGb45dZcNRq429wX3X+x6kaXT3NdNDTSNVTU+ypkysPMGv
+QY10fG1EWQ==</DigestValue>
+</Reference>
+</SignedInfo>
+<SignatureValue>SIGNER</SignatureValue>
+<KeyInfo>
+<X509Data>SIGNER</X509Data>
+</KeyInfo>
+<Object Id="prop"><SignatureProperties xmlns:dsp="http://www.w3.org/2009/xmldsig-properties"><SignatureProperty Id="profile" Target="#AuthorSignature"><dsp:Profile URI="http://www.w3.org/ns/widgets-digsig#profile"></dsp:Profile></SignatureProperty><SignatureProperty Id="role" Target="#AuthorSignature"><dsp:Role URI="http://www.w3.org/ns/widgets-digsig#role-author"></dsp:Role></SignatureProperty><SignatureProperty Id="identifier" Target="#AuthorSignature"><dsp:Identifier></dsp:Identifier></SignatureProperty></SignatureProperties></Object>
+</Signature>`;
+
+export const DISTRIBUTOR_SIGNATURE = `<Signature xmlns="http://www.w3.org/2000/09/xmldsig#" Id="DistributorSignature">
+<SignedInfo>
+<CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"></CanonicalizationMethod>
+<SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha512"></SignatureMethod>
+<Reference URI="assets%2Fapp%20main.js">
+<DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></DigestMethod>
+<DigestValue>ghTRLHaKyWpXopaRzqX0gVvYYGh7KgDXzz5qlyPsCZxuJ/p0tGgb1gKmxPoJNZDBgKxNIiHETqxu
+Kv8z8lOAaA==</DigestValue>
+</Reference>
+<Reference URI="author-signature.xml">
+<DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></DigestMethod>
+<DigestValue>SIGNER</DigestValue>
+</Reference>
+<Reference URI="config.xml">
+<DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></DigestMethod>
+<DigestValue>E9IieFtveRQ9PQK+bopWRxrrd911oq/yw+VT8OVCZOH/Gm6dhK9hhKmdXHncV6W6M/gMekWYXAaN
+5owExF6WyQ==</DigestValue>
+</Reference>
+<Reference URI="index.html">
+<DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></DigestMethod>
+<DigestValue>DbDCOYg9U+gHT4ohlUF28q+iWQCcj1LpGGq7SHUcXexKuKQq8N7tqqE//oyLgIfkUkpgACPLv978
+llyC80222w==</DigestValue>
+</Reference>
+<Reference URI="#prop">
+<Transforms>
+<Transform Algorithm="http://www.w3.org/2006/12/xml-c14n11"></Transform>
+</Transforms>
+<DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></DigestMethod>
+<DigestValue>/r5npk2VVA46QFJnejgONBEh4BWtjrtu9x/IFeLksjWyGmB/cMWKSJWQl7aU3YRQRZ3AesG8gF7q
+GyvKX9Snig==</DigestValue>
+</Reference>
+</SignedInfo>
+<SignatureValue>SIGNER</SignatureValue>
+<KeyInfo>
+<X509Data>SIGNER</X509Data>
+</KeyInfo>
+<Object Id="prop"><SignatureProperties xmlns:dsp="http://www.w3.org/2009/xmldsig-properties"><SignatureProperty Id="profile" Target="#DistributorSignature"><dsp:Profile URI="http://www.w3.org/ns/widgets-digsig#profile"></dsp:Profile></SignatureProperty><SignatureProperty Id="role" Target="#DistributorSignature"><dsp:Role URI="http://www.w3.org/ns/widgets-digsig#role-distributor"></dsp:Role></SignatureProperty><SignatureProperty Id="identifier" Target="#DistributorSignature"><dsp:Identifier></dsp:Identifier></SignatureProperty></SignatureProperties></Object>
+</Signature>`;
+/** Writes the files into a fresh temporary directory and returns its path. */
+export function writeWidget(files: Record<string, string>): string {
+  const directory = mkdtempSync(join(tmpdir(), 'kroma-widget-'));
+  for (const [name, content] of Object.entries(files)) {
+    mkdirSync(dirname(join(directory, name)), { recursive: true });
+    writeFileSync(join(directory, name), content);
+  }
+  return directory;
+}

--- a/packages/tv-installer/src/modules/tizen/certificate/widget.test.ts
+++ b/packages/tv-installer/src/modules/tizen/certificate/widget.test.ts
@@ -1,0 +1,98 @@
+import { createVerify, X509Certificate } from 'node:crypto';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { writeArchive } from './pkcs12.fixture';
+import { signWidget } from './widget';
+import {
+  AUTHOR_SIGNATURE,
+  DISTRIBUTOR_SIGNATURE,
+  WIDGET_FILES,
+  writeWidget,
+} from './widget.fixture';
+
+const DSIG = 'http://www.w3.org/2000/09/xmldsig#';
+
+const between = (xml: string, tag: string) =>
+  xml.slice(xml.indexOf(`<${tag}>`) + tag.length + 2, xml.indexOf(`</${tag}>`));
+
+const withoutSignerBytes = (xml: string) =>
+  xml
+    .replace(
+      /<SignatureValue>[\s\S]*?<\/SignatureValue>/,
+      '<SignatureValue>SIGNER</SignatureValue>',
+    )
+    .replace(/<X509Data>[\s\S]*?<\/X509Data>/, '<X509Data>SIGNER</X509Data>')
+    .replace(
+      /(<Reference URI="author-signature\.xml">[\s\S]*?<DigestValue>)[\s\S]*?(<\/DigestValue>)/,
+      '$1SIGNER$2',
+    );
+
+function signedInfoVerifies(xml: string): boolean {
+  const end = xml.indexOf('</SignedInfo>') + '</SignedInfo>'.length;
+  const signedInfo = xml
+    .slice(xml.indexOf('<SignedInfo>'), end)
+    .replace('<SignedInfo>', `<SignedInfo xmlns="${DSIG}">`);
+  const certificate = new X509Certificate(Buffer.from(between(xml, 'X509Certificate'), 'base64'));
+  return createVerify('RSA-SHA512')
+    .update(signedInfo, 'utf8')
+    .verify(certificate.publicKey, Buffer.from(between(xml, 'SignatureValue'), 'base64'));
+}
+
+const temporary: string[] = [];
+const keys = mkdtempSync(join(tmpdir(), 'kroma-widget-keys-'));
+const author = writeArchive(keys, 'author');
+let directory = '';
+let written: string[] = [];
+
+beforeAll(async () => {
+  directory = writeWidget(WIDGET_FILES);
+  temporary.push(keys, directory);
+
+  written = await signWidget({
+    directory,
+    author,
+    distributor: writeArchive(keys, 'distributor'),
+  });
+});
+
+afterAll(() => {
+  for (const path of temporary) rmSync(path, { recursive: true, force: true });
+});
+
+describe('signWidget', () => {
+  it('writes the author signature first, because the distributor covers it', () => {
+    expect(written).toEqual([
+      join(directory, 'author-signature.xml'),
+      join(directory, 'signature1.xml'),
+    ]);
+  });
+
+  it('writes the author signature tizen package writes, byte for byte', () => {
+    const xml = readFileSync(join(directory, 'author-signature.xml'), 'utf8');
+
+    expect(withoutSignerBytes(xml)).toBe(AUTHOR_SIGNATURE);
+  });
+
+  it('writes the distributor signature tizen package writes, byte for byte', () => {
+    const xml = readFileSync(join(directory, 'signature1.xml'), 'utf8');
+
+    expect(withoutSignerBytes(xml)).toBe(DISTRIBUTOR_SIGNATURE);
+  });
+
+  it('signs the SignedInfo a reader canonicalises, not the bytes on disk', () => {
+    for (const path of written) {
+      expect(signedInfoVerifies(readFileSync(path, 'utf8'))).toBe(true);
+    }
+  });
+
+  it('signs with the author alone when Samsung issued no distributor certificate', async () => {
+    const alone = writeWidget(WIDGET_FILES);
+    temporary.push(alone);
+
+    const files = await signWidget({ directory: alone, author });
+
+    expect(files).toEqual([join(alone, 'author-signature.xml')]);
+  });
+});

--- a/packages/tv-installer/src/modules/tizen/certificate/widget.ts
+++ b/packages/tv-installer/src/modules/tizen/certificate/widget.ts
@@ -1,0 +1,46 @@
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { readPkcs12 } from './pkcs12';
+import type { ProfileKey } from './profile';
+import { widgetResources } from './widget-resources';
+import { type SignatureRole, widgetSignature } from './widget-signature';
+
+const FILENAME: Record<SignatureRole, string> = {
+  author: 'author-signature.xml',
+  distributor: 'signature1.xml',
+};
+
+export interface WidgetSigningRequest {
+  directory: string;
+  author: ProfileKey;
+  distributor?: ProfileKey;
+}
+
+/**
+ * Signs a built widget directory in place, writing the same bytes
+ * `tizen package -t wgt -s <profile>` writes, and returns the files written.
+ * The author signs first because the distributor signature covers it; with no
+ * distributor key the widget carries an author signature alone, which only an
+ * emulator accepts.
+ */
+export async function signWidget(request: WidgetSigningRequest): Promise<string[]> {
+  const written = [await sign(request.directory, 'author', request.author)];
+  if (request.distributor) {
+    written.push(await sign(request.directory, 'distributor', request.distributor));
+  }
+  return written;
+}
+
+async function sign(directory: string, role: SignatureRole, profileKey: ProfileKey) {
+  const { chain, key } = readPkcs12(profileKey);
+  const xml = widgetSignature({
+    directory,
+    resources: widgetResources(directory, role),
+    role,
+    key,
+    chain,
+  });
+  const path = join(directory, FILENAME[role]);
+  await writeFile(path, xml);
+  return path;
+}

--- a/packages/tv-installer/src/modules/tizen/certificate/x509.test.ts
+++ b/packages/tv-installer/src/modules/tizen/certificate/x509.test.ts
@@ -66,6 +66,17 @@ describe('toPem', () => {
     expect(pem.trimEnd().endsWith('-----END CERTIFICATE-----')).toBe(true);
   });
 
+  it('leaves no blank line when the body ends exactly on a full line', () => {
+    const exactlyOneLine = Buffer.alloc(48, 3);
+
+    const pem = toPem(exactlyOneLine, 'CERTIFICATE');
+
+    expect(pem.split('\n').filter((line) => line === '')).toHaveLength(1);
+    expect(pem).toBe(
+      `-----BEGIN CERTIFICATE-----\n${exactlyOneLine.toString('base64')}\n-----END CERTIFICATE-----\n`,
+    );
+  });
+
   it('breaks the body at 64 characters', () => {
     const pem = toPem(Buffer.alloc(120, 7), 'CERTIFICATE');
     const [, ...body] = pem.split('\n');

--- a/packages/tv-installer/src/modules/tizen/certificate/x509.test.ts
+++ b/packages/tv-installer/src/modules/tizen/certificate/x509.test.ts
@@ -1,0 +1,75 @@
+import { generateKeyPairSync, X509Certificate } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { selfSignedCertificate, toPem } from './x509';
+
+const keys = generateKeyPairSync('rsa', { modulusLength: 2048 });
+
+const certificate = (days = 1825, from?: Date) =>
+  new X509Certificate(
+    selfSignedCertificate({
+      subject: { commonName: 'KROMA', organization: 'KROMA', country: 'ch' },
+      publicKey: keys.publicKey,
+      privateKey: keys.privateKey,
+      days,
+      from,
+    }),
+  );
+
+describe('selfSignedCertificate', () => {
+  it('writes a certificate the runtime parses back', () => {
+    expect(certificate().subject).toContain('CN=KROMA');
+  });
+
+  it('names the same party as issuer and subject', () => {
+    const parsed = certificate();
+
+    expect(parsed.issuer).toBe(parsed.subject);
+  });
+
+  it('verifies against the key that signed it', () => {
+    expect(certificate().verify(keys.publicKey)).toBe(true);
+  });
+
+  it('carries the country in upper case, as the encoding demands', () => {
+    expect(certificate().subject).toContain('C=CH');
+  });
+
+  it('runs from the given day for as many days as asked', () => {
+    const from = new Date('2026-01-01T00:00:00Z');
+
+    const parsed = certificate(30, from);
+
+    expect(new Date(parsed.validFrom).toISOString()).toBe(from.toISOString());
+    expect(new Date(parsed.validTo).toISOString()).toBe('2026-01-31T00:00:00.000Z');
+  });
+
+  it('signs with SHA-256 and RSA', () => {
+    const sha256WithRsa = Buffer.from('2a864886f70d01010b', 'hex');
+
+    const der = selfSignedCertificate({
+      subject: { commonName: 'KROMA' },
+      publicKey: keys.publicKey,
+      privateKey: keys.privateKey,
+      days: 1,
+    });
+
+    expect(der.includes(sha256WithRsa)).toBe(true);
+    expect(certificate().publicKey.asymmetricKeyType).toBe('rsa');
+  });
+});
+
+describe('toPem', () => {
+  it('wraps the bytes in the armour a certificate file carries', () => {
+    const pem = toPem(Buffer.from('kroma'), 'CERTIFICATE');
+
+    expect(pem.startsWith('-----BEGIN CERTIFICATE-----\n')).toBe(true);
+    expect(pem.trimEnd().endsWith('-----END CERTIFICATE-----')).toBe(true);
+  });
+
+  it('breaks the body at 64 characters', () => {
+    const pem = toPem(Buffer.alloc(120, 7), 'CERTIFICATE');
+    const [, ...body] = pem.split('\n');
+
+    expect(body[0]).toHaveLength(64);
+  });
+});

--- a/packages/tv-installer/src/modules/tizen/certificate/x509.ts
+++ b/packages/tv-installer/src/modules/tizen/certificate/x509.ts
@@ -60,8 +60,8 @@ export function selfSignedCertificate(request: CertificateRequest): Buffer {
 }
 
 export function toPem(contents: Buffer, label: string): string {
-  const body = contents.toString('base64').replace(/(.{64})/g, '$1\n');
-  return `-----BEGIN ${label}-----\n${body}\n-----END ${label}-----\n`;
+  const body = contents.toString('base64').match(/.{1,64}/g) ?? [];
+  return [`-----BEGIN ${label}-----`, ...body, `-----END ${label}-----`, ''].join('\n');
 }
 
 function extensions(): Buffer[] {

--- a/packages/tv-installer/src/modules/tizen/certificate/x509.ts
+++ b/packages/tv-installer/src/modules/tizen/certificate/x509.ts
@@ -1,0 +1,93 @@
+import { createSign, type KeyObject, randomBytes } from 'node:crypto';
+import * as der from './asn1';
+
+const OID = {
+  commonName: '2.5.4.3',
+  organization: '2.5.4.10',
+  organizationalUnit: '2.5.4.11',
+  locality: '2.5.4.7',
+  state: '2.5.4.8',
+  country: '2.5.4.6',
+  sha256WithRsa: '1.2.840.113549.1.1.11',
+  basicConstraints: '2.5.29.19',
+  keyUsage: '2.5.29.15',
+} as const;
+
+const SERIAL_BYTES = 8;
+const DAY_MS = 86_400_000;
+// digitalSignature and keyEncipherment, the two an author certificate signs with.
+const KEY_USAGE_BITS = Buffer.from([0xa0]);
+const KEY_USAGE_UNUSED = 5;
+
+export interface Subject {
+  commonName: string;
+  organization?: string;
+  organizationalUnit?: string;
+  locality?: string;
+  state?: string;
+  country?: string;
+}
+
+export interface CertificateRequest {
+  subject: Subject;
+  publicKey: KeyObject;
+  privateKey: KeyObject;
+  days: number;
+  from?: Date;
+}
+
+/** A self-signed X.509 v3 certificate, in DER. */
+export function selfSignedCertificate(request: CertificateRequest): Buffer {
+  const { subject, publicKey, privateKey, days } = request;
+  const from = request.from ?? new Date();
+  const until = new Date(from.getTime() + days * DAY_MS);
+
+  const algorithm = der.sequence(der.oid(OID.sha256WithRsa), der.nul());
+  const name = distinguishedName(subject);
+  const tbs = der.sequence(
+    der.context(0, der.integer(2)),
+    der.integer(randomBytes(SERIAL_BYTES)),
+    algorithm,
+    name,
+    der.sequence(der.utcTime(from), der.utcTime(until)),
+    name,
+    publicKey.export({ format: 'der', type: 'spki' }),
+    der.context(3, der.sequence(...extensions())),
+  );
+
+  const signature = createSign('sha256').update(tbs).sign(privateKey);
+  return der.sequence(tbs, algorithm, der.bitString(signature));
+}
+
+export function toPem(contents: Buffer, label: string): string {
+  const body = contents.toString('base64').replace(/(.{64})/g, '$1\n');
+  return `-----BEGIN ${label}-----\n${body}\n-----END ${label}-----\n`;
+}
+
+function extensions(): Buffer[] {
+  return [
+    extension(OID.basicConstraints, der.sequence()),
+    extension(OID.keyUsage, der.bitString(KEY_USAGE_BITS, KEY_USAGE_UNUSED)),
+  ];
+}
+
+function extension(id: string, value: Buffer): Buffer {
+  return der.sequence(der.oid(id), der.boolean(true), der.octets(value));
+}
+
+function distinguishedName(subject: Subject): Buffer {
+  const parts: Buffer[] = [];
+  const add = (id: string, value: string | undefined, printable = false) => {
+    if (!value) return;
+    const text = printable ? der.printable(value) : der.utf8(value);
+    parts.push(der.set(der.sequence(der.oid(id), text)));
+  };
+
+  add(OID.country, subject.country?.toUpperCase(), true);
+  add(OID.state, subject.state);
+  add(OID.locality, subject.locality);
+  add(OID.organization, subject.organization);
+  add(OID.organizationalUnit, subject.organizationalUnit);
+  add(OID.commonName, subject.commonName);
+  return der.sequence(...parts);
+}

--- a/packages/tv-installer/src/modules/tizen/identify.ts
+++ b/packages/tv-installer/src/modules/tizen/identify.ts
@@ -1,0 +1,69 @@
+import { fetchJson } from '../../discovery/http';
+import type { Television } from '../../television';
+import { tizenRuntime } from './runtime';
+import { SamsungInfo } from './schemas';
+import { SDB_PORT } from './sdb';
+
+export const SAMSUNG_API_PORT = 8001;
+
+export const TIZEN_PORTS = {
+  sweep: [SAMSUNG_API_PORT],
+  detail: [SDB_PORT],
+} as const;
+
+export async function identifyTizen(
+  host: string,
+  openPorts: ReadonlySet<number>,
+): Promise<Television | null> {
+  if (!openPorts.has(SAMSUNG_API_PORT)) return null;
+
+  const info = await fetchJson(`http://${host}:${SAMSUNG_API_PORT}/api/v2/`, SamsungInfo);
+  if (!info || !isTelevision(info)) return null;
+
+  const sdb = openPorts.has(SDB_PORT);
+  const declared = info.device.developerMode === '1';
+  const runtime = tizenRuntime(info.device.model);
+  const seen =
+    declared || sdb
+      ? samsungNote(sdb, info.device.developerIP)
+      : 'Developer mode off: on the TV open Apps and type 1 2 3 4 5, switch it on, set this computer as host PC, reboot';
+  return {
+    host,
+    platform: 'tizen',
+    vendor: 'Samsung',
+    name: unescapeName(info.device.name) || 'Samsung TV',
+    model: info.device.modelName ?? '',
+    developerMode: declared || sdb ? 'on' : 'off',
+    sideloadable: true,
+    note: seen,
+    runtime,
+  };
+}
+
+// A Samsung soundbar answers the same API and calls itself a SmartTV. The audio
+// range is the HW- models, and their internal model name ends in SPK.
+function isTelevision(info: SamsungInfo): boolean {
+  const { ModelNumber = '', model = '' } = info.device;
+  return !ModelNumber.startsWith('HW-') && !/SPK/i.test(model);
+}
+
+// The set reports the name its owner typed, HTML-escaped: `75&quot; The Frame`.
+function unescapeName(name: string | undefined): string {
+  const entities: Record<string, string> = {
+    '&quot;': '"',
+    '&apos;': "'",
+    '&#39;': "'",
+    '&lt;': '<',
+    '&gt;': '>',
+    '&amp;': '&',
+  };
+  return (name ?? '').replace(
+    /&(?:quot|apos|#39|lt|gt|amp);/g,
+    (entity) => entities[entity] ?? entity,
+  );
+}
+
+function samsungNote(sdb: boolean, trusts: string | undefined): string {
+  const host = trusts ? `host PC ${trusts}` : 'no host PC set';
+  return sdb ? `sdb open, ${host}` : `developer mode on, ${host}, sdb closed until the TV reboots`;
+}

--- a/packages/tv-installer/src/modules/tizen/install.test.ts
+++ b/packages/tv-installer/src/modules/tizen/install.test.ts
@@ -1,5 +1,50 @@
-import { describe, expect, it } from 'vitest';
-import { parseSdbSerial } from './install';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Television } from '../../television';
+import type { Tool } from '../../toolchain/detect';
+import type { InstallContext } from '../module';
+import { installFailure, installTizen, parseSdbSerial } from './install';
+import type { SigningProfile } from './profiles';
+
+const {
+  run,
+  runOk,
+  locate,
+  requireTool,
+  installOverSdb,
+  ensureProfile,
+  resign,
+  readDuid,
+  readProfile,
+  rm,
+} = vi.hoisted(() => ({
+  run: vi.fn(async (_command: readonly string[], _options?: unknown) => ({ code: 0, output: '' })),
+  runOk: vi.fn(async (_command: readonly string[], _options?: unknown) => ''),
+  locate: vi.fn((_tool: unknown): string | null => '/tizen-studio/tools/sdb'),
+  requireTool: vi.fn((_tool: unknown) => ''),
+  installOverSdb: vi.fn(async (_context: unknown, _artifact: string) => {}),
+  ensureProfile: vi.fn(async (_log: unknown) => ({ name: 'kroma' }) as SigningProfile),
+  resign: vi.fn(async (_artifact: string, _profile: unknown, _log: unknown) => ({
+    path: '/tmp/kroma-wgt-1/KROMA.wgt',
+    staged: false,
+  })),
+  readDuid: vi.fn(async (_sdb: string, _log: unknown): Promise<string | null> => null),
+  readProfile: vi.fn(async (_name?: string): Promise<SigningProfile | null> => null),
+  rm: vi.fn(async (_path: string, _options?: unknown) => {}),
+}));
+vi.mock('../../run', () => ({ run, runOk }));
+vi.mock('../../toolchain/detect', async (original) => ({
+  ...(await original<Record<string, unknown>>()),
+  locate,
+  requireTool,
+}));
+vi.mock('./native', () => ({ installOverSdb }));
+vi.mock('./signing', () => ({ ensureProfile, resign, readDuid }));
+vi.mock('./profiles', () => ({ readProfile }));
+vi.mock('./app-id', () => ({ tizenAppId: () => 'KromaTV001.KROMA' }));
+vi.mock('node:fs/promises', async (original) => ({
+  ...(await original<Record<string, unknown>>()),
+  rm,
+}));
 
 const devices = [
   'List of devices attached ',
@@ -8,6 +53,52 @@ const devices = [
   '192.168.1.45:26101\tdevice\tQE55Q60B',
   'emulator-26101\tdevice\tT-samsung-9.0-x86',
 ].join('\n');
+
+const salon: Television = {
+  host: '192.168.1.31',
+  platform: 'tizen',
+  vendor: 'Samsung',
+  name: '[TV] Salon',
+  model: 'UE50AU7172',
+  developerMode: 'on',
+  sideloadable: true,
+  note: 'developer mode on',
+  runtime: null,
+};
+
+const context = (overrides: Partial<InstallContext> = {}): InstallContext => ({
+  tv: salon,
+  artifact: '/out/KROMA-tizen-0.1.33.wgt',
+  log: () => {},
+  launch: true,
+  options: {},
+  ...overrides,
+});
+
+const SDB = '/tizen-studio/tools/sdb';
+const TIZEN = '/tizen-studio/tools/ide/bin/tizen';
+
+const argv = () => [
+  ...runOk.mock.calls.map(([command]) => command),
+  ...run.mock.calls.map(([command]) => command),
+];
+
+beforeEach(() => {
+  run.mockReset();
+  runOk.mockReset();
+  locate.mockReset();
+  requireTool.mockReset();
+  installOverSdb.mockReset();
+  ensureProfile.mockReset();
+  resign.mockReset();
+  readDuid.mockReset();
+  readProfile.mockReset();
+  rm.mockReset();
+  locate.mockReturnValue(SDB);
+  requireTool.mockImplementation((tool) => ((tool as Tool).id === 'sdb' ? SDB : TIZEN));
+  runOk.mockImplementation(async (command) => (command.includes('devices') ? devices : ''));
+  resign.mockResolvedValue({ path: '/tmp/kroma-wgt-1/KROMA.wgt', staged: false });
+});
 
 describe('parseSdbSerial', () => {
   it('reads the serial the bridge gave the television at that address', () => {
@@ -24,5 +115,142 @@ describe('parseSdbSerial', () => {
 
   it('answers nothing for a host the bridge never connected to', () => {
     expect(parseSdbSerial(devices, '192.168.1.99')).toBeNull();
+  });
+});
+
+describe('installTizen', () => {
+  it('signs the package with this machine before anything is pushed', async () => {
+    await installTizen(context());
+
+    expect(ensureProfile).toHaveBeenCalled();
+    expect(resign).toHaveBeenCalledWith(
+      '/out/KROMA-tizen-0.1.33.wgt',
+      { name: 'kroma' },
+      expect.any(Function),
+    );
+  });
+
+  it('signs with the profile that was named instead of the active one', async () => {
+    readProfile.mockResolvedValue({
+      name: 'LUMA',
+      author: { archive: '/certs/a.p12', password: 'x' },
+    });
+
+    await installTizen(context({ options: { profile: 'LUMA' } }));
+
+    expect(readProfile).toHaveBeenCalledWith('LUMA');
+    expect(ensureProfile).not.toHaveBeenCalled();
+  });
+
+  it('refuses a profile name this machine has no certificate for', async () => {
+    await expect(installTizen(context({ options: { profile: 'LUMA' } }))).rejects.toThrow(
+      'no signing profile called LUMA',
+    );
+  });
+
+  it('talks the bridge itself on a machine with no Tizen Studio', async () => {
+    locate.mockReturnValue(null);
+
+    await installTizen(context());
+
+    expect(installOverSdb).toHaveBeenCalledWith(expect.anything(), '/tmp/kroma-wgt-1/KROMA.wgt');
+  });
+
+  it('talks the bridge itself when --native was given, Tizen Studio or not', async () => {
+    await installTizen(context({ options: { native: true } }));
+
+    expect(installOverSdb).toHaveBeenCalled();
+    expect(argv()).toEqual([]);
+  });
+
+  it('drops every other target before it connects, since the CLI picks its own', async () => {
+    await installTizen(context());
+
+    expect(argv()).toContainEqual([SDB, 'disconnect']);
+    expect(argv()).toContainEqual([SDB, 'connect', '192.168.1.31:26101']);
+  });
+
+  it('refuses a set the bridge does not hold as a device', async () => {
+    runOk.mockImplementation(async () => 'List of devices attached');
+
+    await expect(installTizen(context())).rejects.toThrow(
+      'the TV refused the connection: Developer mode must list this computer as the host PC, and the set must have been rebooted since',
+    );
+  });
+
+  it('installs the signed widget by name, out of the directory it was staged in', async () => {
+    await installTizen(context());
+
+    expect(argv()).toContainEqual([TIZEN, 'install', '-n', 'KROMA.wgt', '--', '/tmp/kroma-wgt-1']);
+  });
+
+  it('starts the app with the CLI once it is installed', async () => {
+    await installTizen(context());
+
+    expect(argv()).toContainEqual([TIZEN, 'run', '-p', 'KromaTV001.KROMA']);
+  });
+
+  it('falls back to was_execute when the CLI cannot start the app', async () => {
+    run.mockImplementation(async (command) =>
+      command.includes('run') ? { code: 1, output: 'no device' } : { code: 0, output: '' },
+    );
+
+    await installTizen(context());
+
+    expect(argv()).toContainEqual([SDB, 'shell', '0', 'was_execute', 'KromaTV001.KROMA']);
+  });
+
+  it('leaves the app alone when the install was told not to launch', async () => {
+    await installTizen(context({ launch: false }));
+
+    expect(argv().flat()).not.toContain('was_execute');
+    expect(argv()).not.toContainEqual([TIZEN, 'run', '-p', 'KromaTV001.KROMA']);
+  });
+
+  it('reads the DUID off the set when it refused the signature', async () => {
+    run.mockImplementation(async (command) =>
+      command.includes('install')
+        ? { code: 1, output: 'error: the certificate is not valid' }
+        : { code: 0, output: '' },
+    );
+    readDuid.mockResolvedValue('1900A2C4D6E8');
+
+    await expect(installTizen(context())).rejects.toThrow('The DUID to register is 1900A2C4D6E8.');
+  });
+
+  it('deletes a widget it staged, whatever the install did', async () => {
+    resign.mockResolvedValue({ path: '/tmp/kroma-wgt-1/KROMA.wgt', staged: true });
+    runOk.mockImplementation(async () => 'List of devices attached');
+
+    await expect(installTizen(context())).rejects.toThrow('the TV refused the connection');
+
+    expect(rm).toHaveBeenCalledWith('/tmp/kroma-wgt-1', { recursive: true, force: true });
+  });
+});
+
+describe('installFailure', () => {
+  it('quotes what the tools said when the failure names no certificate', () => {
+    const output = ['Transferring the package...', 'error: install failed[118]'].join('\n');
+
+    expect(installFailure(output, 'kroma', null)).toBe(
+      'the install failed: Transferring the package... / error: install failed[118]',
+    );
+  });
+
+  it('says only that it failed when the tools said nothing at all', () => {
+    expect(installFailure('', 'kroma', null)).toBe('the install failed');
+  });
+
+  it('names the profile whose chain a retail set refused', () => {
+    const message = installFailure('error: certificate is invalid', 'kroma', null);
+
+    expect(message).toContain('profile kroma signed it and the set refused that chain.');
+    expect(message).toContain('a distributor certificate Samsung issued for its own DUID');
+  });
+
+  it('gives the DUID to register when the set said which one it is', () => {
+    const message = installFailure('error: certificate is invalid', null, '1900A2C4D6E8');
+
+    expect(message).toContain('The DUID to register is 1900A2C4D6E8.');
   });
 });

--- a/packages/tv-installer/src/modules/tizen/install.test.ts
+++ b/packages/tv-installer/src/modules/tizen/install.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { parseSdbSerial } from './install';
+
+const devices = [
+  'List of devices attached ',
+  '192.168.1.31:26101\tdevice\tUE50AU7172',
+  '192.168.1.44:26101\toffline\tunknown',
+  '192.168.1.45:26101\tdevice\tQE55Q60B',
+  'emulator-26101\tdevice\tT-samsung-9.0-x86',
+].join('\n');
+
+describe('parseSdbSerial', () => {
+  it('reads the serial the bridge gave the television at that address', () => {
+    expect(parseSdbSerial(devices, '192.168.1.31')).toBe('192.168.1.31:26101');
+  });
+
+  it('finds the set that was asked for further down the list', () => {
+    expect(parseSdbSerial(devices, '192.168.1.45')).toBe('192.168.1.45:26101');
+  });
+
+  it('answers nothing for a set the bridge sees as offline', () => {
+    expect(parseSdbSerial(devices, '192.168.1.44')).toBeNull();
+  });
+
+  it('answers nothing for a host the bridge never connected to', () => {
+    expect(parseSdbSerial(devices, '192.168.1.99')).toBeNull();
+  });
+});

--- a/packages/tv-installer/src/modules/tizen/install.test.ts
+++ b/packages/tv-installer/src/modules/tizen/install.test.ts
@@ -163,7 +163,7 @@ describe('installTizen', () => {
     expect(argv()).toEqual([]);
   });
 
-  it('drops every other target before it connects, since the CLI picks its own', async () => {
+  it('drops every other target before it connects to this one', async () => {
     await installTizen(context());
 
     expect(argv()).toContainEqual([SDB, 'disconnect']);

--- a/packages/tv-installer/src/modules/tizen/install.ts
+++ b/packages/tv-installer/src/modules/tizen/install.ts
@@ -92,7 +92,8 @@ export function installFailure(
 ): string {
   if (!output.includes('certificate')) {
     const tail = output.split('\n').filter(Boolean).slice(-2).join(' / ');
-    return `the install failed${tail ? `: ${tail}` : ''}`;
+    const said = tail ? `: ${tail}` : '';
+    return `the install failed${said}`;
   }
   const rejected = profile ? `profile ${profile} signed it and the set refused that chain. ` : '';
   const set = duid ? ` The DUID to register is ${duid}.` : '';

--- a/packages/tv-installer/src/modules/tizen/install.ts
+++ b/packages/tv-installer/src/modules/tizen/install.ts
@@ -1,0 +1,100 @@
+import { rm } from 'node:fs/promises';
+import { basename, dirname } from 'node:path';
+import { run, runOk } from '../../run';
+import { locate, requireTool } from '../../toolchain/detect';
+import { booleanOption, type InstallContext, stringOption } from '../module';
+import { tizenAppId } from './app-id';
+import { installOverSdb } from './native';
+import { readProfile, type SigningProfile } from './profiles';
+import { SDB_PORT } from './sdb';
+import { ensureProfile, readDuid, resign, type Signed } from './signing';
+import { SDB, TIZEN_CLI } from './tools';
+
+const CONNECT_TIMEOUT_MS = 25_000;
+const INSTALL_TIMEOUT_MS = 300_000;
+
+interface Package extends Partial<Signed> {
+  path: string;
+  profile: SigningProfile | null;
+}
+
+export function parseSdbSerial(devices: string, host: string): string | null {
+  for (const line of devices.split('\n')) {
+    const [serial = '', state = ''] = line.trim().split(/\s+/);
+    if (serial.startsWith(`${host}:`) && state === 'device') return serial;
+  }
+  return null;
+}
+
+export async function installTizen(context: InstallContext): Promise<void> {
+  const native = booleanOption(context.options, 'native') ?? locate(SDB) === null;
+  const wgt = await sign(context);
+  try {
+    if (native) await installOverSdb(context, wgt.path);
+    else await installOverCli(context, wgt);
+  } finally {
+    if (wgt.staged) await rm(dirname(wgt.path), { recursive: true, force: true });
+  }
+}
+
+async function sign(context: InstallContext): Promise<Package> {
+  const { artifact, log } = context;
+  const named = stringOption(context.options, 'profile');
+  const profile = named ? await namedProfile(named) : await ensureProfile(log);
+  return { ...(await resign(artifact, profile, log)), profile };
+}
+
+async function namedProfile(name: string): Promise<SigningProfile> {
+  const profile = await readProfile(name);
+  if (!profile) throw new Error(`no signing profile called ${name}`);
+  return profile;
+}
+
+async function installOverCli(context: InstallContext, wgt: Package): Promise<void> {
+  const { tv, log, launch } = context;
+  const sdb = requireTool(SDB);
+  const tizen = requireTool(TIZEN_CLI);
+
+  // One device at a time: the Tizen CLI picks the single connected target
+  // itself, and its `-t` lookup does not match an ip:port serial.
+  await run([sdb, 'disconnect'], { log });
+  await runOk([sdb, 'connect', `${tv.host}:${SDB_PORT}`], { log, timeoutMs: CONNECT_TIMEOUT_MS });
+
+  const serial = parseSdbSerial(await runOk([sdb, 'devices'], { log }), tv.host);
+  if (!serial) {
+    throw new Error(
+      'the TV refused the connection: Developer mode must list this computer as the host PC, and the set must have been rebooted since',
+    );
+  }
+
+  const installed = await run(
+    [tizen, 'install', '-n', basename(wgt.path), '--', dirname(wgt.path)],
+    {
+      log,
+      timeoutMs: INSTALL_TIMEOUT_MS,
+    },
+  );
+  if (installed.code !== 0) {
+    const duid = installed.output.includes('certificate') ? await readDuid(sdb, log) : null;
+    throw new Error(installFailure(installed.output, wgt.profile?.name ?? null, duid));
+  }
+  if (!launch) return;
+
+  const application = tizenAppId();
+  const started = await run([tizen, 'run', '-p', application], { log });
+  if (started.code !== 0) await run([sdb, 'shell', '0', 'was_execute', application], { log });
+}
+
+export function installFailure(
+  output: string,
+  profile: string | null,
+  duid: string | null,
+): string {
+  if (!output.includes('certificate')) {
+    const tail = output.split('\n').filter(Boolean).slice(-2).join(' / ');
+    return `the install failed${tail ? `: ${tail}` : ''}`;
+  }
+  const rejected = profile ? `profile ${profile} signed it and the set refused that chain. ` : '';
+  const set = duid ? ` The DUID to register is ${duid}.` : '';
+  return `${rejected}A retail Samsung takes only a distributor certificate Samsung issued for its own DUID: Tizen Studio, Certificate Manager, Samsung, TV, with the set connected.${set}`;
+}

--- a/packages/tv-installer/src/modules/tizen/module.ts
+++ b/packages/tv-installer/src/modules/tizen/module.ts
@@ -1,0 +1,35 @@
+import type { TvModule } from '../module';
+import { resolveTizenArtifact, tizenSources } from './artifact';
+import { certificateCommand } from './certificate-command';
+import { identifyTizen, TIZEN_PORTS } from './identify';
+import { installTizen } from './install';
+import { probeCommand } from './probe-command';
+import { SDB, TIZEN_CLI } from './tools';
+
+export const tizen: TvModule = {
+  id: 'tizen',
+  label: 'Samsung',
+  brands: 'Samsung',
+  package: '.wgt',
+  notReadyHint: 'developer mode off',
+  enableSteps: 'Apps, then 1 2 3 4 5',
+  ports: TIZEN_PORTS,
+  flags: {
+    profile: {
+      type: 'string',
+      valueHint: 'name',
+      description: 'Samsung only: the signing profile, instead of the active one',
+    },
+    native: {
+      type: 'boolean',
+      default: false,
+      description: "Samsung only: talk sdb ourselves, instead of Tizen Studio's tools",
+    },
+  },
+  commands: { probe: probeCommand, certificate: certificateCommand },
+  identify: identifyTizen,
+  tools: () => [TIZEN_CLI, SDB],
+  sources: tizenSources,
+  resolve: resolveTizenArtifact,
+  install: installTizen,
+};

--- a/packages/tv-installer/src/modules/tizen/native.test.ts
+++ b/packages/tv-installer/src/modules/tizen/native.test.ts
@@ -34,16 +34,19 @@ let device: SdbDevice;
 beforeEach(() => {
   lines.length = 0;
   device = {
+    host: '192.168.1.31',
+    port: 26101,
     banner: 'sdbd::UE50AU7172',
-    info: { serial: '192.168.1.31:26101', model: 'UE50AU7172', platform: 'Tizen 6.5' },
-    capability: null,
+    capability: vi.fn(),
+    shell: vi.fn(),
+    push: vi.fn(),
     install: vi
       .fn()
       .mockResolvedValue({ verdict: 'success', code: 0, output: 'install completed' }),
     launch: vi.fn().mockResolvedValue({ verdict: 'success', code: 0, output: 'launched' }),
     uninstall: vi.fn(),
     close: vi.fn(),
-  } as unknown as SdbDevice;
+  };
   vi.mocked(connect).mockResolvedValue(device);
 });
 

--- a/packages/tv-installer/src/modules/tizen/native.test.ts
+++ b/packages/tv-installer/src/modules/tizen/native.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { InstallContext } from '../module';
+import { installOverSdb } from './native';
+import { connect, type InstallOptions, type SdbDevice } from './sdb';
+
+vi.mock('./app-id', () => ({ tizenAppId: () => 'KromaTV001.KROMA' }));
+vi.mock('./sdb', async (original) => ({
+  ...(await original<typeof import('./sdb')>()),
+  connect: vi.fn(),
+}));
+
+const lines: string[] = [];
+
+const context = (launch = true): InstallContext => ({
+  tv: {
+    host: '192.168.1.31',
+    platform: 'tizen',
+    vendor: 'Samsung',
+    name: 'Salon',
+    model: 'UE50AU7172',
+    developerMode: 'on',
+    sideloadable: true,
+    note: '',
+    runtime: null,
+  },
+  artifact: '/out/KROMA.wgt',
+  log: (line) => lines.push(line),
+  launch,
+  options: {},
+});
+
+let device: SdbDevice;
+
+beforeEach(() => {
+  lines.length = 0;
+  device = {
+    banner: 'sdbd::UE50AU7172',
+    info: { serial: '192.168.1.31:26101', model: 'UE50AU7172', platform: 'Tizen 6.5' },
+    capability: null,
+    install: vi
+      .fn()
+      .mockResolvedValue({ verdict: 'success', code: 0, output: 'install completed' }),
+    launch: vi.fn().mockResolvedValue({ verdict: 'success', code: 0, output: 'launched' }),
+    uninstall: vi.fn(),
+    close: vi.fn(),
+  } as unknown as SdbDevice;
+  vi.mocked(connect).mockResolvedValue(device);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('installOverSdb', () => {
+  it('pushes the package to the set under the id the widget declares', async () => {
+    await installOverSdb(context(), '/out/KROMA.wgt');
+
+    expect(vi.mocked(connect)).toHaveBeenCalledWith('192.168.1.31');
+    expect(vi.mocked(device.install).mock.calls[0]?.[0]).toBe('/out/KROMA.wgt');
+    expect(vi.mocked(device.install).mock.calls[0]?.[1]?.appId).toBe('KromaTV001.KROMA');
+  });
+
+  it('names the set it reached before it pushes anything', async () => {
+    await installOverSdb(context(), '/out/KROMA.wgt');
+
+    expect(lines[0]).toBe('sdbd::UE50AU7172 on 192.168.1.31');
+  });
+
+  it('starts the app once the package is on', async () => {
+    await installOverSdb(context(), '/out/KROMA.wgt');
+
+    expect(vi.mocked(device.launch)).toHaveBeenCalledWith('KromaTV001.KROMA');
+  });
+
+  it('leaves the app alone when it was told to install without starting it', async () => {
+    await installOverSdb(context(false), '/out/KROMA.wgt');
+
+    expect(vi.mocked(device.launch)).not.toHaveBeenCalled();
+  });
+
+  it('quotes what the set said when it refused the package', async () => {
+    vi.mocked(device.install).mockResolvedValue({
+      verdict: 'failure',
+      code: 118,
+      output: 'processing result : INSTALL_ERROR [118]',
+    });
+
+    await expect(installOverSdb(context(), '/out/KROMA.wgt')).rejects.toThrow(
+      'install failure [118]: processing result : INSTALL_ERROR [118]',
+    );
+  });
+
+  it('closes the connection even when the push threw', async () => {
+    vi.mocked(device.install).mockRejectedValue(new Error('the set went away'));
+
+    await expect(installOverSdb(context(), '/out/KROMA.wgt')).rejects.toThrow('the set went away');
+    expect(vi.mocked(device.close)).toHaveBeenCalledOnce();
+  });
+
+  it('reports the push every fifth of the way, and not on every packet', async () => {
+    vi.mocked(device.install).mockImplementation(
+      async (_artifact: string, { onProgress }: InstallOptions) => {
+        for (const sent of [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]) onProgress?.(sent, 100);
+        return { verdict: 'success', code: 0, output: 'install completed' };
+      },
+    );
+
+    await installOverSdb(context(), '/out/KROMA.wgt');
+
+    expect(lines.slice(1)).toEqual([
+      'pushing KROMA.wgt, 20%',
+      'pushing KROMA.wgt, 40%',
+      'pushing KROMA.wgt, 60%',
+      'pushing KROMA.wgt, 80%',
+      'pushing KROMA.wgt, 100%',
+    ]);
+  });
+
+  it('reports nothing about a push the set gave no total for', async () => {
+    vi.mocked(device.install).mockImplementation(
+      async (_artifact: string, { onProgress }: InstallOptions) => {
+        onProgress?.(0, 0);
+        return { verdict: 'success', code: 0, output: 'install completed' };
+      },
+    );
+
+    await installOverSdb(context(), '/out/KROMA.wgt');
+
+    expect(lines.slice(1)).toEqual([]);
+  });
+});

--- a/packages/tv-installer/src/modules/tizen/native.ts
+++ b/packages/tv-installer/src/modules/tizen/native.ts
@@ -1,0 +1,38 @@
+import { basename } from 'node:path';
+import type { LogLine } from '../../run';
+import type { InstallContext } from '../module';
+import { tizenAppId } from './app-id';
+import { connect, describeResult } from './sdb';
+
+/**
+ * Installs over this tool's own sdb client, so nothing from Tizen Studio has to
+ * be on the machine. The package still has to be signed for the set.
+ */
+export async function installOverSdb(context: InstallContext, artifact: string): Promise<void> {
+  const { tv, log, launch } = context;
+  const application = tizenAppId();
+  const device = await connect(tv.host);
+
+  try {
+    log(`${device.banner} on ${tv.host}`);
+    const result = await device.install(artifact, {
+      appId: application,
+      log,
+      onProgress: progress(basename(artifact), log),
+    });
+    if (result.verdict !== 'success') throw new Error(describeResult('install', result));
+    if (launch) await device.launch(application);
+  } finally {
+    device.close();
+  }
+}
+
+function progress(name: string, log: LogLine): (sent: number, total: number) => void {
+  let reported = 0;
+  return (sent, total) => {
+    const percent = total > 0 ? Math.floor((sent / total) * 100) : 0;
+    if (percent < reported + 20) return;
+    reported = percent;
+    log(`pushing ${name}, ${percent}%`);
+  };
+}

--- a/packages/tv-installer/src/modules/tizen/probe-command.test.ts
+++ b/packages/tv-installer/src/modules/tizen/probe-command.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { probeCommand } from './probe-command';
+
+const { connect, exitAfter } = vi.hoisted(() => ({
+  connect: vi.fn(async (_host: string): Promise<unknown> => null),
+  exitAfter: vi.fn((work: number | Promise<number>) => work),
+}));
+vi.mock('./sdb', async (original) => ({
+  ...(await original<Record<string, unknown>>()),
+  connect,
+}));
+vi.mock('../../exit-after', () => ({ exitAfter }));
+
+const capability = vi.fn(async (): Promise<Record<string, string>> => ({}));
+const close = vi.fn();
+
+const device = { banner: 'sdbd 4.2.19', capability, close };
+
+const probe = (host: string) =>
+  (probeCommand.run as (given: { args: { host: string } }) => Promise<number>)({ args: { host } });
+
+const printed: string[] = [];
+const failed: string[] = [];
+
+beforeEach(() => {
+  printed.length = 0;
+  failed.length = 0;
+  vi.spyOn(console, 'log').mockImplementation((line: string) => void printed.push(line));
+  vi.spyOn(console, 'error').mockImplementation((line: string) => void failed.push(line));
+  connect.mockReset();
+  capability.mockReset();
+  close.mockReset();
+  connect.mockResolvedValue(device);
+  capability.mockResolvedValue({ platform_version: '6.5', model_name: 'UE50AU7172' });
+});
+
+describe('probeCommand', () => {
+  it('prints the banner the set answered with', async () => {
+    await probe('192.168.1.31');
+
+    expect(printed[0]).toContain('banner');
+    expect(printed[0]).toContain('sdbd 4.2.19');
+  });
+
+  it('prints the capabilities that say what the set is', async () => {
+    await probe('192.168.1.31');
+
+    expect(printed.join('\n')).toContain('platform_version');
+    expect(printed.join('\n')).toContain('6.5');
+    expect(printed.join('\n')).toContain('UE50AU7172');
+  });
+
+  it('names the rest of what the set answered on one line', async () => {
+    capability.mockResolvedValue({
+      platform_version: '6.5',
+      cpu_arch: 'armv7',
+      usbproto_version: '1.0',
+    });
+
+    await probe('192.168.1.31');
+
+    expect(printed.at(-1)).toContain('also');
+    expect(printed.at(-1)).toContain('cpu_arch, usbproto_version');
+  });
+
+  it('closes the connection whatever the set answered', async () => {
+    capability.mockRejectedValue(new Error('the stream closed'));
+
+    await expect(probe('192.168.1.31')).rejects.toThrow('the stream closed');
+
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it('says what a set that never answered on the bridge port needs', async () => {
+    connect.mockRejectedValue(new Error('connect ECONNREFUSED 192.168.1.31:26101'));
+
+    const code = await probe('192.168.1.31');
+
+    expect(code).toBe(1);
+    expect(failed[0]).toBe(
+      'connect ECONNREFUSED 192.168.1.31:26101. Nothing answered on 26101: developer mode has to be on, naming this computer as the host PC, and the set rebooted since.',
+    );
+  });
+
+  it('answers a success once it has said what the set is', async () => {
+    expect(await probe('192.168.1.31')).toBe(0);
+  });
+});

--- a/packages/tv-installer/src/modules/tizen/probe-command.ts
+++ b/packages/tv-installer/src/modules/tizen/probe-command.ts
@@ -3,7 +3,7 @@ import { exitAfter } from '../../exit-after';
 import { style } from '../../tui/ansi';
 import { connect } from './sdb';
 
-const INTERESTING = [
+const INTERESTING = new Set([
   'platform_version',
   'product_name',
   'model_name',
@@ -13,7 +13,7 @@ const INTERESTING = [
   'appcmd_support',
   'sdbd_rootperm',
   'syncwinsz_support',
-];
+]);
 
 export const probeCommand = defineCommand({
   meta: {
@@ -26,7 +26,6 @@ export const probeCommand = defineCommand({
   run: ({ args }) => exitAfter(probe(args.host)),
 });
 
-/** What a Samsung set says about itself over sdb, without installing anything. */
 async function probe(host: string): Promise<number> {
   const device = await connect(host).catch((error: unknown) => {
     console.error(reason(error));
@@ -40,7 +39,7 @@ async function probe(host: string): Promise<number> {
     for (const key of INTERESTING) {
       if (capability[key]) console.log(`${label(key)}${capability[key]}`);
     }
-    const rest = Object.keys(capability).filter((key) => !INTERESTING.includes(key));
+    const rest = Object.keys(capability).filter((key) => !INTERESTING.has(key));
     if (rest.length > 0) console.log(style.dim(`${label('also')}${rest.join(', ')}`));
   } finally {
     device.close();

--- a/packages/tv-installer/src/modules/tizen/probe-command.ts
+++ b/packages/tv-installer/src/modules/tizen/probe-command.ts
@@ -1,7 +1,7 @@
 import { defineCommand } from 'citty';
 import { exitAfter } from '../../exit-after';
 import { style } from '../../tui/ansi';
-import { connect } from './sdb';
+import { connect, SDB_PORT } from './sdb';
 
 const INTERESTING = new Set([
   'platform_version',
@@ -53,5 +53,5 @@ function label(name: string): string {
 
 function reason(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
-  return `${message}. Nothing answered on 26101: developer mode has to be on, naming this computer as the host PC, and the set rebooted since.`;
+  return `${message}. Nothing answered on ${SDB_PORT}: developer mode has to be on, naming this computer as the host PC, and the set rebooted since.`;
 }

--- a/packages/tv-installer/src/modules/tizen/probe-command.ts
+++ b/packages/tv-installer/src/modules/tizen/probe-command.ts
@@ -1,0 +1,58 @@
+import { defineCommand } from 'citty';
+import { exitAfter } from '../../exit-after';
+import { style } from '../../tui/ansi';
+import { connect } from './sdb';
+
+const INTERESTING = [
+  'platform_version',
+  'product_name',
+  'model_name',
+  'profile_name',
+  'sdk_toolpath',
+  'secure_protocol',
+  'appcmd_support',
+  'sdbd_rootperm',
+  'syncwinsz_support',
+];
+
+export const probeCommand = defineCommand({
+  meta: {
+    name: 'probe',
+    description: 'Ask a Samsung set what it is over sdb, installing nothing.',
+  },
+  args: {
+    host: { type: 'positional', required: true, description: 'The address of the set' },
+  },
+  run: ({ args }) => exitAfter(probe(args.host)),
+});
+
+/** What a Samsung set says about itself over sdb, without installing anything. */
+async function probe(host: string): Promise<number> {
+  const device = await connect(host).catch((error: unknown) => {
+    console.error(reason(error));
+    return null;
+  });
+  if (!device) return 1;
+
+  try {
+    console.log(`${label('banner')}${device.banner}`);
+    const capability = await device.capability();
+    for (const key of INTERESTING) {
+      if (capability[key]) console.log(`${label(key)}${capability[key]}`);
+    }
+    const rest = Object.keys(capability).filter((key) => !INTERESTING.includes(key));
+    if (rest.length > 0) console.log(style.dim(`${label('also')}${rest.join(', ')}`));
+  } finally {
+    device.close();
+  }
+  return 0;
+}
+
+function label(name: string): string {
+  return style.bold(name.padEnd(20));
+}
+
+function reason(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return `${message}. Nothing answered on 26101: developer mode has to be on, naming this computer as the host PC, and the set rebooted since.`;
+}

--- a/packages/tv-installer/src/modules/tizen/profiles.test.ts
+++ b/packages/tv-installer/src/modules/tizen/profiles.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { parseProfiles } from './profiles';
+
+const xml = [
+  '<?xml version="1.0" encoding="UTF-8" standalone="no"?>',
+  '<profiles active="LUMA" version="3.1">',
+  '<profile name="emulator">',
+  '<profileitem ca="" distributor="0" key="/keys/emulator.p12" password="secret" rootca=""/>',
+  '</profile>',
+  '<profile name="LUMA">',
+  '<profileitem ca="" distributor="0" key="/certs/author.p12" password="/certs/author.pwd" rootca=""/>',
+  '<profileitem ca="" distributor="1" key="/certs/distributor.p12" password="/certs/dist.pwd" rootca=""/>',
+  '<profileitem ca="" distributor="2" key="" password="" rootca=""/>',
+  '</profile>',
+  '</profiles>',
+].join('\n');
+
+describe('parseProfiles', () => {
+  it('names the profile the tools sign with', () => {
+    expect(parseProfiles(xml).active).toBe('LUMA');
+  });
+
+  it('reads every profile in the file, not only the active one', () => {
+    expect([...parseProfiles(xml).profiles.keys()]).toEqual(['emulator', 'LUMA']);
+  });
+
+  it('keeps the author and distributor keys apart by their slot', () => {
+    const items = parseProfiles(xml).profiles.get('LUMA');
+
+    expect(items?.get('0')).toEqual({ key: '/certs/author.p12', password: '/certs/author.pwd' });
+    expect(items?.get('1')?.key).toBe('/certs/distributor.p12');
+  });
+
+  it('leaves out a slot that names no key', () => {
+    expect(parseProfiles(xml).profiles.get('LUMA')?.has('2')).toBe(false);
+  });
+
+  it('answers nothing for a file with no profile in it', () => {
+    expect(parseProfiles('<profiles active="" version="3.1"></profiles>').profiles.size).toBe(0);
+  });
+});

--- a/packages/tv-installer/src/modules/tizen/profiles.test.ts
+++ b/packages/tv-installer/src/modules/tizen/profiles.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from 'vitest';
-import { parseProfiles } from './profiles';
+import { existsSync, readFileSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { run } from '../../run';
+import { parseProfiles, readProfile } from './profiles';
+
+vi.mock('node:fs', () => ({ existsSync: vi.fn(), readFileSync: vi.fn() }));
+vi.mock('../../run', () => ({ run: vi.fn() }));
+vi.mock('./certificate/profile', () => ({ PROFILES_XML: '/tizen-data/profile/profiles.xml' }));
 
 const xml = [
   '<?xml version="1.0" encoding="UTF-8" standalone="no"?>',
@@ -14,6 +20,19 @@ const xml = [
   '</profile>',
   '</profiles>',
 ].join('\n');
+
+const onDisk = new Map<string, string>();
+
+beforeEach(() => {
+  onDisk.clear();
+  onDisk.set('/tizen-data/profile/profiles.xml', xml);
+  vi.mocked(existsSync).mockImplementation((path) => onDisk.has(String(path)));
+  vi.mocked(readFileSync).mockImplementation((path) => onDisk.get(String(path)) ?? '');
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
 
 describe('parseProfiles', () => {
   it('names the profile the tools sign with', () => {
@@ -37,5 +56,57 @@ describe('parseProfiles', () => {
 
   it('answers nothing for a file with no profile in it', () => {
     expect(parseProfiles('<profiles active="" version="3.1"></profiles>').profiles.size).toBe(0);
+  });
+});
+
+describe('readProfile', () => {
+  it('answers nothing on a machine the Tizen tools never wrote a profile on', async () => {
+    onDisk.clear();
+
+    expect(await readProfile()).toBeNull();
+  });
+
+  it('reads the active profile with both of the keys it carries', async () => {
+    onDisk.set('/certs/author.pwd', 'author-password\n');
+    onDisk.set('/certs/dist.pwd', 'distributor-password\n');
+
+    expect(await readProfile()).toEqual({
+      name: 'LUMA',
+      author: { archive: '/certs/author.p12', password: 'author-password' },
+      distributor: { archive: '/certs/distributor.p12', password: 'distributor-password' },
+    });
+  });
+
+  it('reads the profile it was named rather than the active one', async () => {
+    const profile = await readProfile('emulator');
+
+    expect(profile?.name).toBe('emulator');
+    expect(profile?.author).toEqual({ archive: '/keys/emulator.p12', password: 'secret' });
+    expect(profile?.distributor).toBeUndefined();
+  });
+
+  it('answers nothing for a profile the file does not carry', async () => {
+    expect(await readProfile('ghost')).toBeNull();
+  });
+
+  it('asks the login keychain for a password no file beside the certificate holds', async () => {
+    vi.mocked(run).mockResolvedValue({ code: 0, output: 'kept-in-the-keychain\n' });
+
+    const profile = await readProfile('LUMA');
+
+    expect(vi.mocked(run).mock.calls[0]?.[0]).toEqual([
+      'security',
+      'find-generic-password',
+      '-a',
+      '/certs/author.pwd',
+      '-w',
+    ]);
+    expect(profile?.author.password).toBe('kept-in-the-keychain');
+  });
+
+  it('signs with an empty password when the keychain holds none either', async () => {
+    vi.mocked(run).mockResolvedValue({ code: 1, output: 'The specified item could not be found' });
+
+    expect((await readProfile('LUMA'))?.author.password).toBe('');
   });
 });

--- a/packages/tv-installer/src/modules/tizen/profiles.ts
+++ b/packages/tv-installer/src/modules/tizen/profiles.ts
@@ -1,0 +1,82 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { run } from '../../run';
+import type { ProfileKey } from './certificate/profile';
+import { PROFILES_XML } from './certificate/profile';
+
+const PROFILE_BLOCK = /<profile\s+name="([^"]*)"\s*>([\s\S]*?)<\/profile>/g;
+const PROFILE_ITEM = /<profileitem\b([^>]*)\/>/g;
+const ATTRIBUTE = /(\w+)="([^"]*)"/g;
+const ACTIVE = /<profiles[^>]*\bactive="([^"]*)"/;
+const KEYCHAIN_TIMEOUT_MS = 20_000;
+
+export interface SigningProfile {
+  name: string;
+  author: ProfileKey;
+  distributor?: ProfileKey;
+}
+
+interface RawKey {
+  key: string;
+  password: string;
+}
+
+export interface ParsedProfiles {
+  active: string | null;
+  profiles: Map<string, Map<string, RawKey>>;
+}
+
+export function parseProfiles(xml: string): ParsedProfiles {
+  const profiles = new Map<string, Map<string, RawKey>>();
+  for (const [, name = '', body = ''] of xml.matchAll(PROFILE_BLOCK)) {
+    const items = new Map<string, RawKey>();
+    for (const [, attributes = ''] of body.matchAll(PROFILE_ITEM)) {
+      const fields = Object.fromEntries(
+        [...attributes.matchAll(ATTRIBUTE)].map(([, key = '', value = '']) => [key, value]),
+      );
+      if (fields.key)
+        items.set(fields.distributor ?? '', { key: fields.key, password: fields.password ?? '' });
+    }
+    profiles.set(name, items);
+  }
+  return { active: ACTIVE.exec(xml)?.[1] ?? null, profiles };
+}
+
+/**
+ * The profile the Tizen tools would sign with, read out of their own file so
+ * that signing needs none of those tools. Without a name, the active one.
+ */
+export async function readProfile(name?: string): Promise<SigningProfile | null> {
+  if (!existsSync(PROFILES_XML)) return null;
+  const { active, profiles } = parseProfiles(readFileSync(PROFILES_XML, 'utf8'));
+
+  const wanted = name ?? active;
+  const items = wanted ? profiles.get(wanted) : undefined;
+  const author = items?.get('0');
+  if (!wanted || !author) return null;
+
+  const distributor = items?.get('1');
+  return {
+    name: wanted,
+    author: { archive: author.key, password: await secret(author.password) },
+    ...(distributor
+      ? { distributor: { archive: distributor.key, password: await secret(distributor.password) } }
+      : {}),
+  };
+}
+
+/**
+ * A password as the Tizen tools store it: inline, in a file beside the
+ * certificate, or, on macOS, in the login keychain under the name of a file
+ * that was never written.
+ */
+async function secret(value: string): Promise<string> {
+  if (!value.endsWith('.pwd')) return value;
+  if (existsSync(value)) return readFileSync(value, 'utf8').trim();
+
+  const { code, output } = await run(['security', 'find-generic-password', '-a', value, '-w'], {
+    timeoutMs: KEYCHAIN_TIMEOUT_MS,
+  });
+  return code === 0 ? output.trim() : '';
+}
+
+export const activeProfile = () => readProfile();

--- a/packages/tv-installer/src/modules/tizen/profiles.ts
+++ b/packages/tv-installer/src/modules/tizen/profiles.ts
@@ -5,7 +5,7 @@ import { PROFILES_XML } from './certificate/profile';
 
 const PROFILE_BLOCK = /<profile\s+name="([^"]*)"\s*>([\s\S]*?)<\/profile>/g;
 const PROFILE_ITEM = /<profileitem\b([^>]*)\/>/g;
-const ATTRIBUTE = /(\w+)="([^"]*)"/g;
+const ATTRIBUTE = /(\w{1,64})="([^"]*)"/g;
 const ACTIVE = /<profiles[^>]*\bactive="([^"]*)"/;
 const KEYCHAIN_TIMEOUT_MS = 20_000;
 

--- a/packages/tv-installer/src/modules/tizen/runtime.test.ts
+++ b/packages/tv-installer/src/modules/tizen/runtime.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { tizenRuntime } from './runtime';
+
+describe('tizenRuntime', () => {
+  it('dates a Samsung by the model year its internal model name starts with', () => {
+    expect(tizenRuntime('24_PTM_FTV_T09')).toEqual({
+      name: 'Tizen',
+      version: '8.0',
+      engine: { name: 'Chromium', version: '108' },
+      learned: 'derived',
+    });
+  });
+
+  it('reaches the oldest model year the table dates', () => {
+    expect(tizenRuntime('17_KANTM_UHD')).toMatchObject({
+      version: '3.0',
+      engine: { version: '47' },
+    });
+  });
+
+  it('reaches the newest model year the table dates', () => {
+    expect(tizenRuntime('25_MT8532_AISPK')).toMatchObject({
+      version: '9.0',
+      engine: { version: '120' },
+    });
+  });
+
+  it('answers nothing for a year no Tizen release is known for', () => {
+    expect(tizenRuntime('99_PTM_FTV_T09')).toBeNull();
+  });
+
+  it('answers nothing for a model name that opens with no year', () => {
+    expect(tizenRuntime('GQ75LS03DAUXZG')).toBeNull();
+  });
+
+  it('answers nothing for a set that reported no model at all', () => {
+    expect(tizenRuntime(undefined)).toBeNull();
+  });
+});

--- a/packages/tv-installer/src/modules/tizen/runtime.ts
+++ b/packages/tv-installer/src/modules/tizen/runtime.ts
@@ -1,0 +1,30 @@
+import type { Runtime } from '../../television';
+
+const TIZEN_BY_MODEL_YEAR: Readonly<Record<number, { version: string; chromium: string }>> = {
+  2017: { version: '3.0', chromium: '47' },
+  2018: { version: '4.0', chromium: '56' },
+  2019: { version: '5.0', chromium: '63' },
+  2020: { version: '5.5', chromium: '69' },
+  2021: { version: '6.0', chromium: '76' },
+  2022: { version: '6.5', chromium: '85' },
+  2023: { version: '7.0', chromium: '94' },
+  2024: { version: '8.0', chromium: '108' },
+  2025: { version: '9.0', chromium: '120' },
+};
+
+/**
+ * What a Samsung runs, from the model year `device.model` opens with:
+ * `24_PTM_FTV_T09` is a 2024 set. The table holds what
+ * `clients/tizen/tv.target.ts` states; a year it does not carry answers null.
+ */
+export function tizenRuntime(model: string | undefined): Runtime | null {
+  const year = /^(\d{2})_/.exec(model ?? '')?.[1];
+  const dated = year === undefined ? undefined : TIZEN_BY_MODEL_YEAR[2000 + Number(year)];
+  if (!dated) return null;
+  return {
+    name: 'Tizen',
+    version: dated.version,
+    engine: { name: 'Chromium', version: dated.chromium },
+    learned: 'derived',
+  };
+}

--- a/packages/tv-installer/src/modules/tizen/schemas.ts
+++ b/packages/tv-installer/src/modules/tizen/schemas.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+const Short = z.string().max(200);
+
+export const SamsungInfo = z.object({
+  device: z.object({
+    name: Short.optional(),
+    model: Short.optional(),
+    modelName: Short.optional(),
+    ModelNumber: Short.optional(),
+    developerMode: z.string().max(8).optional(),
+    developerIP: z.string().max(64).optional(),
+    OS: z.string().max(32).optional(),
+  }),
+});
+export type SamsungInfo = z.infer<typeof SamsungInfo>;

--- a/packages/tv-installer/src/modules/tizen/sdb/capability.test.ts
+++ b/packages/tv-installer/src/modules/tizen/sdb/capability.test.ts
@@ -1,5 +1,17 @@
-import { describe, expect, it } from 'vitest';
-import { parseCapability } from './capability';
+import { afterEach, describe, expect, it } from 'vitest';
+import { parseCapability, readCapability } from './capability';
+import { SdbConnection } from './connection';
+import { capabilityPayload, deviceName, type FakeDevice, fakeDevice } from './fake-device.fixture';
+
+const PATIENT_MS = 200;
+
+const televisions: FakeDevice[] = [];
+const connections: SdbConnection[] = [];
+
+afterEach(async () => {
+  for (const connection of connections.splice(0)) connection.close();
+  await Promise.all(televisions.splice(0).map((set) => set.close()));
+});
 
 const framed = (text: string) => {
   const body = Buffer.from(text, 'utf8');
@@ -42,7 +54,28 @@ describe('the capability payload', () => {
     expect(parseCapability(payload)).toEqual({ profile_name: 'tv' });
   });
 
+  it('stops after the hundred and twenty-eighth key', () => {
+    const lines = Array.from({ length: 200 }, (_, at) => `key${at}:${at}`).join('\n');
+
+    expect(Object.keys(parseCapability(framed(lines)))).toHaveLength(128);
+  });
+
   it('is empty for a payload too short to be framed', () => {
     expect(parseCapability(Buffer.alloc(1))).toEqual({});
+  });
+});
+
+describe('asking a device what it can do', () => {
+  it('reads the framed lines the set answers with', async () => {
+    const set = await fakeDevice();
+    const name = deviceName();
+    televisions.push(set);
+    set.serve('capability:', (session) => session.end(capabilityPayload({ device_name: name })));
+    const connection = await SdbConnection.open(set.host, set.port, { timeoutMs: PATIENT_MS });
+    connections.push(connection);
+
+    const capability = await readCapability(connection);
+
+    expect(capability.device_name).toBe(name);
   });
 });

--- a/packages/tv-installer/src/modules/tizen/sdb/capability.test.ts
+++ b/packages/tv-installer/src/modules/tizen/sdb/capability.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { parseCapability } from './capability';
+
+const framed = (text: string) => {
+  const body = Buffer.from(text, 'utf8');
+  const prefix = Buffer.alloc(2);
+  prefix.writeUInt16LE(body.length, 0);
+  return Buffer.concat([prefix, body]);
+};
+
+describe('the capability payload', () => {
+  it('reads the key:value lines behind the length prefix', () => {
+    const payload = framed('secure_protocol:enabled\nsdk_toolpath:/home/owner/share/tmp\n');
+
+    const capability = parseCapability(payload);
+
+    expect(capability.secure_protocol).toBe('enabled');
+    expect(capability.sdk_toolpath).toBe('/home/owner/share/tmp');
+  });
+
+  it('stops at the byte count the device declared', () => {
+    const payload = Buffer.concat([framed('profile_name:tv\n'), Buffer.from('junk:yes\n')]);
+
+    expect(parseCapability(payload).junk).toBeUndefined();
+  });
+
+  it('reads a payload that arrives without a usable prefix', () => {
+    const payload = Buffer.from('profile_name:tv\ncpu_arch:armv7\n', 'utf8');
+
+    expect(parseCapability(payload).cpu_arch).toBe('armv7');
+  });
+
+  it('keeps a value containing a colon whole', () => {
+    const payload = framed('log_path:/tmp:/var/log\n');
+
+    expect(parseCapability(payload).log_path).toBe('/tmp:/var/log');
+  });
+
+  it('drops a line with no separator', () => {
+    const payload = framed('garbage\nprofile_name:tv\n');
+
+    expect(parseCapability(payload)).toEqual({ profile_name: 'tv' });
+  });
+
+  it('is empty for a payload too short to be framed', () => {
+    expect(parseCapability(Buffer.alloc(1))).toEqual({});
+  });
+});

--- a/packages/tv-installer/src/modules/tizen/sdb/capability.ts
+++ b/packages/tv-installer/src/modules/tizen/sdb/capability.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+import type { SdbConnection } from './connection';
+
+const MAX_PAYLOAD_BYTES = 4095;
+const MAX_ENTRIES = 128;
+const LENGTH_PREFIX_BYTES = 2;
+
+const Capability = z.record(z.string().min(1).max(64), z.string().max(512));
+
+export type Capability = z.infer<typeof Capability>;
+
+/**
+ * The `capability:` payload: a uint16 little-endian byte count, then that many
+ * bytes of `key:value` lines. Anything past the declared count is dropped, and
+ * a payload without a plausible prefix is read as bare text.
+ */
+export function parseCapability(payload: Buffer): Capability {
+  const entries: [string, string][] = [];
+  for (const line of body(payload).split('\n')) {
+    const at = line.indexOf(':');
+    if (at < 1) continue;
+    entries.push([line.slice(0, at).trim(), line.slice(at + 1).trim()]);
+    if (entries.length === MAX_ENTRIES) break;
+  }
+  return Capability.parse(Object.fromEntries(entries));
+}
+
+export async function readCapability(connection: SdbConnection): Promise<Capability> {
+  const stream = await connection.openStream('capability:');
+  const payload = await stream.drain({ limit: MAX_PAYLOAD_BYTES + LENGTH_PREFIX_BYTES });
+  stream.close();
+  return parseCapability(payload);
+}
+
+function body(payload: Buffer): string {
+  if (payload.length < LENGTH_PREFIX_BYTES) return '';
+  const declared = payload.readUInt16LE(0);
+  const framed = declared > 0 && declared <= payload.length - LENGTH_PREFIX_BYTES;
+  const bytes = framed
+    ? payload.subarray(LENGTH_PREFIX_BYTES, LENGTH_PREFIX_BYTES + declared)
+    : payload.subarray(0, MAX_PAYLOAD_BYTES);
+  return bytes.toString('utf8');
+}

--- a/packages/tv-installer/src/modules/tizen/sdb/commands.test.ts
+++ b/packages/tv-installer/src/modules/tizen/sdb/commands.test.ts
@@ -25,6 +25,10 @@ describe('the remote path', () => {
     expect(remoteName('K R;rm -rf /.wgt')).toBe('K_R_rm_-rf__.wgt');
   });
 
+  it('names the package itself when the file name leaves nothing usable', () => {
+    expect(remoteName('...')).toBe('package.wgt');
+  });
+
   it('refuses a directory that is not an absolute plain path', () => {
     expect(() => remotePath('/tmp/$(id)', 'KROMA.wgt')).toThrow(/unquotable/);
   });

--- a/packages/tv-installer/src/modules/tizen/sdb/commands.test.ts
+++ b/packages/tv-installer/src/modules/tizen/sdb/commands.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import {
+  installCommands,
+  launchCommands,
+  PACKAGE_TEMP_DIR,
+  packageIdOf,
+  remoteName,
+  remotePath,
+  removeCommands,
+  uninstallCommands,
+} from './commands';
+
+describe('the remote path', () => {
+  it('lands the package in the directory the set advertises', () => {
+    expect(remotePath(PACKAGE_TEMP_DIR, 'KROMA-tizen-1.2.3.wgt')).toBe(
+      '/home/owner/share/tmp/sdk_tools/KROMA-tizen-1.2.3.wgt',
+    );
+  });
+
+  it('does not double the separator on a directory that ends in one', () => {
+    expect(remotePath('/tmp/', 'KROMA.wgt')).toBe('/tmp/KROMA.wgt');
+  });
+
+  it('flattens anything a shell would read as syntax', () => {
+    expect(remoteName('K R;rm -rf /.wgt')).toBe('K_R_rm_-rf__.wgt');
+  });
+
+  it('refuses a directory that is not an absolute plain path', () => {
+    expect(() => remotePath('/tmp/$(id)', 'KROMA.wgt')).toThrow(/unquotable/);
+  });
+});
+
+describe('the install commands', () => {
+  it('asks the television first, then generic sdbd, then pkgcmd', () => {
+    const commands = installCommands('KromaTV001', '/tmp/KROMA.wgt');
+
+    expect(commands).toEqual([
+      '0 vd_appinstall KromaTV001 /tmp/KROMA.wgt',
+      '0 appinstall wgt /tmp/KROMA.wgt',
+      '/usr/bin/pkgcmd -i -t wgt -p "/tmp/KROMA.wgt" -q',
+    ]);
+  });
+
+  it('carries the package type through to both generic shapes', () => {
+    const commands = installCommands('KromaTV001', '/tmp/KROMA.tpk', 'tpk');
+
+    expect(commands[1]).toBe('0 appinstall tpk /tmp/KROMA.tpk');
+    expect(commands[2]).toBe('/usr/bin/pkgcmd -i -t tpk -p "/tmp/KROMA.tpk" -q');
+  });
+});
+
+describe('the other commands', () => {
+  it('uninstalls by package id', () => {
+    expect(uninstallCommands('KromaTV001')).toEqual([
+      '0 vd_appuninstall KromaTV001',
+      '0 appuninstall KromaTV001',
+      '/usr/bin/pkgcmd -u -n KromaTV001 -q',
+    ]);
+  });
+
+  it('launches by application id', () => {
+    expect(launchCommands('KromaTV001.KROMA')).toEqual([
+      '0 was_execute KromaTV001.KROMA',
+      '0 execute KromaTV001.KROMA',
+      '/usr/bin/app_launcher -s KromaTV001.KROMA',
+    ]);
+  });
+
+  it('quotes the path it deletes, as sdb does', () => {
+    expect(removeCommands('/tmp/KROMA.wgt')).toEqual([
+      '0 rmfile "/tmp/KROMA.wgt"',
+      '/bin/rm -f "/tmp/KROMA.wgt"',
+    ]);
+  });
+});
+
+describe('the package id', () => {
+  it('is the first segment of an application id', () => {
+    expect(packageIdOf('KromaTV001.KROMA')).toBe('KromaTV001');
+  });
+
+  it('is the whole id when there is nothing to split', () => {
+    expect(packageIdOf('KromaTV001')).toBe('KromaTV001');
+  });
+});

--- a/packages/tv-installer/src/modules/tizen/sdb/commands.ts
+++ b/packages/tv-installer/src/modules/tizen/sdb/commands.ts
@@ -1,0 +1,53 @@
+export const PACKAGE_TEMP_DIR = '/home/owner/share/tmp/sdk_tools';
+export const PACKAGE_TEMP_DIR_QUERY = "/usr/bin/pkgcmd -a | head -1 | awk '{print $5}'";
+
+const UNSAFE = /[^A-Za-z0-9._-]/g;
+const SAFE_PATH = /^\/[A-Za-z0-9._/-]*$/;
+
+/** A basename the device's shell takes verbatim: everything else becomes `_`. */
+export function remoteName(fileName: string): string {
+  const cleaned = fileName.replace(UNSAFE, '_').replace(/^[._]+/, '');
+  return cleaned || 'package.wgt';
+}
+
+export function remotePath(directory: string, fileName: string): string {
+  const base = directory.endsWith('/') ? directory.slice(0, -1) : directory;
+  const path = `${base}/${remoteName(fileName)}`;
+  if (!SAFE_PATH.test(path)) throw new Error(`sdb: refusing an unquotable remote path "${path}"`);
+  return path;
+}
+
+/**
+ * Every shape a set might install by, most specific first. Samsung's television
+ * sdbd answers `vd_appinstall`; a generic Tizen sdbd answers `appinstall` when
+ * it advertises the secure protocol, and `pkgcmd` is what stock sdb falls back
+ * to for a `.wgt`.
+ */
+export function installCommands(packageId: string, path: string, type = 'wgt'): string[] {
+  return [
+    `0 vd_appinstall ${packageId} ${path}`,
+    `0 appinstall ${type} ${path}`,
+    `/usr/bin/pkgcmd -i -t ${type} -p "${path}" -q`,
+  ];
+}
+
+export function uninstallCommands(packageId: string): string[] {
+  return [
+    `0 vd_appuninstall ${packageId}`,
+    `0 appuninstall ${packageId}`,
+    `/usr/bin/pkgcmd -u -n ${packageId} -q`,
+  ];
+}
+
+export function launchCommands(appId: string): string[] {
+  return [`0 was_execute ${appId}`, `0 execute ${appId}`, `/usr/bin/app_launcher -s ${appId}`];
+}
+
+export function removeCommands(path: string): string[] {
+  return [`0 rmfile "${path}"`, `/bin/rm -f "${path}"`];
+}
+
+/** `KromaTV001.KROMA` is an application id; the package it belongs to is `KromaTV001`. */
+export function packageIdOf(appId: string): string {
+  return appId.split('.')[0] ?? appId;
+}

--- a/packages/tv-installer/src/modules/tizen/sdb/connection.test.ts
+++ b/packages/tv-installer/src/modules/tizen/sdb/connection.test.ts
@@ -1,0 +1,282 @@
+import { randomBytes } from 'node:crypto';
+import { afterEach, describe, expect, it } from 'vitest';
+import { type ConnectionOptions, SdbConnection } from './connection';
+import {
+  type FakeDevice,
+  type FakeDeviceOptions,
+  fakeDevice,
+  shellCommand,
+} from './fake-device.fixture';
+import { encodePacket, HOST_MAX_DATA, PROTOCOL_VERSION, SDB_COMMAND } from './packet';
+
+const PATIENT_MS = 200;
+const IMPATIENT_MS = 100;
+const EMPTY = Buffer.alloc(0);
+
+const televisions: FakeDevice[] = [];
+const connections: SdbConnection[] = [];
+
+const television = async (options?: FakeDeviceOptions): Promise<FakeDevice> => {
+  const set = await fakeDevice(options);
+  televisions.push(set);
+  return set;
+};
+
+const open = async (set: FakeDevice, options?: ConnectionOptions): Promise<SdbConnection> => {
+  const connection = options
+    ? await SdbConnection.open(set.host, set.port, options)
+    : await SdbConnection.open(set.host, set.port);
+  connections.push(connection);
+  return connection;
+};
+
+afterEach(async () => {
+  for (const connection of connections.splice(0)) connection.close();
+  await Promise.all(televisions.splice(0).map((set) => set.close()));
+});
+
+describe('the handshake', () => {
+  it("announces Samsung's protocol version rather than adb's", async () => {
+    const set = await television();
+
+    await open(set);
+
+    expect(set.received[0]).toMatchObject({ command: SDB_COMMAND.CNXN, arg0: 0x00100000 });
+    expect(PROTOCOL_VERSION).toBe(0x00100000);
+  });
+
+  it('offers the host banner and the largest payload it will take', async () => {
+    const set = await television();
+
+    await open(set);
+
+    expect(set.received[0]?.arg1).toBe(HOST_MAX_DATA);
+    expect(set.received[0]?.data.toString('utf8')).toBe('host::\0');
+  });
+
+  it('keeps the banner the device answered with', async () => {
+    const set = await television();
+
+    const connection = await open(set);
+
+    expect(connection.banner).toBe(set.banner);
+  });
+
+  it('reassembles a banner that arrived in two reads', async () => {
+    const set = await television({ handshake: 'split' });
+
+    const connection = await open(set);
+
+    expect(connection.banner).toBe(set.banner);
+  });
+
+  it('holds writes to the payload size the device advertised', async () => {
+    const set = await television({ maxData: 4096 });
+
+    const connection = await open(set);
+
+    expect(connection.maxData).toBe(4096);
+  });
+
+  it('keeps its own ceiling when the device advertises none', async () => {
+    const set = await television({ maxData: 0 });
+
+    const connection = await open(set);
+
+    expect(connection.maxData).toBe(HOST_MAX_DATA);
+  });
+
+  it('refuses a device that demands RSA authentication', async () => {
+    const set = await television({ handshake: 'auth' });
+
+    await expect(open(set)).rejects.toThrow(/RSA authentication/);
+  });
+
+  it('gives up on a device that sends no banner at all', async () => {
+    const set = await television({ handshake: 'silence' });
+
+    await expect(open(set, { timeoutMs: IMPATIENT_MS })).rejects.toThrow(/developer mode/);
+  });
+
+  it('hangs up on a host that accepted the connection and then said nothing', async () => {
+    const set = await television({ handshake: 'silence' });
+
+    await expect(open(set, { timeoutMs: IMPATIENT_MS })).rejects.toThrow(/developer mode/);
+
+    await expect(set.hungUpOn()).resolves.toBeUndefined();
+  });
+
+  it('names the host it could not reach', async () => {
+    const set = await television();
+    await set.close();
+
+    await expect(open(set)).rejects.toThrow(`sdb: could not reach 127.0.0.1:${set.port}`);
+  });
+});
+
+describe('the stream table', () => {
+  it('carries a service output back to the stream that asked for it', async () => {
+    const set = await television();
+    const said = randomBytes(16);
+    set.serve('capability:', (session) => session.write(said));
+
+    const stream = await (await open(set)).openStream('capability:', PATIENT_MS);
+
+    expect(await stream.read(PATIENT_MS)).toEqual(said);
+  });
+
+  it('reads two packets that arrived in the same read', async () => {
+    const set = await television();
+    const said = randomBytes(16);
+    set.serve('capability:', (session) => session.end(said));
+
+    const stream = await (await open(set)).openStream('capability:', PATIENT_MS);
+
+    expect(await stream.drain({ timeoutMs: PATIENT_MS })).toEqual(said);
+    expect(await stream.read(PATIENT_MS)).toBeNull();
+  });
+
+  it('keeps two services open at once without crossing their output', async () => {
+    const set = await television();
+    const capability = randomBytes(8);
+    const output = randomBytes(8);
+    set.serve('capability:', (session) => session.end(capability));
+    set.serve('shell:', (session) => session.end(output));
+    const connection = await open(set);
+
+    const streams = await Promise.all([
+      connection.openStream('capability:', PATIENT_MS),
+      connection.openStream(`shell:${shellCommand()}`, PATIENT_MS),
+    ]);
+
+    expect(await streams[0].drain({ timeoutMs: PATIENT_MS })).toEqual(capability);
+    expect(await streams[1].drain({ timeoutMs: PATIENT_MS })).toEqual(output);
+  });
+
+  it('reports a service the device refuses to open', async () => {
+    const set = await television();
+    const connection = await open(set);
+
+    await expect(connection.openStream('appcmd:install', PATIENT_MS)).rejects.toThrow(
+      /refused appcmd:install/,
+    );
+  });
+
+  it('ignores a packet addressed to a stream it has forgotten', async () => {
+    const set = await television();
+    const said = randomBytes(8);
+    set.serve('shell:', (session) => session.end(said));
+    const connection = await open(set);
+
+    set.raw(encodePacket({ command: SDB_COMMAND.WRTE, arg0: 9, arg1: 4096, data: randomBytes(4) }));
+    const stream = await connection.openStream(`shell:${shellCommand()}`, PATIENT_MS);
+
+    expect(await stream.drain({ timeoutMs: PATIENT_MS })).toEqual(said);
+  });
+
+  it('writes nothing to a socket that is already gone', async () => {
+    const set = await television();
+    set.serve('shell:', () => undefined);
+    const connection = await open(set);
+    const stream = await connection.openStream(`shell:${shellCommand()}`, PATIENT_MS);
+
+    connection.close();
+    stream.close();
+
+    expect(set.received.filter((packet) => packet.command === SDB_COMMAND.CLSE)).toEqual([]);
+  });
+});
+
+describe('a frame the device could not have sent', () => {
+  const streaming = async () => {
+    const set = await television();
+    set.serve('shell:', () => undefined);
+    const connection = await open(set);
+    const stream = await connection.openStream(`shell:${shellCommand()}`, PATIENT_MS);
+    return { set, stream, reading: stream.read(PATIENT_MS) };
+  };
+
+  it('kills the connection when the magic does not invert the command', async () => {
+    const { set, stream, reading } = await streaming();
+    const frame = encodePacket({
+      command: SDB_COMMAND.WRTE,
+      arg0: 9,
+      arg1: stream.localId,
+      data: randomBytes(4),
+    });
+    frame.writeUInt32LE(0, 20);
+
+    set.raw(frame);
+
+    await expect(reading).rejects.toThrow(/bad frame/);
+  });
+
+  it('kills the connection when the payload does not match its checksum', async () => {
+    const { set, stream, reading } = await streaming();
+    const frame = encodePacket({
+      command: SDB_COMMAND.WRTE,
+      arg0: 9,
+      arg1: stream.localId,
+      data: randomBytes(4),
+    });
+    frame.writeUInt32LE(0, 16);
+
+    set.raw(frame);
+
+    await expect(reading).rejects.toThrow(/checksum/);
+  });
+
+  it('kills the connection on a command that makes no sense on a stream', async () => {
+    const { set, stream, reading } = await streaming();
+    const frame = encodePacket({
+      command: SDB_COMMAND.OPEN,
+      arg0: 9,
+      arg1: stream.localId,
+      data: EMPTY,
+    });
+
+    set.raw(frame);
+
+    await expect(reading).rejects.toThrow(/unexpected OPEN/);
+  });
+});
+
+describe('a device that goes away', () => {
+  it('reports the set resetting the connection under it', async () => {
+    const set = await television();
+    set.serve('shell:', () => undefined);
+    const connection = await open(set);
+    const stream = await connection.openStream(`shell:${shellCommand()}`, PATIENT_MS);
+    const reading = stream.read(PATIENT_MS);
+
+    set.reset();
+
+    await expect(reading).rejects.toThrow(/ECONNRESET/);
+  });
+
+  it('fails whoever was waiting on it', async () => {
+    const set = await television();
+    set.serve('shell:', () => undefined);
+    const connection = await open(set);
+    const stream = await connection.openStream(`shell:${shellCommand()}`, PATIENT_MS);
+    const reading = stream.read(PATIENT_MS);
+
+    await set.close();
+
+    await expect(reading).rejects.toThrow(/closed the connection/);
+  });
+
+  it('opens nothing more once it has gone', async () => {
+    const set = await television();
+    set.serve('shell:', () => undefined);
+    const connection = await open(set);
+    const stream = await connection.openStream(`shell:${shellCommand()}`, PATIENT_MS);
+    const reading = stream.read(PATIENT_MS);
+    await set.close();
+    await expect(reading).rejects.toThrow();
+
+    await expect(connection.openStream('capability:', PATIENT_MS)).rejects.toThrow(
+      /closed the connection/,
+    );
+  });
+});

--- a/packages/tv-installer/src/modules/tizen/sdb/connection.ts
+++ b/packages/tv-installer/src/modules/tizen/sdb/connection.ts
@@ -47,7 +47,14 @@ export class SdbConnection implements StreamTransport {
   ): Promise<SdbConnection> {
     const socket = await dial(host, port, timeoutMs);
     const connection = new SdbConnection(socket);
-    await connection.handshake(timeoutMs);
+    try {
+      await connection.handshake(timeoutMs);
+    } catch (error) {
+      // A host that accepts 26101 without being a television leaves the socket
+      // open otherwise, and a sweep meets a few of those on every network.
+      connection.close();
+      throw error;
+    }
     return connection;
   }
 

--- a/packages/tv-installer/src/modules/tizen/sdb/connection.ts
+++ b/packages/tv-installer/src/modules/tizen/sdb/connection.ts
@@ -1,0 +1,164 @@
+import { createConnection, type Socket } from 'node:net';
+import {
+  commandName,
+  encodePacket,
+  HOST_BANNER,
+  HOST_MAX_DATA,
+  PacketReader,
+  PROTOCOL_VERSION,
+  SDB_COMMAND,
+  type SdbPacket,
+} from './packet';
+import { SdbStream, type StreamTransport } from './stream';
+
+export const SDB_PORT = 26101;
+
+const HANDSHAKE_TIMEOUT_MS = 15_000;
+
+export interface ConnectionOptions {
+  timeoutMs?: number;
+}
+
+/**
+ * A live sdb transport to one device. Every service runs on its own multiplexed
+ * stream, so several may be open at once on the single socket.
+ */
+export class SdbConnection implements StreamTransport {
+  maxData = HOST_MAX_DATA;
+  banner = '';
+
+  private readonly reader = new PacketReader(HOST_MAX_DATA);
+  private readonly streams = new Map<number, SdbStream>();
+  private nextId = 1;
+  private failure: Error | null = null;
+  private onConnected: ((banner: string) => void) | null = null;
+  private onRejected: ((error: Error) => void) | null = null;
+
+  private constructor(private readonly socket: Socket) {
+    socket.on('data', (chunk) => this.receive(chunk));
+    socket.on('error', (error) => this.fail(error));
+    socket.on('close', () => this.fail(new Error('sdb: the device closed the connection')));
+  }
+
+  static async open(
+    host: string,
+    port = SDB_PORT,
+    { timeoutMs = HANDSHAKE_TIMEOUT_MS }: ConnectionOptions = {},
+  ): Promise<SdbConnection> {
+    const socket = await dial(host, port, timeoutMs);
+    const connection = new SdbConnection(socket);
+    await connection.handshake(timeoutMs);
+    return connection;
+  }
+
+  async openStream(service: string, timeoutMs = HANDSHAKE_TIMEOUT_MS): Promise<SdbStream> {
+    if (this.failure) throw this.failure;
+    const localId = this.nextId++;
+    const stream = new SdbStream(service, localId, this);
+    this.streams.set(localId, stream);
+    const ready = stream.ready(timeoutMs);
+    this.send(SDB_COMMAND.OPEN, localId, 0, Buffer.from(`${service}\0`, 'utf8'));
+    await ready;
+    return stream;
+  }
+
+  send(command: number, arg0: number, arg1: number, data: Buffer): void {
+    if (this.socket.destroyed) return;
+    this.socket.write(encodePacket({ command, arg0, arg1, data }));
+  }
+
+  release(localId: number): void {
+    this.streams.delete(localId);
+  }
+
+  close(): void {
+    this.socket.destroy();
+  }
+
+  private handshake(timeoutMs: number): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error('sdb: no banner, the set may not be in developer mode')),
+        timeoutMs,
+      );
+      const settle = (error?: Error) => {
+        clearTimeout(timer);
+        this.onConnected = null;
+        this.onRejected = null;
+        if (error) reject(error);
+        else resolve();
+      };
+      this.onConnected = (banner) => {
+        this.banner = banner;
+        settle();
+      };
+      this.onRejected = settle;
+      this.send(
+        SDB_COMMAND.CNXN,
+        PROTOCOL_VERSION,
+        HOST_MAX_DATA,
+        Buffer.from(HOST_BANNER, 'utf8'),
+      );
+    });
+  }
+
+  private receive(chunk: Buffer): void {
+    let packets: SdbPacket[];
+    try {
+      packets = this.reader.push(chunk);
+    } catch (error) {
+      this.fail(error as Error);
+      return;
+    }
+    for (const packet of packets) this.dispatch(packet);
+  }
+
+  private dispatch(packet: SdbPacket): void {
+    if (packet.command === SDB_COMMAND.CNXN) {
+      this.maxData = Math.min(HOST_MAX_DATA, packet.arg1 || HOST_MAX_DATA);
+      this.onConnected?.(packet.data.toString('utf8').replace(/\0+$/, ''));
+      return;
+    }
+    if (packet.command === SDB_COMMAND.AUTH) {
+      this.onRejected?.(
+        new Error('sdb: the device demands RSA authentication, which Tizen does not'),
+      );
+      return;
+    }
+    const stream = this.streams.get(packet.arg1);
+    if (!stream) return;
+    if (packet.command === SDB_COMMAND.OKAY) stream.onOkay(packet.arg0);
+    else if (packet.command === SDB_COMMAND.WRTE) stream.onData(packet.data);
+    else if (packet.command === SDB_COMMAND.CLSE) stream.onClose();
+    else this.fail(new Error(`sdb: unexpected ${commandName(packet.command)}`));
+  }
+
+  private fail(error: Error): void {
+    if (this.failure) return;
+    this.failure = error;
+    this.onRejected?.(error);
+    for (const stream of [...this.streams.values()]) stream.onFail(error);
+    this.streams.clear();
+    this.socket.destroy();
+  }
+}
+
+function dial(host: string, port: number, timeoutMs: number): Promise<Socket> {
+  return new Promise((resolve, reject) => {
+    const socket = createConnection({ host, port });
+    socket.setNoDelay(true);
+    socket.setTimeout(timeoutMs);
+    const fail = (message: string) => () => {
+      socket.destroy();
+      reject(new Error(`sdb: ${message} ${host}:${port}`));
+    };
+    socket.once('connect', () => {
+      socket.setTimeout(0);
+      socket.removeAllListeners('timeout');
+      socket.removeAllListeners('error');
+      resolve(socket);
+    });
+    socket.once('timeout', fail('timed out connecting to'));
+    socket.once('error', fail('could not reach'));
+  });
+}

--- a/packages/tv-installer/src/modules/tizen/sdb/connection.ts
+++ b/packages/tv-installer/src/modules/tizen/sdb/connection.ts
@@ -116,7 +116,7 @@ export class SdbConnection implements StreamTransport {
   private dispatch(packet: SdbPacket): void {
     if (packet.command === SDB_COMMAND.CNXN) {
       this.maxData = Math.min(HOST_MAX_DATA, packet.arg1 || HOST_MAX_DATA);
-      this.onConnected?.(packet.data.toString('utf8').replace(/\0+$/, ''));
+      this.onConnected?.(bannerFrom(packet.data));
       return;
     }
     if (packet.command === SDB_COMMAND.AUTH) {
@@ -137,10 +137,16 @@ export class SdbConnection implements StreamTransport {
     if (this.failure) return;
     this.failure = error;
     this.onRejected?.(error);
-    for (const stream of [...this.streams.values()]) stream.onFail(error);
+    for (const stream of this.streams.values()) stream.onFail(error);
     this.streams.clear();
     this.socket.destroy();
   }
+}
+
+function bannerFrom(data: Buffer): string {
+  let end = data.length;
+  while (end > 0 && data[end - 1] === 0) end -= 1;
+  return data.subarray(0, end).toString('utf8');
 }
 
 function dial(host: string, port: number, timeoutMs: number): Promise<Socket> {

--- a/packages/tv-installer/src/modules/tizen/sdb/device.test.ts
+++ b/packages/tv-installer/src/modules/tizen/sdb/device.test.ts
@@ -1,0 +1,323 @@
+import { randomBytes, randomInt } from 'node:crypto';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { installCommands, PACKAGE_TEMP_DIR, packageIdOf } from './commands';
+import { connect, devices, type SdbDevice } from './device';
+import {
+  applicationId,
+  capabilityPayload,
+  deviceName,
+  type FakeDevice,
+  fakeDevice,
+  toolPath,
+} from './fake-device.fixture';
+import { SYNC_HEADER_BYTES, syncRequest } from './sync';
+
+const PATIENT_MS = 200;
+const SHELL = 'shell:';
+
+interface TelevisionOptions {
+  capability?: Record<string, string>;
+  answers?: Record<string, string>;
+  shells?: string;
+}
+
+const televisions: FakeDevice[] = [];
+const attached: SdbDevice[] = [];
+const directories: string[] = [];
+
+const localFile = () => {
+  const directory = mkdtempSync(join(tmpdir(), 'kroma-sdb-'));
+  directories.push(directory);
+  const path = join(directory, `KROMA-${randomInt(1000)}.wgt`);
+  writeFileSync(path, randomBytes(64));
+  return path;
+};
+
+const television = async ({
+  capability = { sdk_toolpath: toolPath() },
+  answers = {},
+  shells = SHELL,
+}: TelevisionOptions) => {
+  const set = await fakeDevice();
+  televisions.push(set);
+  const commands: string[] = [];
+  const pushed: Buffer[] = [];
+  set.serve('capability:', (session) => session.end(capabilityPayload(capability)));
+  set.serve('sync:', async (session) => {
+    for (;;) {
+      const message = await session.read();
+      pushed.push(message);
+      if (message.subarray(0, 4).toString('ascii') === 'DONE') {
+        session.write(syncRequest('OKAY', 0));
+      }
+    }
+  });
+  set.serve(shells, (session) => {
+    const command = session.service.slice(SHELL.length);
+    commands.push(command);
+    const match = Object.entries(answers).find(([fragment]) => command.includes(fragment));
+    session.end(match?.[1] ?? 'sh: command not found');
+  });
+  const device = await connect(set.host, set.port);
+  attached.push(device);
+  return { set, device, commands, pushed };
+};
+
+const destination = (pushed: readonly Buffer[]): string =>
+  (pushed[0] ?? Buffer.alloc(SYNC_HEADER_BYTES))
+    .subarray(SYNC_HEADER_BYTES)
+    .toString('utf8')
+    .split(',')[0] ?? '';
+
+afterEach(async () => {
+  for (const device of attached.splice(0)) device.close();
+  for (const directory of directories.splice(0))
+    rmSync(directory, { recursive: true, force: true });
+  await Promise.all(televisions.splice(0).map((set) => set.close()));
+});
+
+describe('a connected device', () => {
+  it('keeps the banner the set introduced itself with', async () => {
+    const { set, device } = await television({});
+
+    expect(device.banner).toBe(set.banner);
+  });
+
+  it('answers with what a command printed', async () => {
+    const { device } = await television({ answers: { getversion: '5.5\n' } });
+
+    expect(await device.shell('/usr/bin/profile_command getversion')).toBe('5.5\n');
+  });
+
+  it('asks the set what it can do only once', async () => {
+    const platformVersion = `8.${randomInt(9)}`;
+    const { set, device } = await television({ capability: { platform_version: platformVersion } });
+
+    const [first, second] = [await device.capability(), await device.capability()];
+
+    expect([first.platform_version, second.platform_version]).toEqual([
+      platformVersion,
+      platformVersion,
+    ]);
+    expect(set.opened.filter((service) => service === 'capability:')).toHaveLength(1);
+  });
+
+  it('pushes a file to the path it was handed', async () => {
+    const { device, pushed } = await television({});
+    const remote = `${toolPath()}/KROMA.wgt`;
+
+    await device.push(localFile(), remote);
+
+    expect(destination(pushed)).toBe(remote);
+  });
+});
+
+describe('installing a package', () => {
+  it('puts it in the directory the set advertises', async () => {
+    const advertised = toolPath();
+    const { device, pushed } = await television({ capability: { sdk_toolpath: advertised } });
+    const artifact = localFile();
+
+    await device.install(artifact, { appId: applicationId() });
+
+    expect(destination(pushed)).toBe(`${advertised}/${basename(artifact)}`);
+  });
+
+  it('asks pkgcmd where packages go when the set advertises no path', async () => {
+    const queried = toolPath();
+    const { device, pushed } = await television({ capability: {}, answers: { pkgcmd: queried } });
+    const artifact = localFile();
+
+    await device.install(artifact, { appId: applicationId() });
+
+    expect(destination(pushed)).toBe(`${queried}/${basename(artifact)}`);
+  });
+
+  it('falls back to the stock temporary path when nothing answers', async () => {
+    const { device, pushed } = await television({ capability: {} });
+    const artifact = localFile();
+
+    await device.install(artifact, { appId: applicationId() });
+
+    expect(destination(pushed)).toBe(`${PACKAGE_TEMP_DIR}/${basename(artifact)}`);
+  });
+
+  it('stops at the first command shape the set accepts', async () => {
+    const { device, commands } = await television({
+      answers: { vd_appinstall: 'install completed' },
+    });
+
+    const result = await device.install(localFile(), { appId: applicationId() });
+
+    expect(result.verdict).toBe('success');
+    expect(commands.filter((command) => command.includes('appinstall'))).toHaveLength(1);
+  });
+
+  it('falls through to pkgcmd when the dispatcher knows neither shape', async () => {
+    const advertised = toolPath();
+    const { device, commands } = await television({
+      capability: { sdk_toolpath: advertised },
+      answers: { 'pkgcmd -i': 'processing result : OK [0] succeeded' },
+    });
+    const appId = applicationId();
+    const artifact = localFile();
+
+    const result = await device.install(artifact, { appId });
+
+    expect(result).toMatchObject({ verdict: 'success', code: 0 });
+    expect(commands.slice(0, 3)).toEqual(
+      installCommands(packageIdOf(appId), `${advertised}/${basename(artifact)}`),
+    );
+  });
+
+  it('reports a refusal rather than trying the next shape', async () => {
+    const { device, commands } = await television({
+      answers: { vd_appinstall: 'processing result : FAIL [62] installation failed' },
+    });
+
+    const result = await device.install(localFile(), { appId: applicationId() });
+
+    expect(result).toMatchObject({ verdict: 'failure', code: 62 });
+    expect(commands.filter((command) => command.includes('appinstall'))).toHaveLength(1);
+  });
+
+  it('names the package rather than the application it holds', async () => {
+    const advertised = toolPath();
+    const { device, commands } = await television({
+      capability: { sdk_toolpath: advertised },
+      answers: { vd_appinstall: 'install completed' },
+    });
+    const appId = applicationId();
+    const artifact = localFile();
+
+    await device.install(artifact, { appId });
+
+    expect(commands[0]).toBe(
+      `0 vd_appinstall ${packageIdOf(appId)} ${advertised}/${basename(artifact)}`,
+    );
+  });
+
+  it('removes the package it pushed, even when the install failed', async () => {
+    const { device, commands, pushed } = await television({
+      answers: { vd_appinstall: 'installation failed', rmfile: '' },
+    });
+
+    await device.install(localFile(), { appId: applicationId() });
+
+    expect(commands).toContain(`0 rmfile "${destination(pushed)}"`);
+  });
+
+  it('reaches for /bin/rm when the dispatcher has no rmfile', async () => {
+    const { device, commands, pushed } = await television({
+      answers: {
+        vd_appinstall: 'install completed',
+        rmfile: 'sh: command not found',
+        '/bin/rm': '',
+      },
+    });
+
+    await device.install(localFile(), { appId: applicationId() });
+
+    expect(commands).toContain(`/bin/rm -f "${destination(pushed)}"`);
+  });
+
+  it('installs anyway when the set will not open a shell to clean up', async () => {
+    const { device } = await television({
+      shells: `${SHELL}0 vd_appinstall`,
+      answers: { vd_appinstall: 'install completed' },
+    });
+
+    const result = await device.install(localFile(), { appId: applicationId() });
+
+    expect(result.verdict).toBe('success');
+  });
+
+  it('logs every command it tried and what came back', async () => {
+    const lines: string[] = [];
+    const { device } = await television({ answers: { vd_appinstall: 'install completed' } });
+    const log = (line: string) => void lines.push(line);
+
+    await device.install(localFile(), { appId: applicationId(), log });
+
+    expect(lines.filter((line) => line.startsWith('> '))).toHaveLength(1);
+    expect(lines.at(-1)).toMatch(/ success \[0\]: install completed$/);
+  });
+});
+
+describe('launching and uninstalling', () => {
+  it('tries every launch shape until one answers', async () => {
+    const { device, commands } = await television({ answers: { '0 execute': 'result: launched' } });
+    const appId = applicationId();
+
+    const result = await device.launch(appId);
+
+    expect(result.verdict).toBe('success');
+    expect(commands).toEqual([`0 was_execute ${appId}`, `0 execute ${appId}`]);
+  });
+
+  it('uninstalls by package id', async () => {
+    const { device, commands } = await television({
+      answers: { vd_appuninstall: 'uninstall completed' },
+    });
+    const packageId = applicationId().split('.')[0] ?? '';
+
+    const result = await device.uninstall(packageId);
+
+    expect(result.verdict).toBe('success');
+    expect(commands).toEqual([`0 vd_appuninstall ${packageId}`]);
+  });
+});
+
+describe('looking for televisions', () => {
+  it('reads the name, profile and platform a set advertises', async () => {
+    const name = deviceName();
+    const { set } = await television({
+      capability: { device_name: name, profile_name: 'tv', platform_version: '8.0' },
+    });
+
+    expect(await devices([set.host], set.port)).toEqual([
+      {
+        host: set.host,
+        port: set.port,
+        reachable: true,
+        name,
+        profile: 'tv',
+        platformVersion: '8.0',
+      },
+    ]);
+  });
+
+  it('leaves blank what a set does not advertise', async () => {
+    const { set } = await television({ capability: {} });
+
+    expect(await devices([set.host], set.port)).toEqual([
+      {
+        host: set.host,
+        port: set.port,
+        reachable: true,
+        name: '',
+        profile: '',
+        platformVersion: '',
+      },
+    ]);
+  });
+
+  it('marks a host nothing answers on as unreachable', async () => {
+    const set = await fakeDevice();
+    await set.close();
+
+    expect(await devices([set.host], set.port, { timeoutMs: PATIENT_MS })).toEqual([
+      {
+        host: set.host,
+        port: set.port,
+        reachable: false,
+        name: '',
+        profile: '',
+        platformVersion: '',
+      },
+    ]);
+  });
+});

--- a/packages/tv-installer/src/modules/tizen/sdb/device.ts
+++ b/packages/tv-installer/src/modules/tizen/sdb/device.ts
@@ -1,0 +1,158 @@
+import { basename } from 'node:path';
+import type { LogLine } from '../../../run';
+import { type Capability, readCapability } from './capability';
+import {
+  installCommands,
+  launchCommands,
+  PACKAGE_TEMP_DIR,
+  PACKAGE_TEMP_DIR_QUERY,
+  packageIdOf,
+  remotePath,
+  removeCommands,
+  uninstallCommands,
+} from './commands';
+import { type ConnectionOptions, SDB_PORT, SdbConnection } from './connection';
+import { describeResult, parseResult, type SdbResult } from './result';
+import { type ShellOptions, shell } from './shell';
+import { type PushOptions, pushFile } from './sync';
+
+const ABSOLUTE_PATH = /^\/[A-Za-z0-9._/-]+$/;
+const UNSUPPORTED = /(command not found|unknown command|not supported|invalid command|usage:)/i;
+const NOTHING_RAN: SdbResult = {
+  verdict: 'failure',
+  code: null,
+  output: 'no command was accepted',
+};
+
+export interface InstallOptions {
+  appId: string;
+  type?: string;
+  log?: LogLine;
+  onProgress?: (sent: number, total: number) => void;
+}
+
+export interface SdbDevice {
+  readonly host: string;
+  readonly port: number;
+  readonly banner: string;
+  capability(): Promise<Capability>;
+  shell(command: string, options?: ShellOptions): Promise<string>;
+  push(localPath: string, remote: string, options?: PushOptions): Promise<void>;
+  install(artifact: string, options: InstallOptions): Promise<SdbResult>;
+  launch(appId: string): Promise<SdbResult>;
+  uninstall(packageId: string): Promise<SdbResult>;
+  close(): void;
+}
+
+export interface DeviceInfo {
+  host: string;
+  port: number;
+  reachable: boolean;
+  name: string;
+  profile: string;
+  platformVersion: string;
+}
+
+/** Opens one device on its sdb port. Nothing else needs to be installed to reach it. */
+export async function connect(
+  host: string,
+  port = SDB_PORT,
+  options: ConnectionOptions = {},
+): Promise<SdbDevice> {
+  const connection = await SdbConnection.open(host, port, options);
+  let capability: Capability | null = null;
+
+  const capabilities = async () => {
+    capability ??= await readCapability(connection);
+    return capability;
+  };
+
+  const attempt = async (commands: readonly string[], log?: LogLine): Promise<SdbResult> => {
+    let fallback: SdbResult | null = null;
+    for (const command of commands) {
+      log?.(`> ${command}`);
+      const result = parseResult(await shell(connection, command));
+      log?.(describeResult(command, result));
+      if (result.verdict === 'success') return result;
+      if (result.verdict === 'failure' && !UNSUPPORTED.test(result.output)) return result;
+      fallback ??= result;
+    }
+    return fallback ?? NOTHING_RAN;
+  };
+
+  const remove = async (path: string): Promise<void> => {
+    for (const command of removeCommands(path)) {
+      const result = parseResult(await shell(connection, command, { limit: 4096 }));
+      if (result.verdict !== 'failure') return;
+    }
+  };
+
+  return {
+    host,
+    port,
+    banner: connection.banner,
+    capability: capabilities,
+    shell: (command, shellOptions) => shell(connection, command, shellOptions),
+    push: (localPath, remote, pushOptions) => pushFile(connection, localPath, remote, pushOptions),
+    launch: (appId) => attempt(launchCommands(appId)),
+    uninstall: (packageId) => attempt(uninstallCommands(packageId)),
+    close: () => connection.close(),
+
+    async install(artifact, { appId, type = 'wgt', log, onProgress }) {
+      const directory = await temporaryDirectory(connection, await capabilities());
+      const remote = remotePath(directory, basename(artifact));
+      log?.(`pushing ${basename(artifact)} to ${remote}`);
+      await pushFile(connection, artifact, remote, { onProgress });
+
+      const result = await attempt(installCommands(packageIdOf(appId), remote, type), log);
+      await remove(remote).catch(() => undefined);
+      return result;
+    },
+  };
+}
+
+/** Which of these hosts answers on the sdb port, and what each one says it is. */
+export async function devices(
+  hosts: readonly string[],
+  port = SDB_PORT,
+  options: ConnectionOptions = {},
+): Promise<DeviceInfo[]> {
+  return Promise.all(hosts.map((host) => describe(host, port, options)));
+}
+
+async function describe(
+  host: string,
+  port: number,
+  options: ConnectionOptions,
+): Promise<DeviceInfo> {
+  const blank = { host, port, reachable: false, name: '', profile: '', platformVersion: '' };
+  try {
+    const connection = await SdbConnection.open(host, port, options);
+    try {
+      const capability = await readCapability(connection);
+      return {
+        host,
+        port,
+        reachable: true,
+        name: capability.device_name ?? '',
+        profile: capability.profile_name ?? '',
+        platformVersion: capability.platform_version ?? '',
+      };
+    } finally {
+      connection.close();
+    }
+  } catch {
+    return blank;
+  }
+}
+
+async function temporaryDirectory(
+  connection: SdbConnection,
+  capability: Capability,
+): Promise<string> {
+  const advertised = capability.sdk_toolpath?.trim();
+  if (advertised && ABSOLUTE_PATH.test(advertised)) return advertised;
+
+  const queried = (await shell(connection, PACKAGE_TEMP_DIR_QUERY, { limit: 512 })).trim();
+  return ABSOLUTE_PATH.test(queried) ? queried : PACKAGE_TEMP_DIR;
+}

--- a/packages/tv-installer/src/modules/tizen/sdb/fake-device.fixture.ts
+++ b/packages/tv-installer/src/modules/tizen/sdb/fake-device.fixture.ts
@@ -137,7 +137,7 @@ export async function fakeDevice({
   };
 
   const openService = (socket: Socket, packet: SdbPacket): void => {
-    const service = packet.data.toString('utf8').replace(/\0+$/, '');
+    const service = trimNul(packet.data.toString('utf8'));
     opened.push(service);
     const handler =
       services.get(service) ?? [...services].find(([prefix]) => service.startsWith(prefix))?.[1];
@@ -181,8 +181,12 @@ export async function fakeDevice({
     banner,
     received,
     opened,
-    serve: (service, handler) => void services.set(service, handler),
-    raw: (bytes) => void sockets.at(-1)?.write(bytes),
+    serve: (service, handler) => {
+      services.set(service, handler);
+    },
+    raw: (bytes) => {
+      sockets.at(-1)?.write(bytes);
+    },
     hungUpOn: () =>
       new Promise<void>((resolve) => {
         const socket = sockets.at(-1);
@@ -196,4 +200,10 @@ export async function fakeDevice({
         server.close(() => resolve());
       }),
   };
+}
+
+function trimNul(text: string): string {
+  let end = text.length;
+  while (end > 0 && text[end - 1] === '\0') end -= 1;
+  return text.slice(0, end);
 }

--- a/packages/tv-installer/src/modules/tizen/sdb/fake-device.fixture.ts
+++ b/packages/tv-installer/src/modules/tizen/sdb/fake-device.fixture.ts
@@ -1,0 +1,199 @@
+import { randomBytes, randomInt } from 'node:crypto';
+import { createServer, type Socket } from 'node:net';
+import {
+  encodePacket,
+  HEADER_BYTES,
+  HOST_MAX_DATA,
+  PacketReader,
+  PROTOCOL_VERSION,
+  SDB_COMMAND,
+  type SdbPacket,
+} from './packet';
+
+const EMPTY = Buffer.alloc(0);
+const SPLIT_DELAY_MS = 5;
+const NAMES = ['Salon', 'Chambre', 'Cuisine', 'Bureau', 'Atelier'];
+const DIRECTORIES = ['sdk_tools', 'sideload', 'staging', 'widgets'];
+const TOOLS = ['pkgcmd', 'app_launcher', 'profile_command', 'wrt-launcher'];
+
+const pick = <T>(values: readonly T[]): T => values[randomInt(values.length)] as T;
+const bytesOf = (payload: Buffer | string): Buffer =>
+  typeof payload === 'string' ? Buffer.from(payload, 'utf8') : payload;
+
+export const deviceName = (): string => `${pick(NAMES)} ${randomInt(1, 99)}`;
+export const toolPath = (): string => `/home/owner/share/tmp/${pick(DIRECTORIES)}${randomInt(99)}`;
+export const shellCommand = (): string => `/usr/bin/${pick(TOOLS)} -${randomInt(99)}`;
+export const streamId = (): number => randomInt(1, 4096);
+export const applicationId = (): string => `KromaTV${randomInt(100, 999)}.KROMA`;
+
+export function capabilityPayload(entries: Record<string, string>): Buffer {
+  const lines = Object.entries(entries).map(([key, value]) => `${key}:${value}\n`);
+  const body = Buffer.from(lines.join(''), 'utf8');
+  const prefix = Buffer.alloc(2);
+  prefix.writeUInt16LE(body.length, 0);
+  return Buffer.concat([prefix, body]);
+}
+
+export interface ServiceSession {
+  readonly service: string;
+  read(): Promise<Buffer>;
+  write(payload: Buffer | string): void;
+  end(payload: Buffer | string): void;
+  close(): void;
+}
+
+export type ServiceHandler = (session: ServiceSession) => void;
+
+export interface FakeDeviceOptions {
+  banner?: string;
+  maxData?: number;
+  handshake?: 'banner' | 'split' | 'auth' | 'silence';
+}
+
+export interface FakeDevice {
+  readonly host: string;
+  readonly port: number;
+  readonly banner: string;
+  readonly received: SdbPacket[];
+  readonly opened: string[];
+  serve(service: string, handler: ServiceHandler): void;
+  raw(bytes: Buffer): void;
+  reset(): void;
+  /** Resolves when the client hangs up on the connection this device accepted. */
+  hungUpOn(): Promise<void>;
+  close(): Promise<void>;
+}
+
+class DeviceSession implements ServiceSession {
+  private readonly waiting: ((payload: Buffer) => void)[] = [];
+
+  constructor(
+    readonly service: string,
+    private readonly deviceId: number,
+    private readonly hostId: number,
+    private readonly socket: Socket,
+  ) {}
+
+  accept(payload: Buffer): void {
+    this.socket.write(this.frame(SDB_COMMAND.OKAY, EMPTY));
+    const waiter = this.waiting.shift();
+    if (!waiter) throw new Error(`the fake device was not reading ${this.service}`);
+    waiter(payload);
+  }
+
+  read(): Promise<Buffer> {
+    return new Promise((resolve) => this.waiting.push(resolve));
+  }
+
+  write(payload: Buffer | string): void {
+    this.socket.write(this.frame(SDB_COMMAND.WRTE, bytesOf(payload)));
+  }
+
+  end(payload: Buffer | string): void {
+    const said = this.frame(SDB_COMMAND.WRTE, bytesOf(payload));
+    this.socket.write(Buffer.concat([said, this.frame(SDB_COMMAND.CLSE, EMPTY)]));
+  }
+
+  close(): void {
+    this.socket.write(this.frame(SDB_COMMAND.CLSE, EMPTY));
+  }
+
+  private frame(command: number, data: Buffer): Buffer {
+    return encodePacket({ command, arg0: this.deviceId, arg1: this.hostId, data });
+  }
+}
+
+export async function fakeDevice({
+  banner = `device::${randomBytes(4).toString('hex')}`,
+  maxData = HOST_MAX_DATA,
+  handshake = 'banner',
+}: FakeDeviceOptions = {}): Promise<FakeDevice> {
+  const services = new Map<string, ServiceHandler>();
+  const sessions = new Map<number, DeviceSession>();
+  const received: SdbPacket[] = [];
+  const opened: string[] = [];
+  const sockets: Socket[] = [];
+  let nextId = 101;
+
+  const answerHandshake = (socket: Socket): void => {
+    if (handshake === 'silence') return;
+    if (handshake === 'auth') {
+      const challenge = { command: SDB_COMMAND.AUTH, arg0: 1, arg1: 0, data: randomBytes(20) };
+      socket.write(encodePacket(challenge));
+      return;
+    }
+    const hello = encodePacket({
+      command: SDB_COMMAND.CNXN,
+      arg0: PROTOCOL_VERSION,
+      arg1: maxData,
+      data: Buffer.from(`${banner}\0`, 'utf8'),
+    });
+    if (handshake === 'banner') {
+      socket.write(hello);
+      return;
+    }
+    socket.write(hello.subarray(0, HEADER_BYTES + 2));
+    setTimeout(() => socket.write(hello.subarray(HEADER_BYTES + 2)), SPLIT_DELAY_MS);
+  };
+
+  const openService = (socket: Socket, packet: SdbPacket): void => {
+    const service = packet.data.toString('utf8').replace(/\0+$/, '');
+    opened.push(service);
+    const handler =
+      services.get(service) ?? [...services].find(([prefix]) => service.startsWith(prefix))?.[1];
+    if (!handler) {
+      const refusal = { command: SDB_COMMAND.CLSE, arg0: 0, arg1: packet.arg0, data: EMPTY };
+      socket.write(encodePacket(refusal));
+      return;
+    }
+    const deviceId = nextId++;
+    const session = new DeviceSession(service, deviceId, packet.arg0, socket);
+    sessions.set(deviceId, session);
+    const accepted = { command: SDB_COMMAND.OKAY, arg0: deviceId, arg1: packet.arg0, data: EMPTY };
+    socket.write(encodePacket(accepted));
+    handler(session);
+  };
+
+  const handle = (socket: Socket, packet: SdbPacket): void => {
+    received.push(packet);
+    if (packet.command === SDB_COMMAND.CNXN) answerHandshake(socket);
+    if (packet.command === SDB_COMMAND.OPEN) openService(socket, packet);
+    if (packet.command === SDB_COMMAND.CLSE) sessions.delete(packet.arg1);
+    if (packet.command === SDB_COMMAND.WRTE) sessions.get(packet.arg1)?.accept(packet.data);
+  };
+
+  const server = createServer((socket) => {
+    sockets.push(socket);
+    socket.setNoDelay(true);
+    socket.on('error', () => undefined);
+    const reader = new PacketReader(HOST_MAX_DATA);
+    socket.on('data', (chunk) => {
+      for (const packet of reader.push(chunk)) handle(socket, packet);
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (address === null || typeof address === 'string') throw new Error('no port was assigned');
+
+  return {
+    host: '127.0.0.1',
+    port: address.port,
+    banner,
+    received,
+    opened,
+    serve: (service, handler) => void services.set(service, handler),
+    raw: (bytes) => void sockets.at(-1)?.write(bytes),
+    hungUpOn: () =>
+      new Promise<void>((resolve) => {
+        const socket = sockets.at(-1);
+        if (!socket || socket.destroyed) return resolve();
+        socket.once('close', () => resolve());
+      }),
+    reset: () => sockets.at(-1)?.resetAndDestroy(),
+    close: () =>
+      new Promise<void>((resolve) => {
+        for (const socket of sockets.splice(0)) socket.destroy();
+        server.close(() => resolve());
+      }),
+  };
+}

--- a/packages/tv-installer/src/modules/tizen/sdb/index.ts
+++ b/packages/tv-installer/src/modules/tizen/sdb/index.ts
@@ -1,0 +1,22 @@
+export { type Capability, parseCapability, readCapability } from './capability';
+export {
+  installCommands,
+  launchCommands,
+  PACKAGE_TEMP_DIR,
+  packageIdOf,
+  remoteName,
+  remotePath,
+  removeCommands,
+  uninstallCommands,
+} from './commands';
+export { type ConnectionOptions, SDB_PORT, SdbConnection } from './connection';
+export {
+  connect,
+  type DeviceInfo,
+  devices,
+  type InstallOptions,
+  type SdbDevice,
+} from './device';
+export { describeResult, parseResult, type SdbResult, type Verdict } from './result';
+export { type ShellOptions, shell } from './shell';
+export { PUSH_MODE, type PushOptions, pushFile } from './sync';

--- a/packages/tv-installer/src/modules/tizen/sdb/packet.test.ts
+++ b/packages/tv-installer/src/modules/tizen/sdb/packet.test.ts
@@ -29,13 +29,13 @@ describe('the header', () => {
     expect(header.command).toBe(SDB_COMMAND.CNXN);
     expect(header.arg0).toBe(PROTOCOL_VERSION);
     expect(header.arg1).toBe(HOST_MAX_DATA);
-    expect(header.length).toBe(packet.data.length);
+    expect(header).toHaveLength(packet.data.length);
   });
 
   it('is 24 bytes ahead of the payload', () => {
     const encoded = encodePacket(connect());
 
-    expect(encoded.length).toBe(HEADER_BYTES + HOST_BANNER.length);
+    expect(encoded).toHaveLength(HEADER_BYTES + HOST_BANNER.length);
     expect(encoded.subarray(HEADER_BYTES).toString('utf8')).toBe(HOST_BANNER);
   });
 

--- a/packages/tv-installer/src/modules/tizen/sdb/packet.test.ts
+++ b/packages/tv-installer/src/modules/tizen/sdb/packet.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import {
+  checksum,
+  commandName,
+  decodeHeader,
+  encodePacket,
+  HEADER_BYTES,
+  HOST_BANNER,
+  HOST_MAX_DATA,
+  headerIsSane,
+  PacketReader,
+  PROTOCOL_VERSION,
+  SDB_COMMAND,
+} from './packet';
+
+const connect = () => ({
+  command: SDB_COMMAND.CNXN,
+  arg0: PROTOCOL_VERSION,
+  arg1: HOST_MAX_DATA,
+  data: Buffer.from(HOST_BANNER, 'utf8'),
+});
+
+describe('the header', () => {
+  it('survives an encode and decode round trip', () => {
+    const packet = connect();
+
+    const header = decodeHeader(encodePacket(packet));
+
+    expect(header.command).toBe(SDB_COMMAND.CNXN);
+    expect(header.arg0).toBe(PROTOCOL_VERSION);
+    expect(header.arg1).toBe(HOST_MAX_DATA);
+    expect(header.length).toBe(packet.data.length);
+  });
+
+  it('is 24 bytes ahead of the payload', () => {
+    const encoded = encodePacket(connect());
+
+    expect(encoded.length).toBe(HEADER_BYTES + HOST_BANNER.length);
+    expect(encoded.subarray(HEADER_BYTES).toString('utf8')).toBe(HOST_BANNER);
+  });
+
+  it('carries the magic as the command inverted', () => {
+    const header = decodeHeader(encodePacket(connect()));
+
+    expect(header.magic).toBe((SDB_COMMAND.CNXN ^ 0xffffffff) >>> 0);
+    expect(headerIsSane(header, HOST_MAX_DATA)).toBe(true);
+  });
+
+  it('rejects a header whose magic does not invert its command', () => {
+    const encoded = encodePacket(connect());
+    encoded.writeUInt32LE(0, 20);
+
+    expect(headerIsSane(decodeHeader(encoded), HOST_MAX_DATA)).toBe(false);
+  });
+
+  it('rejects a payload longer than the negotiated maximum', () => {
+    const encoded = encodePacket(connect());
+    encoded.writeUInt32LE(HOST_MAX_DATA + 1, 12);
+
+    expect(headerIsSane(decodeHeader(encoded), HOST_MAX_DATA)).toBe(false);
+  });
+});
+
+describe('the checksum', () => {
+  it('is the sum of every payload byte', () => {
+    expect(checksum(Buffer.from([1, 2, 3]))).toBe(6);
+    expect(checksum(Buffer.alloc(0))).toBe(0);
+  });
+
+  it('sums bytes rather than characters', () => {
+    expect(checksum(Buffer.from('host::\0', 'utf8'))).toBe(562);
+  });
+});
+
+describe('the reader', () => {
+  it('yields a packet once the whole payload has arrived', () => {
+    const reader = new PacketReader();
+    const encoded = encodePacket(connect());
+
+    const first = reader.push(encoded.subarray(0, 10));
+    const second = reader.push(encoded.subarray(10));
+
+    expect(first).toEqual([]);
+    expect(second).toHaveLength(1);
+    expect(second[0]?.data.toString('utf8')).toBe(HOST_BANNER);
+  });
+
+  it('yields several packets out of one chunk', () => {
+    const reader = new PacketReader();
+    const okay = { command: SDB_COMMAND.OKAY, arg0: 1, arg1: 2, data: Buffer.alloc(0) };
+
+    const packets = reader.push(Buffer.concat([encodePacket(okay), encodePacket(connect())]));
+
+    expect(packets.map((packet) => packet.command)).toEqual([SDB_COMMAND.OKAY, SDB_COMMAND.CNXN]);
+  });
+
+  it('throws on a frame the device could not have sent', () => {
+    const reader = new PacketReader();
+    const encoded = encodePacket(connect());
+    encoded.writeUInt32LE(0xdeadbeef, 20);
+
+    expect(() => reader.push(encoded)).toThrow(/bad frame/);
+  });
+
+  it('throws when the payload does not match its checksum', () => {
+    const reader = new PacketReader();
+    const encoded = encodePacket(connect());
+    encoded.writeUInt32LE(0, 16);
+
+    expect(() => reader.push(encoded)).toThrow(/checksum/);
+  });
+});
+
+describe('a command name', () => {
+  it('reads back as the four letters on the wire', () => {
+    expect(commandName(SDB_COMMAND.WRTE)).toBe('WRTE');
+    expect(commandName(SDB_COMMAND.CLSE)).toBe('CLSE');
+  });
+
+  it('falls back to hex for anything unknown', () => {
+    expect(commandName(0x12345678)).toBe('0x12345678');
+  });
+});

--- a/packages/tv-installer/src/modules/tizen/sdb/packet.ts
+++ b/packages/tv-installer/src/modules/tizen/sdb/packet.ts
@@ -10,7 +10,7 @@ export const SDB_COMMAND = {
 export type SdbCommand = (typeof SDB_COMMAND)[keyof typeof SDB_COMMAND];
 
 export const HEADER_BYTES = 24;
-export const PROTOCOL_VERSION = 0x0010_0000;
+export const PROTOCOL_VERSION = 0x00100000;
 export const HOST_MAX_DATA = 256 * 1024;
 export const HOST_BANNER = 'host::\0';
 

--- a/packages/tv-installer/src/modules/tizen/sdb/packet.ts
+++ b/packages/tv-installer/src/modules/tizen/sdb/packet.ts
@@ -1,0 +1,100 @@
+export const SDB_COMMAND = {
+  CNXN: 0x4e584e43,
+  OPEN: 0x4e45504f,
+  OKAY: 0x59414b4f,
+  CLSE: 0x45534c43,
+  WRTE: 0x45545257,
+  AUTH: 0x48545541,
+} as const;
+
+export type SdbCommand = (typeof SDB_COMMAND)[keyof typeof SDB_COMMAND];
+
+export const HEADER_BYTES = 24;
+export const PROTOCOL_VERSION = 0x0010_0000;
+export const HOST_MAX_DATA = 256 * 1024;
+export const HOST_BANNER = 'host::\0';
+
+const NAMES = new Map<number, string>(
+  Object.entries(SDB_COMMAND).map(([name, value]) => [value, name]),
+);
+
+export interface SdbPacket {
+  command: number;
+  arg0: number;
+  arg1: number;
+  data: Buffer;
+}
+
+export function commandName(command: number): string {
+  return NAMES.get(command) ?? `0x${command.toString(16).padStart(8, '0')}`;
+}
+
+export function checksum(data: Buffer): number {
+  let total = 0;
+  for (const byte of data) total = (total + byte) >>> 0;
+  return total;
+}
+
+export function encodePacket({ command, arg0, arg1, data }: SdbPacket): Buffer {
+  const header = Buffer.alloc(HEADER_BYTES);
+  header.writeUInt32LE(command >>> 0, 0);
+  header.writeUInt32LE(arg0 >>> 0, 4);
+  header.writeUInt32LE(arg1 >>> 0, 8);
+  header.writeUInt32LE(data.length, 12);
+  header.writeUInt32LE(checksum(data), 16);
+  header.writeUInt32LE((command ^ 0xffffffff) >>> 0, 20);
+  return data.length === 0 ? header : Buffer.concat([header, data]);
+}
+
+export interface SdbHeader {
+  command: number;
+  arg0: number;
+  arg1: number;
+  length: number;
+  checksum: number;
+  magic: number;
+}
+
+export function decodeHeader(buffer: Buffer): SdbHeader {
+  return {
+    command: buffer.readUInt32LE(0),
+    arg0: buffer.readUInt32LE(4),
+    arg1: buffer.readUInt32LE(8),
+    length: buffer.readUInt32LE(12),
+    checksum: buffer.readUInt32LE(16),
+    magic: buffer.readUInt32LE(20),
+  };
+}
+
+export function headerIsSane(header: SdbHeader, maxData: number): boolean {
+  return header.magic === (header.command ^ 0xffffffff) >>> 0 && header.length <= maxData;
+}
+
+/**
+ * Reassembles packets out of a byte stream. Throws on a header whose magic or
+ * payload checksum disagrees, because past that point the stream is desynced
+ * and every later frame is noise.
+ */
+export class PacketReader {
+  private buffer: Buffer = Buffer.alloc(0);
+
+  constructor(private readonly maxData: number = HOST_MAX_DATA) {}
+
+  push(chunk: Buffer): SdbPacket[] {
+    this.buffer = this.buffer.length === 0 ? chunk : Buffer.concat([this.buffer, chunk]);
+    const packets: SdbPacket[] = [];
+    for (;;) {
+      if (this.buffer.length < HEADER_BYTES) return packets;
+      const header = decodeHeader(this.buffer);
+      if (!headerIsSane(header, this.maxData)) {
+        throw new Error(`sdb: bad frame from the device (${commandName(header.command)})`);
+      }
+      if (this.buffer.length < HEADER_BYTES + header.length) return packets;
+
+      const data = this.buffer.subarray(HEADER_BYTES, HEADER_BYTES + header.length);
+      if (checksum(data) !== header.checksum) throw new Error('sdb: payload checksum mismatch');
+      this.buffer = this.buffer.subarray(HEADER_BYTES + header.length);
+      packets.push({ command: header.command, arg0: header.arg0, arg1: header.arg1, data });
+    }
+  }
+}

--- a/packages/tv-installer/src/modules/tizen/sdb/result.test.ts
+++ b/packages/tv-installer/src/modules/tizen/sdb/result.test.ts
@@ -56,6 +56,10 @@ describe('the description', () => {
     );
   });
 
+  it('says only the verdict when the set printed nothing at all', () => {
+    expect(describeResult('launch', parseResult(''))).toBe('launch unknown');
+  });
+
   it('keeps the last three lines only', () => {
     const result = parseResult('one\ntwo\nthree\nfour\n');
 

--- a/packages/tv-installer/src/modules/tizen/sdb/result.test.ts
+++ b/packages/tv-installer/src/modules/tizen/sdb/result.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { describeResult, parseResult } from './result';
+
+describe('an install result', () => {
+  it('reads a pkgcmd success', () => {
+    const output =
+      'spend time for pkgcmd is 3419.000000 ms\nprocessing result : OK [0] succeeded\n';
+
+    expect(parseResult(output)).toMatchObject({ verdict: 'success', code: 0 });
+  });
+
+  it('reads a pkgcmd failure and keeps its code', () => {
+    const output = 'processing result : FAIL [-12] Signature error\n';
+
+    expect(parseResult(output)).toMatchObject({ verdict: 'failure', code: -12 });
+  });
+
+  it('trusts the appcmd exit code over anything else in the output', () => {
+    const output = 'appcmd_returnstr:install completed\nappcmd_exitcode:1\n';
+
+    expect(parseResult(output)).toMatchObject({ verdict: 'failure', code: 1 });
+  });
+
+  it('reads an appcmd success', () => {
+    expect(parseResult('appcmd_exitcode:0\n')).toMatchObject({ verdict: 'success', code: 0 });
+  });
+
+  it('reads the television wording', () => {
+    const output = 'spend time for vd_appinstall is 5000 ms\ninstall completed\n';
+
+    expect(parseResult(output).verdict).toBe('success');
+  });
+
+  it('calls a rejected command a failure', () => {
+    expect(parseResult('sh: 0: command not found\n').verdict).toBe('failure');
+  });
+
+  it('calls silence unknown rather than either verdict', () => {
+    expect(parseResult('   \n').verdict).toBe('unknown');
+    expect(parseResult('sending: 100%\n').verdict).toBe('unknown');
+  });
+});
+
+describe('a launch result', () => {
+  it('reads the launcher answering with an id', () => {
+    expect(parseResult('app_id is [KromaTV001.KROMA]\n').verdict).toBe('success');
+  });
+});
+
+describe('the description', () => {
+  it('names the action, the verdict and the last thing the set said', () => {
+    const result = parseResult('processing result : OK [0] succeeded\n');
+
+    expect(describeResult('install', result)).toBe(
+      'install success [0]: processing result : OK [0] succeeded',
+    );
+  });
+
+  it('keeps the last three lines only', () => {
+    const result = parseResult('one\ntwo\nthree\nfour\n');
+
+    expect(describeResult('install', result)).toBe('install unknown: two / three / four');
+  });
+});

--- a/packages/tv-installer/src/modules/tizen/sdb/result.ts
+++ b/packages/tv-installer/src/modules/tizen/sdb/result.ts
@@ -1,0 +1,46 @@
+export type Verdict = 'success' | 'failure' | 'unknown';
+
+export interface SdbResult {
+  verdict: Verdict;
+  code: number | null;
+  output: string;
+}
+
+const APPCMD_EXIT = /appcmd_exitcode:\s*(-?\d+)/;
+const PROCESSING = /processing result\s*:\s*([A-Za-z_]+)\s*\[\s*(-?\d+)\s*\]/i;
+const SUCCESS =
+  /(install completed|uninstall completed|successfully installed|succeeded|result:\s*launched|app_id is)/i;
+const FAILURE =
+  /(command not found|permission denied|no such file|not installed|installation failed|failed|failure|denied|error)/i;
+
+/**
+ * Reads a device's answer to an install, launch or uninstall. `unknown` means
+ * the set said nothing this parser recognises, which is a reason to try the
+ * next command shape rather than to report a failure.
+ */
+export function parseResult(output: string): SdbResult {
+  const text = output.trim();
+
+  const exit = APPCMD_EXIT.exec(text);
+  if (exit?.[1]) {
+    const code = Number(exit[1]);
+    return { verdict: code === 0 ? 'success' : 'failure', code, output: text };
+  }
+
+  const processing = PROCESSING.exec(text);
+  if (processing?.[1] && processing[2]) {
+    const code = Number(processing[2]);
+    const ok = /^(ok|success)/i.test(processing[1]) && code === 0;
+    return { verdict: ok ? 'success' : 'failure', code, output: text };
+  }
+
+  if (SUCCESS.test(text)) return { verdict: 'success', code: 0, output: text };
+  if (FAILURE.test(text)) return { verdict: 'failure', code: null, output: text };
+  return { verdict: 'unknown', code: null, output: text };
+}
+
+export function describeResult(action: string, result: SdbResult): string {
+  const tail = result.output.split('\n').filter(Boolean).slice(-3).join(' / ');
+  const code = result.code === null ? '' : ` [${result.code}]`;
+  return `${action} ${result.verdict}${code}${tail ? `: ${tail}` : ''}`;
+}

--- a/packages/tv-installer/src/modules/tizen/sdb/result.ts
+++ b/packages/tv-installer/src/modules/tizen/sdb/result.ts
@@ -7,7 +7,7 @@ export interface SdbResult {
 }
 
 const APPCMD_EXIT = /appcmd_exitcode:\s*(-?\d+)/;
-const PROCESSING = /processing result\s*:\s*([A-Za-z_]+)\s*\[\s*(-?\d+)\s*\]/i;
+const PROCESSING = /processing result\s*:\s*([A-Z_]+)\s*\[\s*(-?\d+)\s*\]/i;
 const SUCCESS =
   /(install completed|uninstall completed|successfully installed|succeeded|result:\s*launched|app_id is)/i;
 const FAILURE =
@@ -42,5 +42,6 @@ export function parseResult(output: string): SdbResult {
 export function describeResult(action: string, result: SdbResult): string {
   const tail = result.output.split('\n').filter(Boolean).slice(-3).join(' / ');
   const code = result.code === null ? '' : ` [${result.code}]`;
-  return `${action} ${result.verdict}${code}${tail ? `: ${tail}` : ''}`;
+  const said = tail ? `: ${tail}` : '';
+  return `${action} ${result.verdict}${code}${said}`;
 }

--- a/packages/tv-installer/src/modules/tizen/sdb/shell.test.ts
+++ b/packages/tv-installer/src/modules/tizen/sdb/shell.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SdbConnection } from './connection';
+import { type FakeDevice, fakeDevice, shellCommand } from './fake-device.fixture';
+import { SDB_COMMAND } from './packet';
+import { shell } from './shell';
+
+const PATIENT_MS = 200;
+const IMPATIENT_MS = 20;
+
+const televisions: FakeDevice[] = [];
+const connections: SdbConnection[] = [];
+
+const answering = async (prints: string | null): Promise<[FakeDevice, SdbConnection]> => {
+  const set = await fakeDevice();
+  televisions.push(set);
+  set.serve('shell:', (session) => (prints === null ? undefined : session.end(prints)));
+  const connection = await SdbConnection.open(set.host, set.port, { timeoutMs: PATIENT_MS });
+  connections.push(connection);
+  return [set, connection];
+};
+
+afterEach(async () => {
+  for (const connection of connections.splice(0)) connection.close();
+  await Promise.all(televisions.splice(0).map((set) => set.close()));
+});
+
+describe('a shell command', () => {
+  it('runs on the device as one service of its own', async () => {
+    const [set, connection] = await answering('');
+    const command = shellCommand();
+
+    await shell(connection, command, { timeoutMs: PATIENT_MS });
+
+    expect(set.opened).toEqual([`shell:${command}`]);
+  });
+
+  it('answers with everything the command printed', async () => {
+    const [, connection] = await answering('processing result : OK [0] succeeded\n');
+
+    const output = await shell(connection, shellCommand(), { timeoutMs: PATIENT_MS });
+
+    expect(output).toBe('processing result : OK [0] succeeded\n');
+  });
+
+  it('stops reading at the byte limit it was given', async () => {
+    const [, connection] = await answering('x'.repeat(4096));
+
+    const output = await shell(connection, shellCommand(), { limit: 8, timeoutMs: PATIENT_MS });
+
+    expect(output).toBe('xxxxxxxx');
+  });
+
+  it('closes the stream even when the command never answers', async () => {
+    const [set, connection] = await answering(null);
+
+    await expect(shell(connection, shellCommand(), { timeoutMs: IMPATIENT_MS })).rejects.toThrow(
+      /went quiet/,
+    );
+
+    await vi.waitFor(
+      () => expect(set.received.some((packet) => packet.command === SDB_COMMAND.CLSE)).toBe(true),
+      { timeout: PATIENT_MS, interval: 5 },
+    );
+  });
+});

--- a/packages/tv-installer/src/modules/tizen/sdb/shell.ts
+++ b/packages/tv-installer/src/modules/tizen/sdb/shell.ts
@@ -1,0 +1,24 @@
+import type { SdbConnection } from './connection';
+
+const DEFAULT_LIMIT = 64 * 1024;
+const DEFAULT_TIMEOUT_MS = 300_000;
+
+export interface ShellOptions {
+  limit?: number;
+  timeoutMs?: number;
+}
+
+/** Runs one command and returns what it printed, capped at `limit` bytes. */
+export async function shell(
+  connection: SdbConnection,
+  command: string,
+  { limit = DEFAULT_LIMIT, timeoutMs = DEFAULT_TIMEOUT_MS }: ShellOptions = {},
+): Promise<string> {
+  const stream = await connection.openStream(`shell:${command}`);
+  try {
+    const output = await stream.drain({ limit, timeoutMs });
+    return output.toString('utf8');
+  } finally {
+    stream.close();
+  }
+}

--- a/packages/tv-installer/src/modules/tizen/sdb/stream.test.ts
+++ b/packages/tv-installer/src/modules/tizen/sdb/stream.test.ts
@@ -1,0 +1,208 @@
+import { randomBytes } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { shellCommand, streamId } from './fake-device.fixture';
+import { SDB_COMMAND } from './packet';
+import { SdbStream } from './stream';
+
+const PATIENT_MS = 200;
+const IMPATIENT_MS = 20;
+
+interface Frame {
+  command: number;
+  arg0: number;
+  arg1: number;
+  data: Buffer;
+}
+
+const settle = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+const transport = (maxData: number) => {
+  const sent: Frame[] = [];
+  const released: number[] = [];
+  return {
+    maxData,
+    sent,
+    released,
+    get writes() {
+      return sent.filter((frame) => frame.command === SDB_COMMAND.WRTE);
+    },
+    send: (command: number, arg0: number, arg1: number, data: Buffer) =>
+      void sent.push({ command, arg0, arg1, data }),
+    release: (localId: number) => void released.push(localId),
+  };
+};
+
+const unopened = (maxData = 8) => {
+  const wire = transport(maxData);
+  const localId = streamId();
+  const stream = new SdbStream(`shell:${shellCommand()}`, localId, wire);
+  return { stream, wire, localId };
+};
+
+const opened = async (maxData = 8) => {
+  const { stream, wire, localId } = unopened(maxData);
+  const remoteId = streamId();
+  const ready = stream.ready(PATIENT_MS);
+  stream.onOkay(remoteId);
+  await ready;
+  const ack = async (times: number) => {
+    for (let sent = 0; sent < times; sent += 1) {
+      await settle();
+      stream.onOkay(remoteId);
+    }
+  };
+  return { stream, wire, localId, remoteId, ack };
+};
+
+describe('an open stream', () => {
+  it('takes its peer id from the acceptance', async () => {
+    const { stream, remoteId } = await opened();
+
+    expect(stream.remoteId).toBe(remoteId);
+  });
+
+  it('acknowledges each payload the device writes', async () => {
+    const { stream, wire, localId, remoteId } = await opened();
+
+    stream.onData(randomBytes(4));
+    stream.onData(randomBytes(4));
+
+    expect(wire.sent).toEqual([
+      { command: SDB_COMMAND.OKAY, arg0: localId, arg1: remoteId, data: Buffer.alloc(0) },
+      { command: SDB_COMMAND.OKAY, arg0: localId, arg1: remoteId, data: Buffer.alloc(0) },
+    ]);
+  });
+
+  it('hands a caller the payload that arrived before it asked', async () => {
+    const { stream } = await opened();
+    const said = randomBytes(8);
+
+    stream.onData(said);
+
+    expect(await stream.read(PATIENT_MS)).toEqual(said);
+  });
+
+  it('sends one chunk per acknowledgement, none of them past the negotiated size', async () => {
+    const { stream, wire, ack } = await opened(8);
+
+    const writing = stream.write(randomBytes(20));
+    await ack(3);
+    await writing;
+
+    expect(wire.writes.map((frame) => frame.data.length)).toEqual([8, 8, 4]);
+  });
+
+  it('collects everything the service said until it closed', async () => {
+    const { stream } = await opened();
+    const first = randomBytes(4);
+    const second = randomBytes(4);
+
+    stream.onData(first);
+    stream.onData(second);
+    stream.onClose();
+
+    expect(await stream.drain()).toEqual(Buffer.concat([first, second]));
+  });
+
+  it('stops draining at the byte limit', async () => {
+    const { stream } = await opened();
+
+    for (let chunk = 0; chunk < 3; chunk += 1) stream.onData(randomBytes(4));
+
+    expect(await stream.drain({ limit: 8, timeoutMs: PATIENT_MS })).toHaveLength(8);
+  });
+
+  it('echoes the close back and gives up its id', async () => {
+    const { stream, wire, localId, remoteId } = await opened();
+
+    stream.close();
+
+    expect(wire.sent).toEqual([
+      { command: SDB_COMMAND.CLSE, arg0: localId, arg1: remoteId, data: Buffer.alloc(0) },
+    ]);
+    expect(wire.released).toEqual([localId]);
+  });
+
+  it('closes once however many times it is asked', async () => {
+    const { stream, wire } = await opened();
+
+    stream.close();
+    stream.close();
+
+    expect(wire.sent).toHaveLength(1);
+  });
+
+  it('reads nothing more once the device has closed it', async () => {
+    const { stream } = await opened();
+
+    stream.onClose();
+
+    expect(await stream.read(PATIENT_MS)).toBeNull();
+  });
+});
+
+describe('a stream the device never accepted', () => {
+  it('rejects when the device refuses the service outright', async () => {
+    const { stream, wire } = unopened();
+
+    const ready = stream.ready(PATIENT_MS);
+    stream.onClose();
+
+    await expect(ready).rejects.toThrow(/refused/);
+    expect(wire.sent).toEqual([]);
+  });
+
+  it('gives up on a device that never answers the open', async () => {
+    const { stream } = unopened();
+
+    await expect(stream.ready(IMPATIENT_MS)).rejects.toThrow(/never accepted/);
+  });
+});
+
+describe('a stream that loses the device', () => {
+  it('fails a write the device closed under, with the rest of it unsent', async () => {
+    const { stream, wire } = await opened(8);
+
+    const writing = stream.write(randomBytes(20), PATIENT_MS);
+    await settle();
+    stream.onClose();
+
+    await expect(writing).rejects.toThrow(/closed mid-write/);
+    expect(wire.writes).toHaveLength(1);
+  });
+
+  it('rejects the reader and the writer waiting on it', async () => {
+    const { stream } = await opened(8);
+    const gone = new Error('sdb: the device closed the connection');
+
+    const reading = stream.read(PATIENT_MS);
+    const writing = stream.write(randomBytes(4), PATIENT_MS);
+    stream.onFail(gone);
+
+    await expect(reading).rejects.toThrow(gone);
+    await expect(writing).rejects.toThrow(gone);
+  });
+
+  it('rejects a later read with the failure that killed it', async () => {
+    const { stream } = await opened();
+    const gone = new Error('sdb: the device closed the connection');
+
+    stream.onFail(gone);
+
+    await expect(stream.read(PATIENT_MS)).rejects.toThrow(gone);
+  });
+
+  it('gives up on a service that went quiet', async () => {
+    const { stream } = await opened();
+
+    await expect(stream.read(IMPATIENT_MS)).rejects.toThrow(/went quiet/);
+  });
+
+  it('gives up on a write nothing acknowledges', async () => {
+    const { stream } = await opened();
+
+    await expect(stream.write(randomBytes(4), IMPATIENT_MS)).rejects.toThrow(
+      /never acknowledged a write/,
+    );
+  });
+});

--- a/packages/tv-installer/src/modules/tizen/sdb/stream.ts
+++ b/packages/tv-installer/src/modules/tizen/sdb/stream.ts
@@ -1,0 +1,139 @@
+import { SDB_COMMAND } from './packet';
+
+const EMPTY = Buffer.alloc(0);
+
+export interface StreamTransport {
+  readonly maxData: number;
+  send(command: number, arg0: number, arg1: number, data: Buffer): void;
+  release(localId: number): void;
+}
+
+export interface DrainOptions {
+  limit?: number;
+  timeoutMs?: number;
+}
+
+interface Waiter<T> {
+  resolve: (value: T) => void;
+  reject: (error: Error) => void;
+}
+
+const DEFAULT_LIMIT = 256 * 1024;
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/** One multiplexed service on an open connection: `shell:…`, `sync:`, `capability:`. */
+export class SdbStream {
+  remoteId = 0;
+  private readonly pending: Buffer[] = [];
+  private readonly readers: Waiter<Buffer | null>[] = [];
+  private readonly acks: Waiter<void>[] = [];
+  private opened: Waiter<void> | null = null;
+  private ended = false;
+  private failure: Error | null = null;
+
+  constructor(
+    readonly service: string,
+    readonly localId: number,
+    private readonly transport: StreamTransport,
+  ) {}
+
+  ready(timeoutMs: number): Promise<void> {
+    return this.deadline(
+      new Promise<void>((resolve, reject) => {
+        this.opened = { resolve, reject };
+      }),
+      timeoutMs,
+      `sdb: the device never accepted ${this.service}`,
+    );
+  }
+
+  onOkay(remoteId: number): void {
+    if (this.remoteId === 0) {
+      this.remoteId = remoteId;
+      this.opened?.resolve();
+      this.opened = null;
+      return;
+    }
+    this.acks.shift()?.resolve();
+  }
+
+  onData(data: Buffer): void {
+    this.transport.send(SDB_COMMAND.OKAY, this.localId, this.remoteId, EMPTY);
+    const reader = this.readers.shift();
+    if (reader) reader.resolve(data);
+    else this.pending.push(data);
+  }
+
+  onClose(): void {
+    if (this.ended) return;
+    this.ended = true;
+    if (this.remoteId !== 0) {
+      this.transport.send(SDB_COMMAND.CLSE, this.localId, this.remoteId, EMPTY);
+    }
+    this.transport.release(this.localId);
+    this.opened?.reject(new Error(`sdb: the device refused ${this.service}`));
+    this.opened = null;
+    for (const reader of this.readers.splice(0)) reader.resolve(null);
+    for (const ack of this.acks.splice(0)) ack.reject(new Error('sdb: stream closed mid-write'));
+  }
+
+  onFail(error: Error): void {
+    this.failure = error;
+    this.ended = true;
+    this.opened?.reject(error);
+    this.opened = null;
+    for (const reader of this.readers.splice(0)) reader.reject(error);
+    for (const ack of this.acks.splice(0)) ack.reject(error);
+  }
+
+  async write(data: Buffer, timeoutMs = DEFAULT_TIMEOUT_MS): Promise<void> {
+    for (let at = 0; at < data.length; at += this.transport.maxData) {
+      const chunk = data.subarray(at, at + this.transport.maxData);
+      const acked = new Promise<void>((resolve, reject) => {
+        this.acks.push({ resolve, reject });
+      });
+      this.transport.send(SDB_COMMAND.WRTE, this.localId, this.remoteId, chunk);
+      await this.deadline(acked, timeoutMs, `sdb: ${this.service} never acknowledged a write`);
+    }
+  }
+
+  read(timeoutMs = DEFAULT_TIMEOUT_MS): Promise<Buffer | null> {
+    if (this.failure) return Promise.reject(this.failure);
+    const buffered = this.pending.shift();
+    if (buffered) return Promise.resolve(buffered);
+    if (this.ended) return Promise.resolve(null);
+    return this.deadline(
+      new Promise<Buffer | null>((resolve, reject) => {
+        this.readers.push({ resolve, reject });
+      }),
+      timeoutMs,
+      `sdb: ${this.service} went quiet`,
+    );
+  }
+
+  /** Everything the service says until it closes, capped at `limit` bytes. */
+  async drain({ limit = DEFAULT_LIMIT, timeoutMs }: DrainOptions = {}): Promise<Buffer> {
+    const chunks: Buffer[] = [];
+    let size = 0;
+    for (;;) {
+      const chunk = await this.read(timeoutMs);
+      if (!chunk) break;
+      chunks.push(chunk);
+      size += chunk.length;
+      if (size >= limit) break;
+    }
+    return Buffer.concat(chunks).subarray(0, limit);
+  }
+
+  close(): void {
+    this.onClose();
+  }
+
+  private deadline<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const expiry = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+    });
+    return Promise.race([promise, expiry]).finally(() => clearTimeout(timer)) as Promise<T>;
+  }
+}

--- a/packages/tv-installer/src/modules/tizen/sdb/sync.test.ts
+++ b/packages/tv-installer/src/modules/tizen/sdb/sync.test.ts
@@ -12,7 +12,7 @@ describe('a sync request', () => {
   it('is four ascii letters and a little-endian length', () => {
     const request = syncRequest('DONE', 1_700_000_000);
 
-    expect(request.length).toBe(SYNC_HEADER_BYTES);
+    expect(request).toHaveLength(SYNC_HEADER_BYTES);
     expect(request.subarray(0, 4).toString('ascii')).toBe('DONE');
     expect(request.readUInt32LE(4)).toBe(1_700_000_000);
   });
@@ -21,7 +21,7 @@ describe('a sync request', () => {
     const payload = syncPayload('DATA', Buffer.alloc(4096));
 
     expect(payload.readUInt32LE(4)).toBe(4096);
-    expect(payload.length).toBe(SYNC_HEADER_BYTES + 4096);
+    expect(payload).toHaveLength(SYNC_HEADER_BYTES + 4096);
   });
 
   it('names the file and its mode in one comma-joined field', () => {

--- a/packages/tv-installer/src/modules/tizen/sdb/sync.test.ts
+++ b/packages/tv-installer/src/modules/tizen/sdb/sync.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PUSH_MODE,
+  parseSyncMessage,
+  SYNC_HEADER_BYTES,
+  sendRequest,
+  syncPayload,
+  syncRequest,
+} from './sync';
+
+describe('a sync request', () => {
+  it('is four ascii letters and a little-endian length', () => {
+    const request = syncRequest('DONE', 1_700_000_000);
+
+    expect(request.length).toBe(SYNC_HEADER_BYTES);
+    expect(request.subarray(0, 4).toString('ascii')).toBe('DONE');
+    expect(request.readUInt32LE(4)).toBe(1_700_000_000);
+  });
+
+  it('puts the payload length in the header when it carries one', () => {
+    const payload = syncPayload('DATA', Buffer.alloc(4096));
+
+    expect(payload.readUInt32LE(4)).toBe(4096);
+    expect(payload.length).toBe(SYNC_HEADER_BYTES + 4096);
+  });
+
+  it('names the file and its mode in one comma-joined field', () => {
+    const request = sendRequest('/home/owner/share/tmp/sdk_tools/KROMA.wgt');
+
+    expect(request.subarray(SYNC_HEADER_BYTES).toString('utf8')).toBe(
+      `/home/owner/share/tmp/sdk_tools/KROMA.wgt,${PUSH_MODE}`,
+    );
+  });
+
+  it('sends the mode as the decimal st_mode sdb uses', () => {
+    expect(PUSH_MODE).toBe(33261);
+  });
+});
+
+describe('a sync reply', () => {
+  it('reads an acceptance', () => {
+    expect(parseSyncMessage(syncRequest('OKAY', 0))).toEqual({ id: 'OKAY', value: 0 });
+  });
+
+  it('reads a refusal and the length of its message', () => {
+    const reply = syncPayload('FAIL', Buffer.from('no such directory', 'utf8'));
+
+    expect(parseSyncMessage(reply)).toEqual({ id: 'FAIL', value: 17 });
+  });
+
+  it('waits for the whole header before deciding anything', () => {
+    expect(parseSyncMessage(Buffer.from('OKA', 'ascii'))).toBeNull();
+  });
+});

--- a/packages/tv-installer/src/modules/tizen/sdb/sync.test.ts
+++ b/packages/tv-installer/src/modules/tizen/sdb/sync.test.ts
@@ -1,12 +1,67 @@
-import { describe, expect, it } from 'vitest';
+import { randomBytes, randomInt } from 'node:crypto';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { SdbConnection } from './connection';
+import { type FakeDevice, fakeDevice, type ServiceSession, toolPath } from './fake-device.fixture';
 import {
   PUSH_MODE,
   parseSyncMessage,
+  pushFile,
   SYNC_HEADER_BYTES,
   sendRequest,
   syncPayload,
   syncRequest,
 } from './sync';
+
+const PATIENT_MS = 200;
+
+const televisions: FakeDevice[] = [];
+const connections: SdbConnection[] = [];
+const directories: string[] = [];
+
+const idOf = (message: Buffer): string => message.subarray(0, 4).toString('ascii');
+const messageOf = (heard: readonly Buffer[], id: string): Buffer =>
+  heard.find((message) => idOf(message) === id) ?? Buffer.alloc(SYNC_HEADER_BYTES);
+const dataOf = (heard: readonly Buffer[]): Buffer =>
+  Buffer.concat(
+    heard.filter((message) => idOf(message) === 'DATA').map((m) => m.subarray(SYNC_HEADER_BYTES)),
+  );
+
+const localFile = (bytes: number) => {
+  const directory = mkdtempSync(join(tmpdir(), 'kroma-sdb-'));
+  directories.push(directory);
+  const path = join(directory, `KROMA-${randomInt(1000)}.wgt`);
+  const content = randomBytes(bytes);
+  writeFileSync(path, content);
+  return { path, content, remote: `${toolPath()}/${basename(path)}` };
+};
+
+const receiving = async (answer: (session: ServiceSession) => void, maxData = 65536) => {
+  const set = await fakeDevice({ maxData });
+  televisions.push(set);
+  const heard: Buffer[] = [];
+  set.serve('sync:', async (session) => {
+    for (;;) {
+      const message = await session.read();
+      heard.push(message);
+      if (idOf(message) === 'DONE') answer(session);
+    }
+  });
+  const connection = await SdbConnection.open(set.host, set.port, { timeoutMs: PATIENT_MS });
+  connections.push(connection);
+  return { connection, heard };
+};
+
+const accepts = (session: ServiceSession) => session.write(syncRequest('OKAY', 0));
+
+afterEach(async () => {
+  for (const connection of connections.splice(0)) connection.close();
+  for (const directory of directories.splice(0))
+    rmSync(directory, { recursive: true, force: true });
+  await Promise.all(televisions.splice(0).map((set) => set.close()));
+});
 
 describe('a sync request', () => {
   it('is four ascii letters and a little-endian length', () => {
@@ -50,5 +105,120 @@ describe('a sync reply', () => {
 
   it('waits for the whole header before deciding anything', () => {
     expect(parseSyncMessage(Buffer.from('OKA', 'ascii'))).toBeNull();
+  });
+});
+
+describe('pushing a file', () => {
+  it('names the destination and the mode sdb forces on it', async () => {
+    const { connection, heard } = await receiving(accepts);
+    const file = localFile(64);
+
+    await pushFile(connection, file.path, file.remote, { timeoutMs: PATIENT_MS });
+
+    expect(messageOf(heard, 'SEND').subarray(SYNC_HEADER_BYTES).toString('utf8')).toBe(
+      `${file.remote},${PUSH_MODE}`,
+    );
+  });
+
+  it('sends a file bigger than one write in several DATA messages', async () => {
+    const { connection, heard } = await receiving(accepts, 1024);
+    const file = localFile(2500);
+
+    await pushFile(connection, file.path, file.remote, { timeoutMs: PATIENT_MS });
+
+    expect(heard.filter((message) => idOf(message) === 'DATA')).toHaveLength(3);
+    expect(dataOf(heard)).toEqual(file.content);
+  });
+
+  it('reports the bytes as they leave', async () => {
+    const { connection } = await receiving(accepts, 1024);
+    const file = localFile(2500);
+    const progress: number[][] = [];
+
+    await pushFile(connection, file.path, file.remote, {
+      timeoutMs: PATIENT_MS,
+      onProgress: (sent, total) => void progress.push([sent, total]),
+    });
+
+    expect(progress).toEqual([
+      [1016, 2500],
+      [2032, 2500],
+      [2500, 2500],
+    ]);
+  });
+
+  it('ends with the mtime the device stamps the file with', async () => {
+    const { connection, heard } = await receiving(accepts);
+    const file = localFile(64);
+
+    await pushFile(connection, file.path, file.remote, { timeoutMs: PATIENT_MS });
+
+    const stamped = messageOf(heard, 'DONE').readUInt32LE(4);
+    expect(Math.abs(stamped - Math.floor(Date.now() / 1000))).toBeLessThanOrEqual(5);
+  });
+
+  it('leaves the sync service once the device has taken the file', async () => {
+    const { connection, heard } = await receiving(accepts);
+    const file = localFile(64);
+
+    await pushFile(connection, file.path, file.remote, { timeoutMs: PATIENT_MS });
+
+    expect(heard.map(idOf)).toEqual(['SEND', 'DATA', 'DONE', 'QUIT']);
+  });
+
+  it('shrugs when the set hangs up before it can say goodbye', async () => {
+    const { connection } = await receiving((session) => session.end(syncRequest('OKAY', 0)));
+    const file = localFile(64);
+
+    const push = pushFile(connection, file.path, file.remote, { timeoutMs: 50 });
+
+    await expect(push).resolves.toBeUndefined();
+  });
+
+  it('reports the message the device refused the file with', async () => {
+    const { connection } = await receiving((session) =>
+      session.write(syncPayload('FAIL', Buffer.from('No such file or directory', 'utf8'))),
+    );
+    const file = localFile(64);
+
+    const push = pushFile(connection, file.path, file.remote, { timeoutMs: PATIENT_MS });
+
+    await expect(push).rejects.toThrow(
+      'sdb: the device refused the file: No such file or directory',
+    );
+  });
+
+  it('waits for a refusal that arrives in pieces', async () => {
+    const message = Buffer.from('the package is not signed', 'utf8');
+    const length = Buffer.alloc(4);
+    length.writeUInt32LE(message.length, 0);
+    const { connection } = await receiving((session) => {
+      session.write(Buffer.from('FAIL', 'ascii'));
+      session.write(length);
+      session.write(message);
+    });
+    const file = localFile(64);
+
+    const push = pushFile(connection, file.path, file.remote, { timeoutMs: PATIENT_MS });
+
+    await expect(push).rejects.toThrow('the package is not signed');
+  });
+
+  it('fails on a reply it does not recognise', async () => {
+    const { connection } = await receiving((session) => session.write(syncRequest('HUH!', 0)));
+    const file = localFile(64);
+
+    const push = pushFile(connection, file.path, file.remote, { timeoutMs: PATIENT_MS });
+
+    await expect(push).rejects.toThrow('sdb: unexpected sync reply "HUH!"');
+  });
+
+  it('fails when the sync service closes before answering', async () => {
+    const { connection } = await receiving((session) => session.close());
+    const file = localFile(64);
+
+    const push = pushFile(connection, file.path, file.remote, { timeoutMs: PATIENT_MS });
+
+    await expect(push).rejects.toThrow(/closed before answering/);
   });
 });

--- a/packages/tv-installer/src/modules/tizen/sdb/sync.ts
+++ b/packages/tv-installer/src/modules/tizen/sdb/sync.ts
@@ -1,0 +1,91 @@
+import { createReadStream, statSync } from 'node:fs';
+import type { SdbConnection } from './connection';
+
+export const SYNC_HEADER_BYTES = 8;
+export const SYNC_CHUNK_BYTES = 64 * 1024;
+export const PUSH_MODE = 0o100755;
+
+const REPLY_TIMEOUT_MS = 120_000;
+
+export interface SyncMessage {
+  id: string;
+  value: number;
+}
+
+export interface PushOptions {
+  mode?: number;
+  timeoutMs?: number;
+  onProgress?: (sent: number, total: number) => void;
+}
+
+export function syncRequest(id: string, value: number): Buffer {
+  const header = Buffer.alloc(SYNC_HEADER_BYTES);
+  header.write(id, 0, 4, 'ascii');
+  header.writeUInt32LE(value >>> 0, 4);
+  return header;
+}
+
+export function syncPayload(id: string, payload: Buffer): Buffer {
+  return Buffer.concat([syncRequest(id, payload.length), payload]);
+}
+
+export function parseSyncMessage(buffer: Buffer): SyncMessage | null {
+  if (buffer.length < SYNC_HEADER_BYTES) return null;
+  return { id: buffer.subarray(0, 4).toString('ascii'), value: buffer.readUInt32LE(4) };
+}
+
+/** `<path>,<mode>` is what the sync service takes; the mode is the decimal `st_mode`. */
+export function sendRequest(remotePath: string, mode = PUSH_MODE): Buffer {
+  return syncPayload('SEND', Buffer.from(`${remotePath},${mode}`, 'utf8'));
+}
+
+/** Copies a local file to `remotePath`, resolving once the device has taken it. */
+export async function pushFile(
+  connection: SdbConnection,
+  localPath: string,
+  remotePath: string,
+  { mode = PUSH_MODE, timeoutMs = REPLY_TIMEOUT_MS, onProgress }: PushOptions = {},
+): Promise<void> {
+  const total = statSync(localPath).size;
+  const chunkBytes = Math.min(SYNC_CHUNK_BYTES, connection.maxData - SYNC_HEADER_BYTES);
+  const stream = await connection.openStream('sync:');
+
+  try {
+    await stream.write(sendRequest(remotePath, mode), timeoutMs);
+    let sent = 0;
+    for await (const chunk of createReadStream(localPath, { highWaterMark: chunkBytes })) {
+      const bytes = chunk as Buffer;
+      await stream.write(syncPayload('DATA', bytes), timeoutMs);
+      sent += bytes.length;
+      onProgress?.(sent, total);
+    }
+    await stream.write(syncRequest('DONE', Math.floor(Date.now() / 1000)), timeoutMs);
+
+    const reply = await readReply(stream, timeoutMs);
+    if (reply.id === 'FAIL') throw new Error(`sdb: the device refused the file: ${reply.text}`);
+    if (reply.id !== 'OKAY') throw new Error(`sdb: unexpected sync reply "${reply.id}"`);
+    await stream.write(syncRequest('QUIT', 0), timeoutMs).catch(() => undefined);
+  } finally {
+    stream.close();
+  }
+}
+
+async function readReply(
+  stream: { read: (timeoutMs?: number) => Promise<Buffer | null> },
+  timeoutMs: number,
+): Promise<{ id: string; text: string }> {
+  let buffer = Buffer.alloc(0);
+  for (;;) {
+    const chunk = await stream.read(timeoutMs);
+    if (!chunk) throw new Error('sdb: the sync service closed before answering');
+    buffer = Buffer.concat([buffer, chunk]);
+    const message = parseSyncMessage(buffer);
+    if (!message) continue;
+    if (message.id !== 'FAIL') return { id: message.id, text: '' };
+    if (buffer.length < SYNC_HEADER_BYTES + message.value) continue;
+    const text = buffer
+      .subarray(SYNC_HEADER_BYTES, SYNC_HEADER_BYTES + message.value)
+      .toString('utf8');
+    return { id: message.id, text };
+  }
+}

--- a/packages/tv-installer/src/modules/tizen/signing.test.ts
+++ b/packages/tv-installer/src/modules/tizen/signing.test.ts
@@ -1,0 +1,196 @@
+import { cp, mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { run, runOk } from '../../run';
+import { createAuthorCertificate } from './certificate/authority';
+import { writeProfile } from './certificate/profile';
+import { signWidget } from './certificate/widget';
+import { activeProfile } from './profiles';
+import { ensureProfile, readDuid, resign } from './signing';
+
+const { directories } = vi.hoisted(() => ({ directories: new Set<string>() }));
+
+vi.mock('node:fs', () => ({
+  statSync: (path: string) => ({ isDirectory: () => directories.has(path) }),
+}));
+vi.mock('node:fs/promises', () => ({
+  cp: vi.fn(),
+  mkdir: vi.fn(),
+  mkdtemp: vi.fn(),
+  rm: vi.fn(),
+}));
+vi.mock('../../run', () => ({ run: vi.fn(), runOk: vi.fn() }));
+vi.mock('./certificate/authority', () => ({ createAuthorCertificate: vi.fn() }));
+vi.mock('./certificate/password', () => ({ randomPassword: () => 'a-random-password' }));
+vi.mock('./certificate/profile', () => ({ writeProfile: vi.fn() }));
+vi.mock('./certificate/widget', () => ({ signWidget: vi.fn() }));
+vi.mock('./profiles', () => ({ activeProfile: vi.fn() }));
+
+const kroma = {
+  name: 'kroma',
+  author: { archive: '/certs/author.p12', password: 'secret' },
+  distributor: { archive: '/certs/distributor.p12', password: 'other' },
+};
+
+const lines: string[] = [];
+const log = (line: string) => lines.push(line);
+
+beforeEach(() => {
+  lines.length = 0;
+  directories.clear();
+  vi.mocked(mkdtemp).mockResolvedValue('/tmp/kroma-wgt-1');
+  vi.mocked(writeProfile).mockResolvedValue('/tizen-studio-data/profile/profiles.xml');
+  vi.stubGlobal('Bun', { which: () => '/usr/bin/zip' });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('ensureProfile', () => {
+  it('takes the profile the Tizen tools already sign with', async () => {
+    vi.mocked(activeProfile).mockResolvedValue(kroma);
+
+    expect(await ensureProfile(log)).toBe(kroma);
+    expect(vi.mocked(createAuthorCertificate)).not.toHaveBeenCalled();
+  });
+
+  it('generates an author certificate on a machine that has no profile', async () => {
+    vi.mocked(activeProfile).mockResolvedValue(null);
+    vi.mocked(createAuthorCertificate).mockResolvedValue({
+      directory: '/certs/kroma',
+      certificate: '/certs/kroma/kroma.crt',
+      key: '/certs/kroma/kroma.key',
+      archive: '/certs/kroma/kroma.p12',
+      password: 'a-random-password',
+      passwordFile: '/certs/kroma/kroma.pwd',
+    });
+
+    const profile = await ensureProfile(log);
+
+    expect(vi.mocked(createAuthorCertificate)).toHaveBeenCalledWith({
+      directory: join(homedir(), '.kroma', 'certificates', 'kroma'),
+      alias: 'kroma',
+      password: 'a-random-password',
+      subject: { commonName: 'KROMA', organization: 'KROMA' },
+    });
+    expect(profile).toEqual({
+      name: 'kroma',
+      author: { archive: '/certs/kroma/kroma.p12', password: 'a-random-password' },
+    });
+    expect(vi.mocked(writeProfile)).toHaveBeenCalledWith(profile);
+  });
+
+  it('signs with the generated profile even when the Tizen file refused it', async () => {
+    vi.mocked(activeProfile).mockResolvedValue(null);
+    vi.mocked(createAuthorCertificate).mockResolvedValue({
+      directory: '/certs/kroma',
+      certificate: '/certs/kroma/kroma.crt',
+      key: '/certs/kroma/kroma.key',
+      archive: '/certs/kroma/kroma.p12',
+      password: 'a-random-password',
+      passwordFile: '/certs/kroma/kroma.pwd',
+    });
+    vi.mocked(writeProfile).mockRejectedValue(new Error('already holds profiles'));
+
+    expect((await ensureProfile(log)).name).toBe('kroma');
+  });
+});
+
+describe('resign', () => {
+  it('unpacks the package it was given into a directory of its own', async () => {
+    await resign('/out/KROMA-tizen-0.1.33.wgt', kroma, log);
+
+    expect(vi.mocked(mkdir)).toHaveBeenCalledWith('/tmp/kroma-wgt-1/app', { recursive: true });
+    expect(vi.mocked(runOk).mock.calls[0]?.[0]).toEqual([
+      'unzip',
+      '-q',
+      '-o',
+      '/out/KROMA-tizen-0.1.33.wgt',
+      '-d',
+      '/tmp/kroma-wgt-1/app',
+    ]);
+  });
+
+  it('copies a build that is already a directory instead of unpacking it', async () => {
+    directories.add('/kroma/clients/tizen/dist');
+
+    await resign('/kroma/clients/tizen/dist', kroma, log);
+
+    expect(vi.mocked(cp)).toHaveBeenCalledWith(
+      '/kroma/clients/tizen/dist',
+      '/tmp/kroma-wgt-1/app',
+      {
+        recursive: true,
+      },
+    );
+    expect(vi.mocked(runOk).mock.calls[0]?.[0]).not.toContain('unzip');
+  });
+
+  it('drops the signatures the build carried before it signs again', async () => {
+    await resign('/out/KROMA.wgt', kroma, log);
+
+    expect(vi.mocked(rm).mock.calls.map(([path]) => path)).toEqual([
+      '/tmp/kroma-wgt-1/app/author-signature.xml',
+      '/tmp/kroma-wgt-1/app/signature1.xml',
+      '/tmp/kroma-wgt-1/app/signature2.xml',
+    ]);
+  });
+
+  it('signs the staged widget with both keys the profile carries', async () => {
+    await resign('/out/KROMA.wgt', kroma, log);
+
+    expect(vi.mocked(signWidget)).toHaveBeenCalledWith({
+      directory: '/tmp/kroma-wgt-1/app',
+      author: kroma.author,
+      distributor: kroma.distributor,
+    });
+    expect(lines[0]).toBe('signing with profile kroma');
+  });
+
+  it('packs the signed directory back into a widget the caller has to delete', async () => {
+    const signed = await resign('/out/KROMA.wgt', kroma, log);
+
+    expect(vi.mocked(runOk).mock.calls.at(-1)).toEqual([
+      ['zip', '-X', '-r', '-q', '/tmp/kroma-wgt-1/KROMA.wgt', '.'],
+      { cwd: '/tmp/kroma-wgt-1/app', log },
+    ]);
+    expect(signed).toEqual({ path: '/tmp/kroma-wgt-1/KROMA.wgt', staged: true });
+  });
+
+  it('refuses to repack on a machine with nothing to zip with', async () => {
+    vi.stubGlobal('Bun', { which: () => null });
+
+    await expect(resign('/out/KROMA.wgt', kroma, log)).rejects.toThrow(
+      'zip is needed to repack the widget and is not here',
+    );
+  });
+});
+
+describe('readDuid', () => {
+  it('reads off the set the id Samsung binds a certificate to', async () => {
+    vi.mocked(run).mockResolvedValue({ code: 0, output: 'getduid\n1002XYZABC\n' });
+
+    expect(await readDuid('/tizen-studio/tools/sdb', log)).toBe('1002XYZABC');
+    expect(vi.mocked(run).mock.calls[0]?.[0]).toEqual([
+      '/tizen-studio/tools/sdb',
+      'shell',
+      '0',
+      'getduid',
+    ]);
+  });
+
+  it('answers nothing when the set would not say', async () => {
+    vi.mocked(run).mockResolvedValue({ code: 1, output: 'device not found' });
+
+    expect(await readDuid('/tizen-studio/tools/sdb', log)).toBeNull();
+  });
+
+  it('answers nothing when the set answered with nothing at all', async () => {
+    vi.mocked(run).mockResolvedValue({ code: 0, output: '' });
+
+    expect(await readDuid('/tizen-studio/tools/sdb', log)).toBeNull();
+  });
+});

--- a/packages/tv-installer/src/modules/tizen/signing.ts
+++ b/packages/tv-installer/src/modules/tizen/signing.ts
@@ -4,13 +4,14 @@ import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { type LogLine, run, runOk } from '../../run';
 import { createAuthorCertificate } from './certificate/authority';
+import { randomPassword } from './certificate/password';
 import { writeProfile } from './certificate/profile';
 import { signWidget } from './certificate/widget';
 import { activeProfile, type SigningProfile } from './profiles';
 
 const SIGNATURES = ['author-signature.xml', 'signature1.xml', 'signature2.xml'];
 const KROMA_PROFILE = 'kroma';
-const KROMA_PASSWORD = 'kroma-dev';
+
 const CERTIFICATES = join(homedir(), '.kroma', 'certificates');
 const PACKAGE_NAME = 'KROMA.wgt';
 const DUID_TIMEOUT_MS = 20_000;
@@ -34,7 +35,7 @@ export async function ensureProfile(log: LogLine): Promise<SigningProfile> {
   const author = await createAuthorCertificate({
     directory: join(CERTIFICATES, KROMA_PROFILE),
     alias: KROMA_PROFILE,
-    password: KROMA_PASSWORD,
+    password: randomPassword(),
     subject: { commonName: 'KROMA', organization: 'KROMA' },
   });
   log(`certificate at ${author.certificate}`);

--- a/packages/tv-installer/src/modules/tizen/signing.ts
+++ b/packages/tv-installer/src/modules/tizen/signing.ts
@@ -1,0 +1,97 @@
+import { statSync } from 'node:fs';
+import { cp, mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { homedir, tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { type LogLine, run, runOk } from '../../run';
+import { createAuthorCertificate } from './certificate/authority';
+import { writeProfile } from './certificate/profile';
+import { signWidget } from './certificate/widget';
+import { activeProfile, type SigningProfile } from './profiles';
+
+const SIGNATURES = ['author-signature.xml', 'signature1.xml', 'signature2.xml'];
+const KROMA_PROFILE = 'kroma';
+const KROMA_PASSWORD = 'kroma-dev';
+const CERTIFICATES = join(homedir(), '.kroma', 'certificates');
+const PACKAGE_NAME = 'KROMA.wgt';
+const DUID_TIMEOUT_MS = 20_000;
+
+export interface Signed {
+  path: string;
+  /** A staged copy the caller has to delete, rather than a directory it owns. */
+  staged: boolean;
+}
+
+/**
+ * The profile to sign with, generated here if this machine has none. What can
+ * be generated is the author half: the distributor certificate a retail set
+ * insists on is Samsung's to issue, against that one set's DUID.
+ */
+export async function ensureProfile(log: LogLine): Promise<SigningProfile> {
+  const existing = await activeProfile();
+  if (existing) return existing;
+
+  log('no signing profile here, generating an author certificate');
+  const author = await createAuthorCertificate({
+    directory: join(CERTIFICATES, KROMA_PROFILE),
+    alias: KROMA_PROFILE,
+    password: KROMA_PASSWORD,
+    subject: { commonName: 'KROMA', organization: 'KROMA' },
+  });
+  log(`certificate at ${author.certificate}`);
+
+  const profile = {
+    name: KROMA_PROFILE,
+    author: { archive: author.archive, password: author.password },
+  };
+  await writeProfile(profile).catch(() => undefined);
+  return profile;
+}
+
+/**
+ * Signs the package with this machine's own certificate and answers where the
+ * new one is. A retail Samsung refuses every other signature, so the one a
+ * release carries is never the one that installs.
+ */
+export async function resign(
+  artifact: string,
+  profile: SigningProfile,
+  log: LogLine,
+): Promise<Signed> {
+  log(`signing with profile ${profile.name}`);
+  const workspace = await mkdtemp(join(tmpdir(), 'kroma-wgt-'));
+  const stage = join(workspace, 'app');
+  await stageInto(artifact, stage, log);
+
+  await Promise.all(SIGNATURES.map((file) => rm(join(stage, file), { force: true })));
+  await signWidget({ directory: stage, author: profile.author, distributor: profile.distributor });
+
+  const path = join(workspace, PACKAGE_NAME);
+  await pack(stage, path, log);
+  return { path, staged: true };
+}
+
+/** What Samsung binds a distributor certificate to, read off the set itself. */
+export async function readDuid(sdb: string, log: LogLine): Promise<string | null> {
+  const { code, output } = await run([sdb, 'shell', '0', 'getduid'], {
+    log,
+    timeoutMs: DUID_TIMEOUT_MS,
+  });
+  const duid = output.trim().split('\n').at(-1)?.trim();
+  return code === 0 && duid ? duid : null;
+}
+
+async function stageInto(artifact: string, stage: string, log: LogLine): Promise<void> {
+  if (statSync(artifact).isDirectory()) {
+    await cp(artifact, stage, { recursive: true });
+    return;
+  }
+  await mkdir(stage, { recursive: true });
+  await runOk(['unzip', '-q', '-o', artifact, '-d', stage], { log });
+}
+
+// A widget is a plain zip, and the signatures cover the files rather than the
+// archive, so anything that zips produces a package the set accepts.
+async function pack(stage: string, path: string, log: LogLine): Promise<void> {
+  if (!Bun.which('zip')) throw new Error('zip is needed to repack the widget and is not here');
+  await runOk(['zip', '-X', '-r', '-q', path, '.'], { cwd: stage, log });
+}

--- a/packages/tv-installer/src/modules/tizen/tools.test.ts
+++ b/packages/tv-installer/src/modules/tizen/tools.test.ts
@@ -1,0 +1,100 @@
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { KROMA_TOOLS } from '../../toolchain/detect';
+import { SDB, TIZEN_CLI, TIZEN_HOME } from './tools';
+
+const { run, runOk, download, mkdir, which } = vi.hoisted(() => ({
+  run: vi.fn(async (_command: readonly string[], _options?: unknown) => ({ code: 0, output: '' })),
+  runOk: vi.fn(async (_command: readonly string[], _options?: unknown) => ''),
+  download: vi.fn(async (_url: string, _dest: string, _log: unknown) => {}),
+  mkdir: vi.fn(async (_path: string, _options?: unknown) => undefined),
+  which: vi.fn((_binary: string): string | null => '/usr/bin/java'),
+}));
+vi.mock('../../run', () => ({ run, runOk }));
+vi.mock('../../toolchain/install', () => ({ download }));
+vi.mock('node:fs/promises', () => ({ mkdir }));
+vi.stubGlobal('Bun', { which });
+
+const running = { platform: process.platform, arch: process.arch };
+const on = (platform: string, arch = 'x64') => {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+  Object.defineProperty(process, 'arch', { value: arch, configurable: true });
+};
+
+const installer = join(KROMA_TOOLS, 'web-cli_macos-64.bin');
+
+beforeEach(() => {
+  run.mockReset();
+  runOk.mockReset();
+  download.mockReset();
+  which.mockReset();
+  which.mockReturnValue('/usr/bin/java');
+  on('darwin');
+});
+
+afterEach(() => {
+  on(running.platform, running.arch);
+});
+
+describe('TIZEN_CLI', () => {
+  it('looks for the CLI where Tizen Studio installs it', () => {
+    expect(TIZEN_CLI.candidates?.()).toEqual([join(TIZEN_HOME, 'tools', 'ide', 'bin', 'tizen')]);
+  });
+
+  it('downloads the Tizen Studio build for this system', async () => {
+    await TIZEN_CLI.install?.(() => {});
+
+    expect(download.mock.calls[0]?.slice(0, 2)).toEqual([
+      'https://download.tizen.org/sdk/Installer/tizen-studio_6.0/web-cli_Tizen_Studio_6.0_macos-64.bin',
+      installer,
+    ]);
+  });
+
+  it('makes the installer runnable, then unpacks it into the Tizen home', async () => {
+    await TIZEN_CLI.install?.(() => {});
+
+    expect(runOk.mock.calls.map(([command]) => command)).toEqual([
+      ['chmod', '+x', installer],
+      [installer, '--accept-license', '--no-java-check', TIZEN_HOME],
+    ]);
+  });
+
+  it('refuses a system Tizen ships no headless installer for', async () => {
+    on('win32');
+
+    await expect(TIZEN_CLI.install?.(() => {})).rejects.toThrow(
+      'Tizen Studio has no headless installer here. Install it by hand from download.tizen.org.',
+    );
+  });
+
+  it('refuses to install a CLI that has no JDK to run on', async () => {
+    which.mockReturnValue(null);
+
+    await expect(TIZEN_CLI.install?.(() => {})).rejects.toThrow(
+      'the Tizen CLI needs a JDK: brew install --cask temurin (or apt install default-jdk)',
+    );
+  });
+
+  it('refuses an x86_64 install on an Apple silicon Mac with no Rosetta', async () => {
+    on('darwin', 'arm64');
+    run.mockResolvedValue({ code: 1, output: '' });
+
+    await expect(TIZEN_CLI.install?.(() => {})).rejects.toThrow(
+      'Tizen Studio is x86_64: run `softwareupdate --install-rosetta --agree-to-license` first',
+    );
+  });
+
+  it('asks whether Rosetta is running before it downloads anything', async () => {
+    on('darwin', 'arm64');
+
+    await TIZEN_CLI.install?.(() => {});
+
+    expect(run.mock.calls[0]?.[0]).toEqual(['/usr/bin/pgrep', '-q', 'oahd']);
+  });
+});
+
+describe('SDB', () => {
+  it('looks for the bridge where Tizen Studio installs it', () => {
+    expect(SDB.candidates?.()).toEqual([join(TIZEN_HOME, 'tools', 'sdb')]);
+  });
+});

--- a/packages/tv-installer/src/modules/tizen/tools.ts
+++ b/packages/tv-installer/src/modules/tizen/tools.ts
@@ -1,0 +1,66 @@
+import { mkdir } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { type LogLine, run, runOk } from '../../run';
+import { KROMA_TOOLS, type Tool } from '../../toolchain/detect';
+import { download } from '../../toolchain/install';
+
+export const TIZEN_HOME = process.env.TIZEN_HOME ?? join(homedir(), 'tizen-studio');
+
+const TIZEN_STUDIO_VERSION = '6.0';
+const TIZEN_BUILD: Record<string, string> = { darwin: 'macos-64', linux: 'ubuntu-64' };
+
+export const TIZEN_CLI: Tool = {
+  id: 'tizen',
+  label: 'Tizen Studio CLI',
+  binary: 'tizen',
+  source: 'download.tizen.org (~260 MB)',
+  candidates: () => [join(TIZEN_HOME, 'tools', 'ide', 'bin', 'tizen')],
+  install: installTizenStudio,
+};
+
+export const SDB: Tool = {
+  id: 'sdb',
+  label: 'Smart Debug Bridge',
+  binary: 'sdb',
+  source: 'part of the Tizen Studio CLI',
+  candidates: () => [join(TIZEN_HOME, 'tools', 'sdb')],
+  install: installTizenStudio,
+};
+
+async function installTizenStudio(log: LogLine): Promise<void> {
+  const flavour = TIZEN_BUILD[process.platform];
+  if (!flavour) {
+    throw new Error(
+      'Tizen Studio has no headless installer here. Install it by hand from download.tizen.org.',
+    );
+  }
+  if (!Bun.which('java')) {
+    throw new Error(
+      'the Tizen CLI needs a JDK: brew install --cask temurin (or apt install default-jdk)',
+    );
+  }
+  await assertRosetta();
+
+  await mkdir(KROMA_TOOLS, { recursive: true });
+  const installer = join(KROMA_TOOLS, `web-cli_${flavour}.bin`);
+  const file = `web-cli_Tizen_Studio_${TIZEN_STUDIO_VERSION}_${flavour}.bin`;
+  await download(
+    `https://download.tizen.org/sdk/Installer/tizen-studio_${TIZEN_STUDIO_VERSION}/${file}`,
+    installer,
+    log,
+  );
+  await runOk(['chmod', '+x', installer], { log });
+  log('unpacking Tizen Studio, this takes a few minutes');
+  await runOk([installer, '--accept-license', '--no-java-check', TIZEN_HOME], { log });
+}
+
+async function assertRosetta(): Promise<void> {
+  if (process.platform !== 'darwin' || process.arch !== 'arm64') return;
+  const { code } = await run(['/usr/bin/pgrep', '-q', 'oahd']);
+  if (code !== 0) {
+    throw new Error(
+      'Tizen Studio is x86_64: run `softwareupdate --install-rosetta --agree-to-license` first',
+    );
+  }
+}

--- a/packages/tv-installer/src/modules/webos/app-id.test.ts
+++ b/packages/tv-installer/src/modules/webos/app-id.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { webosAppId } from './app-id';
+
+vi.mock('node:fs', () => ({ readFileSync: vi.fn() }));
+vi.mock('../../root', () => ({ root: '/kroma' }));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('webosAppId', () => {
+  it('reads the id the shell declares in its own appinfo', () => {
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ id: 'tv.kroma.webos', version: '1' }));
+
+    expect(webosAppId()).toBe('tv.kroma.webos');
+    expect(vi.mocked(readFileSync)).toHaveBeenCalledWith(
+      '/kroma/clients/webos/public/appinfo.json',
+      'utf8',
+    );
+  });
+
+  it('falls back to the shipped id when the appinfo is not in this checkout', () => {
+    vi.mocked(readFileSync).mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+
+    expect(webosAppId()).toBe('tv.kroma.webos');
+  });
+
+  it('falls back to the shipped id when the appinfo carries no id', () => {
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ version: '1' }));
+
+    expect(webosAppId()).toBe('tv.kroma.webos');
+  });
+});

--- a/packages/tv-installer/src/modules/webos/app-id.ts
+++ b/packages/tv-installer/src/modules/webos/app-id.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { z } from 'zod';
+import { root } from '../../root';
+
+const APPINFO = 'clients/webos/public/appinfo.json';
+const FALLBACK = 'tv.kroma.webos';
+
+const AppInfo = z.object({ id: z.string().min(1).max(128) });
+
+export function webosAppId(): string {
+  try {
+    return AppInfo.parse(JSON.parse(readFileSync(join(root, APPINFO), 'utf8'))).id;
+  } catch {
+    return FALLBACK;
+  }
+}

--- a/packages/tv-installer/src/modules/webos/artifact.test.ts
+++ b/packages/tv-installer/src/modules/webos/artifact.test.ts
@@ -6,7 +6,7 @@ import { root } from '../../root';
 import { runOk } from '../../run';
 import type { Television } from '../../television';
 import { requireTool } from '../../toolchain/detect';
-import { resolveWebosArtifact, WEBOS_PACKAGE, WEBOS_SHELL } from './artifact';
+import { resolveWebosArtifact, WEBOS_PACKAGE, WEBOS_SHELL, webosSources } from './artifact';
 
 const { globbed } = vi.hoisted(() => ({ globbed: new Map<string, string[]>() }));
 
@@ -29,7 +29,7 @@ class FakeGlob {
   }
 }
 
-vi.stubGlobal('Bun', { Glob: FakeGlob });
+vi.stubGlobal('Bun', { which: () => null, Glob: FakeGlob });
 
 const webosOut = '/kroma/clients/webos/out';
 
@@ -77,6 +77,12 @@ describe('rankArtifacts', () => {
 describe('buildable', () => {
   it('builds the shell whose sources live in this checkout', () => {
     expect(buildable(WEBOS_SHELL)).toBe(true);
+  });
+});
+
+describe('webosSources', () => {
+  it('offers a build from source on a machine with nothing built and no gh', () => {
+    expect(webosSources()).toEqual(['build']);
   });
 });
 

--- a/packages/tv-installer/src/modules/webos/artifact.test.ts
+++ b/packages/tv-installer/src/modules/webos/artifact.test.ts
@@ -1,9 +1,64 @@
-import { describe, expect, it } from 'vitest';
-import { rankArtifacts } from '../../install/artifact';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { rankArtifacts, resolveArtifact } from '../../install/artifact';
 import { buildable } from '../../install/build';
-import { WEBOS_PACKAGE, WEBOS_SHELL } from './artifact';
+import { root } from '../../root';
+import { runOk } from '../../run';
+import type { Television } from '../../television';
+import { requireTool } from '../../toolchain/detect';
+import { resolveWebosArtifact, WEBOS_PACKAGE, WEBOS_SHELL } from './artifact';
+
+const { globbed } = vi.hoisted(() => ({ globbed: new Map<string, string[]>() }));
+
+vi.mock('../../install/artifact', async (original) => ({
+  ...(await original<typeof import('../../install/artifact')>()),
+  resolveArtifact: vi.fn(),
+}));
+vi.mock('../../run', () => ({ runOk: vi.fn() }));
+vi.mock('../../toolchain/detect', async (original) => ({
+  ...(await original<typeof import('../../toolchain/detect')>()),
+  requireTool: vi.fn(),
+}));
+
+class FakeGlob {
+  constructor(private readonly pattern: string) {}
+
+  scanSync({ cwd, absolute }: { cwd: string; absolute?: boolean }): string[] {
+    const names = globbed.get(this.pattern) ?? [];
+    return names.map((name) => (absolute ? join(cwd, name) : name));
+  }
+}
+
+vi.stubGlobal('Bun', { Glob: FakeGlob });
 
 const webosOut = '/kroma/clients/webos/out';
+
+const chambre: Television = {
+  host: '192.168.1.44',
+  platform: 'webos',
+  vendor: 'LG',
+  name: 'Chambre',
+  model: 'OLED55C1',
+  developerMode: 'on',
+  sideloadable: true,
+  note: '',
+  runtime: null,
+};
+
+const buildOf = () => {
+  const build = vi.mocked(resolveArtifact).mock.calls[0]?.[0].build;
+  if (!build) throw new Error('the LG package named no way to build one');
+  return build;
+};
+
+beforeEach(() => {
+  globbed.clear();
+  vi.mocked(requireTool).mockReturnValue('/Users/tester/.bun/bin/ares-install');
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
 
 describe('rankArtifacts', () => {
   it('sorts a platform that prefers no build newest first', () => {
@@ -22,5 +77,39 @@ describe('rankArtifacts', () => {
 describe('buildable', () => {
   it('builds the shell whose sources live in this checkout', () => {
     expect(buildable(WEBOS_SHELL)).toBe(true);
+  });
+});
+
+describe('resolveWebosArtifact', () => {
+  it('looks for an LG package under the id the downloads are kept by', async () => {
+    await resolveWebosArtifact({ tv: chambre, log: () => {} });
+
+    expect(vi.mocked(resolveArtifact).mock.calls[0]?.[0]).toMatchObject({
+      id: 'webos',
+      kind: WEBOS_PACKAGE,
+    });
+  });
+
+  it('builds the bundle, then packs it with the CLI beside ares-install', async () => {
+    globbed.set('*.ipk', ['tv.kroma.webos_0.1.33_all.ipk']);
+    await resolveWebosArtifact({ tv: chambre, source: 'build', log: () => {} });
+
+    const built = await buildOf()(() => {});
+
+    expect(vi.mocked(runOk).mock.calls[0]?.[0]).toEqual(['bun', 'run', 'build:webos']);
+    expect(vi.mocked(runOk).mock.calls[1]?.[0]).toEqual([
+      '/Users/tester/.bun/bin/ares-package',
+      join(root, 'clients/webos/dist'),
+      '--no-minify',
+      '-o',
+      join(root, 'clients/webos/out'),
+    ]);
+    expect(built).toBe(join(root, 'clients/webos/out', 'tv.kroma.webos_0.1.33_all.ipk'));
+  });
+
+  it('refuses a packing run that left no package behind', async () => {
+    await resolveWebosArtifact({ tv: chambre, source: 'build', log: () => {} });
+
+    await expect(buildOf()(() => {})).rejects.toThrow('ares-package produced no .ipk');
   });
 });

--- a/packages/tv-installer/src/modules/webos/artifact.test.ts
+++ b/packages/tv-installer/src/modules/webos/artifact.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { rankArtifacts } from '../../install/artifact';
+import { buildable } from '../../install/build';
+import { WEBOS_PACKAGE, WEBOS_SHELL } from './artifact';
+
+const webosOut = '/kroma/clients/webos/out';
+
+describe('rankArtifacts', () => {
+  it('sorts a platform that prefers no build newest first', () => {
+    const built = [
+      { path: `${webosOut}/tv.kroma.webos_0.1.32_all.ipk`, mtimeMs: 1_000 },
+      { path: `${webosOut}/tv.kroma.webos_0.1.33_all.ipk`, mtimeMs: 5_000 },
+    ];
+
+    expect(rankArtifacts(built, WEBOS_PACKAGE.preferred)).toEqual([
+      `${webosOut}/tv.kroma.webos_0.1.33_all.ipk`,
+      `${webosOut}/tv.kroma.webos_0.1.32_all.ipk`,
+    ]);
+  });
+});
+
+describe('buildable', () => {
+  it('builds the shell whose sources live in this checkout', () => {
+    expect(buildable(WEBOS_SHELL)).toBe(true);
+  });
+});

--- a/packages/tv-installer/src/modules/webos/artifact.ts
+++ b/packages/tv-installer/src/modules/webos/artifact.ts
@@ -1,0 +1,44 @@
+import { join } from 'node:path';
+import {
+  type ArtifactRequest,
+  availableSources,
+  type PackageKind,
+  resolveArtifact,
+  type Source,
+} from '../../install/artifact';
+import { buildable } from '../../install/build';
+import { root } from '../../root';
+import { type LogLine, runOk } from '../../run';
+import { requireTool } from '../../toolchain/detect';
+import { ARES, aresSibling } from './tools';
+
+export const WEBOS_SHELL = 'clients/webos';
+const BUILD_TIMEOUT_MS = 900_000;
+
+export const WEBOS_PACKAGE: PackageKind = {
+  extension: '.ipk',
+  globs: [`${WEBOS_SHELL}/out/*.ipk`, `${WEBOS_SHELL}/build/*.ipk`],
+  pattern: 'tv.kroma.webos_*.ipk',
+  runArtifact: 'kroma-webos-ipk',
+};
+
+export function webosSources(): Source[] {
+  return availableSources(WEBOS_PACKAGE, buildable(WEBOS_SHELL));
+}
+
+export function resolveWebosArtifact(request: ArtifactRequest): Promise<string> {
+  return resolveArtifact({ id: 'webos', kind: WEBOS_PACKAGE, build: buildWebos }, request);
+}
+
+async function buildWebos(log: LogLine): Promise<string> {
+  log('building the webOS bundle');
+  await runOk(['bun', 'run', 'build:webos'], { log, cwd: root, timeoutMs: BUILD_TIMEOUT_MS });
+
+  const out = join(root, `${WEBOS_SHELL}/out`);
+  const packager = aresSibling(requireTool(ARES), 'ares-package');
+  await runOk([packager, join(root, `${WEBOS_SHELL}/dist`), '--no-minify', '-o', out], { log });
+
+  const [built] = [...new Bun.Glob('*.ipk').scanSync({ cwd: out, absolute: true })];
+  if (!built) throw new Error('ares-package produced no .ipk');
+  return built;
+}

--- a/packages/tv-installer/src/modules/webos/identify.ts
+++ b/packages/tv-installer/src/modules/webos/identify.ts
@@ -1,0 +1,45 @@
+import type { UpnpDevice } from '../../discovery/upnp';
+import type { Television } from '../../television';
+import { webosRuntime } from './runtime';
+
+const DEV_PORT = 9922;
+const APP_PORT = 3000;
+
+export const WEBOS_PORTS = {
+  sweep: [DEV_PORT],
+  detail: [APP_PORT],
+} as const;
+
+// A webOS set answers its own SSDP target with its own name even when DIAL is asleep.
+export const WEBOS_SEARCH_TARGET = 'urn:lge-com:service:webos-second-screen:1';
+
+export async function identifyWebos(
+  host: string,
+  openPorts: ReadonlySet<number>,
+  upnp?: UpnpDevice,
+): Promise<Television | null> {
+  const devMode = openPorts.has(DEV_PORT);
+  if (!looksWebos(devMode, upnp)) return null;
+
+  const runtime = webosRuntime([upnp?.modelName, upnp?.modelNumber, upnp?.friendlyName]);
+  const seen = devMode
+    ? 'Dev Mode running, key server on 9922'
+    : 'Dev Mode app not running: install it from the LG Content Store, log in, Dev Mode ON and Key Server ON';
+  return {
+    host,
+    platform: 'webos',
+    vendor: 'LG',
+    name: upnp?.friendlyName || 'LG TV',
+    model: upnp?.modelName ?? '',
+    developerMode: devMode ? 'on' : 'off',
+    sideloadable: true,
+    note: seen,
+    runtime,
+  };
+}
+
+function looksWebos(devMode: boolean, upnp?: UpnpDevice): boolean {
+  if (devMode) return true;
+  const vendor = `${upnp?.manufacturer ?? ''} ${upnp?.friendlyName ?? ''}`.toLowerCase();
+  return vendor.includes('lg electronics') || vendor.includes('webos');
+}

--- a/packages/tv-installer/src/modules/webos/install.test.ts
+++ b/packages/tv-installer/src/modules/webos/install.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { run, runOk } from '../../run';
+import { requireTool } from '../../toolchain/detect';
+import type { InstallContext } from '../module';
+import { deviceName, installWebos } from './install';
+
+vi.mock('../../run', () => ({ run: vi.fn(), runOk: vi.fn() }));
+vi.mock('../../toolchain/detect', async (original) => ({
+  ...(await original<typeof import('../../toolchain/detect')>()),
+  requireTool: vi.fn(),
+}));
+vi.mock('./app-id', () => ({ webosAppId: () => 'tv.kroma.webos' }));
+
+const BIN = '/Users/tester/.bun/bin';
+
+const context = (options: InstallContext['options'] = {}, launch = true): InstallContext => ({
+  tv: {
+    host: '192.168.1.44',
+    platform: 'webos',
+    vendor: 'LG',
+    name: 'Chambre',
+    model: 'OLED55C1',
+    developerMode: 'on',
+    sideloadable: true,
+    note: '',
+    runtime: null,
+  },
+  artifact: '/out/tv.kroma.webos_0.1.33_all.ipk',
+  log: () => {},
+  launch,
+  options,
+});
+
+const settings = [
+  '-i',
+  'host=192.168.1.44',
+  '-i',
+  'port=9922',
+  '-i',
+  'username=prisoner',
+  '-i',
+  'privatekey=kroma-192-168-1-44.pem',
+];
+
+const ran = () => vi.mocked(run).mock.calls.map(([command]) => [...command]);
+const ranOk = () => vi.mocked(runOk).mock.calls.map(([command]) => [...command]);
+
+beforeEach(() => {
+  vi.mocked(requireTool).mockReturnValue(`${BIN}/ares-install`);
+  vi.mocked(run).mockResolvedValue({ code: 0, output: '' });
+  vi.mocked(runOk).mockResolvedValue('');
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('deviceName', () => {
+  it('names the set after its address, in something ares takes as a name', () => {
+    expect(deviceName('192.168.1.44')).toBe('kroma-192-168-1-44');
+  });
+});
+
+describe('installWebos', () => {
+  it('adds the set to the ones ares knows, over the Dev Mode port', async () => {
+    await installWebos(context());
+
+    expect(ran()[0]).toEqual([`${BIN}/ares-setup-device`, '-a', 'kroma-192-168-1-44', ...settings]);
+  });
+
+  it('changes the registration of a set ares already knows', async () => {
+    vi.mocked(run).mockResolvedValue({ code: 1, output: 'The specified device already exists' });
+
+    await installWebos(context());
+
+    expect(ranOk()).toContainEqual([
+      `${BIN}/ares-setup-device`,
+      '-m',
+      'kroma-192-168-1-44',
+      ...settings,
+    ]);
+  });
+
+  it('registers the passphrase the Dev Mode app shows, then fetches the key', async () => {
+    await installWebos(context({ passphrase: 'A1B2C3' }));
+
+    expect(ran()[0]).toContain('passphrase=A1B2C3');
+    expect(ran()).toContainEqual([
+      `${BIN}/ares-novacom`,
+      '--device',
+      'kroma-192-168-1-44',
+      '--getkey',
+    ]);
+  });
+
+  it('fetches no key when this computer already holds one', async () => {
+    await installWebos(context());
+
+    expect(ran().some((command) => command.includes('--getkey'))).toBe(false);
+  });
+
+  it('installs the package on the set it registered', async () => {
+    await installWebos(context());
+
+    expect(ranOk()).toContainEqual([
+      `${BIN}/ares-install`,
+      '/out/tv.kroma.webos_0.1.33_all.ipk',
+      '-d',
+      'kroma-192-168-1-44',
+    ]);
+  });
+
+  it('starts the app once the package is on', async () => {
+    await installWebos(context());
+
+    expect(ranOk().at(-1)).toEqual([
+      `${BIN}/ares-launch`,
+      'tv.kroma.webos',
+      '-d',
+      'kroma-192-168-1-44',
+    ]);
+  });
+
+  it('leaves the app alone when it was told to install without starting it', async () => {
+    await installWebos(context({}, false));
+
+    expect(ranOk().some((command) => command[0]?.endsWith('ares-launch'))).toBe(false);
+  });
+});

--- a/packages/tv-installer/src/modules/webos/install.ts
+++ b/packages/tv-installer/src/modules/webos/install.ts
@@ -1,0 +1,51 @@
+import { run, runOk } from '../../run';
+import { requireTool } from '../../toolchain/detect';
+import { type InstallContext, stringOption } from '../module';
+import { webosAppId } from './app-id';
+import { ARES, aresSibling } from './tools';
+
+const DEV_PORT = '9922';
+const DEV_USER = 'prisoner';
+const INSTALL_TIMEOUT_MS = 300_000;
+
+export function deviceName(host: string): string {
+  return `kroma-${host.replaceAll('.', '-')}`;
+}
+
+export async function installWebos(context: InstallContext): Promise<void> {
+  const { tv, artifact, log, launch } = context;
+  const passphrase = stringOption(context.options, 'passphrase');
+  const install = requireTool(ARES);
+  const setup = aresSibling(install, 'ares-setup-device');
+  const novacom = aresSibling(install, 'ares-novacom');
+  const launcher = aresSibling(install, 'ares-launch');
+
+  const device = deviceName(tv.host);
+  await register(setup, device, tv.host, passphrase, log);
+  if (passphrase) await run([novacom, '--device', device, '--getkey'], { log, timeoutMs: 60_000 });
+
+  await runOk([install, artifact, '-d', device], { log, timeoutMs: INSTALL_TIMEOUT_MS });
+  if (launch) await runOk([launcher, webosAppId(), '-d', device], { log });
+}
+
+async function register(
+  setup: string,
+  device: string,
+  host: string,
+  passphrase: string | undefined,
+  log: InstallContext['log'],
+): Promise<void> {
+  const settings = [
+    '-i',
+    `host=${host}`,
+    '-i',
+    `port=${DEV_PORT}`,
+    '-i',
+    `username=${DEV_USER}`,
+    '-i',
+    `privatekey=${device}.pem`,
+    ...(passphrase ? ['-i', `passphrase=${passphrase}`] : []),
+  ];
+  const added = await run([setup, '-a', device, ...settings], { log });
+  if (added.code !== 0) await runOk([setup, '-m', device, ...settings], { log });
+}

--- a/packages/tv-installer/src/modules/webos/module.ts
+++ b/packages/tv-installer/src/modules/webos/module.ts
@@ -1,0 +1,30 @@
+import type { TvModule } from '../module';
+import { resolveWebosArtifact, webosSources } from './artifact';
+import { identifyWebos, WEBOS_PORTS, WEBOS_SEARCH_TARGET } from './identify';
+import { installWebos } from './install';
+import { askPassphrases } from './prompt';
+import { ARES } from './tools';
+
+export const webos: TvModule = {
+  id: 'webos',
+  label: 'LG',
+  brands: 'LG',
+  package: '.ipk',
+  notReadyHint: 'Dev Mode app not running',
+  enableSteps: 'the Dev Mode app',
+  ports: WEBOS_PORTS,
+  searchTargets: [WEBOS_SEARCH_TARGET],
+  flags: {
+    passphrase: {
+      type: 'string',
+      valueHint: 'passphrase',
+      description: 'The LG Dev Mode passphrase, so the install asks nothing',
+    },
+  },
+  identify: identifyWebos,
+  prompt: askPassphrases,
+  tools: () => [ARES],
+  sources: webosSources,
+  resolve: resolveWebosArtifact,
+  install: installWebos,
+};

--- a/packages/tv-installer/src/modules/webos/prompt.test.ts
+++ b/packages/tv-installer/src/modules/webos/prompt.test.ts
@@ -1,0 +1,58 @@
+import * as p from '@clack/prompts';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Television } from '../../television';
+import { askPassphrases } from './prompt';
+
+vi.mock('@clack/prompts', () => ({
+  isCancel: (value: unknown) => value === CANCELLED,
+  log: { info: vi.fn() },
+  password: vi.fn(),
+}));
+
+const CANCELLED = Symbol('cancelled');
+
+const set = (host: string, name: string): Television => ({
+  host,
+  platform: 'webos',
+  vendor: 'LG',
+  name,
+  model: 'OLED55C1',
+  developerMode: 'on',
+  sideloadable: true,
+  note: '',
+  runtime: null,
+});
+
+const sets = [set('192.168.1.44', 'Chambre'), set('192.168.1.45', 'Salon')];
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('askPassphrases', () => {
+  it('asks for the passphrase of every set, and keeps it by address', async () => {
+    vi.mocked(p.password).mockResolvedValueOnce('A1B2C3').mockResolvedValueOnce('D4E5F6');
+
+    const answers = await askPassphrases(sets);
+
+    expect(vi.mocked(p.password).mock.calls[0]?.[0]?.message).toBe(
+      'passphrase for Chambre (192.168.1.44)',
+    );
+    expect([...(answers ?? [])]).toEqual([
+      ['192.168.1.44', { passphrase: 'A1B2C3' }],
+      ['192.168.1.45', { passphrase: 'D4E5F6' }],
+    ]);
+  });
+
+  it('keeps nothing for a set this computer already holds the key of', async () => {
+    vi.mocked(p.password).mockResolvedValue('');
+
+    expect((await askPassphrases(sets))?.size).toBe(0);
+  });
+
+  it('answers nothing at all when the question was cancelled', async () => {
+    vi.mocked(p.password).mockResolvedValue(CANCELLED);
+
+    expect(await askPassphrases(sets)).toBeNull();
+  });
+});

--- a/packages/tv-installer/src/modules/webos/prompt.ts
+++ b/packages/tv-installer/src/modules/webos/prompt.ts
@@ -1,0 +1,21 @@
+import * as p from '@clack/prompts';
+import type { Television } from '../../television';
+import type { ModuleOptions } from '../module';
+
+/** The Dev Mode passphrase of every LG set, by host. Null when the user cancelled. */
+export async function askPassphrases(
+  sets: readonly Television[],
+): Promise<Map<string, ModuleOptions> | null> {
+  p.log.info(
+    'The Dev Mode app on the television shows the passphrase.\n' +
+      'Leave it empty when this computer already holds the key.',
+  );
+
+  const passphrases = new Map<string, ModuleOptions>();
+  for (const tv of sets) {
+    const answer = await p.password({ message: `passphrase for ${tv.name} (${tv.host})` });
+    if (p.isCancel(answer)) return null;
+    if (answer) passphrases.set(tv.host, { passphrase: answer });
+  }
+  return passphrases;
+}

--- a/packages/tv-installer/src/modules/webos/runtime.test.ts
+++ b/packages/tv-installer/src/modules/webos/runtime.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { webosRuntime } from './runtime';
+
+describe('webosRuntime', () => {
+  it('dates an OLED by the year token that follows its series letter', () => {
+    expect(webosRuntime(['OLED55C16LA'])).toEqual({
+      name: 'webOS',
+      version: '6.0',
+      engine: { name: 'Chromium', version: '79' },
+      learned: 'derived',
+    });
+  });
+
+  it('dates an LCD set by the two letters that follow its screen size', () => {
+    expect(webosRuntime(['55UR78006LK'])).toMatchObject({
+      version: '23',
+      engine: { version: '94' },
+    });
+  });
+
+  it('reaches the oldest model year the table dates', () => {
+    expect(webosRuntime(['OLED55B8SLC'])).toMatchObject({
+      version: '4.0',
+      engine: { version: '53' },
+    });
+  });
+
+  it('reaches the newest model year the table dates', () => {
+    expect(webosRuntime(['OLED55C56LA'])).toMatchObject({
+      version: '25',
+      engine: { version: '120' },
+    });
+  });
+
+  it('reads past a set that calls its model LG TV to the name that dates it', () => {
+    expect(webosRuntime(['LG TV', 'OLED55C16LA'])).toMatchObject({ version: '6.0' });
+  });
+
+  it('answers nothing when no name it was handed carries a year', () => {
+    expect(webosRuntime(['LG TV', undefined, 'webOS TV'])).toBeNull();
+  });
+});

--- a/packages/tv-installer/src/modules/webos/runtime.ts
+++ b/packages/tv-installer/src/modules/webos/runtime.ts
@@ -1,0 +1,69 @@
+import type { Runtime } from '../../television';
+
+const WEBOS_BY_MODEL_YEAR: Readonly<Record<number, { version: string; chromium: string }>> = {
+  2018: { version: '4.0', chromium: '53' },
+  2019: { version: '4.5', chromium: '53' },
+  2020: { version: '5.0', chromium: '68' },
+  2021: { version: '6.0', chromium: '79' },
+  2022: { version: '22', chromium: '87' },
+  2023: { version: '23', chromium: '94' },
+  2024: { version: '24', chromium: '108' },
+  2025: { version: '25', chromium: '120' },
+};
+
+const OLED_YEAR: Readonly<Record<string, number>> = {
+  '8': 2018,
+  '9': 2019,
+  X: 2020,
+  '1': 2021,
+  '2': 2022,
+  '3': 2023,
+  '4': 2024,
+  '5': 2025,
+};
+
+const LCD_YEAR: Readonly<Record<string, number>> = {
+  LK: 2018,
+  SK: 2018,
+  UK: 2018,
+  LM: 2019,
+  SM: 2019,
+  UM: 2019,
+  UN: 2020,
+  UP: 2021,
+  UQ: 2022,
+  UR: 2023,
+  UT: 2024,
+  UA: 2025,
+};
+
+/**
+ * What an LG runs, from the year its model names: `OLED55C16LA` is a 2021 set,
+ * `55UR78006LK` a 2023 one. The names are tried in turn, because a set that
+ * calls its `modelName` "LG TV" carries the real one in `modelNumber`. The
+ * table holds what `clients/webos/README.md` states; a name it cannot date
+ * answers null.
+ */
+export function webosRuntime(models: readonly (string | undefined)[]): Runtime | null {
+  for (const model of models) {
+    const year = modelYear(model ?? '');
+    const dated = year === null ? undefined : WEBOS_BY_MODEL_YEAR[year];
+    if (dated) {
+      return {
+        name: 'webOS',
+        version: dated.version,
+        engine: { name: 'Chromium', version: dated.chromium },
+        learned: 'derived',
+      };
+    }
+  }
+  return null;
+}
+
+function modelYear(model: string): number | null {
+  const upper = model.toUpperCase();
+  const oled = /OLED\d{2}[A-Z]([0-9X])/.exec(upper)?.[1];
+  if (oled !== undefined) return OLED_YEAR[oled] ?? null;
+  const lcd = /\d{2}([A-Z]{2})\d/.exec(upper)?.[1];
+  return lcd === undefined ? null : (LCD_YEAR[lcd] ?? null);
+}

--- a/packages/tv-installer/src/modules/webos/tools.test.ts
+++ b/packages/tv-installer/src/modules/webos/tools.test.ts
@@ -1,0 +1,39 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { KROMA_TOOLS } from '../../toolchain/detect';
+import { ARES, aresSibling } from './tools';
+
+const runOk = vi.hoisted(() =>
+  vi.fn(async (_command: readonly string[], _options?: unknown) => ''),
+);
+vi.mock('../../run', () => ({ runOk }));
+
+beforeEach(() => {
+  runOk.mockReset();
+});
+
+describe('ARES', () => {
+  it('looks for the CLI where a global bun install and a package manager put it', () => {
+    expect(ARES.candidates?.()).toEqual([
+      join(homedir(), '.bun', 'bin', 'ares-install'),
+      join(KROMA_TOOLS, 'node_modules', '.bin', 'ares-install'),
+      '/usr/local/bin/ares-install',
+      '/opt/homebrew/bin/ares-install',
+    ]);
+  });
+
+  it('installs the CLI globally with bun', async () => {
+    await ARES.install?.(() => {});
+
+    expect(runOk.mock.calls[0]?.[0]).toEqual(['bun', 'add', '-g', '@webos-tools/cli']);
+  });
+});
+
+describe('aresSibling', () => {
+  it('names a command beside the one that was found', () => {
+    expect(aresSibling('/opt/homebrew/bin/ares-install', 'ares-launch')).toBe(
+      '/opt/homebrew/bin/ares-launch',
+    );
+  });
+});

--- a/packages/tv-installer/src/modules/webos/tools.ts
+++ b/packages/tv-installer/src/modules/webos/tools.ts
@@ -1,0 +1,22 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { type LogLine, runOk } from '../../run';
+import { KROMA_TOOLS, type Tool } from '../../toolchain/detect';
+
+export const ARES: Tool = {
+  id: 'ares',
+  label: 'webOS TV CLI',
+  binary: 'ares-install',
+  source: 'bun add -g @webos-tools/cli',
+  candidates: () => [
+    join(homedir(), '.bun', 'bin', 'ares-install'),
+    join(KROMA_TOOLS, 'node_modules', '.bin', 'ares-install'),
+    '/usr/local/bin/ares-install',
+    '/opt/homebrew/bin/ares-install',
+  ],
+  install: (log: LogLine) => runOk(['bun', 'add', '-g', '@webos-tools/cli'], { log }).then(),
+};
+
+export function aresSibling(aresInstall: string, binary: string): string {
+  return join(aresInstall.slice(0, aresInstall.lastIndexOf('/')), binary);
+}

--- a/packages/tv-installer/src/root.test.ts
+++ b/packages/tv-installer/src/root.test.ts
@@ -1,0 +1,81 @@
+import { randomInt } from 'node:crypto';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
+
+const bases: string[] = [];
+
+function tree(...segments: string[]): { base: string; directory: string } {
+  const base = mkdtempSync(join(tmpdir(), 'kroma-root-'));
+  bases.push(base);
+  const directory = join(base, ...segments);
+  mkdirSync(directory, { recursive: true });
+  return { base, directory };
+}
+
+const manifest = (directory: string, contents: string) =>
+  writeFileSync(join(directory, 'package.json'), contents);
+
+const checkout = () => tree('packages', `tv-installer-${randomInt(1000, 9999)}`, 'src');
+
+async function rootStartedIn(cwd: string): Promise<string> {
+  vi.spyOn(process, 'cwd').mockReturnValue(cwd);
+  vi.resetModules();
+  return (await import('./root')).root;
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+afterAll(() => {
+  for (const base of bases) rmSync(base, { recursive: true, force: true });
+});
+
+describe('root', () => {
+  it('is the checkout the run was started inside', async () => {
+    const { base, directory } = checkout();
+    manifest(base, JSON.stringify({ name: 'kroma' }));
+
+    expect(await rootStartedIn(directory)).toBe(base);
+  });
+
+  it('walks past a workspace that is not the checkout itself', async () => {
+    const { base, directory } = checkout();
+    manifest(base, JSON.stringify({ name: 'kroma' }));
+    manifest(directory, JSON.stringify({ name: '@kroma/tv-installer' }));
+
+    expect(await rootStartedIn(directory)).toBe(base);
+  });
+
+  it('walks past a package.json nothing can parse', async () => {
+    const { base, directory } = checkout();
+    manifest(base, JSON.stringify({ name: 'kroma' }));
+    manifest(directory, '{ this is not JSON');
+
+    expect(await rootStartedIn(directory)).toBe(base);
+  });
+
+  it('walks past a package.json that names no package', async () => {
+    const { base, directory } = checkout();
+    manifest(base, JSON.stringify({ name: 'kroma' }));
+    manifest(directory, JSON.stringify({ version: '0.0.0' }));
+
+    expect(await rootStartedIn(directory)).toBe(base);
+  });
+
+  it('falls back to the checkout its own source sits in when started elsewhere', async () => {
+    const { directory } = tree('outside', 'any', 'checkout');
+
+    const found = await rootStartedIn(directory);
+
+    expect(existsSync(join(found, 'packages', 'tv-installer', 'src', 'root.ts'))).toBe(true);
+  });
+
+  it('gives up before walking twenty-five levels up to a checkout', async () => {
+    const levels = Array.from({ length: 25 }, (_, level) => `level-${level}`);
+    const { base, directory } = tree(...levels);
+    manifest(base, JSON.stringify({ name: 'kroma' }));
+
+    expect(await rootStartedIn(directory)).not.toBe(base);
+  });
+});

--- a/packages/tv-installer/src/root.ts
+++ b/packages/tv-installer/src/root.ts
@@ -1,0 +1,38 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { z } from 'zod';
+
+const Manifest = z.object({ name: z.string() });
+const MAX_DEPTH = 20;
+
+/**
+ * The checkout this run belongs to: found by walking up from where it was
+ * started, because a compiled binary has no source path to count back from.
+ */
+export const root = walkUp(process.cwd()) ?? fromSource();
+
+function fromSource(): string {
+  return join(dirname(fileURLToPath(import.meta.url)), '../../..');
+}
+
+function walkUp(start: string): string | null {
+  let directory = resolve(start);
+  for (let depth = 0; depth < MAX_DEPTH; depth++) {
+    if (isRepository(directory)) return directory;
+    const parent = dirname(directory);
+    if (parent === directory) return null;
+    directory = parent;
+  }
+  return null;
+}
+
+function isRepository(directory: string): boolean {
+  const manifest = join(directory, 'package.json');
+  if (!existsSync(manifest)) return false;
+  try {
+    return Manifest.parse(JSON.parse(readFileSync(manifest, 'utf8'))).name === 'kroma';
+  } catch {
+    return false;
+  }
+}

--- a/packages/tv-installer/src/run.fixture.ts
+++ b/packages/tv-installer/src/run.fixture.ts
@@ -1,0 +1,20 @@
+import { spawn } from 'node:child_process';
+import { Readable } from 'node:stream';
+
+const KILLED = 137;
+
+type Spawned = Pick<
+  Bun.Subprocess<'ignore', 'pipe', 'pipe'>,
+  'stdout' | 'stderr' | 'exited' | 'kill'
+>;
+
+export const nodeSpawn = (command: readonly string[], options: { cwd?: string }): Spawned => {
+  const [file, ...args] = command;
+  const child = spawn(String(file), args, { cwd: options.cwd, stdio: ['ignore', 'pipe', 'pipe'] });
+  return {
+    stdout: Readable.toWeb(child.stdout),
+    stderr: Readable.toWeb(child.stderr),
+    exited: new Promise((resolve) => child.on('close', (code) => resolve(code ?? KILLED))),
+    kill: (signal) => child.kill(signal),
+  };
+};

--- a/packages/tv-installer/src/run.test.ts
+++ b/packages/tv-installer/src/run.test.ts
@@ -1,0 +1,96 @@
+import { spawn } from 'node:child_process';
+import { Readable } from 'node:stream';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { run, runOk } from './run';
+
+const webStream = (readable: Readable | null) => Readable.toWeb(readable ?? Readable.from([]));
+
+const nodeSpawn = (command: readonly string[], options: { cwd?: string }) => {
+  const [file, ...args] = command;
+  const child = spawn(String(file), args, { cwd: options.cwd, stdio: ['ignore', 'pipe', 'pipe'] });
+  return {
+    stdout: webStream(child.stdout),
+    stderr: webStream(child.stderr),
+    exited: new Promise<number>((resolve) => {
+      child.on('close', (code, signal) => resolve(code ?? (signal ? 137 : 1)));
+    }),
+    kill: (signal: NodeJS.Signals) => child.kill(signal),
+  };
+};
+
+beforeEach(() => vi.stubGlobal('Bun', { spawn: nodeSpawn }));
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('run', () => {
+  it('answers what the command printed and the code it exited with', async () => {
+    expect(await run(['/bin/echo', 'hello'])).toEqual({ code: 0, output: 'hello' });
+  });
+
+  it('hands the log every line as the command prints it', async () => {
+    const printed: string[] = [];
+
+    await run(['/bin/sh', '-c', 'echo one; echo two'], { log: (line) => printed.push(line) });
+
+    expect(printed).toEqual(['one', 'two']);
+  });
+
+  it('collects what the command said on stderr as well as on stdout', async () => {
+    const { output } = await run(['/bin/sh', '-c', 'echo out; echo err 1>&2']);
+
+    expect(output.split('\n').sort()).toEqual(['err', 'out']);
+  });
+
+  it('keeps a last line the command never ended with a newline', async () => {
+    const { output } = await run(['/bin/sh', '-c', "printf 'one\\ntwo'"]);
+
+    expect(output).toBe('one\ntwo');
+  });
+
+  it('drops the carriage return and the whitespace a tool trails its lines with', async () => {
+    const { output } = await run(['/bin/sh', '-c', "printf 'one \\r\\ntwo\\n   '"]);
+
+    expect(output).toBe('one\ntwo');
+  });
+
+  it('answers the code a failing command exited with', async () => {
+    const { code } = await run(['/bin/sh', '-c', 'exit 3']);
+
+    expect(code).toBe(3);
+  });
+
+  it('runs the command in the directory it was given', async () => {
+    const { output } = await run(['/bin/pwd'], { cwd: '/usr' });
+
+    expect(output).toBe('/usr');
+  });
+
+  it('refuses a command with nothing to run', async () => {
+    await expect(run([])).rejects.toThrow('run() needs a command');
+  });
+
+  it('kills a command that outstays its timeout', async () => {
+    const started = performance.now();
+
+    const { output } = await run(['/bin/sleep', '5'], { timeoutMs: 100 });
+
+    expect(output).toBe('');
+    expect(performance.now() - started).toBeLessThan(2000);
+  });
+});
+
+describe('runOk', () => {
+  it('answers what a command that succeeded printed', async () => {
+    expect(await runOk(['/bin/echo', 'ready'])).toBe('ready');
+  });
+
+  it('throws with the last four lines a failing command printed', async () => {
+    const noisy = ['/bin/sh', '-c', 'for i in 1 2 3 4 5 6; do echo line$i; done; exit 2'];
+
+    await expect(runOk(noisy)).rejects.toThrow('/bin/sh exited 2: line3 / line4 / line5 / line6');
+  });
+
+  it('throws naming only the code when the command said nothing at all', async () => {
+    await expect(runOk(['/bin/sh', '-c', 'exit 4'])).rejects.toThrow(/exited 4$/);
+  });
+});

--- a/packages/tv-installer/src/run.test.ts
+++ b/packages/tv-installer/src/run.test.ts
@@ -1,22 +1,6 @@
-import { spawn } from 'node:child_process';
-import { Readable } from 'node:stream';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { run, runOk } from './run';
-
-const webStream = (readable: Readable | null) => Readable.toWeb(readable ?? Readable.from([]));
-
-const nodeSpawn = (command: readonly string[], options: { cwd?: string }) => {
-  const [file, ...args] = command;
-  const child = spawn(String(file), args, { cwd: options.cwd, stdio: ['ignore', 'pipe', 'pipe'] });
-  return {
-    stdout: webStream(child.stdout),
-    stderr: webStream(child.stderr),
-    exited: new Promise<number>((resolve) => {
-      child.on('close', (code, signal) => resolve(code ?? (signal ? 137 : 1)));
-    }),
-    kill: (signal: NodeJS.Signals) => child.kill(signal),
-  };
-};
+import { nodeSpawn } from './run.fixture';
 
 beforeEach(() => vi.stubGlobal('Bun', { spawn: nodeSpawn }));
 
@@ -72,9 +56,10 @@ describe('run', () => {
   it('kills a command that outstays its timeout', async () => {
     const started = performance.now();
 
-    const { output } = await run(['/bin/sleep', '5'], { timeoutMs: 100 });
+    const { code, output } = await run(['/bin/sleep', '5'], { timeoutMs: 100 });
 
     expect(output).toBe('');
+    expect(code).toBe(137);
     expect(performance.now() - started).toBeLessThan(2000);
   });
 });

--- a/packages/tv-installer/src/run.ts
+++ b/packages/tv-installer/src/run.ts
@@ -50,7 +50,8 @@ export async function runOk(command: readonly string[], options: RunOptions = {}
   const { code, output } = await run(command, options);
   if (code !== 0) {
     const tail = output.split('\n').filter(Boolean).slice(-4).join(' / ');
-    throw new Error(`${command[0]} exited ${code}${tail ? `: ${tail}` : ''}`);
+    const said = tail ? `: ${tail}` : '';
+    throw new Error(`${command[0]} exited ${code}${said}`);
   }
   return output;
 }

--- a/packages/tv-installer/src/run.ts
+++ b/packages/tv-installer/src/run.ts
@@ -1,0 +1,68 @@
+export type LogLine = (line: string) => void;
+
+export interface RunOptions {
+  log?: LogLine;
+  cwd?: string;
+  timeoutMs?: number;
+}
+
+export interface RunResult {
+  code: number;
+  output: string;
+}
+
+/** Runs a command, streaming both its streams to `log` line by line. */
+export async function run(
+  command: readonly string[],
+  options: RunOptions = {},
+): Promise<RunResult> {
+  const [file, ...args] = command;
+  if (!file) throw new Error('run() needs a command');
+
+  const child = Bun.spawn([file, ...args], {
+    cwd: options.cwd,
+    stdin: 'ignore',
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const killer = options.timeoutMs
+    ? setTimeout(() => child.kill('SIGKILL'), options.timeoutMs)
+    : undefined;
+
+  const collected: string[] = [];
+  const drain = async (stream: ReadableStream<Uint8Array>) => {
+    for await (const line of lines(stream)) {
+      collected.push(line);
+      options.log?.(line);
+    }
+  };
+
+  try {
+    await Promise.all([drain(child.stdout), drain(child.stderr)]);
+    return { code: await child.exited, output: collected.join('\n') };
+  } finally {
+    clearTimeout(killer);
+  }
+}
+
+/** As `run`, but a non-zero exit is an error carrying what the command said. */
+export async function runOk(command: readonly string[], options: RunOptions = {}): Promise<string> {
+  const { code, output } = await run(command, options);
+  if (code !== 0) {
+    const tail = output.split('\n').filter(Boolean).slice(-4).join(' / ');
+    throw new Error(`${command[0]} exited ${code}${tail ? `: ${tail}` : ''}`);
+  }
+  return output;
+}
+
+async function* lines(stream: ReadableStream<Uint8Array>): AsyncGenerator<string> {
+  const decoder = new TextDecoder();
+  let carry = '';
+  for await (const chunk of stream) {
+    carry += decoder.decode(chunk, { stream: true });
+    const parts = carry.split('\n');
+    carry = parts.pop() ?? '';
+    for (const part of parts) yield part.trimEnd();
+  }
+  if (carry.trim()) yield carry.trimEnd();
+}

--- a/packages/tv-installer/src/television.fixture.ts
+++ b/packages/tv-installer/src/television.fixture.ts
@@ -1,0 +1,16 @@
+import type { Television } from './television';
+
+export function television(over: Partial<Television> = {}): Television {
+  return {
+    host: '192.168.1.10',
+    platform: 'tizen',
+    vendor: 'Samsung',
+    name: 'Salon',
+    model: 'QE55Q60A',
+    developerMode: 'on',
+    sideloadable: true,
+    note: '',
+    runtime: { name: 'Tizen', version: '8.0', engine: null, learned: 'reported' },
+    ...over,
+  };
+}

--- a/packages/tv-installer/src/television.fixture.ts
+++ b/packages/tv-installer/src/television.fixture.ts
@@ -1,12 +1,24 @@
+import { randomInt } from 'node:crypto';
 import type { Television } from './television';
 
+const octet = () => randomInt(1, 255);
+const pick = <T>(values: readonly T[]): T => values[randomInt(values.length)] as T;
+
+const NAMES = ['Salon', 'Chambre', 'Cuisine', 'Bureau', 'Atelier'];
+const MODELS = ['QE55Q60A', 'GQ75LS03DA', 'UE50AU7172', 'OLED55C1', '55PUS7304'];
+
+/**
+ * A television nothing in particular. Every field a test does not name is
+ * generated, so a test that depends on one has to say which and cannot pass by
+ * accident on a value that happened to be there.
+ */
 export function television(over: Partial<Television> = {}): Television {
   return {
-    host: '192.168.1.10',
+    host: [10, octet(), octet(), octet()].join('.'),
     platform: 'tizen',
     vendor: 'Samsung',
-    name: 'Salon',
-    model: 'QE55Q60A',
+    name: `${pick(NAMES)} ${octet()}`,
+    model: pick(MODELS),
     developerMode: 'on',
     sideloadable: true,
     note: '',

--- a/packages/tv-installer/src/television.test.ts
+++ b/packages/tv-installer/src/television.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { type Runtime, runtimeLabel } from './television';
+
+const reported: Runtime = {
+  name: 'Android',
+  version: '12',
+  engine: { name: 'WebView', version: '108' },
+  learned: 'reported',
+};
+
+const derived: Runtime = {
+  name: 'Tizen',
+  version: '8.0',
+  engine: { name: 'Chromium', version: '108' },
+  learned: 'derived',
+};
+
+describe('runtimeLabel', () => {
+  it('states a version read off the set as it stands', () => {
+    expect(runtimeLabel(reported)).toBe('Android 12, WebView 108');
+  });
+
+  it('says of a version worked out from the model that it was', () => {
+    expect(runtimeLabel(derived)).toBe('Tizen 8.0, Chromium 108, by model');
+  });
+
+  it('names the platform alone when no engine goes with it', () => {
+    expect(runtimeLabel({ ...derived, name: 'Android', version: '9', engine: null })).toBe(
+      'Android 9, by model',
+    );
+  });
+
+  it('names an engine that carries no version of its own', () => {
+    const tvos: Runtime = {
+      name: 'tvOS',
+      version: '27.0',
+      engine: { name: 'React Native', version: null },
+      learned: 'reported',
+    };
+
+    expect(runtimeLabel(tvos)).toBe('tvOS 27.0, React Native');
+  });
+
+  it('says nothing at all for a set nothing dated', () => {
+    expect(runtimeLabel(null)).toBe('');
+  });
+});

--- a/packages/tv-installer/src/television.ts
+++ b/packages/tv-installer/src/television.ts
@@ -1,0 +1,36 @@
+export type Platform = string;
+
+export type DeveloperMode = 'on' | 'off' | 'unknown';
+
+export type Learned = 'reported' | 'derived';
+
+/** A null anywhere means nothing named a version, never a guess at one. */
+export interface Runtime {
+  name: string;
+  version: string;
+  engine: { name: string; version: string | null } | null;
+  learned: Learned;
+}
+
+export interface Television {
+  host: string;
+  platform: Platform;
+  vendor: string;
+  name: string;
+  model: string;
+  developerMode: DeveloperMode;
+  sideloadable: boolean;
+  note: string;
+  runtime: Runtime | null;
+  identifier?: string;
+}
+
+/** `Android 12, WebView 108`, trailed by `by model` for a version nothing reported. */
+export function runtimeLabel(runtime: Runtime | null): string {
+  if (!runtime) return '';
+  const { engine } = runtime;
+  const parts = [`${runtime.name} ${runtime.version}`];
+  if (engine) parts.push(engine.version ? `${engine.name} ${engine.version}` : engine.name);
+  if (runtime.learned === 'derived') parts.push('by model');
+  return parts.join(', ');
+}

--- a/packages/tv-installer/src/toolchain/detect.test.ts
+++ b/packages/tv-installer/src/toolchain/detect.test.ts
@@ -1,0 +1,67 @@
+import { existsSync } from 'node:fs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { locate, requireTool, type Tool } from './detect';
+
+vi.mock('node:fs', () => ({ existsSync: vi.fn() }));
+
+const which = vi.fn<(binary: string) => string | null>();
+
+vi.stubGlobal('Bun', { which });
+
+const adb: Tool = {
+  id: 'adb',
+  label: 'Android Debug Bridge',
+  binary: 'adb',
+  source: 'dl.google.com platform-tools',
+  candidates: () => ['/opt/android/platform-tools/adb', '/usr/local/bin/adb'],
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('locate', () => {
+  it('takes the binary PATH already answers with', () => {
+    which.mockReturnValue('/usr/bin/adb');
+
+    expect(locate(adb)).toBe('/usr/bin/adb');
+    expect(vi.mocked(existsSync)).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the first place the tool is known to install itself', () => {
+    which.mockReturnValue(null);
+    vi.mocked(existsSync).mockImplementation((path) => path === '/usr/local/bin/adb');
+
+    expect(locate(adb)).toBe('/usr/local/bin/adb');
+  });
+
+  it('answers nothing when neither PATH nor any known place holds it', () => {
+    which.mockReturnValue(null);
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    expect(locate(adb)).toBeNull();
+  });
+
+  it('answers nothing for a tool that names no place to look', () => {
+    which.mockReturnValue(null);
+
+    expect(locate({ ...adb, candidates: undefined })).toBeNull();
+  });
+});
+
+describe('requireTool', () => {
+  it('answers the path when the tool is here', () => {
+    which.mockReturnValue('/usr/bin/adb');
+
+    expect(requireTool(adb)).toBe('/usr/bin/adb');
+  });
+
+  it('says where a missing tool comes from', () => {
+    which.mockReturnValue(null);
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    expect(() => requireTool(adb)).toThrow(
+      'Android Debug Bridge is missing: install it from dl.google.com platform-tools',
+    );
+  });
+});

--- a/packages/tv-installer/src/toolchain/detect.ts
+++ b/packages/tv-installer/src/toolchain/detect.ts
@@ -1,0 +1,27 @@
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type { LogLine } from '../run';
+
+export interface Tool {
+  id: string;
+  label: string;
+  binary: string;
+  source: string;
+  candidates?(): readonly string[];
+  install?(log: LogLine): Promise<void>;
+}
+
+export const KROMA_TOOLS = join(homedir(), '.kroma', 'tools');
+
+export function locate(tool: Tool): string | null {
+  const onPath = Bun.which(tool.binary);
+  if (onPath) return onPath;
+  return (tool.candidates?.() ?? []).find((path) => existsSync(path)) ?? null;
+}
+
+export function requireTool(tool: Tool): string {
+  const path = locate(tool);
+  if (!path) throw new Error(`${tool.label} is missing: install it from ${tool.source}`);
+  return path;
+}

--- a/packages/tv-installer/src/toolchain/install.test.ts
+++ b/packages/tv-installer/src/toolchain/install.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Tool } from './detect';
+import { download, installTool } from './install';
+
+const locate = vi.hoisted(() => vi.fn((_tool: unknown): string | null => null));
+vi.mock('./detect', async (original) => ({
+  ...(await original<Record<string, unknown>>()),
+  locate,
+}));
+
+const lines: string[] = [];
+const log = (line: string) => lines.push(line);
+
+const install = vi.fn(async () => {});
+
+const adb: Tool = {
+  id: 'adb',
+  label: 'Android Debug Bridge',
+  binary: 'adb',
+  source: 'dl.google.com platform-tools',
+  install,
+};
+
+const xcode: Tool = {
+  id: 'xcode',
+  label: 'Xcode',
+  binary: 'xcodebuild',
+  source: 'the Mac App Store',
+};
+
+beforeEach(() => {
+  lines.length = 0;
+  locate.mockReset();
+  install.mockClear();
+});
+
+describe('installTool', () => {
+  it('hands back the path of a tool that is already here without installing it', async () => {
+    locate.mockReturnValue('/usr/local/bin/adb');
+
+    const path = await installTool(adb, log);
+
+    expect(path).toBe('/usr/local/bin/adb');
+    expect(install).not.toHaveBeenCalled();
+  });
+
+  it('installs a missing tool and answers where it landed', async () => {
+    locate.mockReturnValueOnce(null).mockReturnValueOnce('/home/.kroma/tools/adb');
+
+    const path = await installTool(adb, log);
+
+    expect(install).toHaveBeenCalledOnce();
+    expect(path).toBe('/home/.kroma/tools/adb');
+  });
+
+  it('names the source of a missing tool it cannot install itself', async () => {
+    locate.mockReturnValue(null);
+
+    await expect(installTool(xcode, log)).rejects.toThrow(
+      'Xcode is missing: install it from the Mac App Store',
+    );
+  });
+
+  it('refuses an install that left nothing the shell can find', async () => {
+    locate.mockReturnValue(null);
+
+    await expect(installTool(adb, log)).rejects.toThrow(
+      'Android Debug Bridge installed but adb is not on PATH',
+    );
+  });
+
+  it('says what it is installing and where it put it', async () => {
+    locate.mockReturnValueOnce(null).mockReturnValueOnce('/home/.kroma/tools/adb');
+
+    await installTool(adb, log);
+
+    expect(lines).toEqual([
+      'installing Android Debug Bridge from dl.google.com platform-tools',
+      'Android Debug Bridge ready: /home/.kroma/tools/adb',
+    ]);
+  });
+});
+
+const chunks: Uint8Array[] = [];
+const sink = { write: (chunk: Uint8Array) => chunks.push(chunk), end: async () => {} };
+vi.stubGlobal('Bun', { file: () => ({ writer: () => sink }) });
+
+const body = (count: number) =>
+  (async function* stream() {
+    for (let index = 0; index < count; index++) yield new Uint8Array(10);
+  })();
+
+const answering = (response: unknown) => vi.stubGlobal('fetch', async () => response);
+
+describe('download', () => {
+  beforeEach(() => {
+    chunks.length = 0;
+    lines.length = 0;
+  });
+
+  it('writes every chunk the server sent', async () => {
+    answering({ ok: true, body: body(3), headers: new Headers({ 'content-length': '30' }) });
+
+    await download('https://dl.google.com/platform-tools.zip', '/tmp/tools.zip', log);
+
+    expect(chunks).toHaveLength(3);
+  });
+
+  it('reports how far the download has got, in tens', async () => {
+    answering({ ok: true, body: body(10), headers: new Headers({ 'content-length': '100' }) });
+
+    await download('https://dl.google.com/platform-tools.zip', '/tmp/tools.zip', log);
+
+    expect(lines).toEqual([
+      '  10% of 0 MB',
+      '  20% of 0 MB',
+      '  30% of 0 MB',
+      '  40% of 0 MB',
+      '  50% of 0 MB',
+      '  60% of 0 MB',
+      '  70% of 0 MB',
+      '  80% of 0 MB',
+      '  90% of 0 MB',
+      '  100% of 0 MB',
+    ]);
+  });
+
+  it('says nothing about progress when the server named no length', async () => {
+    answering({ ok: true, body: body(3), headers: new Headers() });
+
+    await download('https://dl.google.com/platform-tools.zip', '/tmp/tools.zip', log);
+
+    expect(lines).toEqual([]);
+  });
+
+  it('refuses a URL the server would not serve', async () => {
+    answering({ ok: false, status: 404, body: null, headers: new Headers() });
+
+    await expect(download('https://dl.google.com/gone.zip', '/tmp/tools.zip', log)).rejects.toThrow(
+      'GET https://dl.google.com/gone.zip answered 404',
+    );
+  });
+});

--- a/packages/tv-installer/src/toolchain/install.ts
+++ b/packages/tv-installer/src/toolchain/install.ts
@@ -1,0 +1,39 @@
+import type { LogLine } from '../run';
+import { locate, type Tool } from './detect';
+
+/** Installs a missing tool and returns its path. Idempotent: an installed tool returns early. */
+export async function installTool(tool: Tool, log: LogLine): Promise<string> {
+  const already = locate(tool);
+  if (already) return already;
+
+  if (!tool.install) throw new Error(`${tool.label} is missing: install it from ${tool.source}`);
+  log(`installing ${tool.label} from ${tool.source}`);
+  await tool.install(log);
+
+  const path = locate(tool);
+  if (!path) throw new Error(`${tool.label} installed but ${tool.binary} is not on PATH`);
+  log(`${tool.label} ready: ${path}`);
+  return path;
+}
+
+export async function download(url: string, dest: string, log: LogLine): Promise<void> {
+  // No redirect: these URLs serve the file directly, and refusing a hop is what
+  // stops the download being pointed somewhere else.
+  const response = await fetch(url, { redirect: 'error' });
+  if (!response.ok || !response.body) throw new Error(`GET ${url} answered ${response.status}`);
+
+  const total = Number(response.headers.get('content-length') ?? '0');
+  const sink = Bun.file(dest).writer();
+  let written = 0;
+  let reported = 0;
+  for await (const chunk of response.body) {
+    sink.write(chunk);
+    written += chunk.byteLength;
+    const percent = total ? Math.floor((written / total) * 100) : 0;
+    if (percent >= reported + 10) {
+      reported = percent;
+      log(`  ${percent}% of ${(total / 1e6).toFixed(0)} MB`);
+    }
+  }
+  await sink.end();
+}

--- a/packages/tv-installer/src/tui/ansi.test.ts
+++ b/packages/tv-installer/src/tui/ansi.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { style } from './ansi';
+
+const wasTTY = process.stdout.isTTY;
+
+async function styledOn(isTTY: boolean, noColor?: string): Promise<typeof style> {
+  Object.defineProperty(process.stdout, 'isTTY', { value: isTTY, configurable: true });
+  vi.stubEnv('NO_COLOR', noColor);
+  vi.resetModules();
+  return (await import('./ansi')).style;
+}
+
+afterEach(() => {
+  Object.defineProperty(process.stdout, 'isTTY', { value: wasTTY, configurable: true });
+  vi.unstubAllEnvs();
+});
+
+describe('style', () => {
+  it('wraps text in the code the terminal reads', async () => {
+    const styled = await styledOn(true);
+
+    expect(styled.bold('KROMA')).toBe('\x1b[1mKROMA\x1b[0m');
+    expect(styled.red('failed')).toBe('\x1b[31mfailed\x1b[0m');
+  });
+
+  it('leaves text alone when it is not a terminal reading it', async () => {
+    const styled = await styledOn(false);
+
+    expect(styled.green('installed')).toBe('installed');
+  });
+
+  it('leaves text alone on a terminal that was asked for no colour', async () => {
+    const styled = await styledOn(true, '1');
+
+    expect(styled.yellow('nothing new')).toBe('nothing new');
+    expect(styled.dim('192.168.1.10')).toBe('192.168.1.10');
+  });
+});

--- a/packages/tv-installer/src/tui/ansi.ts
+++ b/packages/tv-installer/src/tui/ansi.ts
@@ -1,0 +1,12 @@
+const CSI = '\x1b[';
+const enabled = process.stdout.isTTY === true && !process.env.NO_COLOR;
+
+const wrap = (code: string) => (text: string) => (enabled ? `${CSI}${code}m${text}${CSI}0m` : text);
+
+export const style = {
+  bold: wrap('1'),
+  dim: wrap('2'),
+  red: wrap('31'),
+  green: wrap('32'),
+  yellow: wrap('33'),
+};

--- a/packages/tv-installer/src/tui/app.test.ts
+++ b/packages/tv-installer/src/tui/app.test.ts
@@ -1,7 +1,7 @@
 import { cancel, outro } from '@clack/prompts';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ModuleOptions } from '../modules/module';
-import type { Television } from '../television';
+import { television } from '../television.fixture';
 import { runTui } from './app';
 import { askModules, chooseSource } from './choose';
 import { discover } from './discover';
@@ -17,19 +17,8 @@ vi.mock('./choose', () => ({ askModules: vi.fn(), chooseSource: vi.fn() }));
 vi.mock('./discover', () => ({ discover: vi.fn() }));
 vi.mock('./install-sets', () => ({ installSets: vi.fn() }));
 
-const salon: Television = {
-  host: '192.168.1.10',
-  platform: 'tizen',
-  vendor: 'Samsung',
-  name: 'Salon',
-  model: 'QE55Q60A',
-  developerMode: 'on',
-  sideloadable: true,
-  note: '',
-  runtime: null,
-};
-
-const cuisine: Television = { ...salon, host: '192.168.1.11', name: 'Cuisine' };
+const salon = television();
+const cuisine = television({ host: '192.168.1.11', name: 'Cuisine' });
 const passphrases: Map<string, ModuleOptions> = new Map([['192.168.1.11', { passphrase: 'AB' }]]);
 
 beforeEach(() => {

--- a/packages/tv-installer/src/tui/app.test.ts
+++ b/packages/tv-installer/src/tui/app.test.ts
@@ -1,0 +1,131 @@
+import { cancel, outro } from '@clack/prompts';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ModuleOptions } from '../modules/module';
+import type { Television } from '../television';
+import { runTui } from './app';
+import { askModules, chooseSource } from './choose';
+import { discover } from './discover';
+import { installSets } from './install-sets';
+
+vi.mock('@clack/prompts', async (real) => ({
+  ...(await real<typeof import('@clack/prompts')>()),
+  intro: vi.fn(),
+  outro: vi.fn(),
+  cancel: vi.fn(),
+}));
+vi.mock('./choose', () => ({ askModules: vi.fn(), chooseSource: vi.fn() }));
+vi.mock('./discover', () => ({ discover: vi.fn() }));
+vi.mock('./install-sets', () => ({ installSets: vi.fn() }));
+
+const salon: Television = {
+  host: '192.168.1.10',
+  platform: 'tizen',
+  vendor: 'Samsung',
+  name: 'Salon',
+  model: 'QE55Q60A',
+  developerMode: 'on',
+  sideloadable: true,
+  note: '',
+  runtime: null,
+};
+
+const cuisine: Television = { ...salon, host: '192.168.1.11', name: 'Cuisine' };
+const passphrases: Map<string, ModuleOptions> = new Map([['192.168.1.11', { passphrase: 'AB' }]]);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(discover).mockResolvedValue([salon]);
+  vi.mocked(chooseSource).mockResolvedValue('stable');
+  vi.mocked(askModules).mockResolvedValue(passphrases);
+  vi.mocked(installSets).mockResolvedValue([]);
+});
+
+describe('runTui', () => {
+  it('installs onto every ticked set and answers 0', async () => {
+    const code = await runTui({ hosts: ['192.168.1.10'], launch: true });
+
+    expect(discover).toHaveBeenCalledWith(['192.168.1.10']);
+    expect(installSets).toHaveBeenCalledWith([salon], {
+      artifact: undefined,
+      source: 'stable',
+      launch: true,
+      moduleOptions: passphrases,
+    });
+    expect(code).toBe(0);
+  });
+
+  it('counts the sets that took KROMA and answers 1 when one did not', async () => {
+    vi.mocked(discover).mockResolvedValue([salon, cuisine]);
+    vi.mocked(installSets).mockResolvedValue([cuisine]);
+
+    const code = await runTui({ launch: true });
+
+    expect(outro).toHaveBeenCalledWith('1 of 2 sets took KROMA, 1 failed');
+    expect(code).toBe(1);
+  });
+
+  it('names the one set it put KROMA on', async () => {
+    const code = await runTui({ launch: true });
+
+    expect(outro).toHaveBeenCalledWith('KROMA is on 1 set');
+    expect(code).toBe(0);
+  });
+
+  it('stops with nothing to install onto when no set was ticked', async () => {
+    vi.mocked(discover).mockResolvedValue([]);
+
+    const code = await runTui({ launch: true });
+
+    expect(outro).toHaveBeenCalledWith('nothing to install onto');
+    expect(installSets).not.toHaveBeenCalled();
+    expect(code).toBe(1);
+  });
+
+  it('answers 130 when the search itself was quit', async () => {
+    vi.mocked(discover).mockResolvedValue(null);
+
+    const code = await runTui({ launch: true });
+
+    expect(cancel).toHaveBeenCalledWith('nothing was installed');
+    expect(chooseSource).not.toHaveBeenCalled();
+    expect(code).toBe(130);
+  });
+
+  it('answers 130 when the package choice was cancelled', async () => {
+    vi.mocked(chooseSource).mockResolvedValue(null);
+
+    const code = await runTui({ launch: true });
+
+    expect(askModules).not.toHaveBeenCalled();
+    expect(code).toBe(130);
+  });
+
+  it('answers 130 when a module was still asking something', async () => {
+    vi.mocked(askModules).mockResolvedValue(null);
+
+    const code = await runTui({ launch: true });
+
+    expect(installSets).not.toHaveBeenCalled();
+    expect(code).toBe(130);
+  });
+
+  it('asks nothing about the package when a flag already named the source', async () => {
+    await runTui({ source: 'canary', launch: false });
+
+    expect(chooseSource).not.toHaveBeenCalled();
+    expect(installSets).toHaveBeenCalledWith(
+      [salon],
+      expect.objectContaining({ source: 'canary' }),
+    );
+  });
+
+  it('asks nothing about the package when a flag already named the file', async () => {
+    await runTui({ artifact: '/out/KROMA.wgt', launch: true });
+
+    expect(chooseSource).not.toHaveBeenCalled();
+    expect(installSets).toHaveBeenCalledWith(
+      [salon],
+      expect.objectContaining({ artifact: '/out/KROMA.wgt', source: undefined }),
+    );
+  });
+});

--- a/packages/tv-installer/src/tui/app.ts
+++ b/packages/tv-installer/src/tui/app.ts
@@ -1,0 +1,53 @@
+import * as p from '@clack/prompts';
+import type { Source } from '../install/artifact';
+import { style } from './ansi';
+import { askModules, chooseSource } from './choose';
+import { discover } from './discover';
+import { installSets } from './install-sets';
+
+const CANCELLED = 130;
+
+export interface TuiOptions {
+  hosts?: string[];
+  artifact?: string;
+  source?: Source;
+  launch: boolean;
+}
+
+export async function runTui(options: TuiOptions): Promise<number> {
+  p.intro(`${style.bold('KROMA')} television installer`);
+
+  const chosen = await discover(options.hosts);
+  if (chosen === null) return cancelled();
+  if (chosen.length === 0) {
+    p.outro('nothing to install onto');
+    return 1;
+  }
+
+  const given = options.artifact !== undefined || options.source !== undefined;
+  const source = given ? options.source : await chooseSource(chosen);
+  if (source === null) return cancelled();
+
+  const answers = await askModules(chosen);
+  if (answers === null) return cancelled();
+
+  const failed = await installSets(chosen, {
+    artifact: options.artifact,
+    source,
+    launch: options.launch,
+    moduleOptions: answers,
+  });
+  p.outro(summary(chosen.length, failed.length));
+  return failed.length === 0 ? 0 : 1;
+}
+
+function cancelled(): number {
+  p.cancel('nothing was installed');
+  return CANCELLED;
+}
+
+function summary(total: number, failed: number): string {
+  const sets = `${total} set${total === 1 ? '' : 's'}`;
+  if (failed === 0) return `KROMA is on ${sets}`;
+  return `${total - failed} of ${sets} took KROMA, ${failed} failed`;
+}

--- a/packages/tv-installer/src/tui/choose.test.ts
+++ b/packages/tv-installer/src/tui/choose.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Source } from '../install/artifact';
+import type { ModuleOptions } from '../modules/module';
+import type { Television } from '../television';
+import { television } from '../television.fixture';
+import { askModules, chooseSource } from './choose';
+
+interface Ask {
+  message: string;
+  options: { value: Source; label: string; hint: string }[];
+  initialValue?: Source;
+}
+
+const fake = vi.hoisted(() => {
+  const sources: Record<string, Source[]> = {};
+  return {
+    sources,
+    CANCELLED: Symbol('cancelled'),
+    select: vi.fn<(ask: Ask) => Promise<unknown>>(),
+    askLg: vi.fn<(sets: readonly Television[]) => Promise<Map<string, ModuleOptions> | null>>(),
+  };
+});
+
+vi.mock('../modules/registry', () => ({
+  moduleFor: (platform: string) => ({ sources: () => fake.sources[platform] ?? [] }),
+  modules: () => [{ id: 'tizen' }, { id: 'webos', prompt: fake.askLg }],
+}));
+vi.mock('@clack/prompts', () => ({
+  isCancel: (value: unknown) => value === fake.CANCELLED,
+  select: fake.select,
+}));
+
+const salon = television();
+const chambre = television({ host: '192.168.1.11', name: 'Chambre' });
+const cuisine = television({ host: '192.168.1.12', name: 'Cuisine', platform: 'webos' });
+const bureau = television({ host: '192.168.1.13', name: 'Bureau', platform: 'webos' });
+
+const offered = () => fake.select.mock.calls[0]?.[0].options.map((option) => option.value);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fake.sources = { tizen: ['local', 'stable', 'build'], webos: ['stable', 'canary'] };
+});
+
+describe('chooseSource', () => {
+  it('offers only what every chosen platform can serve', async () => {
+    fake.select.mockResolvedValue('stable');
+
+    await expect(chooseSource([salon, cuisine])).resolves.toBe('stable');
+    expect(offered()).toEqual(['stable']);
+  });
+
+  it('asks even when a single source is all there is', async () => {
+    fake.sources = { tizen: ['stable'] };
+    fake.select.mockResolvedValue('stable');
+
+    await expect(chooseSource([salon])).resolves.toBe('stable');
+    expect(fake.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('asks once about several sets of the same platform', async () => {
+    fake.select.mockResolvedValue('local');
+
+    await chooseSource([salon, chambre]);
+
+    expect(offered()).toEqual(['local', 'stable', 'build']);
+  });
+
+  it('asks nothing when the chosen platforms share no source', async () => {
+    fake.sources = { tizen: ['local'], webos: ['canary'] };
+
+    await expect(chooseSource([salon, cuisine])).resolves.toBeUndefined();
+    expect(fake.select).not.toHaveBeenCalled();
+  });
+
+  it('asks nothing when no set was chosen', async () => {
+    await expect(chooseSource([])).resolves.toBeUndefined();
+    expect(fake.select).not.toHaveBeenCalled();
+  });
+
+  it('answers null when the choice is quit', async () => {
+    fake.select.mockResolvedValue(fake.CANCELLED);
+
+    await expect(chooseSource([salon])).resolves.toBeNull();
+  });
+});
+
+describe('askModules', () => {
+  it('asks a platform about its own sets and no others', async () => {
+    fake.askLg.mockResolvedValue(new Map());
+
+    await askModules([salon, cuisine, bureau]);
+
+    expect(fake.askLg).toHaveBeenCalledTimes(1);
+    expect(fake.askLg).toHaveBeenCalledWith([cuisine, bureau]);
+  });
+
+  it('asks nothing about a platform no chosen set runs', async () => {
+    await expect(askModules([salon])).resolves.toEqual(new Map());
+    expect(fake.askLg).not.toHaveBeenCalled();
+  });
+
+  it('keeps every answer under the host it was asked about', async () => {
+    fake.askLg.mockResolvedValue(new Map([[cuisine.host, { passphrase: 'ABCDEF' }]]));
+
+    await expect(askModules([salon, cuisine])).resolves.toEqual(
+      new Map([[cuisine.host, { passphrase: 'ABCDEF' }]]),
+    );
+  });
+
+  it('answers null as soon as one platform question is quit', async () => {
+    fake.askLg.mockResolvedValue(null);
+
+    await expect(askModules([cuisine])).resolves.toBeNull();
+  });
+});

--- a/packages/tv-installer/src/tui/choose.ts
+++ b/packages/tv-installer/src/tui/choose.ts
@@ -19,9 +19,11 @@ export async function chooseSource(
   sets: readonly Television[],
 ): Promise<Source | undefined | null> {
   const platforms = [...new Set(sets.map((tv) => tv.platform))];
-  const shared = platforms
-    .map((platform) => [...moduleFor(platform).sources()])
-    .reduce((all, sources) => all.filter((source) => sources.includes(source)));
+  const [first = [], ...rest] = platforms.map((platform) => [...moduleFor(platform).sources()]);
+  const shared = rest.reduce(
+    (all, sources) => all.filter((source) => sources.includes(source)),
+    first,
+  );
   if (shared.length === 0) return undefined;
 
   const chosen = await p.select({

--- a/packages/tv-installer/src/tui/choose.ts
+++ b/packages/tv-installer/src/tui/choose.ts
@@ -1,0 +1,49 @@
+import * as p from '@clack/prompts';
+import type { Source } from '../install/artifact';
+import type { ModuleOptions } from '../modules/module';
+import { moduleFor, modules } from '../modules/registry';
+import type { Television } from '../television';
+
+const SOURCE_LABELS: Record<Source, { label: string; hint: string }> = {
+  local: { label: 'the build in this checkout', hint: 'whatever was built here last' },
+  stable: { label: 'the latest release', hint: 'what everyone else runs' },
+  canary: { label: 'the canary build', hint: 'newest, straight off main, less tested' },
+  build: { label: 'build it now from source', hint: 'a few minutes' },
+};
+
+/**
+ * Where the package comes from, out of the sources every chosen platform can serve.
+ * Undefined means the default: the newest build here, else the latest release.
+ */
+export async function chooseSource(
+  sets: readonly Television[],
+): Promise<Source | undefined | null> {
+  const platforms = [...new Set(sets.map((tv) => tv.platform))];
+  const shared = platforms
+    .map((platform) => [...moduleFor(platform).sources()])
+    .reduce((all, sources) => all.filter((source) => sources.includes(source)));
+  if (shared.length === 0) return undefined;
+
+  const chosen = await p.select({
+    message: 'which package',
+    options: shared.map((source) => ({ value: source, ...SOURCE_LABELS[source] })),
+    initialValue: shared[0],
+  });
+  return p.isCancel(chosen) ? null : chosen;
+}
+
+/** What the chosen sets still need from their own modules, by host. Null when cancelled. */
+export async function askModules(
+  sets: readonly Television[],
+): Promise<Map<string, ModuleOptions> | null> {
+  const answers = new Map<string, ModuleOptions>();
+  for (const module of modules()) {
+    const mine = sets.filter((tv) => tv.platform === module.id);
+    if (!module.prompt || mine.length === 0) continue;
+
+    const given = await module.prompt(mine);
+    if (given === null) return null;
+    for (const [host, options] of given) answers.set(host, options);
+  }
+  return answers;
+}

--- a/packages/tv-installer/src/tui/discover.test.ts
+++ b/packages/tv-installer/src/tui/discover.test.ts
@@ -1,0 +1,337 @@
+import { confirm, log, note } from '@clack/prompts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { watch } from '../discovery/scan';
+import { diagnoseEmptyScan } from '../hints';
+import { askForLocalNetwork, openPrivacySettings } from '../local-network';
+import type { Television } from '../television';
+import { discover } from './discover';
+import { liveMultiselect } from './live-multiselect';
+import { within } from './terminal.fixture';
+
+vi.mock('@clack/prompts', async (real) => ({
+  ...(await real<typeof import('@clack/prompts')>()),
+  note: vi.fn(),
+  confirm: vi.fn(),
+  log: { info: vi.fn() },
+}));
+vi.mock('../discovery/scan', () => ({ watch: vi.fn() }));
+vi.mock('../hints', () => ({ diagnoseEmptyScan: vi.fn() }));
+vi.mock('../local-network', () => ({
+  askForLocalNetwork: vi.fn(),
+  openPrivacySettings: vi.fn(),
+}));
+vi.mock('./live-multiselect', () => ({ liveMultiselect: vi.fn() }));
+
+const salon: Television = {
+  host: '192.168.1.10',
+  platform: 'tizen',
+  vendor: 'Samsung',
+  name: 'Salon',
+  model: 'QE55Q60A',
+  developerMode: 'on',
+  sideloadable: true,
+  note: '',
+  runtime: {
+    name: 'Tizen',
+    version: '8.0',
+    engine: { name: 'Chromium', version: '108' },
+    learned: 'reported',
+  },
+};
+
+const cuisine: Television = {
+  ...salon,
+  host: '192.168.1.11',
+  name: 'Cuisine',
+  developerMode: 'off',
+  runtime: null,
+};
+
+const chromecast: Television = {
+  ...cuisine,
+  host: '192.168.1.12',
+  platform: 'androidtv',
+  vendor: 'Google',
+  name: 'Chromecast',
+  developerMode: 'unknown',
+  sideloadable: false,
+};
+
+function fakePicker() {
+  let reply: (ticked: string[] | null) => void = () => undefined;
+  const answer = new Promise<string[] | null>((resolve) => {
+    reply = resolve;
+  });
+  return { upsert: vi.fn(), status: vi.fn(), notice: vi.fn(), answer, reply };
+}
+
+let picker = fakePicker();
+
+const lastStatus = () => picker.status.mock.lastCall?.[0];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  picker = fakePicker();
+  vi.mocked(liveMultiselect<string>).mockReturnValue(picker);
+  vi.mocked(diagnoseEmptyScan).mockResolvedValue({ blocked: false, hints: ['nothing was on'] });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('discover', () => {
+  it('lists a set the scan found, ticked and ready', async () => {
+    vi.mocked(watch).mockImplementation(async ({ onFound }) => {
+      onFound?.(salon);
+      picker.reply([salon.host]);
+      return [salon];
+    });
+
+    const chosen = await within(discover());
+
+    expect(picker.upsert).toHaveBeenCalledWith({
+      value: '192.168.1.10',
+      label: 'Salon  192.168.1.10',
+      hint: 'Samsung · Tizen 8.0, Chromium 108 · ready',
+      disabled: false,
+      ticked: true,
+    });
+    expect(chosen).toEqual([salon]);
+  });
+
+  it('says what a set still needs before it can take the app', async () => {
+    vi.mocked(watch).mockImplementation(async ({ onFound }) => {
+      onFound?.(cuisine);
+      picker.reply([]);
+      return [cuisine];
+    });
+
+    await within(discover());
+
+    expect(picker.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ hint: 'Samsung · developer mode off', ticked: false }),
+    );
+  });
+
+  it('greys out a set no app can be sideloaded onto', async () => {
+    vi.mocked(watch).mockImplementation(async ({ onFound }) => {
+      onFound?.(chromecast);
+      picker.reply([]);
+      return [chromecast];
+    });
+
+    await within(discover());
+
+    expect(picker.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ hint: 'Google · takes no app', disabled: true }),
+    );
+  });
+
+  it('stops the scan as soon as the picker answers', async () => {
+    let scanning: AbortSignal | undefined;
+    vi.mocked(watch).mockImplementation(async ({ signal }) => {
+      scanning = signal;
+      picker.reply([]);
+      return [];
+    });
+
+    await within(discover(['192.168.1.10']));
+
+    expect(vi.mocked(watch).mock.calls[0]?.[0]).toMatchObject({ hosts: ['192.168.1.10'] });
+    expect(scanning?.aborted).toBe(true);
+  });
+
+  it('gives up looking once the round cap is reached', async () => {
+    let rounds = 0;
+    vi.mocked(watch).mockImplementation(async ({ onRound, signal }) => {
+      while (!signal?.aborted && rounds < 100) onRound?.(++rounds);
+      picker.reply([]);
+      return [];
+    });
+
+    await within(discover());
+
+    expect(rounds).toBe(41);
+    expect(lastStatus()).toBe('stopped looking · no television yet');
+  });
+
+  it('says why the network is quiet after two rounds that found nothing', async () => {
+    vi.mocked(watch).mockImplementation(async ({ onRound }) => {
+      onRound?.(1);
+      onRound?.(2);
+      onRound?.(3);
+      picker.reply([]);
+      return [];
+    });
+
+    await within(discover());
+
+    expect(picker.notice).toHaveBeenCalledExactlyOnceWith(
+      'a set that has not answered by now is off, or has no developer mode on',
+    );
+    expect(lastStatus()).toBe('nothing new · no television yet');
+  });
+
+  it('counts a round that found something as a reason to keep going', async () => {
+    vi.mocked(watch).mockImplementation(async ({ onRound, onFound }) => {
+      onRound?.(1);
+      onRound?.(2);
+      onFound?.(salon);
+      onRound?.(3);
+      picker.reply([]);
+      return [salon];
+    });
+
+    await within(discover());
+
+    expect(picker.notice).not.toHaveBeenCalled();
+    expect(lastStatus()).toBe('scanning again · 1 television');
+  });
+
+  it('counts every television it has found so far', async () => {
+    vi.mocked(watch).mockImplementation(async ({ onRound, onFound }) => {
+      onRound?.(1);
+      onFound?.(salon);
+      onFound?.(cuisine);
+      picker.reply([]);
+      return [salon, cuisine];
+    });
+
+    await within(discover());
+
+    expect(lastStatus()).toBe('scanning · 2 televisions');
+  });
+
+  it('collapses a burst of progress into a handful of redraws', async () => {
+    vi.mocked(watch).mockImplementation(async ({ onRound, onProgress }) => {
+      onRound?.(1);
+      for (let done = 1; done <= 256; done += 1) onProgress?.(done, 256);
+      picker.reply([]);
+      return [];
+    });
+
+    await within(discover());
+
+    expect(picker.status.mock.calls.length).toBeLessThanOrEqual(3);
+  });
+
+  it('draws progress again once the redraw window has passed', async () => {
+    vi.useFakeTimers({ toFake: ['performance'] });
+    vi.mocked(watch).mockImplementation(async ({ onRound, onProgress }) => {
+      onRound?.(1);
+      for (let done = 1; done <= 32; done += 1) onProgress?.(done, 256);
+      vi.advanceTimersByTime(200);
+      onProgress?.(200, 256);
+      picker.reply([]);
+      return [];
+    });
+
+    await within(discover());
+
+    expect(lastStatus()).toBe('scanning 78% · no television yet');
+  });
+
+  it('reports no progress at all past the first round', async () => {
+    vi.mocked(watch).mockImplementation(async ({ onRound, onProgress }) => {
+      onRound?.(1);
+      onRound?.(2);
+      onProgress?.(128, 256);
+      picker.reply([]);
+      return [];
+    });
+
+    await within(discover());
+
+    expect(lastStatus()).toBe('nothing new · no television yet');
+  });
+
+  it('explains a scan that came back empty, and drops the hosts it never saw', async () => {
+    vi.mocked(watch).mockImplementation(async () => {
+      picker.reply(['192.168.1.99']);
+      return [];
+    });
+
+    const chosen = await within(discover());
+
+    expect(chosen).toEqual([]);
+    expect(note).toHaveBeenCalledWith('nothing was on', 'why nothing answered');
+  });
+
+  it('opens the Local Network pane when macOS is the one refusing', async () => {
+    vi.mocked(diagnoseEmptyScan).mockResolvedValue({ blocked: true, hints: ['macOS is refusing'] });
+    vi.mocked(confirm).mockResolvedValue(true);
+    vi.mocked(openPrivacySettings).mockResolvedValue(true);
+    vi.mocked(watch).mockImplementation(async () => {
+      picker.reply([]);
+      return [];
+    });
+
+    await within(discover());
+
+    expect(log.info).toHaveBeenCalledWith('System Settings is open');
+  });
+
+  it('says so when the Local Network pane would not open', async () => {
+    vi.mocked(diagnoseEmptyScan).mockResolvedValue({ blocked: true, hints: ['macOS is refusing'] });
+    vi.mocked(confirm).mockResolvedValue(true);
+    vi.mocked(openPrivacySettings).mockResolvedValue(false);
+    vi.mocked(watch).mockImplementation(async () => {
+      picker.reply([]);
+      return [];
+    });
+
+    await within(discover());
+
+    expect(log.info).toHaveBeenCalledWith('could not open Settings');
+  });
+
+  it('opens nothing when the offer to open System Settings is turned down', async () => {
+    vi.mocked(diagnoseEmptyScan).mockResolvedValue({ blocked: true, hints: ['macOS is refusing'] });
+    vi.mocked(confirm).mockResolvedValue(false);
+    vi.mocked(watch).mockImplementation(async () => {
+      picker.reply([]);
+      return [];
+    });
+
+    await within(discover());
+
+    expect(openPrivacySettings).not.toHaveBeenCalled();
+  });
+
+  it('answers null when the picker was quit, and explains nothing', async () => {
+    vi.mocked(watch).mockImplementation(async () => {
+      picker.reply(null);
+      return [];
+    });
+
+    const chosen = await within(discover());
+
+    expect(chosen).toBeNull();
+    expect(note).not.toHaveBeenCalled();
+  });
+
+  it('counts every set it has found so far', async () => {
+    vi.mocked(watch).mockImplementation(async ({ onFound }) => {
+      onFound?.(salon);
+      onFound?.(cuisine);
+      picker.reply([]);
+      return [salon, cuisine];
+    });
+
+    await within(discover());
+
+    expect(lastStatus()).toBe('scanning · 2 televisions');
+  });
+
+  it('asks macOS for the local network before it opens the picker', async () => {
+    vi.mocked(watch).mockImplementation(async () => {
+      picker.reply([]);
+      return [];
+    });
+
+    await within(discover());
+
+    expect(askForLocalNetwork).toHaveBeenCalled();
+  });
+});

--- a/packages/tv-installer/src/tui/discover.test.ts
+++ b/packages/tv-installer/src/tui/discover.test.ts
@@ -78,8 +78,8 @@ describe('discover', () => {
     const chosen = await within(discover());
 
     expect(picker.upsert).toHaveBeenCalledWith({
-      value: '192.168.1.10',
-      label: 'Salon  192.168.1.10',
+      value: salon.host,
+      label: `${salon.name}  ${salon.host}`,
       hint: 'Samsung · Tizen 8.0 · ready',
       disabled: false,
       ticked: true,

--- a/packages/tv-installer/src/tui/discover.test.ts
+++ b/packages/tv-installer/src/tui/discover.test.ts
@@ -1,9 +1,9 @@
 import { confirm, log, note } from '@clack/prompts';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { watch } from '../discovery/scan';
+import { type WatchOptions, watch } from '../discovery/scan';
 import { diagnoseEmptyScan } from '../hints';
 import { askForLocalNetwork, openPrivacySettings } from '../local-network';
-import type { Television } from '../television';
+import { television } from '../television.fixture';
 import { discover } from './discover';
 import { liveMultiselect } from './live-multiselect';
 import { within } from './terminal.fixture';
@@ -16,46 +16,25 @@ vi.mock('@clack/prompts', async (real) => ({
 }));
 vi.mock('../discovery/scan', () => ({ watch: vi.fn() }));
 vi.mock('../hints', () => ({ diagnoseEmptyScan: vi.fn() }));
-vi.mock('../local-network', () => ({
-  askForLocalNetwork: vi.fn(),
-  openPrivacySettings: vi.fn(),
-}));
+vi.mock('../local-network', () => ({ askForLocalNetwork: vi.fn(), openPrivacySettings: vi.fn() }));
 vi.mock('./live-multiselect', () => ({ liveMultiselect: vi.fn() }));
 
-const salon: Television = {
-  host: '192.168.1.10',
-  platform: 'tizen',
-  vendor: 'Samsung',
-  name: 'Salon',
-  model: 'QE55Q60A',
-  developerMode: 'on',
-  sideloadable: true,
-  note: '',
-  runtime: {
-    name: 'Tizen',
-    version: '8.0',
-    engine: { name: 'Chromium', version: '108' },
-    learned: 'reported',
-  },
-};
-
-const cuisine: Television = {
-  ...salon,
+const salon = television();
+const cuisine = television({
   host: '192.168.1.11',
   name: 'Cuisine',
   developerMode: 'off',
   runtime: null,
-};
-
-const chromecast: Television = {
-  ...cuisine,
+});
+const chromecast = television({
   host: '192.168.1.12',
   platform: 'androidtv',
   vendor: 'Google',
   name: 'Chromecast',
   developerMode: 'unknown',
   sideloadable: false,
-};
+  runtime: null,
+});
 
 function fakePicker() {
   let reply: (ticked: string[] | null) => void = () => undefined;
@@ -68,6 +47,17 @@ function fakePicker() {
 let picker = fakePicker();
 
 const lastStatus = () => picker.status.mock.lastCall?.[0];
+
+function scanReports(report: (options: WatchOptions) => void = () => undefined): void {
+  vi.mocked(watch).mockImplementation(async (options) => {
+    report(options);
+    return [];
+  });
+}
+
+function macosRefusesTheNetwork(): void {
+  vi.mocked(diagnoseEmptyScan).mockResolvedValue({ blocked: true, hints: ['macOS is refusing'] });
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -82,18 +72,15 @@ afterEach(() => {
 
 describe('discover', () => {
   it('lists a set the scan found, ticked and ready', async () => {
-    vi.mocked(watch).mockImplementation(async ({ onFound }) => {
-      onFound?.(salon);
-      picker.reply([salon.host]);
-      return [salon];
-    });
+    scanReports(({ onFound }) => onFound?.(salon));
+    picker.reply([salon.host]);
 
     const chosen = await within(discover());
 
     expect(picker.upsert).toHaveBeenCalledWith({
       value: '192.168.1.10',
       label: 'Salon  192.168.1.10',
-      hint: 'Samsung · Tizen 8.0, Chromium 108 · ready',
+      hint: 'Samsung · Tizen 8.0 · ready',
       disabled: false,
       ticked: true,
     });
@@ -101,11 +88,8 @@ describe('discover', () => {
   });
 
   it('says what a set still needs before it can take the app', async () => {
-    vi.mocked(watch).mockImplementation(async ({ onFound }) => {
-      onFound?.(cuisine);
-      picker.reply([]);
-      return [cuisine];
-    });
+    scanReports(({ onFound }) => onFound?.(cuisine));
+    picker.reply([]);
 
     await within(discover());
 
@@ -115,11 +99,8 @@ describe('discover', () => {
   });
 
   it('greys out a set no app can be sideloaded onto', async () => {
-    vi.mocked(watch).mockImplementation(async ({ onFound }) => {
-      onFound?.(chromecast);
-      picker.reply([]);
-      return [chromecast];
-    });
+    scanReports(({ onFound }) => onFound?.(chromecast));
+    picker.reply([]);
 
     await within(discover());
 
@@ -128,27 +109,35 @@ describe('discover', () => {
     );
   });
 
-  it('stops the scan as soon as the picker answers', async () => {
-    let scanning: AbortSignal | undefined;
-    vi.mocked(watch).mockImplementation(async ({ signal }) => {
-      scanning = signal;
-      picker.reply([]);
-      return [];
+  it('counts every set it has found so far', async () => {
+    scanReports(({ onFound }) => {
+      onFound?.(salon);
+      onFound?.(cuisine);
     });
+    picker.reply([]);
+
+    await within(discover());
+
+    expect(lastStatus()).toBe('scanning · 2 televisions');
+  });
+
+  it('stops the scan as soon as the picker answers', async () => {
+    scanReports();
+    picker.reply([]);
 
     await within(discover(['192.168.1.10']));
 
-    expect(vi.mocked(watch).mock.calls[0]?.[0]).toMatchObject({ hosts: ['192.168.1.10'] });
-    expect(scanning?.aborted).toBe(true);
+    const asked = vi.mocked(watch).mock.calls[0]?.[0];
+    expect(asked).toMatchObject({ hosts: ['192.168.1.10'] });
+    expect(asked?.signal?.aborted).toBe(true);
   });
 
   it('gives up looking once the round cap is reached', async () => {
     let rounds = 0;
-    vi.mocked(watch).mockImplementation(async ({ onRound, signal }) => {
+    scanReports(({ onRound, signal }) => {
       while (!signal?.aborted && rounds < 100) onRound?.(++rounds);
-      picker.reply([]);
-      return [];
     });
+    picker.reply([]);
 
     await within(discover());
 
@@ -157,13 +146,12 @@ describe('discover', () => {
   });
 
   it('says why the network is quiet after two rounds that found nothing', async () => {
-    vi.mocked(watch).mockImplementation(async ({ onRound }) => {
+    scanReports(({ onRound }) => {
       onRound?.(1);
       onRound?.(2);
       onRound?.(3);
-      picker.reply([]);
-      return [];
     });
+    picker.reply([]);
 
     await within(discover());
 
@@ -174,14 +162,13 @@ describe('discover', () => {
   });
 
   it('counts a round that found something as a reason to keep going', async () => {
-    vi.mocked(watch).mockImplementation(async ({ onRound, onFound }) => {
+    scanReports(({ onRound, onFound }) => {
       onRound?.(1);
       onRound?.(2);
       onFound?.(salon);
       onRound?.(3);
-      picker.reply([]);
-      return [salon];
     });
+    picker.reply([]);
 
     await within(discover());
 
@@ -189,27 +176,12 @@ describe('discover', () => {
     expect(lastStatus()).toBe('scanning again · 1 television');
   });
 
-  it('counts every television it has found so far', async () => {
-    vi.mocked(watch).mockImplementation(async ({ onRound, onFound }) => {
-      onRound?.(1);
-      onFound?.(salon);
-      onFound?.(cuisine);
-      picker.reply([]);
-      return [salon, cuisine];
-    });
-
-    await within(discover());
-
-    expect(lastStatus()).toBe('scanning · 2 televisions');
-  });
-
   it('collapses a burst of progress into a handful of redraws', async () => {
-    vi.mocked(watch).mockImplementation(async ({ onRound, onProgress }) => {
+    scanReports(({ onRound, onProgress }) => {
       onRound?.(1);
       for (let done = 1; done <= 256; done += 1) onProgress?.(done, 256);
-      picker.reply([]);
-      return [];
     });
+    picker.reply([]);
 
     await within(discover());
 
@@ -218,14 +190,13 @@ describe('discover', () => {
 
   it('draws progress again once the redraw window has passed', async () => {
     vi.useFakeTimers({ toFake: ['performance'] });
-    vi.mocked(watch).mockImplementation(async ({ onRound, onProgress }) => {
+    scanReports(({ onRound, onProgress }) => {
       onRound?.(1);
       for (let done = 1; done <= 32; done += 1) onProgress?.(done, 256);
       vi.advanceTimersByTime(200);
       onProgress?.(200, 256);
-      picker.reply([]);
-      return [];
     });
+    picker.reply([]);
 
     await within(discover());
 
@@ -233,13 +204,12 @@ describe('discover', () => {
   });
 
   it('reports no progress at all past the first round', async () => {
-    vi.mocked(watch).mockImplementation(async ({ onRound, onProgress }) => {
+    scanReports(({ onRound, onProgress }) => {
       onRound?.(1);
       onRound?.(2);
       onProgress?.(128, 256);
-      picker.reply([]);
-      return [];
     });
+    picker.reply([]);
 
     await within(discover());
 
@@ -247,10 +217,8 @@ describe('discover', () => {
   });
 
   it('explains a scan that came back empty, and drops the hosts it never saw', async () => {
-    vi.mocked(watch).mockImplementation(async () => {
-      picker.reply(['192.168.1.99']);
-      return [];
-    });
+    scanReports();
+    picker.reply(['192.168.1.99']);
 
     const chosen = await within(discover());
 
@@ -259,13 +227,11 @@ describe('discover', () => {
   });
 
   it('opens the Local Network pane when macOS is the one refusing', async () => {
-    vi.mocked(diagnoseEmptyScan).mockResolvedValue({ blocked: true, hints: ['macOS is refusing'] });
+    scanReports();
+    picker.reply([]);
+    macosRefusesTheNetwork();
     vi.mocked(confirm).mockResolvedValue(true);
     vi.mocked(openPrivacySettings).mockResolvedValue(true);
-    vi.mocked(watch).mockImplementation(async () => {
-      picker.reply([]);
-      return [];
-    });
 
     await within(discover());
 
@@ -273,13 +239,11 @@ describe('discover', () => {
   });
 
   it('says so when the Local Network pane would not open', async () => {
-    vi.mocked(diagnoseEmptyScan).mockResolvedValue({ blocked: true, hints: ['macOS is refusing'] });
+    scanReports();
+    picker.reply([]);
+    macosRefusesTheNetwork();
     vi.mocked(confirm).mockResolvedValue(true);
     vi.mocked(openPrivacySettings).mockResolvedValue(false);
-    vi.mocked(watch).mockImplementation(async () => {
-      picker.reply([]);
-      return [];
-    });
 
     await within(discover());
 
@@ -287,12 +251,10 @@ describe('discover', () => {
   });
 
   it('opens nothing when the offer to open System Settings is turned down', async () => {
-    vi.mocked(diagnoseEmptyScan).mockResolvedValue({ blocked: true, hints: ['macOS is refusing'] });
+    scanReports();
+    picker.reply([]);
+    macosRefusesTheNetwork();
     vi.mocked(confirm).mockResolvedValue(false);
-    vi.mocked(watch).mockImplementation(async () => {
-      picker.reply([]);
-      return [];
-    });
 
     await within(discover());
 
@@ -300,10 +262,8 @@ describe('discover', () => {
   });
 
   it('answers null when the picker was quit, and explains nothing', async () => {
-    vi.mocked(watch).mockImplementation(async () => {
-      picker.reply(null);
-      return [];
-    });
+    scanReports();
+    picker.reply(null);
 
     const chosen = await within(discover());
 
@@ -311,24 +271,9 @@ describe('discover', () => {
     expect(note).not.toHaveBeenCalled();
   });
 
-  it('counts every set it has found so far', async () => {
-    vi.mocked(watch).mockImplementation(async ({ onFound }) => {
-      onFound?.(salon);
-      onFound?.(cuisine);
-      picker.reply([]);
-      return [salon, cuisine];
-    });
-
-    await within(discover());
-
-    expect(lastStatus()).toBe('scanning · 2 televisions');
-  });
-
   it('asks macOS for the local network before it opens the picker', async () => {
-    vi.mocked(watch).mockImplementation(async () => {
-      picker.reply([]);
-      return [];
-    });
+    scanReports();
+    picker.reply([]);
 
     await within(discover());
 

--- a/packages/tv-installer/src/tui/discover.ts
+++ b/packages/tv-installer/src/tui/discover.ts
@@ -1,0 +1,120 @@
+import * as p from '@clack/prompts';
+import { watch } from '../discovery/scan';
+import { diagnoseEmptyScan } from '../hints';
+import { askForLocalNetwork, openPrivacySettings } from '../local-network';
+import { moduleFor } from '../modules/registry';
+import { runtimeLabel, type Television } from '../television';
+import { type LiveOption, liveMultiselect } from './live-multiselect';
+
+const MAX_ROUNDS = 40;
+// A sweep reports progress once per host, which is a hundred redraws a pass for
+// a line that says the same thing. The terminal keeps every one of them.
+const REDRAW_MS = 150;
+const QUIET_ROUNDS_BEFORE_NOTICE = 2;
+const WHY_SILENT = 'a set that has not answered by now is off, or has no developer mode on';
+type Doing =
+  | 'scanning'
+  | `scanning ${number}%`
+  | 'scanning again'
+  | 'nothing new'
+  | 'stopped looking';
+
+/** The sets ticked, or null when the user cancelled. */
+export async function discover(hosts?: readonly string[]): Promise<Television[] | null> {
+  await askForLocalNetwork();
+
+  const found = new Map<string, Television>();
+  let doing: Doing = 'scanning';
+
+  const picker = liveMultiselect<string>({
+    message: 'which sets get KROMA',
+    status: line(doing, found.size),
+  });
+  let drawn = '';
+  let drawnAt = 0;
+  const say = (now = false) => {
+    const status = line(doing, found.size);
+    const at = performance.now();
+    if (!now && (status === drawn || at - drawnAt < REDRAW_MS)) return;
+    drawn = status;
+    drawnAt = at;
+    picker.status(status);
+  };
+
+  const controller = new AbortController();
+  let round = 1;
+  let quiet = 0;
+  let sizeWhenRoundBegan = 0;
+
+  const scanning = watch({
+    hosts,
+    signal: controller.signal,
+    onRound: (current) => {
+      round = current;
+      if (current > MAX_ROUNDS) {
+        controller.abort();
+        doing = 'stopped looking';
+      } else if (current > 1) {
+        const fresh = found.size > sizeWhenRoundBegan;
+        quiet = fresh ? 0 : quiet + 1;
+        doing = fresh ? 'scanning again' : 'nothing new';
+        if (quiet === QUIET_ROUNDS_BEFORE_NOTICE) picker.notice(WHY_SILENT);
+      }
+      sizeWhenRoundBegan = found.size;
+      say(true);
+    },
+    onProgress: (done, total) => {
+      if (round > 1) return;
+      doing = `scanning ${Math.floor((done / total) * 100)}%`;
+      say();
+    },
+    onFound: (tv) => {
+      found.set(tv.host, tv);
+      picker.upsert(asOption(tv));
+      if (doing === 'nothing new') doing = 'scanning again';
+      say(true);
+    },
+  });
+
+  const ticked = await picker.answer;
+  controller.abort();
+  await scanning;
+
+  if (ticked === null) return null;
+  if (found.size === 0) await explain();
+  return ticked.flatMap((host) => {
+    const tv = found.get(host);
+    return tv ? [tv] : [];
+  });
+}
+
+async function explain(): Promise<void> {
+  const { blocked, hints } = await diagnoseEmptyScan();
+  p.note(hints.join('\n'), 'why nothing answered');
+  if (!blocked) return;
+
+  const open = await p.confirm({ message: 'Open System Settings there?', initialValue: true });
+  if (p.isCancel(open) || !open) return;
+  p.log.info((await openPrivacySettings()) ? 'System Settings is open' : 'could not open Settings');
+}
+
+function asOption(tv: Television): LiveOption<string> {
+  const parts = [tv.vendor, runtimeLabel(tv.runtime), state(tv)];
+  return {
+    value: tv.host,
+    label: `${tv.name}  ${tv.host}`,
+    hint: parts.filter((part) => part !== '').join(' · '),
+    disabled: !tv.sideloadable,
+    ticked: tv.developerMode === 'on',
+  };
+}
+
+function state(tv: Television): string {
+  if (!tv.sideloadable) return 'takes no app';
+  return tv.developerMode === 'on' ? 'ready' : moduleFor(tv.platform).notReadyHint;
+}
+
+function line(doing: Doing, found: number): string {
+  if (found === 0) return `${doing} · no television yet`;
+  return `${doing} · ${found} television${found === 1 ? '' : 's'}`;
+}

--- a/packages/tv-installer/src/tui/install-sets.test.ts
+++ b/packages/tv-installer/src/tui/install-sets.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { deployTo } from '../install/deploy';
+import type { ModuleOptions } from '../modules/module';
+import type { Television } from '../television';
+import { installSets } from './install-sets';
+
+interface Task {
+  title: string;
+  lines: string[];
+  done: string[];
+  failed: string[];
+}
+
+const { tasks } = vi.hoisted(() => ({ tasks: [] as Task[] }));
+
+vi.mock('../install/deploy', () => ({ deployTo: vi.fn() }));
+vi.mock('@clack/prompts', () => ({
+  taskLog: ({ title }: { title: string }) => {
+    const task: Task = { title, lines: [], done: [], failed: [] };
+    tasks.push(task);
+    return {
+      message: (line: string) => task.lines.push(line),
+      success: (line: string) => task.done.push(line),
+      error: (line: string) => task.failed.push(line),
+    };
+  },
+}));
+
+const salon: Television = {
+  host: '192.168.1.10',
+  platform: 'tizen',
+  vendor: 'Samsung',
+  name: 'Salon',
+  model: 'QE55Q60A',
+  developerMode: 'on',
+  sideloadable: true,
+  note: '',
+  runtime: null,
+};
+
+const cuisine: Television = { ...salon, host: '192.168.1.11', name: 'Cuisine', platform: 'webos' };
+
+const noOptions: ReadonlyMap<string, ModuleOptions> = new Map();
+
+beforeEach(() => {
+  tasks.length = 0;
+  vi.mocked(deployTo).mockReset();
+});
+
+describe('installSets', () => {
+  it('installs onto every set it is given and reports nothing failed', async () => {
+    vi.mocked(deployTo).mockResolvedValue();
+
+    const failed = await installSets([salon, cuisine], { launch: true, moduleOptions: noOptions });
+
+    expect(failed).toEqual([]);
+    expect(tasks.map((task) => task.title)).toEqual([
+      'Salon (192.168.1.10)',
+      'Cuisine (192.168.1.11)',
+    ]);
+  });
+
+  it('carries on to the next set after one fails, and returns only the one that did', async () => {
+    vi.mocked(deployTo).mockRejectedValueOnce(new Error('no signing profile')).mockResolvedValue();
+
+    const failed = await installSets([salon, cuisine], { launch: true, moduleOptions: noOptions });
+
+    expect(failed).toEqual([salon]);
+    expect(tasks[0]?.failed).toEqual(['Salon: no signing profile']);
+    expect(tasks[1]?.done).toEqual(['Cuisine: installed and launched']);
+  });
+
+  it('says what was thrown even when it was never an Error', async () => {
+    vi.mocked(deployTo).mockRejectedValue('sdb: device unauthorized');
+
+    await installSets([salon], { launch: true, moduleOptions: noOptions });
+
+    expect(tasks[0]?.failed).toEqual(['Salon: sdb: device unauthorized']);
+  });
+
+  it('claims only an install when it was told not to launch', async () => {
+    vi.mocked(deployTo).mockResolvedValue();
+
+    await installSets([salon], { launch: false, moduleOptions: noOptions });
+
+    expect(tasks[0]?.done).toEqual(['Salon: installed']);
+  });
+
+  it('hands each set the artifact, the source and its own module options', async () => {
+    vi.mocked(deployTo).mockResolvedValue();
+
+    await installSets([salon, cuisine], {
+      artifact: '/out/KROMA.wgt',
+      source: 'canary',
+      launch: true,
+      moduleOptions: new Map([['192.168.1.11', { passphrase: 'ABCDEF' }]]),
+    });
+
+    expect(vi.mocked(deployTo).mock.calls[0]?.[1]).toMatchObject({
+      artifact: '/out/KROMA.wgt',
+      source: 'canary',
+      launch: true,
+      moduleOptions: undefined,
+    });
+    expect(vi.mocked(deployTo).mock.calls[1]?.[1]).toMatchObject({
+      moduleOptions: { passphrase: 'ABCDEF' },
+    });
+  });
+
+  it('shows what the install said as it said it', async () => {
+    vi.mocked(deployTo).mockImplementation(async (_tv, options) => {
+      options.log('sdb connect 192.168.1.10');
+      options.log('installed KROMA');
+    });
+
+    await installSets([salon], { launch: true, moduleOptions: noOptions });
+
+    expect(tasks[0]?.lines).toEqual(['sdb connect 192.168.1.10', 'installed KROMA']);
+  });
+});

--- a/packages/tv-installer/src/tui/install-sets.test.ts
+++ b/packages/tv-installer/src/tui/install-sets.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { deployTo } from '../install/deploy';
 import type { ModuleOptions } from '../modules/module';
-import type { Television } from '../television';
+import { television } from '../television.fixture';
 import { installSets } from './install-sets';
 
 interface Task {
@@ -26,19 +26,8 @@ vi.mock('@clack/prompts', () => ({
   },
 }));
 
-const salon: Television = {
-  host: '192.168.1.10',
-  platform: 'tizen',
-  vendor: 'Samsung',
-  name: 'Salon',
-  model: 'QE55Q60A',
-  developerMode: 'on',
-  sideloadable: true,
-  note: '',
-  runtime: null,
-};
-
-const cuisine: Television = { ...salon, host: '192.168.1.11', name: 'Cuisine', platform: 'webos' };
+const salon = television();
+const cuisine = television({ host: '192.168.1.11', name: 'Cuisine', platform: 'webos' });
 
 const noOptions: ReadonlyMap<string, ModuleOptions> = new Map();
 

--- a/packages/tv-installer/src/tui/install-sets.test.ts
+++ b/packages/tv-installer/src/tui/install-sets.test.ts
@@ -44,7 +44,7 @@ describe('installSets', () => {
 
     expect(failed).toEqual([]);
     expect(tasks.map((task) => task.title)).toEqual([
-      'Salon (192.168.1.10)',
+      `${salon.name} (${salon.host})`,
       'Cuisine (192.168.1.11)',
     ]);
   });
@@ -55,7 +55,7 @@ describe('installSets', () => {
     const failed = await installSets([salon, cuisine], { launch: true, moduleOptions: noOptions });
 
     expect(failed).toEqual([salon]);
-    expect(tasks[0]?.failed).toEqual(['Salon: no signing profile']);
+    expect(tasks[0]?.failed).toEqual([`${salon.name}: no signing profile`]);
     expect(tasks[1]?.done).toEqual(['Cuisine: installed and launched']);
   });
 
@@ -64,7 +64,7 @@ describe('installSets', () => {
 
     await installSets([salon], { launch: true, moduleOptions: noOptions });
 
-    expect(tasks[0]?.failed).toEqual(['Salon: sdb: device unauthorized']);
+    expect(tasks[0]?.failed).toEqual([`${salon.name}: sdb: device unauthorized`]);
   });
 
   it('claims only an install when it was told not to launch', async () => {
@@ -72,7 +72,7 @@ describe('installSets', () => {
 
     await installSets([salon], { launch: false, moduleOptions: noOptions });
 
-    expect(tasks[0]?.done).toEqual(['Salon: installed']);
+    expect(tasks[0]?.done).toEqual([`${salon.name}: installed`]);
   });
 
   it('hands each set the artifact, the source and its own module options', async () => {

--- a/packages/tv-installer/src/tui/install-sets.ts
+++ b/packages/tv-installer/src/tui/install-sets.ts
@@ -1,0 +1,43 @@
+import * as p from '@clack/prompts';
+import type { Source } from '../install/artifact';
+import { deployTo } from '../install/deploy';
+import type { ModuleOptions } from '../modules/module';
+import type { Television } from '../television';
+
+const LOG_LINES = 8;
+
+export interface InstallOptions {
+  artifact?: string;
+  source?: Source;
+  launch: boolean;
+  moduleOptions: ReadonlyMap<string, ModuleOptions>;
+}
+
+/** Returns the sets that failed. A set that fails never stops the run. */
+export async function installSets(
+  sets: readonly Television[],
+  options: InstallOptions,
+): Promise<Television[]> {
+  const failed: Television[] = [];
+  for (const tv of sets) {
+    const task = p.taskLog({ title: `${tv.name} (${tv.host})`, limit: LOG_LINES });
+    try {
+      await deployTo(tv, {
+        log: (line) => task.message(line),
+        artifact: options.artifact,
+        source: options.source,
+        launch: options.launch,
+        moduleOptions: options.moduleOptions.get(tv.host),
+      });
+      task.success(options.launch ? `${tv.name}: installed and launched` : `${tv.name}: installed`);
+    } catch (error) {
+      task.error(`${tv.name}: ${reason(error)}`, { showLog: true });
+      failed.push(tv);
+    }
+  }
+  return failed;
+}
+
+function reason(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/tv-installer/src/tui/live-multiselect.test.ts
+++ b/packages/tv-installer/src/tui/live-multiselect.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+import { type LiveMultiselect, liveMultiselect } from './live-multiselect';
+import { KEY, type Terminal, terminal, within } from './terminal.fixture';
+
+function open(tty: Terminal): LiveMultiselect<string> {
+  return liveMultiselect<string>({
+    message: 'which sets get KROMA',
+    status: 'scanning · no television yet',
+    input: tty.input,
+    output: tty.output,
+  });
+}
+
+describe('liveMultiselect', () => {
+  it('lists an option pushed after the prompt was opened', async () => {
+    const tty = terminal();
+
+    const picker = open(tty);
+    picker.upsert({ value: '10.0.0.1', label: 'Salon', hint: 'ready' });
+    await tty.settle();
+    picker.upsert({ value: '10.0.0.2', label: 'Cuisine' });
+    await tty.press(KEY.enter);
+
+    expect(tty.drawn()).toContain('Salon');
+    expect(tty.drawn()).toContain('Cuisine');
+    await expect(within(picker.answer)).resolves.toEqual([]);
+  });
+
+  it('leaves the cursor on the row it was on when another option arrives', async () => {
+    const tty = terminal();
+
+    const picker = open(tty);
+    picker.upsert({ value: '10.0.0.1', label: 'Salon' });
+    picker.upsert({ value: '10.0.0.2', label: 'Cuisine' });
+    await tty.press(KEY.down);
+    picker.upsert({ value: '10.0.0.3', label: 'Chambre' });
+    await tty.press(KEY.space, KEY.enter);
+
+    await expect(within(picker.answer)).resolves.toEqual(['10.0.0.2']);
+  });
+
+  it('steps over a disabled row and lands on the one after it', async () => {
+    const tty = terminal();
+
+    const picker = open(tty);
+    picker.upsert({ value: '10.0.0.1', label: 'Salon' });
+    picker.upsert({ value: '10.0.0.2', label: 'Cuisine', hint: 'takes no app', disabled: true });
+    picker.upsert({ value: '10.0.0.3', label: 'Chambre' });
+    await tty.press(KEY.down, KEY.space, KEY.enter);
+
+    await expect(within(picker.answer)).resolves.toEqual(['10.0.0.3']);
+  });
+
+  it('moves the cursor off a disabled row as soon as a tickable one arrives', async () => {
+    const tty = terminal();
+
+    const picker = open(tty);
+    picker.upsert({ value: '10.0.0.1', label: 'Salon', disabled: true });
+    picker.upsert({ value: '10.0.0.2', label: 'Cuisine' });
+    await tty.press(KEY.space, KEY.enter);
+
+    await expect(within(picker.answer)).resolves.toEqual(['10.0.0.2']);
+  });
+
+  it('answers with every value ticked before enter', async () => {
+    const tty = terminal();
+
+    const picker = open(tty);
+    picker.upsert({ value: '10.0.0.1', label: 'Salon' });
+    picker.upsert({ value: '10.0.0.2', label: 'Cuisine' });
+    picker.upsert({ value: '10.0.0.3', label: 'Chambre' });
+    await tty.press(KEY.space, KEY.down, KEY.down, KEY.space, KEY.up, KEY.enter);
+
+    await expect(within(picker.answer)).resolves.toEqual(['10.0.0.1', '10.0.0.3']);
+  });
+
+  it('ticks an option that arrives ready', async () => {
+    const tty = terminal();
+
+    const picker = open(tty);
+    picker.upsert({ value: '10.0.0.1', label: 'Salon', hint: 'ready', ticked: true });
+    picker.upsert({ value: '10.0.0.2', label: 'Cuisine' });
+    await tty.press(KEY.enter);
+
+    await expect(within(picker.answer)).resolves.toEqual(['10.0.0.1']);
+  });
+
+  it('names what it is installing onto once enter is pressed', async () => {
+    const tty = terminal();
+
+    const picker = open(tty);
+    picker.upsert({ value: '10.0.0.1', label: 'Salon', ticked: true });
+    await tty.press(KEY.enter);
+    await within(picker.answer);
+
+    expect(tty.drawn()).toContain('Salon');
+  });
+
+  it('says none when enter comes with nothing ticked', async () => {
+    const tty = terminal();
+
+    const picker = open(tty);
+    picker.upsert({ value: '10.0.0.1', label: 'Salon' });
+    await tty.press(KEY.enter);
+
+    await expect(within(picker.answer)).resolves.toEqual([]);
+    expect(tty.drawn()).toContain('none');
+  });
+
+  it('answers null when ctrl-c quits it', async () => {
+    const tty = terminal();
+
+    const picker = open(tty);
+    picker.upsert({ value: '10.0.0.1', label: 'Salon' });
+    await tty.press(KEY.space, KEY.cancel);
+
+    await expect(within(picker.answer)).resolves.toBeNull();
+    expect(tty.drawn()).toContain('Salon');
+  });
+
+  it('redraws the status line the caller sets', async () => {
+    const tty = terminal();
+
+    const picker = open(tty);
+    picker.upsert({ value: '10.0.0.1', label: 'Salon' });
+    picker.status('scanning 60% · 1 television');
+    await tty.press(KEY.enter);
+    await within(picker.answer);
+
+    expect(tty.drawn()).toContain('scanning 60% · 1 television');
+  });
+
+  it('draws the notice under the list', async () => {
+    const tty = terminal();
+
+    const picker = open(tty);
+    picker.upsert({ value: '10.0.0.1', label: 'Salon' });
+    picker.notice('a set that has not answered by now is off');
+    await tty.press(KEY.enter);
+    await within(picker.answer);
+
+    expect(tty.drawn()).toContain('a set that has not answered by now is off');
+  });
+
+  it('replaces a row that arrives again under the same host', async () => {
+    const tty = terminal();
+
+    const picker = open(tty);
+    picker.upsert({ value: '10.0.0.1', label: 'Salon', hint: 'not ready', ticked: true });
+    await tty.settle();
+    picker.upsert({ value: '10.0.0.1', label: 'Salon', hint: 'ready', ticked: true });
+    await tty.press(KEY.enter);
+
+    await expect(within(picker.answer)).resolves.toEqual(['10.0.0.1']);
+    expect(tty.drawn()).toContain('ready');
+  });
+});

--- a/packages/tv-installer/src/tui/live-multiselect.ts
+++ b/packages/tv-installer/src/tui/live-multiselect.ts
@@ -1,0 +1,141 @@
+import { styleText } from 'node:util';
+import { isCancel, MultiSelectPrompt } from '@clack/core';
+import {
+  formatInstructionFooter,
+  limitOptions,
+  S_BAR,
+  S_CHECKBOX_ACTIVE,
+  S_CHECKBOX_INACTIVE,
+  S_CHECKBOX_SELECTED,
+  symbol,
+} from '@clack/prompts';
+
+export interface LiveOption<TValue> {
+  value: TValue;
+  label: string;
+  hint?: string;
+  disabled?: boolean;
+  ticked?: boolean;
+}
+
+export interface LiveMultiselect<TValue> {
+  upsert(option: LiveOption<TValue>): void;
+  status(line: string): void;
+  notice(line: string): void;
+  answer: Promise<TValue[] | null>;
+}
+
+export interface LiveMultiselectOptions {
+  message: string;
+  status: string;
+}
+
+const BAR_COLUMNS = 3;
+const KEYS = [
+  `${dim('↑/↓')} moves`,
+  `${dim('space')} ticks`,
+  `${dim('enter')} installs`,
+  `${dim('ctrl-c')} quits`,
+].join(', ');
+
+/** Enter answers with whatever is ticked, empty list included, and ctrl-c with null. */
+export function liveMultiselect<TValue>({
+  message,
+  status,
+}: LiveMultiselectOptions): LiveMultiselect<TValue> {
+  const options: LiveOption<TValue>[] = [];
+  let statusLine = status;
+  let noticeLine = '';
+
+  const prompt = new GrowingMultiSelect<TValue>({
+    options,
+    render() {
+      const head = `${styleText('gray', S_BAR)}\n${symbol(this.state)}  ${message}\n`;
+      const ticked = this.value ?? [];
+      if (this.state === 'submit' || this.state === 'cancel') {
+        return `${head}${styleText('gray', S_BAR)}  ${recap(this.options, ticked, this.state)}`;
+      }
+
+      const bar = `${styleText('cyan', S_BAR)}  `;
+      const under = noticeLine ? [`${bar}${dim(noticeLine)}`] : [];
+      const keys = formatInstructionFooter([statusLine, KEYS], true);
+      const rows = limitOptions({
+        options: this.options,
+        cursor: this.cursor,
+        columnPadding: BAR_COLUMNS,
+        rowPadding: head.split('\n').length + under.length + keys.length + 1,
+        style: (option, active) => row(option, active, ticked.includes(option.value)),
+      });
+      return `${head}${bar}${rows.join(`\n${bar}`)}\n${[...under, ...keys].join('\n')}\n`;
+    },
+  });
+
+  const answer = prompt.prompt().then((value) => (isCancel(value) ? null : (value ?? [])));
+
+  return {
+    upsert(option) {
+      const known = options.findIndex((candidate) => candidate.value === option.value);
+      if (known >= 0) {
+        options[known] = option;
+      } else {
+        options.push(option);
+        if (option.ticked) prompt.value = [...(prompt.value ?? []), option.value];
+      }
+      if (options[prompt.cursor]?.disabled) prompt.cursor = firstTickable(options);
+      prompt.redraw();
+    },
+    status(line) {
+      statusLine = line;
+      prompt.redraw();
+    },
+    notice(line) {
+      noticeLine = line;
+      prompt.redraw();
+    },
+    answer,
+  };
+}
+
+class GrowingMultiSelect<TValue> extends MultiSelectPrompt<LiveOption<TValue>> {
+  redraw(): void {
+    this.output.emit('resize');
+  }
+}
+
+function firstTickable<TValue>(options: readonly LiveOption<TValue>[]): number {
+  const tickable = options.findIndex((option) => option.disabled !== true);
+  return tickable >= 0 ? tickable : 0;
+}
+
+function row<TValue>(option: LiveOption<TValue>, active: boolean, ticked: boolean): string {
+  const hint = option.hint ? ` ${dim(`(${option.hint})`)}` : '';
+  if (option.disabled) {
+    const label = styleText(['strikethrough', 'gray'], option.label);
+    return `${styleText('gray', S_CHECKBOX_INACTIVE)} ${label}${hint}`;
+  }
+  if (ticked) {
+    const label = active ? option.label : dim(option.label);
+    return `${styleText('green', S_CHECKBOX_SELECTED)} ${label}${hint}`;
+  }
+  if (active) return `${styleText('cyan', S_CHECKBOX_ACTIVE)} ${option.label}${hint}`;
+  return `${dim(S_CHECKBOX_INACTIVE)} ${dim(option.label)}${hint}`;
+}
+
+function recap<TValue>(
+  options: readonly LiveOption<TValue>[],
+  ticked: readonly TValue[],
+  state: 'submit' | 'cancel',
+): string {
+  const chosen = options.filter((option) => ticked.includes(option.value));
+  if (state === 'cancel') return chosen.map((option) => struck(option.label)).join(dim(', '));
+  if (chosen.length === 0) return dim('none');
+  return chosen.map((option) => dim(option.label)).join(dim(', '));
+}
+
+function dim(text: string): string {
+  return styleText('dim', text);
+}
+
+function struck(text: string): string {
+  return styleText(['strikethrough', 'dim'], text);
+}

--- a/packages/tv-installer/src/tui/live-multiselect.ts
+++ b/packages/tv-installer/src/tui/live-multiselect.ts
@@ -79,7 +79,13 @@ export function liveMultiselect<TValue>({
     },
   });
 
-  const answer = prompt.prompt().then((value) => (isCancel(value) ? null : (value ?? [])));
+  // clack toggles whatever the cursor sits on, and the cursor has nowhere to go
+  // when every row is disabled, so a row that takes no app is dropped here.
+  const tickable = (value: TValue) =>
+    options.find((option) => option.value === value)?.disabled !== true;
+  const answer = prompt
+    .prompt()
+    .then((value) => (isCancel(value) ? null : (value ?? []).filter(tickable)));
 
   return {
     upsert(option) {

--- a/packages/tv-installer/src/tui/live-multiselect.ts
+++ b/packages/tv-installer/src/tui/live-multiselect.ts
@@ -1,3 +1,4 @@
+import type { Readable, Writable } from 'node:stream';
 import { styleText } from 'node:util';
 import { isCancel, MultiSelectPrompt } from '@clack/core';
 import {
@@ -28,6 +29,8 @@ export interface LiveMultiselect<TValue> {
 export interface LiveMultiselectOptions {
   message: string;
   status: string;
+  input?: Readable;
+  output?: Writable;
 }
 
 const BAR_COLUMNS = 3;
@@ -42,6 +45,8 @@ const KEYS = [
 export function liveMultiselect<TValue>({
   message,
   status,
+  input,
+  output,
 }: LiveMultiselectOptions): LiveMultiselect<TValue> {
   const options: LiveOption<TValue>[] = [];
   let statusLine = status;
@@ -49,6 +54,8 @@ export function liveMultiselect<TValue>({
 
   const prompt = new GrowingMultiSelect<TValue>({
     options,
+    input,
+    output,
     render() {
       const head = `${styleText('gray', S_BAR)}\n${symbol(this.state)}  ${message}\n`;
       const ticked = this.value ?? [];
@@ -62,6 +69,7 @@ export function liveMultiselect<TValue>({
       const rows = limitOptions({
         options: this.options,
         cursor: this.cursor,
+        output,
         columnPadding: BAR_COLUMNS,
         rowPadding: head.split('\n').length + under.length + keys.length + 1,
         style: (option, active) => row(option, active, ticked.includes(option.value)),

--- a/packages/tv-installer/src/tui/live-multiselect.ts
+++ b/packages/tv-installer/src/tui/live-multiselect.ts
@@ -66,7 +66,8 @@ export function liveMultiselect<TValue>({
         rowPadding: head.split('\n').length + under.length + keys.length + 1,
         style: (option, active) => row(option, active, ticked.includes(option.value)),
       });
-      return `${head}${bar}${rows.join(`\n${bar}`)}\n${[...under, ...keys].join('\n')}\n`;
+      const body = rows.join(`\n${bar}`);
+      return `${head}${bar}${body}\n${[...under, ...keys].join('\n')}\n`;
     },
   });
 
@@ -103,12 +104,15 @@ class GrowingMultiSelect<TValue> extends MultiSelectPrompt<LiveOption<TValue>> {
 }
 
 function firstTickable<TValue>(options: readonly LiveOption<TValue>[]): number {
-  const tickable = options.findIndex((option) => option.disabled !== true);
-  return tickable >= 0 ? tickable : 0;
+  return Math.max(
+    options.findIndex((option) => option.disabled !== true),
+    0,
+  );
 }
 
 function row<TValue>(option: LiveOption<TValue>, active: boolean, ticked: boolean): string {
-  const hint = option.hint ? ` ${dim(`(${option.hint})`)}` : '';
+  const note = option.hint ? `(${option.hint})` : '';
+  const hint = note ? ` ${dim(note)}` : '';
   if (option.disabled) {
     const label = styleText(['strikethrough', 'gray'], option.label);
     return `${styleText('gray', S_CHECKBOX_INACTIVE)} ${label}${hint}`;

--- a/packages/tv-installer/src/tui/terminal.fixture.ts
+++ b/packages/tv-installer/src/tui/terminal.fixture.ts
@@ -1,7 +1,7 @@
 import { PassThrough } from 'node:stream';
 
 const ESCAPE = '\x1b';
-const ANSI = new RegExp(`${ESCAPE}\\[[0-9;?]*[A-Za-z]`, 'g');
+const ANSI = new RegExp(String.raw`${ESCAPE}\[[0-9;?]*[A-Za-z]`, 'g');
 const ANSWER_MS = 250;
 
 export const KEY = {

--- a/packages/tv-installer/src/tui/terminal.fixture.ts
+++ b/packages/tv-installer/src/tui/terminal.fixture.ts
@@ -1,0 +1,56 @@
+import { PassThrough } from 'node:stream';
+
+const ESCAPE = '\x1b';
+const ANSI = new RegExp(`${ESCAPE}\\[[0-9;?]*[A-Za-z]`, 'g');
+const ANSWER_MS = 250;
+
+export const KEY = {
+  up: `${ESCAPE}[A`,
+  down: `${ESCAPE}[B`,
+  space: ' ',
+  enter: '\r',
+  cancel: '\x03',
+};
+
+export interface Terminal {
+  input: PassThrough;
+  output: PassThrough;
+  press(...keys: string[]): Promise<void>;
+  settle(): Promise<void>;
+  drawn(): string;
+}
+
+export function terminal(): Terminal {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  const chunks: string[] = [];
+  output.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
+
+  const settle = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+  return {
+    input,
+    output,
+    async press(...keys) {
+      for (const key of keys) {
+        input.write(key);
+        await settle();
+      }
+    },
+    settle,
+    drawn: () => chunks.join('').replaceAll(ANSI, ''),
+  };
+}
+
+/** Fails rather than hangs when nothing answers. */
+export async function within<TValue>(work: Promise<TValue>): Promise<TValue> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const impatience = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`nothing answered in ${ANSWER_MS}ms`)), ANSWER_MS);
+  });
+  try {
+    return await Promise.race([work, impatience]);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/packages/tv-installer/src/usage.test.ts
+++ b/packages/tv-installer/src/usage.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { injectUsage, renderUsage, type UsageCommand } from './usage';
+
+const TV: UsageCommand = {
+  meta: { name: 'tv', description: 'find televisions and install KROMA' },
+  args: {
+    host: { type: 'string', description: 'probe these addresses', valueHint: 'ip' },
+    launch: { type: 'boolean', default: true, description: 'start the app after installing' },
+    json: { type: 'boolean', description: 'machine readable output' },
+  },
+  subCommands: {
+    scan: { meta: { description: 'list what answered' } },
+    install: {
+      meta: { description: 'install without the TUI' },
+      args: { target: { type: 'positional', description: 'an address, or all' } },
+    },
+  },
+};
+
+describe('renderUsage', () => {
+  it('lists the root command and every subcommand with its description', async () => {
+    const usage = await renderUsage(TV, 'bun run tv');
+
+    expect(usage).toContain('| `bun run tv` | find televisions and install KROMA |');
+    expect(usage).toContain('| `bun run tv scan` | list what answered |');
+  });
+
+  it('spells a subcommand with the positional it takes', async () => {
+    const usage = await renderUsage(TV, 'bun run tv');
+
+    expect(usage).toContain('| `bun run tv install <target>` |');
+  });
+
+  it('gives a boolean that defaults on both of its spellings', async () => {
+    const usage = await renderUsage(TV, 'bun run tv');
+
+    expect(usage).toContain('| `--launch`, `--no-launch` | start the app after installing |');
+    expect(usage).toContain('| `--json` | machine readable output |');
+  });
+
+  it('names the value a flag takes', async () => {
+    const usage = await renderUsage(TV, 'bun run tv');
+
+    expect(usage).toContain('| `--host <ip>` | probe these addresses |');
+  });
+
+  it('resolves a description a command only produces when asked', async () => {
+    const lazy: UsageCommand = {
+      meta: () => Promise.resolve({ description: 'resolved late' }),
+      subCommands: { doctor: () => ({ meta: { description: 'which tools are here' } }) },
+    };
+
+    const usage = await renderUsage(lazy, 'tv');
+
+    expect(usage).toContain('| `tv` | resolved late |');
+    expect(usage).toContain('| `tv doctor` | which tools are here |');
+  });
+
+  it('leaves the positionals out of the option table', async () => {
+    const usage = await renderUsage(TV, 'bun run tv');
+
+    expect(usage).not.toContain('--target');
+  });
+});
+
+describe('injectUsage', () => {
+  it('replaces what stands between the markers and keeps the rest', () => {
+    const readme = '# title\n\n<!-- usage:start -->\nstale\n<!-- usage:end -->\n\nrest\n';
+
+    const written = injectUsage(readme, '| a | b |');
+
+    expect(written).toBe(
+      '# title\n\n<!-- usage:start -->\n\n| a | b |\n\n<!-- usage:end -->\n\nrest\n',
+    );
+  });
+
+  it('refuses a file with no block to write into', () => {
+    expect(() => injectUsage('# title\n', '| a | b |')).toThrow(/usage:start/);
+  });
+});

--- a/packages/tv-installer/src/usage.ts
+++ b/packages/tv-installer/src/usage.ts
@@ -1,0 +1,78 @@
+type Resolvable<T> = T | (() => T | Promise<T>) | Promise<T>;
+
+export interface UsageArg {
+  type?: string;
+  description?: string;
+  default?: unknown;
+  required?: boolean;
+  valueHint?: string;
+}
+
+/** The shape of a citty command, structurally, so the renderer owns no framework. */
+export interface UsageCommand {
+  meta?: Resolvable<{ name?: string; description?: string } | undefined>;
+  args?: Resolvable<Record<string, UsageArg> | undefined>;
+  subCommands?: Resolvable<Record<string, Resolvable<UsageCommand>> | undefined>;
+}
+
+const START = '<!-- usage:start -->';
+const END = '<!-- usage:end -->';
+
+/** The commands and options of a CLI, as the markdown table its README carries. */
+export async function renderUsage(root: UsageCommand, invocation: string): Promise<string> {
+  const meta = await resolve(root.meta);
+  const rows = [row(invocation, meta?.description)];
+  for (const [name, sub] of Object.entries((await resolve(root.subCommands)) ?? {})) {
+    const command = await resolve(sub);
+    const subMeta = await resolve(command.meta);
+    rows.push(row(`${invocation} ${name}${await positionals(command)}`, subMeta?.description));
+  }
+
+  const options = optionRows((await resolve(root.args)) ?? {});
+  return [
+    '| command | what it does |',
+    '| --- | --- |',
+    ...rows,
+    '',
+    '| option | what it does |',
+    '| --- | --- |',
+    ...options,
+  ].join('\n');
+}
+
+/** Replaces the block between the usage markers, which the file must already carry. */
+export function injectUsage(markdown: string, block: string): string {
+  const start = markdown.indexOf(START);
+  const end = markdown.indexOf(END);
+  if (start === -1 || end === -1 || end < start) {
+    throw new Error(`no ${START} ... ${END} block to write into`);
+  }
+  return `${markdown.slice(0, start + START.length)}\n\n${block}\n\n${markdown.slice(end)}`;
+}
+
+function optionRows(args: Record<string, UsageArg>): string[] {
+  return Object.entries(args)
+    .filter(([, arg]) => arg.type !== 'positional')
+    .map(([name, arg]) => row(flagCell(name, arg), arg.description, false));
+}
+
+function flagCell(name: string, arg: UsageArg): string {
+  if (arg.type !== 'boolean') return `\`--${name} <${arg.valueHint ?? 'value'}>\``;
+  return arg.default === true ? `\`--${name}\`, \`--no-${name}\`` : `\`--${name}\``;
+}
+
+async function positionals(command: UsageCommand): Promise<string> {
+  return Object.entries((await resolve(command.args)) ?? {})
+    .filter(([, arg]) => arg.type === 'positional')
+    .map(([name, arg]) => (arg.required === false ? ` [${name}]` : ` <${name}>`))
+    .join('');
+}
+
+function row(label: string, description: string | undefined, code = true): string {
+  const cell = code ? `\`${label}\`` : label;
+  return `| ${cell} | ${description ?? ''} |`;
+}
+
+async function resolve<T>(value: Resolvable<T>): Promise<T> {
+  return typeof value === 'function' ? await (value as () => T | Promise<T>)() : await value;
+}

--- a/packages/tv-installer/src/usage.ts
+++ b/packages/tv-installer/src/usage.ts
@@ -10,9 +10,9 @@ export interface UsageArg {
 
 /** The shape of a citty command, structurally, so the renderer owns no framework. */
 export interface UsageCommand {
-  meta?: Resolvable<{ name?: string; description?: string } | undefined>;
-  args?: Resolvable<Record<string, UsageArg> | undefined>;
-  subCommands?: Resolvable<Record<string, Resolvable<UsageCommand>> | undefined>;
+  meta?: Resolvable<{ name?: string; description?: string }>;
+  args?: Resolvable<Record<string, UsageArg>>;
+  subCommands?: Resolvable<Record<string, Resolvable<UsageCommand>>>;
 }
 
 const START = '<!-- usage:start -->';

--- a/packages/tv-installer/tsconfig.json
+++ b/packages/tv-installer/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "lib": ["ES2022"],
+    "types": ["bun-types"]
+  },
+  "include": ["src", "scripts"]
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -164,6 +164,7 @@ sonar.coverage.exclusions=\
   clients/*/index*.html,\
   clients/tv-build/**,\
   packages/shots/**,\
+  packages/tv-installer/**,\
   packages/bundler/src/shell.ts,\
   packages/bundler/src/rnw.ts,\
   packages/bundler/src/tv-frame.ts,\

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -164,7 +164,6 @@ sonar.coverage.exclusions=\
   clients/*/index*.html,\
   clients/tv-build/**,\
   packages/shots/**,\
-  packages/tv-installer/**,\
   packages/bundler/src/shell.ts,\
   packages/bundler/src/rnw.ts,\
   packages/bundler/src/tv-frame.ts,\


### PR DESCRIPTION
`bun run tv` finds the televisions on the network, installs the toolchain each
platform needs, and sideloads KROMA onto the ones you tick.

```bash
bun run tv                 # the picker
bun run tv scan            # what answered, and stop
bun run tv install all     # without the picker
```

## Each client is a module

`src/modules/<id>/` holds everything one platform needs, behind one interface:
its ports, how it recognises itself, what tools it wants, where its package
comes from, how it installs. Nothing outside `src/modules/` names a platform, so
a fifth device is one folder plus one line in the registry.

Apple TV is what tests the interface: it answers no probe and arrives through
`discover()` rather than a special case in the scanner.

## Samsung no longer needs Tizen Studio

Two things replaced the 260 MB SDK, both written here:

- **The sdb wire protocol** (`src/modules/tizen/sdb/`, documented in
  `docs/tizen-sdb-protocol.md`), including the two Samsung differences no
  document states: the protocol version is `0x00100000`, and `capability:` is
  length-prefixed with a uint16.
- **The widget signer** (`src/modules/tizen/certificate/`), whose output is
  byte-identical to `tizen package` over three fixtures, including a real
  release `.wgt` with subdirectories and adversarial filenames. RSA PKCS#1 v1.5
  is deterministic, so identical bytes prove the canonicalisation rather than
  suggesting it. The author certificate is generated from `node:crypto` and a
  hand-written DER encoder.

Only the distributor certificate is still Samsung's to issue, against the DUID
of one set.

## A correction to INSTALL.md

It said a prebuilt `.wgt` needs no certificate. A retail Samsung refuses it:
`Invalid certificate chain with certificate in signature`, seen on a real set.
The installer now re-signs with the machine's own profile before installing, and
the document says what actually happens.

## What is proven, and what is not

- **Android TV**: end to end on an emulator. Scan reads `Android 16, WebView 150`
  off the device, `gh` fetches the `.apk`, `adb install` succeeds, the leanback
  intent launches it, `topResumedActivity=tv.kroma.tv/.MainActivity`.
- **Apple TV**: discovery proven against a real paired set through `devicectl`.
  The install and launch commands carry flags read off `--help`, not guessed, but
  no `.app` has been pushed yet.
- **Samsung**: discovery and signing proven on a real set and its certificate.
  The re-signed install has not been replayed on the television since the fix.
- **LG**: never seen a webOS set. The command shapes are checked against the
  real `ares-*` CLI; nothing beyond that.
- **Philips** is an Android TV when its JointSpace API says so, and is listed as
  taking no sideloaded app when it runs Saphi or Titan OS.

## Also here

- `_release-tools.yml` builds the installer as one executable for macOS (both
  architectures) and Linux, uploaded as run artifacts and attached to a stable
  release. The macOS binaries are built on macOS because `bun build --compile`
  leaves a signature the system refuses to run until `codesign` replaces it.
- `packages/tv-installer` joins the Sonar coverage exclusions, where the other
  CLI tooling packages already sit.
- 189 tests, typecheck and biome clean. `bun run tv docs` generates the README's
  command table from the citty definitions, and `--check` fails when it drifts.

