### PR TITLE
fix(indexer): robustness fixes for public trackers and qBittorrent

### DIFF
--- a/modules/tv.kroma.engine.qbittorrent/module.json
+++ b/modules/tv.kroma.engine.qbittorrent/module.json
@@ -3,7 +3,7 @@
   "schemaVersion": 2,
   "id": "tv.kroma.engine.qbittorrent",
   "name": "qBittorrent engine",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "description": "qBittorrent WebUI as a download sub-engine for the Downloads module. Toggle it to add/remove qBittorrent from the download-client picker.",
   "engines": {
     "server": ">=0.1.39"

--- a/modules/tv.kroma.engine.qbittorrent/server/src/lib.rs
+++ b/modules/tv.kroma.engine.qbittorrent/server/src/lib.rs
@@ -45,7 +45,10 @@ impl QBittorrent {
             &[("username", &self.username), ("password", &self.password)],
         )?;
         let resp = resp.ensure_ok()?;
-        if !resp.text().contains("Ok") {
+        // qBittorrent >= 4.6 returns 204 No Content on success; older versions
+        // return 200 with "Ok." in the body. A 2xx status (validated by
+        // ensure_ok) is the reliable signal; the body text is a legacy check.
+        if resp.status != 204 && !resp.text().contains("Ok") {
             bail!("authentication failed (check username/password)");
         }
         Ok(())
@@ -406,6 +409,17 @@ mod tests {
         });
         let err = s.client().test().unwrap_err().to_string();
         assert!(err.contains("authentication failed"), "{err}");
+    }
+
+    #[test]
+    fn a_204_login_response_is_success() {
+        // qBittorrent >= 4.6 returns 204 No Content (empty body) on success.
+        let s = FakeQbit::start(|key, _| match key {
+            "POST /api/v2/auth/login" => (204, String::new()),
+            "GET /api/v2/app/version" => (200, "v5.0.0".into()),
+            _ => (200, String::new()),
+        });
+        assert_eq!(s.client().test().unwrap(), "qBittorrent v5.0.0");
     }
 
     #[test]

--- a/modules/tv.kroma.engine.qbittorrent/server/src/port.rs
+++ b/modules/tv.kroma.engine.qbittorrent/server/src/port.rs
@@ -88,7 +88,9 @@ fn engine<S: HostCtx>(host: &S, client: &Client) -> QBittorrent {
         username: client.username.clone(),
         password: client.password.clone(),
     };
-    let jar = cookie_jar_path(&host.data_dir().join("qbittorrent"), &def);
+    let state_dir = host.data_dir().join("qbittorrent");
+    std::fs::create_dir_all(&state_dir).ok();
+    let jar = cookie_jar_path(&state_dir, &def);
     QBittorrent::new(&def, jar)
 }
 

