### PR TITLE
chore(deps): migrate to Bun 1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ qBittorrent, no Gluetun. Just KROMA.
 [![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=maxscharwath_kroma&metric=ncloc)](https://sonarcloud.io/component_measures?id=maxscharwath_kroma&metric=ncloc)
 
 [![License: GPL-2.0](https://img.shields.io/badge/License-GPL--2.0-F4B642.svg?style=flat-square)](LICENSE)
-[![Bun ≥ 1.3](https://img.shields.io/badge/Bun-%E2%89%A5%201.3-0A0A0C.svg?style=flat-square&logo=bun&logoColor=F4B642)](https://bun.sh)
+[![Bun ≥ 1.4](https://img.shields.io/badge/Bun-%E2%89%A5%201.4-0A0A0C.svg?style=flat-square&logo=bun&logoColor=F4B642)](https://bun.sh)
 [![Rust ≥ 1.88](https://img.shields.io/badge/Rust-%E2%89%A5%201.88-0A0A0C.svg?style=flat-square&logo=rust&logoColor=F4B642)](https://www.rust-lang.org)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-0A0A0C.svg?style=flat-square&logo=typescript&logoColor=3178C6)](https://www.typescriptlang.org)
 [![Platforms](https://img.shields.io/badge/platforms-web%20%C2%B7%20TV%20%C2%B7%20mobile%20%C2%B7%20desktop%20%C2%B7%20NAS-0A0A0C.svg?style=flat-square)](#platforms)
@@ -282,7 +282,7 @@ each other, and both reach a library by its `@kroma/*` name.
 
 ## Prerequisites
 
-- **[Bun](https://bun.sh)** ≥ 1.3, the package manager and runner (the repo is a Bun workspace)
+- **[Bun](https://bun.sh)** ≥ 1.4, the package manager and runner (the repo is a Bun workspace)
 - **[Rust](https://www.rust-lang.org)** ≥ 1.88 + **ffmpeg/ffprobe** for the server's
   metadata and HLS path. `rust-toolchain.toml` pins the build to a concrete stable
   and rustup installs it for you.


### PR DESCRIPTION
## What

Finishes the Bun 1.3 → 1.4 migration. The bulk of the pins on `main` were **already on Bun 1.4.0** — `packageManager: "bun@1.4.0"`, `engines.bun: ">=1.4.0"`, `.bun-version` = `1.4.0` (now the single source of truth for every workflow via `bun-version-file: .bun-version`), `server/Dockerfile` (`npm install -g bun@1.4.0`), and every `bun-types` at `^1.4.0`. The only residual `1.3` references were two lines in `README.md` (the badge and the Prerequisites line), bumped here to `≥ 1.4` so the docs match `engines`.

Verified the whole workspace installs, typechecks, and tests cleanly on Bun **1.4.0** — see below.

## Closes

no issue — housekeeping to align docs with the already-migrated toolchain and to confirm the repo is green on 1.4.

## Checks

- [x] `bun run test` passes — **680 files, 7855 tests passed** on Bun 1.4.0
- [x] `bun run typecheck` — all workspaces `ok`
- [x] `bun run biome check` — clean (2723 files; one pre-existing schema-version *info*, unrelated to Bun)
- [x] `bun run sonar:precheck` / `bun run sonar:lint` — clean
- [x] `bun install` — no lockfile churn
- [x] One idea: docs alignment for the Bun 1.4 migration

## Risk

None meaningful — a two-line documentation edit. If the badge/prose were wrong a reviewer sees it in the rendered README. All build/test gates ran green on Bun 1.4.0.

---

### Verify output (Bun 1.4.0)

```
$ bun --version
1.4.0

$ bun install
1165 packages installed  (bun.lock unchanged)

$ bun run typecheck
ok   (all workspaces — @kroma/web, @kroma/tv, @kroma/mobile, @kroma/server-*, …)

$ bun run test
Test Files  680 passed (680)
     Tests  7855 passed (7855)
   Duration  687.00s
[exited with code 0]

$ bun run biome check
Checked 2723 files. No fixes applied. (1 info: biome schema 2.5.5 vs 2.5.8 — pre-existing, unrelated)

$ bun run sonar:lint
sonar-project.properties: every exclusion and suppression still matches something.
```

### Required follow-up (workflow scope)

**None.** The workflows on `main` already resolve their Bun version from `bun-version-file: .bun-version`, and `.bun-version` is `1.4.0`. No `.github/workflows/*` edits are needed for this migration — nothing was withheld from this push for scope reasons.
