### PR TITLE
fix(server): a title asked for in one language stops arriving in another

### DIFF
--- a/server/crates/kroma-db/src/localize.rs
+++ b/server/crates/kroma-db/src/localize.rs
@@ -44,6 +44,17 @@ fn overlay_season_cast(
     Ok(())
 }
 
+// The title in the requested locale, or `None` to keep whatever the caller has.
+//
+// Its own function because the entity's OWN `title` is what every list, card and
+// hero renders; `metadata.title` is the enriched blob's copy, and a client that
+// happens to read the first while the overlay only wrote the second shows the
+// household language to a reader who asked for another. `splash_entries` has
+// always overwritten the entity's title, and these overlays now agree with it.
+fn localized_title(tr: &TransData) -> Option<String> {
+    tr.title.clone().filter(|t| !t.trim().is_empty())
+}
+
 // Overlay the localized text fields onto an item's metadata (no-op when the item
 // has no blob metadata yet, i.e. not enriched).
 fn apply(meta: Option<&mut Metadata>, tr: &TransData) {
@@ -64,7 +75,17 @@ fn apply(meta: Option<&mut Metadata>, tr: &TransData) {
 }
 
 // A show's metadata overlay (same fields; shows carry no per-title cast here).
+fn apply_item(item: &mut kroma_domain::MediaItem, tr: &TransData) {
+    if let Some(title) = localized_title(tr) {
+        item.title = title;
+    }
+    apply(item.metadata.as_mut(), tr);
+}
+
 fn apply_show(show: &mut Show, tr: &TransData) {
+    if let Some(title) = localized_title(tr) {
+        show.title = title;
+    }
     apply(show.metadata.as_mut(), tr);
 }
 

--- a/server/crates/kroma-db/src/localize/items.rs
+++ b/server/crates/kroma-db/src/localize/items.rs
@@ -1,6 +1,6 @@
 //! Overlaying a locale onto items and home-section rows.
 
-use super::{apply, apply_show};
+use super::{apply_item, apply_show};
 use crate::{metadata_core, translations, Pool};
 use anyhow::Result;
 
@@ -32,7 +32,7 @@ pub fn overlay_items(pool: &Pool, items: &mut [MediaItem], locale: &str) -> Resu
             &movie_tr
         };
         if let Some(tr) = table.get(&item.id) {
-            apply(item.metadata.as_mut(), tr);
+            apply_item(item, tr);
         }
     }
     Ok(())