--- a/modules/tv.kroma.indexer/module.json
+++ b/modules/tv.kroma.indexer/module.json
@@ -3,7 +3,7 @@
   "schemaVersion": 2,
   "id": "tv.kroma.indexer",
   "name": "Indexers",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Native Cardigann indexer engine: searches trackers from community YAML definitions, no external Torznab aggregator.",
   "engines": {
     "server": ">=0.1.39"

--- a/modules/tv.kroma.indexer/module.json
+++ b/modules/tv.kroma.indexer/module.json
@@ -3,7 +3,7 @@
   "schemaVersion": 2,
   "id": "tv.kroma.indexer",
   "name": "Indexers",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Native Cardigann indexer engine: searches trackers from community YAML definitions, no external Torznab aggregator.",
   "engines": {
     "server": ">=0.1.39"

--- a/modules/tv.kroma.indexer/module.json
+++ b/modules/tv.kroma.indexer/module.json
@@ -3,7 +3,7 @@
   "schemaVersion": 2,
   "id": "tv.kroma.indexer",
   "name": "Indexers",
-  "version": "0.4.0",
+  "version": "0.4.2",
   "description": "Native Cardigann indexer engine: searches trackers from community YAML definitions, no external Torznab aggregator.",
   "engines": {
     "server": ">=0.1.39"

--- a/modules/tv.kroma.indexer/server/src/definition.rs
+++ b/modules/tv.kroma.indexer/server/src/definition.rs
@@ -186,6 +186,10 @@ pub struct ResponseSpec {
 pub struct Rows {
     #[serde(default)]
     pub selector: Option<String>,
+    // For JSON: a sub-key on each row element whose array value is expanded
+    // into individual rows (YTS: `data.movies` → each movie's `torrents`).
+    #[serde(default)]
+    pub attribute: Option<String>,
     // Rows to merge upward into the previous one (multi-line row layouts).
     #[serde(default)]
     pub after: i64,

--- a/modules/tv.kroma.indexer/server/src/engine/parse_json.rs
+++ b/modules/tv.kroma.indexer/server/src/engine/parse_json.rs
@@ -26,16 +26,39 @@ pub fn parse_json(
         .selector
         .as_deref()
         .ok_or_else(|| anyhow::anyhow!("definition has no rows selector"))?;
-    let rows = match json_get(&root, row_sel) {
+    // The rows selector can itself be templated (Pirate Bay:
+    // `${{ if .Config.uploader }}:has(...){{ end }}`).
+    let row_sel = template::render(row_sel, &base_ctx);
+    let matched = match json_get(&root, &row_sel) {
         Some(serde_json::Value::Array(arr)) => arr.clone(),
-        // A single object row, or nothing.
         Some(v @ serde_json::Value::Object(_)) => vec![v.clone()],
         _ => Vec::new(),
     };
+    // Cardigann `rows.attribute`: each matched element is expanded by that
+    // sub-key's array into individual rows (YTS: movies → torrents). The parent
+    // element is kept so `..foo` field selectors can traverse up to it.
+    let attr = def.search.rows.attribute.as_deref();
+    let rows: Vec<(&serde_json::Value, Option<&serde_json::Value>)> = if let Some(attr) = attr {
+        let mut expanded = Vec::new();
+        for el in &matched {
+            if let Some(sub) = json_get(el, attr) {
+                if let Some(arr) = sub.as_array() {
+                    for item in arr {
+                        expanded.push((item, Some(el)));
+                    }
+                } else {
+                    expanded.push((sub, Some(el)));
+                }
+            }
+        }
+        expanded
+    } else {
+        matched.iter().map(|r| (r, None)).collect()
+    };
 
     let mut releases = Vec::new();
-    for row in &rows {
-        if let Some(result) = extract_row_json(def, &base_ctx, row) {
+    for (row, parent) in &rows {
+        if let Some(result) = extract_row_json(def, &base_ctx, row, *parent) {
             releases.push(to_release(def, cfg, &result));
         }
     }
@@ -46,18 +69,24 @@ fn extract_row_json(
     def: &Definition,
     base_ctx: &Context,
     row: &serde_json::Value,
+    parent: Option<&serde_json::Value>,
 ) -> Option<HashMap<String, String>> {
     let mut result: HashMap<String, String> = HashMap::new();
     for (name, field) in &def.search.fields {
         let mut ctx = base_ctx.clone();
         ctx.result = result.clone();
-        let value = resolve_field_json(field, row, &ctx)?;
+        let value = resolve_field_json(field, row, parent, &ctx)?;
         result.insert(name.clone(), value);
     }
     Some(result)
 }
 
-fn resolve_field_json(field: &Field, row: &serde_json::Value, ctx: &Context) -> Option<String> {
+fn resolve_field_json(
+    field: &Field,
+    row: &serde_json::Value,
+    parent: Option<&serde_json::Value>,
+    ctx: &Context,
+) -> Option<String> {
     let raw: Option<String> = if let Some(text) = &field.text {
         Some(template::render(text, ctx))
     } else if !field.case.is_empty() {
@@ -67,14 +96,14 @@ fn resolve_field_json(field: &Field, row: &serde_json::Value, ctx: &Context) -> 
         for (path, val) in &field.case {
             if path == "*" {
                 default = Some(val);
-            } else if json_get(row, path).is_some_and(json_truthy) {
+            } else if resolve_selector(row, parent, path).is_some_and(json_truthy) {
                 hit = Some(val);
                 break;
             }
         }
         hit.or(default).map(|v| template::render(v, ctx))
     } else if let Some(sel) = &field.selector {
-        json_get(row, sel).map(json_scalar_string)
+        resolve_selector(row, parent, sel).map(json_scalar_string)
     } else {
         Some(json_scalar_string(row))
     };
@@ -88,6 +117,25 @@ fn resolve_field_json(field: &Field, row: &serde_json::Value, ctx: &Context) -> 
         },
     };
     Some(filters::apply(&value, &field.filters, ctx))
+}
+
+/// Resolve a field selector against the row, with `..` prefix traversing to
+/// the parent element (Cardigann parent traversal for `rows.attribute`).
+fn resolve_selector<'a>(
+    row: &'a serde_json::Value,
+    parent: Option<&'a serde_json::Value>,
+    sel: &str,
+) -> Option<&'a serde_json::Value> {
+    let sel = sel.trim();
+    if let Some(rest) = sel.strip_prefix("..") {
+        let p = parent?;
+        let rest = rest.trim_start_matches('.');
+        if rest.is_empty() {
+            return Some(p);
+        }
+        return json_get(p, rest);
+    }
+    json_get(row, sel)
 }
 
 #[cfg(test)]
@@ -247,4 +295,50 @@ search:
         assert_eq!(rels[0].seeders, None);
         assert_eq!(rels[0].grabs, Some(7));
     }
+
+    #[test]
+    fn rows_attribute_expands_sub_arrays_with_parent_traversal() {
+        // Mirrors YTS: `data.movies` → each movie's `torrents` array expanded,
+        // `..year` and `..title` traverse up to the parent movie.
+        let def = build_def(
+            r#"
+id: t
+name: T
+caps: {}
+search:
+  rows:
+    selector: "data.movies"
+    attribute: "torrents"
+  fields:
+    title:
+      selector: "..title"
+    year:
+      selector: "..year"
+    quality:
+      selector: "quality"
+    seeders:
+      selector: "seeds"
+"#,
+        );
+        let body = r#"{"data":{"movies":[
+          {"title":"Film A","year":2024,"torrents":[
+            {"quality":"1080p","seeds":10},
+            {"quality":"2160p","seeds":5}
+          ]},
+          {"title":"Film B","year":2023,"torrents":[
+            {"quality":"720p","seeds":1}
+          ]}
+        ]}}"#;
+        let rels = parse_json(&def, &cfg("https://x/"), body).unwrap();
+        assert_eq!(rels.len(), 3);
+        assert_eq!(rels[0].title, "Film A");
+        // quality is parsed into the release title suffix by to_release;
+        // check the raw parsed quality via the release's codec/source fields instead.
+        assert_eq!(rels[0].seeders, Some(10));
+        assert_eq!(rels[1].seeders, Some(5));
+        assert_eq!(rels[2].title, "Film B");
+        assert_eq!(rels[2].seeders, Some(1));
+    }
+
+
 }

--- a/modules/tv.kroma.indexer/server/src/engine/parse_json.rs
+++ b/modules/tv.kroma.indexer/server/src/engine/parse_json.rs
@@ -29,40 +29,46 @@ pub fn parse_json(
     // The rows selector can itself be templated (Pirate Bay:
     // `${{ if .Config.uploader }}:has(...){{ end }}`).
     let row_sel = template::render(row_sel, &base_ctx);
-    let matched = match json_get(&root, &row_sel) {
+    let matched = matched_rows(&root, &row_sel);
+    let rows = expand_rows(&matched, def.search.rows.attribute.as_deref());
+
+    let releases = rows
+        .iter()
+        .filter_map(|(row, parent)| extract_row_json(def, &base_ctx, row, *parent))
+        .map(|result| to_release(def, cfg, &result))
+        .collect();
+    Ok(releases)
+}
+
+/// Resolve the rows selector to the matched elements: an array yields its
+/// items, a single object yields one row, anything else yields nothing.
+fn matched_rows(root: &serde_json::Value, row_sel: &str) -> Vec<serde_json::Value> {
+    match json_get(root, row_sel) {
         Some(serde_json::Value::Array(arr)) => arr.clone(),
         Some(v @ serde_json::Value::Object(_)) => vec![v.clone()],
         _ => Vec::new(),
-    };
-    // Cardigann `rows.attribute`: each matched element is expanded by that
-    // sub-key's array into individual rows (YTS: movies → torrents). The parent
-    // element is kept so `..foo` field selectors can traverse up to it.
-    let attr = def.search.rows.attribute.as_deref();
-    let rows: Vec<(&serde_json::Value, Option<&serde_json::Value>)> = if let Some(attr) = attr {
-        let mut expanded = Vec::new();
-        for el in &matched {
-            if let Some(sub) = json_get(el, attr) {
-                if let Some(arr) = sub.as_array() {
-                    for item in arr {
-                        expanded.push((item, Some(el)));
-                    }
-                } else {
-                    expanded.push((sub, Some(el)));
-                }
-            }
-        }
-        expanded
-    } else {
-        matched.iter().map(|r| (r, None)).collect()
-    };
-
-    let mut releases = Vec::new();
-    for (row, parent) in &rows {
-        if let Some(result) = extract_row_json(def, &base_ctx, row, *parent) {
-            releases.push(to_release(def, cfg, &result));
-        }
     }
-    Ok(releases)
+}
+
+/// Apply Cardigann `rows.attribute`: each matched element is expanded by that
+/// sub-key's array into individual rows (YTS: movies → torrents). The parent
+/// element is kept so `..foo` field selectors can traverse up to it. Without
+/// an attribute, each matched element is a row with no parent.
+fn expand_rows<'a>(
+    matched: &'a [serde_json::Value],
+    attr: Option<&str>,
+) -> Vec<(&'a serde_json::Value, Option<&'a serde_json::Value>)> {
+    let Some(attr) = attr else {
+        return matched.iter().map(|r| (r, None)).collect();
+    };
+    matched
+        .iter()
+        .filter_map(|el| json_get(el, attr).map(|sub| (el, sub)))
+        .flat_map(|(el, sub)| match sub.as_array() {
+            Some(arr) => arr.iter().map(|item| (item, Some(el))).collect::<Vec<_>>(),
+            None => vec![(sub, Some(el))],
+        })
+        .collect()
 }
 
 fn extract_row_json(

--- a/modules/tv.kroma.indexer/server/src/engine/parse_json.rs
+++ b/modules/tv.kroma.indexer/server/src/engine/parse_json.rs
@@ -119,8 +119,8 @@ fn resolve_field_json(
     Some(filters::apply(&value, &field.filters, ctx))
 }
 
-/// Resolve a field selector against the row, with `..` prefix traversing to
-/// the parent element (Cardigann parent traversal for `rows.attribute`).
+// A `..` prefix traverses to the parent element (Cardigann parent traversal
+// for `rows.attribute`); otherwise the selector resolves against the row.
 fn resolve_selector<'a>(
     row: &'a serde_json::Value,
     parent: Option<&'a serde_json::Value>,
@@ -332,13 +332,9 @@ search:
         let rels = parse_json(&def, &cfg("https://x/"), body).unwrap();
         assert_eq!(rels.len(), 3);
         assert_eq!(rels[0].title, "Film A");
-        // quality is parsed into the release title suffix by to_release;
-        // check the raw parsed quality via the release's codec/source fields instead.
         assert_eq!(rels[0].seeders, Some(10));
         assert_eq!(rels[1].seeders, Some(5));
         assert_eq!(rels[2].title, "Film B");
         assert_eq!(rels[2].seeders, Some(1));
     }
-
-
 }

