### PR TITLE
chore(rust): bump toolchain to 1.98.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,7 +5,7 @@
 # needs edition2024 (>= 1.85), so a recent stable satisfies both. rustup
 # auto-installs this in the repo.
 [toolchain]
-channel = "1.96.1"
+channel = "1.98.0"
 # This file overrides any CI-installed toolchain (e.g. dtolnay/rust-toolchain@stable)
 # whenever cargo runs in the repo, so the components must be declared HERE or
 # `cargo clippy`/`cargo fmt` break on the pinned toolchain (which ships neither by


### PR DESCRIPTION
Bumps the pinned repo toolchain (`rust-toolchain.toml`) from **1.96.1** to the latest stable **1.98.0** (released 2026-08-18). Two minor versions; well above the `rust-version = "1.88"` MSRV floor.

## Verification (server workspace + module workspaces)
- **`cargo build`** — clean, no errors or new compiler warnings.
- **`cargo test --workspace`** — 973 passed. The only 3 failures are pre-existing `spawn ffmpeg: No such file or directory` environment tests (fingerprint + loudness); they fail **identically on 1.96.1**, so not a regression.
- **`cargo fmt --check`** — **zero reformatting** across `server`, `modules/lib`, `modules/tv.kroma.indexer`, `modules/tv.kroma.torrents`, and `clients/desktop/src-tauri`. The newer rustfmt does not touch the canonical formatting from #140 — no churn.
- **`cargo clippy --workspace --all-targets`** — the delta vs 1.96.1 is just two new hygiene lints firing: `clippy::chunks_exact_to_as_chunks` (3×) and `clippy::useless_borrows_in_formatting` (1×). Both are opt-out-of-nothing style nits and align with the 0-issues goal; note bare `--all-targets` clippy already emits pre-existing warnings on 1.96.1, so it is not part of the gate.

## Benefits (honest)
A minor bump; incremental hygiene rather than a headline win. Concrete: two additional clippy lints to tighten code, newer compiler diagnostics, and staying current with stable. No new stdlib API is required by the codebase.

## Risks / costs
Low. No fmt churn, no build breakage, no new gated warnings, MSRV unaffected. `.github/workflows/*` intentionally untouched.

Do not merge without review.
