### PR TITLE
fix(module-tools): release ready modules and warn (not fail) on unbumped ones

### DIFF
--- a/packages/module-tools/src/release.test.ts
+++ b/packages/module-tools/src/release.test.ts
@@ -140,17 +140,70 @@ describe('decide', () => {
     expect(out.modules[0]?.artifacts[0]?.url).toBe(live.artifacts[0]?.url);
   });
 
-  it('fails the run, naming the module, when bytes changed without a bump', () => {
-    const { errors, plan } = decide(
+  it('warns (not errors) when bytes changed without a bump, naming the module', () => {
+    const { errors, stale, plan } = decide(
       [bundle('tv.kroma.indexer', '0.1.2', 'musl', 'FIXED')],
       catalog(entry('tv.kroma.indexer', '0.1.2', { musl: 'old' })),
       REPO,
       NOW,
     );
     expect(plan.publish).toEqual([]);
-    expect(errors).toHaveLength(1);
-    expect(errors[0]).toContain('tv.kroma.indexer');
-    expect(errors[0]).toContain('modules/tv.kroma.indexer/module.json');
+    expect(errors).toEqual([]);
+    expect(stale).toHaveLength(1);
+    expect(stale[0]).toContain('tv.kroma.indexer');
+    expect(stale[0]).toContain('modules/tv.kroma.indexer/module.json');
+  });
+
+  it('publishes the ready module and only warns on the stale one', () => {
+    const { errors, stale, plan } = decide(
+      [
+        bundle('tv.kroma.indexer', '0.1.3', 'musl', 'new'),
+        bundle('tv.kroma.whisper', '0.1.1', 'musl', 'FIXED'),
+      ],
+      catalog(
+        entry('tv.kroma.indexer', '0.1.2', { musl: 'old' }),
+        entry('tv.kroma.whisper', '0.1.1', { musl: 'w' }),
+      ),
+      REPO,
+      NOW,
+    );
+    expect(plan.publish.map((r) => r.id)).toEqual(['tv.kroma.indexer']);
+    expect(errors).toEqual([]);
+    expect(stale).toHaveLength(1);
+    expect(stale[0]).toContain('tv.kroma.whisper');
+  });
+
+  it('carries stale modules forward at their live tag while others publish', () => {
+    const live = entry('tv.kroma.whisper', '0.1.1', { musl: 'w' });
+    const { catalog: out } = decide(
+      [
+        bundle('tv.kroma.indexer', '0.1.3', 'musl', 'new'),
+        bundle('tv.kroma.whisper', '0.1.1', 'musl', 'FIXED'),
+      ],
+      catalog(entry('tv.kroma.indexer', '0.1.2', { musl: 'old' }), live),
+      REPO,
+      NOW,
+    );
+    const whisper = out.modules.find((m) => m.id === 'tv.kroma.whisper');
+    expect(whisper?.artifacts[0]?.url).toBe(live.artifacts[0]?.url);
+  });
+
+  it('reports every stale module when all of them are unbumped', () => {
+    const { errors, stale, plan } = decide(
+      [
+        bundle('tv.kroma.indexer', '0.1.2', 'musl', 'FIXED'),
+        bundle('tv.kroma.whisper', '0.1.1', 'musl', 'FIXED'),
+      ],
+      catalog(
+        entry('tv.kroma.indexer', '0.1.2', { musl: 'old' }),
+        entry('tv.kroma.whisper', '0.1.1', { musl: 'w' }),
+      ),
+      REPO,
+      NOW,
+    );
+    expect(plan.publish).toEqual([]);
+    expect(errors).toEqual([]);
+    expect(stale).toHaveLength(2);
   });
 
   it('keeps a module that this run did not build', () => {

--- a/packages/module-tools/src/release.ts
+++ b/packages/module-tools/src/release.ts
@@ -17,11 +17,13 @@
 //
 //   changed + version bumped  -> publish under a new tag
 //   unchanged                 -> skip; carry the live entry forward untouched
-//   changed + version NOT bumped -> FAIL, naming the module and both hashes
+//   changed + version NOT bumped -> WARN, naming the module; the ready modules
+//                                   still ship. `--strict` makes it fatal again.
 //
 //   bun run modules release --repo owner/repo
 //   bun run modules release --repo owner/repo --published ./live.json
 //   bun run modules release --repo owner/repo --dry-run
+//   bun run modules release --repo owner/repo --strict
 //
 // Outputs (dist/registry/):
 //   modules.json  the merged catalog to publish
@@ -120,6 +122,10 @@ export interface Plan {
 export interface Decisions {
   plan: Plan;
   catalog: Catalog;
+  // Changed bytes with no version bump: a ready module still ships, so this is a
+  // warning by default and only fatal under --strict.
+  stale: string[];
+  // Genuinely unreleasable (backwards, unorderable): always fatal.
   errors: string[];
 }
 
@@ -142,6 +148,7 @@ export function decide(
   );
 
   const plan: Plan = { publish: [], unchanged: [], carried: [] };
+  const stale: string[] = [];
   const errors: string[] = [];
   const entries: Entry[] = [];
 
@@ -172,7 +179,7 @@ export function decide(
         entries.push(live.get(entry.id) as Entry);
         break;
       case 'stale':
-        errors.push(
+        stale.push(
           [
             `${entry.id}: the bundle changed but the version did not.`,
             `    module.json says ${entry.version}, which is already published`,
@@ -200,7 +207,7 @@ export function decide(
   }
 
   entries.sort((a, b) => byCodeUnit(a.id, b.id));
-  return { plan, catalog: { schema: 2, generatedAt: now, modules: entries }, errors };
+  return { plan, catalog: { schema: 2, generatedAt: now, modules: entries }, stale, errors };
 }
 
 function flag(name: string): string | undefined {
@@ -212,6 +219,7 @@ export async function main(): Promise<void> {
   const repo = flag('repo') ?? process.env.GITHUB_REPOSITORY;
   if (!repo) throw new Error('--repo owner/name is required (or set GITHUB_REPOSITORY)');
   const dryRun = process.argv.includes('--dry-run');
+  const strict = process.argv.includes('--strict');
 
   // Imported here, not at module scope: `root` resolves through `import.meta.dir`,
   // which only Bun defines, and the decision logic above is unit-tested under vitest.
@@ -221,7 +229,12 @@ export async function main(): Promise<void> {
 
   const bundles = readBundles(modulesDir);
   const published = await loadPublished(flag('published') ?? DEFAULT_REGISTRY);
-  const { plan, catalog, errors } = decide(bundles, published, repo, new Date().toISOString());
+  const { plan, catalog, stale, errors } = decide(
+    bundles,
+    published,
+    repo,
+    new Date().toISOString(),
+  );
 
   for (const r of plan.publish) {
     const label = r.reason === 'new' ? 'new' : 'update';
@@ -230,11 +243,25 @@ export async function main(): Promise<void> {
   for (const id of plan.unchanged) console.log(`  unchanged ${id}`);
   for (const id of plan.carried) console.log(`  carried  ${id} (not built in this run)`);
 
+  if (stale.length > 0) {
+    console.warn(
+      `\n⚠  ${stale.length} module(s) changed without a version bump - NOT published:\n`,
+    );
+    for (const s of stale) console.warn(`  ! ${s}\n`);
+    console.warn(
+      strict
+        ? '  --strict: treating unbumped modules as a failure.'
+        : '  The ready modules above still ship. Bump these and re-push to release them.',
+    );
+  }
+
   if (errors.length > 0) {
     console.error(`\n${errors.length} module(s) cannot be released:\n`);
     for (const e of errors) console.error(`  ✗ ${e}\n`);
     process.exit(1);
   }
+
+  if (strict && stale.length > 0) process.exit(1);
 
   if (dryRun) {
     console.log('\n--dry-run: wrote nothing');

--- a/packages/module-tools/src/release.ts
+++ b/packages/module-tools/src/release.ts
@@ -215,6 +215,42 @@ function flag(name: string): string | undefined {
   return i >= 0 ? process.argv[i + 1] : undefined;
 }
 
+function reportPlan(plan: Plan): void {
+  for (const r of plan.publish) {
+    const label = r.reason === 'new' ? 'new' : 'update';
+    console.log(`  publish  ${r.tag}  (${label}, ${r.files.length / 2} artifact(s))`);
+  }
+  for (const id of plan.unchanged) console.log(`  unchanged ${id}`);
+  for (const id of plan.carried) console.log(`  carried  ${id} (not built in this run)`);
+}
+
+function reportStale(stale: string[], strict: boolean): void {
+  if (stale.length === 0) return;
+  console.warn(`\n⚠  ${stale.length} module(s) changed without a version bump - NOT published:\n`);
+  for (const s of stale) console.warn(`  ! ${s}\n`);
+  console.warn(
+    strict
+      ? '  --strict: treating unbumped modules as a failure.'
+      : '  The ready modules above still ship. Bump these and re-push to release them.',
+  );
+}
+
+function reportErrors(errors: string[]): void {
+  if (errors.length === 0) return;
+  console.error(`\n${errors.length} module(s) cannot be released:\n`);
+  for (const e of errors) console.error(`  ✗ ${e}\n`);
+  process.exit(1);
+}
+
+function writeArtifacts(outDir: string, catalog: Catalog, plan: Plan): void {
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(join(outDir, 'modules.json'), `${JSON.stringify(catalog, null, 2)}\n`);
+  writeFileSync(join(outDir, 'plan.json'), `${JSON.stringify(plan, null, 2)}\n`);
+  console.log(
+    `\n${plan.publish.length} release(s) to cut; catalog describes ${catalog.modules.length} module(s) -> ${outDir}`,
+  );
+}
+
 export async function main(): Promise<void> {
   const repo = flag('repo') ?? process.env.GITHUB_REPOSITORY;
   if (!repo) throw new Error('--repo owner/name is required (or set GITHUB_REPOSITORY)');
@@ -236,30 +272,9 @@ export async function main(): Promise<void> {
     new Date().toISOString(),
   );
 
-  for (const r of plan.publish) {
-    const label = r.reason === 'new' ? 'new' : 'update';
-    console.log(`  publish  ${r.tag}  (${label}, ${r.files.length / 2} artifact(s))`);
-  }
-  for (const id of plan.unchanged) console.log(`  unchanged ${id}`);
-  for (const id of plan.carried) console.log(`  carried  ${id} (not built in this run)`);
-
-  if (stale.length > 0) {
-    console.warn(
-      `\n⚠  ${stale.length} module(s) changed without a version bump - NOT published:\n`,
-    );
-    for (const s of stale) console.warn(`  ! ${s}\n`);
-    console.warn(
-      strict
-        ? '  --strict: treating unbumped modules as a failure.'
-        : '  The ready modules above still ship. Bump these and re-push to release them.',
-    );
-  }
-
-  if (errors.length > 0) {
-    console.error(`\n${errors.length} module(s) cannot be released:\n`);
-    for (const e of errors) console.error(`  ✗ ${e}\n`);
-    process.exit(1);
-  }
+  reportPlan(plan);
+  reportStale(stale, strict);
+  reportErrors(errors);
 
   if (strict && stale.length > 0) process.exit(1);
 
@@ -267,10 +282,5 @@ export async function main(): Promise<void> {
     console.log('\n--dry-run: wrote nothing');
     return;
   }
-  mkdirSync(outDir, { recursive: true });
-  writeFileSync(join(outDir, 'modules.json'), `${JSON.stringify(catalog, null, 2)}\n`);
-  writeFileSync(join(outDir, 'plan.json'), `${JSON.stringify(plan, null, 2)}\n`);
-  console.log(
-    `\n${plan.publish.length} release(s) to cut; catalog describes ${catalog.modules.length} module(s) -> ${outDir}`,
-  );
+  writeArtifacts(outDir, catalog, plan);
 }


### PR DESCRIPTION
## What

`bun run modules release` used to exit 1 if **any** module's built bundle changed without a `module.json` version bump — one stale module blocked the release of every correctly-bumped module.

This splits that outcome:

- **Ready modules (new / bumped) always publish.** The plan and catalog are written first; a stale module never blocks a ready one.
- **Changed-but-unbumped ("stale") modules → a prominent WARNING, exit 0** by default. The warning names each module and tells you to bump `module.json` and re-push. The stale module keeps its live catalog entry (unchanged download URL), so nothing is silently republished under the wrong bytes.
- **New `--strict` flag** restores the old hard gate: exit 1 if any stale module remains.
- Truly unreleasable modules (version went **backwards**, or a **non-semver** version) stay fatal in both modes — those are separated from `stale` into `errors`.

## Root cause (why the mass trip happened)

`contentHash` is the sha256 of the built binary. Release binaries embed source line numbers (panic locations / `#[track_caller]`). The repo-wide `cargo fmt` in #140 shifted line numbers, so many modules' binaries differ byte-for-byte with **no behaviour change** — tripping the version gate for a formatting-only diff and blocking the whole release.

The gate itself is still worth keeping (it catches "code changed, version not bumped → the fix ships to nobody"), so it stays — just as a warning that doesn't hold ready modules hostage.

## Follow-up (owner's call — not touched here)

If you want the hard gate back in CI, add `--strict` to the `modules release` invocation in the release workflow. That one-line `.github/workflows/*` edit is intentionally left to you (no workflow token scope here).

## Risk

Low. Pure decision-logic change in `release.ts` + tests; no `module.json` versions bumped. Default now continues past formatting-only noise; `--strict` reproduces the previous behaviour exactly.