--- a/modules/tv.kroma.indexer/server/src/engine/release.rs
+++ b/modules/tv.kroma.indexer/server/src/engine/release.rs
@@ -25,6 +25,21 @@ pub fn to_release(def: &Definition, cfg: &IndexerConfig, r: &HashMap<String, Str
         }
     }
 
+    // Public trackers (e.g. The Pirate Bay) return an infohash but no magnet
+    // link in their search results. Jackett/Prowlarr synthesize one before
+    // returning XML; the built-in indexer must do the same so the release is
+    // grabbable without a details-page round-trip.
+    if magnet.is_none() && link.is_none() {
+        if let Some(hash) = get("infohash") {
+            if def.kind == "public" {
+                magnet = Some(format!(
+                    "magnet:?xt=urn:btih:{hash}&dn={}",
+                    crate::filters::url_encode(&title)
+                ));
+            }
+        }
+    }
+
     let categories = category::newznab_for_tracker_id(def, get("category").unwrap_or_default())
         .into_iter()
         .collect();
@@ -197,4 +212,34 @@ mod tests {
         let rel = to_release(&def, &cfg, &r);
         assert_eq!(rel.link.as_deref(), Some("https://cdn.example/x.torrent"));
     }
+
+    #[test]
+    fn to_release_synthesizes_magnet_from_infohash_for_public() {
+        let mut def = cat_def();
+        def.kind = "public".into();
+        let cfg = cfg("https://tpb.example/");
+        let mut r: HashMap<String, String> = HashMap::new();
+        r.insert("title".into(), "Reacher.S01.COMPLETE.1080p".into());
+        r.insert("infohash".into(), "ABC123DEF456".into());
+        r.insert("details".into(), "/torrent/123".into());
+        let rel = to_release(&def, &cfg, &r);
+        assert!(rel.magnet.is_some());
+        assert!(rel.magnet.as_deref().unwrap().starts_with("magnet:?xt=urn:btih:ABC123DEF456"));
+        assert!(rel.magnet.as_deref().unwrap().contains("dn="));
+        assert_eq!(rel.link, None);
+    }
+
+    #[test]
+    fn to_release_does_not_synthesize_magnet_for_private() {
+        let mut def = cat_def();
+        def.kind = "private".into();
+        let cfg = cfg("https://private.example/");
+        let mut r: HashMap<String, String> = HashMap::new();
+        r.insert("title".into(), "Some.Release".into());
+        r.insert("infohash".into(), "ABC123".into());
+        let rel = to_release(&def, &cfg, &r);
+        assert_eq!(rel.magnet, None);
+        assert_eq!(rel.link, None);
+    }
+
 }

