### PR TITLE
chore(rust): dev builds keep backtraces and drop full DWARF

### DIFF
--- a/clients/desktop/src-tauri/Cargo.toml
+++ b/clients/desktop/src-tauri/Cargo.toml
@@ -76,3 +76,7 @@ raw-window-handle = "0.6"
 # Process-group kill of the mpv sidecar tree (the AppImage runtime execs the real
 # mpv as a grandchild, so Child::kill alone orphans the player).
 libc = "0.2"
+
+[profile.dev]
+# Keep backtraces, drop full DWARF. debug/deps was 81 GB with the default.
+debug = "line-tables-only"

--- a/modules/lib/Cargo.toml
+++ b/modules/lib/Cargo.toml
@@ -24,3 +24,7 @@ license = "MIT"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 anyhow = "1"
+
+[profile.dev]
+# Keep backtraces, drop full DWARF. debug/deps was 81 GB with the default.
+debug = "line-tables-only"

--- a/modules/tv.kroma.acquisition/server/Cargo.toml
+++ b/modules/tv.kroma.acquisition/server/Cargo.toml
@@ -78,3 +78,7 @@ strip = true
 [profile.release-kmod]
 inherits = "release"
 panic = "abort"
+
+[profile.dev]
+# Keep backtraces, drop full DWARF. debug/deps was 81 GB with the default.
+debug = "line-tables-only"

--- a/modules/tv.kroma.engine.qbittorrent/server/Cargo.toml
+++ b/modules/tv.kroma.engine.qbittorrent/server/Cargo.toml
@@ -56,3 +56,7 @@ strip = true
 [profile.release-kmod]
 inherits = "release"
 panic = "abort"
+
+[profile.dev]
+# Keep backtraces, drop full DWARF. debug/deps was 81 GB with the default.
+debug = "line-tables-only"

--- a/modules/tv.kroma.engine.transmission/server/Cargo.toml
+++ b/modules/tv.kroma.engine.transmission/server/Cargo.toml
@@ -54,3 +54,7 @@ strip = true
 [profile.release-kmod]
 inherits = "release"
 panic = "abort"
+
+[profile.dev]
+# Keep backtraces, drop full DWARF. debug/deps was 81 GB with the default.
+debug = "line-tables-only"

--- a/modules/tv.kroma.indexer/server/Cargo.toml
+++ b/modules/tv.kroma.indexer/server/Cargo.toml
@@ -79,3 +79,7 @@ strip = true
 [profile.release-kmod]
 inherits = "release"
 panic = "abort"
+
+[profile.dev]
+# Keep backtraces, drop full DWARF. debug/deps was 81 GB with the default.
+debug = "line-tables-only"

--- a/modules/tv.kroma.mdns/server/Cargo.toml
+++ b/modules/tv.kroma.mdns/server/Cargo.toml
@@ -51,3 +51,7 @@ strip = true
 [profile.release-kmod]
 inherits = "release"
 panic = "abort"
+
+[profile.dev]
+# Keep backtraces, drop full DWARF. debug/deps was 81 GB with the default.
+debug = "line-tables-only"

--- a/modules/tv.kroma.remote/server/Cargo.toml
+++ b/modules/tv.kroma.remote/server/Cargo.toml
@@ -48,3 +48,7 @@ strip = true
 [profile.release-kmod]
 inherits = "release"
 panic = "abort"
+
+[profile.dev]
+# Keep backtraces, drop full DWARF. debug/deps was 81 GB with the default.
+debug = "line-tables-only"

--- a/modules/tv.kroma.scene/server/Cargo.toml
+++ b/modules/tv.kroma.scene/server/Cargo.toml
@@ -39,3 +39,7 @@ strip = true
 [profile.release-kmod]
 inherits = "release"
 panic = "abort"
+
+[profile.dev]
+# Keep backtraces, drop full DWARF. debug/deps was 81 GB with the default.
+debug = "line-tables-only"

--- a/modules/tv.kroma.torznab/server/Cargo.toml
+++ b/modules/tv.kroma.torznab/server/Cargo.toml
@@ -49,3 +49,7 @@ strip = true
 [profile.release-kmod]
 inherits = "release"
 panic = "abort"
+
+[profile.dev]
+# Keep backtraces, drop full DWARF. debug/deps was 81 GB with the default.
+debug = "line-tables-only"

--- a/modules/tv.kroma.vector/server/Cargo.toml
+++ b/modules/tv.kroma.vector/server/Cargo.toml
@@ -69,3 +69,7 @@ strip = true
 [profile.release-kmod]
 inherits = "release"
 panic = "abort"
+
+[profile.dev]
+# Keep backtraces, drop full DWARF. debug/deps was 81 GB with the default.
+debug = "line-tables-only"

--- a/modules/tv.kroma.vpn/server/Cargo.toml
+++ b/modules/tv.kroma.vpn/server/Cargo.toml
@@ -53,3 +53,7 @@ strip = true
 [profile.release-kmod]
 inherits = "release"
 panic = "abort"
+
+[profile.dev]
+# Keep backtraces, drop full DWARF. debug/deps was 81 GB with the default.
+debug = "line-tables-only"

--- a/modules/tv.kroma.whisper/server/Cargo.toml
+++ b/modules/tv.kroma.whisper/server/Cargo.toml
@@ -85,3 +85,7 @@ strip = true
 [profile.release-kmod]
 inherits = "release"
 panic = "abort"
+
+[profile.dev]
+# Keep backtraces, drop full DWARF. debug/deps was 81 GB with the default.
+debug = "line-tables-only"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -281,3 +281,7 @@ opt-level = 3
 lto = true
 codegen-units = 1
 strip = true
+
+[profile.dev]
+# Keep backtraces, drop full DWARF. debug/deps was 81 GB with the default.
+debug = "line-tables-only"


### PR DESCRIPTION
## What

Adds `[profile.dev] debug = "line-tables-only"` to the 14 cargo workspace roots: `server/`, `modules/lib/`, `clients/desktop/src-tauri/` and every `modules/*/server/` except `tv.kroma.torrents` (which carries the same stanza in its own layer, alongside a dependency change).

The default dev profile wrote 81 GB into `debug/deps` across the server workspace and every module workspace. `line-tables-only` keeps a readable backtrace — file and line for every frame — and drops the DWARF that only a stepping debugger uses.

Not `debug = false`, because a panic backtrace without line numbers is the thing you actually want in a dev build.

## Closes

No issue — it is a local build-time cost, noticed while building the stack this PR sits under.

## Checks

- [ ] n/a — no TypeScript change
- [x] `cargo metadata --no-deps` parses in all 14 edited manifests, with no "profiles for the non root package will be ignored" warning
- [x] Follows `CODE_STYLE.md`
- [x] One idea.

## Risk

Low, and dev-only. `[profile.dev]` does not touch `release` or the `release-kmod` profile a shipped `.kmod` binary is built with, so no artifact changes and no module needs a version bump. All 14 files are genuine workspace roots, so the key is legal where it sits — a `[profile.*]` section in a non-root member manifest is silently ignored, and none was touched.

A reviewer would notice a mistake as a lost backtrace: panic in a dev build and check you still get `file.rs:line` per frame.