@@ -64,7 +64,7 @@ pub fn overlay_section_items(pool: &Pool, items: &mut [SectionItem], locale: &st
         match it {
             SectionItem::Movie { item } => {
                 if let Some(t) = m_tr.get(&item.id) {
-                    apply(item.metadata.as_mut(), t);
+                    apply_item(item, t);
                 }
             }
             SectionItem::Show { show } => {
@@ -82,6 +82,79 @@ mod tests {
     use super::*;
     use crate::localize::test_support::*;
     use crate::translations::TransData;
+
+    #[test]
+    fn the_entity_title_is_localized_and_not_only_the_blobs_copy() {
+        // The bug this pins: every card, rail and hero renders the item's own
+        // `title`, and the overlay used to write only `metadata.title`, so a
+        // reader asking for English saw the household language in the one place
+        // the eye lands first.
+        let p = pool();
+        translations::put(
+            &p,
+            metadata_core::ITEM,
+            "m1",
+            "en",
+            translations::TMDB,
+            &td("Arrival", vec![]),
+        )
+        .unwrap();
+
+        let mut items = vec![item("m1", Kind::Movie)];
+        overlay_items(&p, &mut items, "en").unwrap();
+
+        assert_eq!(items[0].title, "Arrival");
+        assert_eq!(
+            items[0].metadata.as_ref().unwrap().title.as_deref(),
+            Some("Arrival")
+        );
+    }
+
+    #[test]
+    fn an_item_the_locale_has_no_title_for_keeps_the_one_it_had() {
+        let p = pool();
+        translations::put(
+            &p,
+            metadata_core::ITEM,
+            "m1",
+            "en",
+            translations::TMDB,
+            &TransData {
+                overview: Some("only an overview".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let before = item("m1", Kind::Movie).title;
+
+        let mut items = vec![item("m1", Kind::Movie)];
+        overlay_items(&p, &mut items, "en").unwrap();
+
+        assert_eq!(items[0].title, before);
+    }
+
+    #[test]
+    fn a_blank_translated_title_is_not_a_title() {
+        let p = pool();
+        translations::put(
+            &p,
+            metadata_core::ITEM,
+            "m1",
+            "en",
+            translations::TMDB,
+            &TransData {
+                title: Some("   ".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let before = item("m1", Kind::Movie).title;
+
+        let mut items = vec![item("m1", Kind::Movie)];
+        overlay_items(&p, &mut items, "en").unwrap();
+
+        assert_eq!(items[0].title, before);
+    }
 
     #[test]
     fn overlay_items_applies_title_and_characters() {

--- a/server/crates/kroma-db/src/localize/shows.rs
+++ b/server/crates/kroma-db/src/localize/shows.rs
@@ -1,6 +1,6 @@
 //! Overlaying a locale onto a show, its seasons and its episodes.
 
-use super::{apply, apply_show, overlay_season_cast};
+use super::{apply_item, apply_show, overlay_season_cast};
 use crate::{metadata_core, translations, Pool};
 use anyhow::Result;
 
@@ -48,7 +48,7 @@ pub fn overlay_show_detail(pool: &Pool, detail: &mut ShowDetail, locale: &str) -
     for season in &mut detail.seasons {
         for ep in &mut season.episodes {
             if let Some(t) = ep_tr.get(&ep.id) {
-                apply(ep.metadata.as_mut(), t);
+                apply_item(ep, t);
             }
         }
         overlay_season_cast(&conn, &detail.show.id, season, locale)?;


### PR DESCRIPTION
## What

The featured hero showed **"Premier Contact" over an English synopsis**: the
title in the household language, the overview in the reader's.

Both come from the same overlay, and it was resolving the requested locale
correctly. It wrote the translated text onto `metadata.title` and stopped there.
Every card, rail and hero renders the entity's *own* `title`, which is whatever
the scan and the enrichment left on it, so the one field the eye lands on first
was the one field the overlay never touched.

About twenty-five render sites across web and TV read that field. Exactly two in
the whole codebase had learned to write `metadata?.title ?? title` — which is
what a bug looks like when it is being worked around one call site at a time.

So this is fixed where it is wrong rather than at each reader. `splash_entries`
has always overwritten the entity's title from the translation, so the item and
show overlays were simply inconsistent with the one read that got it right. Now
items, section rows, episodes and shows all set their own title when the
resolved translation carries one, keep the title they had when it does not, and
treat a blank translated title as no title.

Confirmed against a copy of a real library: the row for that film stores an `en`
translation whose title is `"Arrival"` and whose overview is the exact English
text that was already on screen. The data was right; only the field being read
was wrong.

## Closes

No issue. Reported from a screenshot mid-session and small enough to fix
directly; the tests below are the record.

## Checks

- [x] `cargo clippy` and `cargo test` pass (44 test binaries, no new warnings)
- [x] Follows `CODE_STYLE.md` — no comments narrating the work, exported API only
- [x] One idea. It is deliberately not part of #153, which is a different feature.

Three new tests: the entity title is localized and not only the blob's copy; an
item the locale has no title for keeps the one it had; a blank translated title
is not a title.

## Risk

Low, and the blast radius is worth naming: `MediaItem.title` and `Show.title`
now carry the request locale on every read that overlays, which is every
catalogue read. Anything that expected the scanned or enriched name to survive
serialization would see the translated one instead. I looked for such a caller
and did not find one: search and sort happen in SQL before the overlay, backup
and restore go through the database rather than the DTO, and the remaining
readers are all rendering a name to a person, which is the thing that was broken.

A title with no stored translation for the requested locale is untouched, so a
library that was never enriched behaves exactly as it did.