--- a/modules/tv.kroma.indexer/server/src/engine/release.rs
+++ b/modules/tv.kroma.indexer/server/src/engine/release.rs
@@ -224,7 +224,11 @@ mod tests {
         r.insert("details".into(), "/torrent/123".into());
         let rel = to_release(&def, &cfg, &r);
         assert!(rel.magnet.is_some());
-        assert!(rel.magnet.as_deref().unwrap().starts_with("magnet:?xt=urn:btih:ABC123DEF456"));
+        assert!(rel
+            .magnet
+            .as_deref()
+            .unwrap()
+            .starts_with("magnet:?xt=urn:btih:ABC123DEF456"));
         assert!(rel.magnet.as_deref().unwrap().contains("dn="));
         assert_eq!(rel.link, None);
     }
@@ -241,5 +245,4 @@ mod tests {
         assert_eq!(rel.magnet, None);
         assert_eq!(rel.link, None);
     }
-
 }

--- a/modules/tv.kroma.indexer/server/src/engine/request.rs
+++ b/modules/tv.kroma.indexer/server/src/engine/request.rs
@@ -78,14 +78,39 @@ pub fn build_requests(
 }
 
 /// Join a base URL with a (possibly absolute) path.
+///
+/// The rendered path is sanitized for URL legality: characters a tracker
+/// template can legitimately produce but curl rejects (space, `"`, `<`, `>`,
+/// backtick, `{`, `}`, `|`, `\`, `^` and ASCII controls) are percent-encoded,
+/// while the structural characters a definition relies on (`? & = / : % # + ~
+/// . - _` and alphanumerics) pass through untouched. Existing `%20`-style
+/// escapes survive because `%` is preserved, so definitions that do their own
+/// escaping (e.g. `replace " " "+"`) are never double-encoded. Absolute and
+/// `magnet:` paths are returned verbatim by the early return above.
 pub fn join_url(base: &str, path: &str) -> String {
     let p = path.trim();
     if p.starts_with("http://") || p.starts_with("https://") || p.starts_with("magnet:") {
         return p.to_string();
     }
     let base = base.trim_end_matches('/');
-    let p = p.trim_start_matches('/');
+    let p = sanitize_url_path(p.trim_start_matches('/'));
     format!("{base}/{p}")
+}
+
+fn sanitize_url_path(p: &str) -> String {
+    let mut out = String::with_capacity(p.len());
+    for c in p.chars() {
+        match c {
+            ' ' | '"' | '<' | '>' | '`' | '{' | '}' | '|' | '\\' | '^' => {
+                out.push_str(&format!("%{:02X}", c as u32));
+            }
+            c if (c as u32) < 0x20 || (c as u32) == 0x7F => {
+                out.push_str(&format!("%{:02X}", c as u32));
+            }
+            _ => out.push(c),
+        }
+    }
+    out
 }
 
 #[cfg(test)]
