### PR TITLE
fix: say unsafe where a raw pointer is dereferenced, and scope CI's permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,6 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-
 env:
   SHARDS: 4
 
@@ -64,6 +61,8 @@ jobs:
   branch-name:
     name: Branch name
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: github.event_name == 'pull_request'
     timeout-minutes: 5
     steps:
@@ -82,6 +81,8 @@ jobs:
     needs: lanes
     if: needs.lanes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -98,6 +99,8 @@ jobs:
     needs: lanes
     if: needs.lanes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -129,6 +132,8 @@ jobs:
     needs: [lanes, test]
     if: ${{ !cancelled() && needs.lanes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -155,6 +160,8 @@ jobs:
     needs: lanes
     if: needs.lanes.outputs.fleet == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -205,6 +212,8 @@ jobs:
     needs: lanes
     if: needs.lanes.outputs.android == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -250,6 +259,8 @@ jobs:
     needs: lanes
     if: needs.lanes.outputs.desktop == 'true'
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -279,6 +290,8 @@ jobs:
     needs: lanes
     if: needs.lanes.outputs.rust == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -326,6 +339,8 @@ jobs:
       && needs.rust.result != 'failure'
       && needs.rust.result != 'cancelled'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/bun.lock
+++ b/bun.lock
@@ -719,6 +719,9 @@
     "packages/sonar-tools": {
       "name": "@kroma/sonar-tools",
       "version": "0.0.0",
+      "dependencies": {
+        "zod": "^4.4.3",
+      },
       "devDependencies": {
         "bun-types": "^1.4.0",
         "typescript": "^7.0.2",

--- a/clients/desktop/src-tauri/src/libmpv_mac.rs
+++ b/clients/desktop/src-tauri/src/libmpv_mac.rs
@@ -39,8 +39,10 @@ static MEDIA_APP: Mutex<Option<AppHandle>> = Mutex::new(None);
 
 /// Called by the Obj-C MPRemoteCommandCenter handlers; forwards the media-key action to
 /// the UI as a `media-key` event.
+/// # Safety
+/// `action` is either null or a NUL-terminated string that outlives the call.
 #[no_mangle]
-pub extern "C" fn kroma_media_key_pressed(action: *const c_char) {
+pub unsafe extern "C" fn kroma_media_key_pressed(action: *const c_char) {
     if action.is_null() {
         return;
     }

--- a/docs/spec/scripts/spec-index.ts
+++ b/docs/spec/scripts/spec-index.ts
@@ -211,7 +211,8 @@ const check = process.argv.includes('--check');
 const { reqs, errors } = await collect();
 
 if (errors.length) {
-  console.error(`Spec index found problems:\n${errors.map((e) => `  ✗ ${e}`).join('\n')}`);
+  const listed = errors.map((error) => `  ✗ ${error}`).join('\n');
+  console.error(`Spec index found problems:\n${listed}`);
   process.exit(1);
 }
 

--- a/packages/sonar-tools/package.json
+++ b/packages/sonar-tools/package.json
@@ -17,5 +17,8 @@
   "devDependencies": {
     "bun-types": "^1.4.0",
     "typescript": "^7.0.2"
+  },
+  "dependencies": {
+    "zod": "^4.4.3"
   }
 }

--- a/packages/sonar-tools/src/accept.ts
+++ b/packages/sonar-tools/src/accept.ts
@@ -1,0 +1,84 @@
+import { parseArgs } from 'node:util';
+import { z } from 'zod';
+
+const API = 'https://sonarcloud.io/api';
+const TRANSITION = 'accept';
+const PROJECT = 'maxscharwath_kroma';
+const PAGE_SIZE = 100;
+
+const Issues = z.object({
+  issues: z.array(
+    z.object({ key: z.string(), component: z.string(), line: z.number().optional() }),
+  ),
+});
+
+type Issue = z.infer<typeof Issues>['issues'][number];
+
+function authorization(token: string): string {
+  return `Basic ${Buffer.from(`${token}:`).toString('base64')}`;
+}
+
+async function open(rule: string, branch: string, token: string): Promise<Issue[]> {
+  const query = new URLSearchParams({
+    componentKeys: PROJECT,
+    branch,
+    rules: rule,
+    resolved: 'false',
+    ps: String(PAGE_SIZE),
+  });
+  const response = await fetch(`${API}/issues/search?${query}`, {
+    headers: { Authorization: authorization(token) },
+  });
+  if (!response.ok) throw new Error(`issues/search answered ${response.status}`);
+  return Issues.parse(await response.json()).issues;
+}
+
+async function accept(issue: Issue, reason: string, token: string): Promise<boolean> {
+  const post = (path: string, body: Record<string, string>) =>
+    fetch(`${API}/${path}`, {
+      method: 'POST',
+      headers: {
+        Authorization: authorization(token),
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams(body),
+    });
+
+  const commented = await post('issues/add_comment', { issue: issue.key, text: reason });
+  const moved = await post('issues/do_transition', { issue: issue.key, transition: TRANSITION });
+  if (commented.ok && moved.ok) return true;
+
+  console.error(`${issue.key}: comment ${commented.status}, transition ${moved.status}`);
+  return false;
+}
+
+/**
+ * Accepts every open issue of one rule, with one reason. The rule is the unit
+ * because the reason is: an issue is accepted for what the rule misunderstands
+ * about this codebase, never for where it happens to have landed.
+ */
+export async function main(argv: string[]): Promise<void> {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      rule: { type: 'string' },
+      reason: { type: 'string' },
+      branch: { type: 'string', default: 'main' },
+    },
+  });
+  const token = process.env.SONAR_TOKEN;
+  if (!token) throw new Error('SONAR_TOKEN is not set: make one at sonarcloud.io/account/security');
+  if (!values.rule || !values.reason) {
+    throw new Error('usage: bun run sonar accept --rule <rule> --reason <why> [--branch <branch>]');
+  }
+
+  const issues = await open(values.rule, values.branch, token);
+  const done = await Promise.all(issues.map((issue) => accept(issue, values.reason ?? '', token)));
+  for (const issue of issues) {
+    console.log(`  ${issue.component.split(':').at(-1)}:${issue.line ?? ''}`);
+  }
+  console.log(`accepted ${done.filter(Boolean).length} of ${issues.length} for ${values.rule}`);
+  if (done.some((ok) => !ok)) process.exit(1);
+}
+
+if (import.meta.main) await main(process.argv.slice(2));


### PR DESCRIPTION
Three findings from the quality gate, fixed rather than accepted.

**`clients/desktop/src-tauri/src/libmpv_mac.rs`** — `kroma_media_key_pressed`
dereferences a pointer its Obj-C caller supplies, so the obligation belongs to
the caller and the signature has to say so. It is now `unsafe extern "C"`, with
the invariant written where a caller reads it. The exported symbol and the ABI
do not change, so the Obj-C side needs nothing. `cargo check` and
`cargo clippy --all-targets` are clean on the crate.

**`.github/workflows/ci.yml`** — `contents: read` was granted at workflow level
and inherited by every job, whether or not it reads anything. Each job now
carries its own, which is what the release workflows already do. `actionlint`
passes.

**`docs/spec/scripts/spec-index.ts`** — the error list was built inside the
template that printed it. `bun run spec:check` still passes.

Also adds a small tool:

```bash
bun packages/sonar-tools/src/accept.ts --rule rust:S2208 --reason "…"
```

It accepts every open issue of one rule with one reason. The rule is the unit
because the reason is: an issue is accepted for what the rule misunderstands
about this codebase, never for where it happened to land. `SONAR_TOKEN` comes
from the environment, and neither the token nor the issue contents are printed.

It was used on 28 findings already: the 26 `use super::*`, which is how a Rust
submodule reuses what its parent imported and how a test module reaches the code
it tests, and the 2 SHA-1 in the torrents module, where BEP 3 defines an info
hash and a peer id as SHA-1 and a tracker that hashes anything else talks to
nobody.

Three findings are deliberately left open rather than accepted, because they are
judgement calls that belong to a reviewer: the `Cast` prefix shared by the
websocket variants, and the two constructors with eight and nine parameters, one
of which is the single place the application is assembled.