@@ -103,6 +128,40 @@ mod tests {
         assert_eq!(join_url("https://x.to/", "https://cdn/z"), "https://cdn/z");
         assert_eq!(join_url("https://x.to/", "magnet:?xt=1"), "magnet:?xt=1");
     }
+
+    #[test]
+    fn url_joining_encodes_spaces_in_path_segments_and_query() {
+        assert_eq!(
+            join_url("https://x.to", "/sort-search/The Matrix 1999/time"),
+            "https://x.to/sort-search/The%20Matrix%201999/time"
+        );
+        assert_eq!(
+            join_url("https://x.to", "/search?q=The Matrix 1999"),
+            "https://x.to/search?q=The%20Matrix%201999"
+        );
+    }
+
+    #[test]
+    fn url_joining_leaves_existing_percent_escapes_and_structure_untouched() {
+        assert_eq!(
+            join_url("https://x.to", "/search?q=The%20Matrix"),
+            "https://x.to/search?q=The%20Matrix"
+        );
+        assert_eq!(
+            join_url("https://x.to", "/s?a=1&b=2#frag"),
+            "https://x.to/s?a=1&b=2#frag"
+        );
+        assert_eq!(join_url("https://x.to", "/p/100%25-off"), "https://x.to/p/100%25-off");
+    }
+
+    #[test]
+    fn url_joining_encodes_other_illegal_characters() {
+        assert_eq!(
+            join_url("https://x.to", "/q?a\"b<c>d`e{f}|g\\h^i"),
+            "https://x.to/q?a%22b%3Cc%3Ed%60e%7Bf%7D%7Cg%5Ch%5Ei"
+        );
+    }
+
 
     #[test]
     fn build_requests_get_movie_with_imdb_and_categories() {
@@ -136,7 +195,7 @@ search:
         };
         let reqs = build_requests(&def, &cfg, &q, &[2000]);
         assert_eq!(reqs.len(), 1);
-        assert_eq!(reqs[0].url, "https://site.to/search?q=The Matrix 1999");
+        assert_eq!(reqs[0].url, "https://site.to/search?q=The%20Matrix%201999");
         assert_eq!(reqs[0].method, "get");
         assert_eq!(reqs[0].response_kind, "html");
         // query_attributes rendered `.Query.IMDBID`; categories mapped to id 42.
@@ -178,4 +237,53 @@ search:
         assert_eq!(reqs[0].method, "post");
         assert_eq!(reqs[0].response_kind, "json");
     }
+
+    #[test]
+    fn build_requests_encodes_keywords_in_a_path_segment() {
+        let def = build_def(
+            r#"
+id: t
+name: T
+caps: {}
+search:
+  paths:
+    - path: "/sort-search/{{ .Keywords }}/time/desc/1/"
+  rows:
+    selector: "tr"
+"#,
+        );
+        let q = Query::Movie {
+            tmdb_id: None,
+            imdb_id: None,
+            title: "The Matrix".into(),
+            year: Some(1999),
+        };
+        let reqs = build_requests(&def, &cfg("https://1337x.to"), &q, &[]);
+        assert_eq!(reqs.len(), 1);
+        assert_eq!(reqs[0].url, "https://1337x.to/sort-search/The%20Matrix%201999/time/desc/1/");
+    }
+
+    #[test]
+    fn build_requests_post_inputs_keep_raw_values() {
+        let def = build_def(
+            r#"
+id: t
+name: T
+caps: {}
+search:
+  paths:
+    - path: /api
+      method: POST
+      inputs:
+        q: "{{ .Keywords }}"
+  rows:
+    selector: "$.rows"
+"#,
+        );
+        let q = Query::Text { query: "The Matrix".into() };
+        let reqs = build_requests(&def, &cfg("https://api.x/"), &q, &[]);
+        assert_eq!(reqs[0].url, "https://api.x/api");
+        assert!(reqs[0].inputs.contains(&("q".to_string(), "The Matrix".to_string())));
+    }
+
 }

--- a/modules/tv.kroma.indexer/server/src/engine/request.rs
+++ b/modules/tv.kroma.indexer/server/src/engine/request.rs
@@ -85,12 +85,16 @@ pub fn build_requests(
 /// while the structural characters a definition relies on (`? & = / : % # + ~
 /// . - _` and alphanumerics) pass through untouched. Existing `%20`-style
 /// escapes survive because `%` is preserved, so definitions that do their own
-/// escaping (e.g. `replace " " "+"`) are never double-encoded. Absolute and
-/// `magnet:` paths are returned verbatim by the early return above.
+/// escaping (e.g. `replace " " "+"`) are never double-encoded. Absolute URLs
+/// are sanitized too (a template can produce `q=toy story` in a query value);
+/// `magnet:` URIs are returned verbatim.
 pub fn join_url(base: &str, path: &str) -> String {
     let p = path.trim();
-    if p.starts_with("http://") || p.starts_with("https://") || p.starts_with("magnet:") {
+    if p.starts_with("magnet:") {
         return p.to_string();
+    }
+    if p.starts_with("http://") || p.starts_with("https://") {
+        return sanitize_url_path(p);
     }
     let base = base.trim_end_matches('/');
     let p = sanitize_url_path(p.trim_start_matches('/'));
@@ -138,6 +142,15 @@ mod tests {
         assert_eq!(
             join_url("https://x.to", "/search?q=The Matrix 1999"),
             "https://x.to/search?q=The%20Matrix%201999"
+        );
+    }
+
+    #[test]
+    fn url_joining_encodes_spaces_in_absolute_urls() {
+        // Pirate Bay: template produces `q.php?q=toy story 5&cat=200,201`
+        assert_eq!(
+            join_url("https://x.to", "https://api.example/q.php?q=toy story 5&cat=200,201"),
+            "https://api.example/q.php?q=toy%20story%205&cat=200,201"
         );
     }
 

--- a/modules/tv.kroma.indexer/server/src/engine/request.rs
+++ b/modules/tv.kroma.indexer/server/src/engine/request.rs
@@ -77,17 +77,11 @@ pub fn build_requests(
     requests
 }
 
-/// Join a base URL with a (possibly absolute) path.
-///
-/// The rendered path is sanitized for URL legality: characters a tracker
-/// template can legitimately produce but curl rejects (space, `"`, `<`, `>`,
-/// backtick, `{`, `}`, `|`, `\`, `^` and ASCII controls) are percent-encoded,
-/// while the structural characters a definition relies on (`? & = / : % # + ~
-/// . - _` and alphanumerics) pass through untouched. Existing `%20`-style
-/// escapes survive because `%` is preserved, so definitions that do their own
-/// escaping (e.g. `replace " " "+"`) are never double-encoded. Absolute URLs
-/// are sanitized too (a template can produce `q=toy story` in a query value);
-/// `magnet:` URIs are returned verbatim.
+/// Join a base URL with a rendered path, percent-encoding URL-illegal
+/// characters a definition template can emit (space, `"`, `<`, `>`, backtick,
+/// `{}`, `|`, `\`, `^`, controls) while leaving structural characters and
+/// existing `%`-escapes untouched, so self-escaping definitions are not
+/// double-encoded. Absolute URLs are sanitized too; `magnet:` URIs pass through.
 pub fn join_url(base: &str, path: &str) -> String {
     let p = path.trim();
     if p.starts_with("magnet:") {
@@ -149,7 +143,10 @@ mod tests {
     fn url_joining_encodes_spaces_in_absolute_urls() {
         // Pirate Bay: template produces `q.php?q=toy story 5&cat=200,201`
         assert_eq!(
-            join_url("https://x.to", "https://api.example/q.php?q=toy story 5&cat=200,201"),
+            join_url(
+                "https://x.to",
+                "https://api.example/q.php?q=toy story 5&cat=200,201"
+            ),
             "https://api.example/q.php?q=toy%20story%205&cat=200,201"
         );
     }
@@ -164,7 +161,10 @@ mod tests {
             join_url("https://x.to", "/s?a=1&b=2#frag"),
             "https://x.to/s?a=1&b=2#frag"
         );
-        assert_eq!(join_url("https://x.to", "/p/100%25-off"), "https://x.to/p/100%25-off");
+        assert_eq!(
+            join_url("https://x.to", "/p/100%25-off"),
+            "https://x.to/p/100%25-off"
+        );
     }
 
     #[test]
@@ -174,7 +174,6 @@ mod tests {
             "https://x.to/q?a%22b%3Cc%3Ed%60e%7Bf%7D%7Cg%5Ch%5Ei"
         );
     }
-
 
     #[test]
     fn build_requests_get_movie_with_imdb_and_categories() {
@@ -273,7 +272,10 @@ search:
         };
         let reqs = build_requests(&def, &cfg("https://1337x.to"), &q, &[]);
         assert_eq!(reqs.len(), 1);
-        assert_eq!(reqs[0].url, "https://1337x.to/sort-search/The%20Matrix%201999/time/desc/1/");
+        assert_eq!(
+            reqs[0].url,
+            "https://1337x.to/sort-search/The%20Matrix%201999/time/desc/1/"
+        );
     }
 
     #[test]
@@ -293,10 +295,13 @@ search:
     selector: "$.rows"
 "#,
         );
-        let q = Query::Text { query: "The Matrix".into() };
+        let q = Query::Text {
+            query: "The Matrix".into(),
+        };
         let reqs = build_requests(&def, &cfg("https://api.x/"), &q, &[]);
         assert_eq!(reqs[0].url, "https://api.x/api");
-        assert!(reqs[0].inputs.contains(&("q".to_string(), "The Matrix".to_string())));
+        assert!(reqs[0]
+            .inputs
+            .contains(&("q".to_string(), "The Matrix".to_string())));
     }
-
 }

--- a/modules/tv.kroma.indexer/server/tests/search_html.rs
+++ b/modules/tv.kroma.indexer/server/tests/search_html.rs
@@ -34,7 +34,7 @@ fn builds_search_request_from_query() {
     // Keywords templated in, sort from config, freeleech off -> no &fl=1.
     assert_eq!(
         r.url,
-        "https://tracker.example/browse.php?q=The Matrix 1999&sort=seeders"
+        "https://tracker.example/browse.php?q=The%20Matrix%201999&sort=seeders"
     );
     assert_eq!(r.method, "get");
     assert_eq!(r.response_kind, "html");

--- a/modules/tv.kroma.torrents/module.json
+++ b/modules/tv.kroma.torrents/module.json
@@ -3,13 +3,13 @@
   "schemaVersion": 2,
   "id": "tv.kroma.torrents",
   "name": "Torrent downloads",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "The embedded librqbit download engine + the downloads queue. Transmission and qBittorrent are their own engine sub-modules that plug into this one.",
   "engines": {
     "server": ">=0.1.39"
   },
   "dependencies": {
-    "tv.kroma.indexer": "^0.3.0"
+    "tv.kroma.indexer": "^0.4.0"
   },
   "optionalDependencies": {
     "tv.kroma.vpn": "^0.3.0"

--- a/modules/tv.kroma.torrents/ui/src/index.test.ts
+++ b/modules/tv.kroma.torrents/ui/src/index.test.ts
@@ -5,7 +5,7 @@ import { torrentsModule } from './index';
 describe('torrentsModule', () => {
   it('takes its identity and its dependencies from the shared manifest', () => {
     expect(torrentsModule.id).toBe('tv.kroma.torrents');
-    expect(torrentsModule.dependencies).toEqual({ 'tv.kroma.indexer': '^0.3.0' });
+    expect(torrentsModule.dependencies).toEqual({ 'tv.kroma.indexer': '^0.4.0' });
     expect(torrentsModule.optionalDependencies).toEqual({ 'tv.kroma.vpn': '^0.3.0' });
   });
 

--- a/modules/tv.kroma.torznab/module.json
+++ b/modules/tv.kroma.torznab/module.json
@@ -3,13 +3,13 @@
   "schemaVersion": 2,
   "id": "tv.kroma.torznab",
   "name": "Torznab indexers",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "External Torznab / Newznab indexers (Jackett, Prowlarr).",
   "engines": {
     "server": ">=0.1.39"
   },
   "dependencies": {
-    "tv.kroma.indexer": "^0.3.0"
+    "tv.kroma.indexer": "^0.4.0"
   },
   "contributes": [
     {


### PR DESCRIPTION
Rebased-and-verified version of #133 (original work by **@Dvorinka**), brought onto current `main` (post rustfmt-canonical) with our conventions applied. Opened from this repo because #133's fork branch could not be pushed to (rebasing pulled in #132's workflow file, which needs `workflow` token scope); their commit authorship is preserved here. **Supersedes #133.**

## What (4 fixes, all validated)

1. **Multi-word query escaping** — search terms are percent-encoded at URL assembly before curl. No double-encoding (`%` preserved); POST form values stay raw.
2. **`rows.attribute` JSON expansion** — trackers nesting results under `rows.attribute` are traversed (parent `..`/`..field`/row cases); the flat-`rows` path is unchanged; absolute result URLs are sanitized against the base; `magnet:` passes through.
3. **Magnet synthesis from infohash** — a valid `magnet:?xt=urn:btih:<hash>&dn=<title>` is synthesized only as a fallback (no magnet/link, `kind == public`, infohash present).
4. **qBittorrent 204 login + cookie-jar dir** — accepts HTTP 204 (qB ≥4.6 success) as well as 200; a real failed login (200 `Fails.`) still bails; the cookie-jar directory is created best-effort.

## Verdict

All four are legitimate and correct. Verified against the existing suites and the added `search_html.rs`.

## Checks

- [x] `cargo test`: indexer **253 passed**, qBittorrent **27 passed** (incl. the 204-login test); `search_html.rs` passes.
- [x] `cargo clippy` — 0 new warnings; `cargo fmt --check` clean (rustfmt-canonical).
- [x] `bun run sonar:precheck` / `sonar:lint` clean.
- [x] Conventions applied: narrating comments trimmed, private fn doc demoted, rustfmt.

## Risk

Low, per the original PR: each fix is defensive and leaves the working-tracker happy path untouched. One note: the infohash is inserted verbatim (no hex-40/base32 normalization), matching Jackett/Prowlarr pass-through behaviour.