### PR TITLE
fix(ui): the kit's controls keep their shape under pressure

### DIFF
--- a/packages/ui/src/components/atoms/badge/badge.tsx
+++ b/packages/ui/src/components/atoms/badge/badge.tsx
@@ -56,7 +56,9 @@ function Badge({ tone = '4K', size = 'sm', children }: Readonly<BadgeProps>) {
   const s = badgeVariants({ tone: known, size });
   return (
     <Box style={s.root}>
-      <Text style={s.label}>{children ?? tone}</Text>
+      <Text lines={1} style={s.label}>
+        {children ?? tone}
+      </Text>
     </Box>
   );
 }

--- a/packages/ui/src/components/atoms/button/button.tsx
+++ b/packages/ui/src/components/atoms/button/button.tsx
@@ -12,6 +12,7 @@ import { useFrostCoat } from '#ui/components/atoms/frost';
 import { Icon, type IconName, type IconProps } from '#ui/components/atoms/icon';
 import { Spinner } from '#ui/components/atoms/spinner';
 import { Text } from '#ui/components/atoms/text';
+import { entryDefaultSize } from '#ui/lib/field-shell';
 import { useGroupMember } from '#ui/lib/group-shape';
 import {
   type ButtonSize,
@@ -70,7 +71,7 @@ function Button({
   ...focusProps
 }: Readonly<ButtonProps>) {
   const group = useGroupMember(onFocus, onBlur);
-  const shell = size ?? group.size ?? 'md';
+  const shell = size ?? group.size ?? entryDefaultSize();
   const s = buttonVariants({ variant, size: shell, block, active }, { disabled });
   const frost = useFrostCoat([s.root, style], {
     on: FROSTED.has(variant) || (disabled && !UNFILLED.has(variant)),

--- a/packages/ui/src/components/atoms/chip/chip.tsx
+++ b/packages/ui/src/components/atoms/chip/chip.tsx
@@ -25,7 +25,16 @@ const chipVariants = svFor<{
   icon: Pick<IconProps, 'color' | 'size'>;
 }>()({
   slots: {
-    root: { row: true, align: 'center', gap: 8, py: 6, px: 14, radius: 'pill', border: 'border' },
+    root: {
+      row: true,
+      align: 'center',
+      gap: 8,
+      py: 6,
+      px: 14,
+      radius: 'pill',
+      border: 'border',
+      shrink: 0,
+    },
     label: { font: 'ui', fontWeight: '600' },
     dot: { w: 7, h: 7, radius: 'circle', shrink: 0 },
     count: { font: 'ui', fontWeight: '600', opacity: 0.6 },
@@ -124,7 +133,11 @@ function Chip({
         <>
           {icon ? <Icon name={icon} thickness={2} {...state.slots.icon} /> : null}
           {dot ? <Box bg={active ? undefined : dot} style={state.slots.dot} /> : null}
-          {label === undefined ? null : <Text style={state.slots.label}>{label}</Text>}
+          {label === undefined ? null : (
+            <Text lines={1} style={state.slots.label}>
+              {label}
+            </Text>
+          )}
           {count === undefined ? null : (
             <Text style={state.slots.count}>{count.toLocaleString(locale)}</Text>
           )}

--- a/packages/ui/src/components/molecules/field/field.test.tsx
+++ b/packages/ui/src/components/molecules/field/field.test.tsx
@@ -3,6 +3,8 @@
 import { cleanup, fireEvent, render as renderRaw, screen } from '@testing-library/react';
 import type { ReactElement } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Button } from '#ui/components/atoms/button';
+import { ButtonGroup } from '#ui/components/molecules/button-group';
 import { Select } from '#ui/components/molecules/select';
 import { setEntryDefaults } from '#ui/lib/field-shell';
 import { onScreen } from '#ui/testing';
@@ -164,5 +166,42 @@ describe('a part outside its Root', () => {
       '<Field.Hint> must be used inside <Field.Root>',
     );
     quiet.mockRestore();
+  });
+});
+
+describe('a field welded into a <ButtonGroup>', () => {
+  const grouped = () =>
+    render(
+      <ButtonGroup.Root label="Rate">
+        <Field.Root label="Amount" hideLabel>
+          <Field.Input />
+        </Field.Root>
+        <Button label="Unlimited" />
+      </ButtonGroup.Root>,
+    );
+
+  const raisedAncestor = (entry: HTMLElement) => {
+    let at: HTMLElement | null = entry;
+    while (at && !at.className.includes('r-zIndex')) at = at.parentElement;
+    return at;
+  };
+
+  it('rises above the member beside it while its entry has focus', () => {
+    grouped();
+    const entry = screen.getByLabelText('Amount');
+
+    fireEvent.focus(entry);
+
+    expect(raisedAncestor(entry)).not.toBeNull();
+  });
+
+  it('sits back down when focus leaves', () => {
+    grouped();
+    const entry = screen.getByLabelText('Amount');
+
+    fireEvent.focus(entry);
+    fireEvent.blur(entry);
+
+    expect(raisedAncestor(entry)).toBeNull();
   });
 });

--- a/packages/ui/src/components/molecules/field/field.tsx
+++ b/packages/ui/src/components/molecules/field/field.tsx
@@ -6,12 +6,13 @@
 // context. `Field.Input` and `Field.Textarea` are the doors to <TextField> and
 // <TextArea>, which is why neither atom is exported.
 
-import { Children, isValidElement, type ReactNode, useMemo } from 'react';
+import { Children, isValidElement, type ReactNode, useCallback, useMemo, useState } from 'react';
 import { Box, type BoxProps } from '#ui/components/atoms/box';
 import { Text } from '#ui/components/atoms/text';
 import { TextArea, type TextAreaProps } from '#ui/components/atoms/text-area';
 import { TextField, type TextFieldProps } from '#ui/components/atoms/text-field';
 import type { ControlSize } from '#ui/lib/field-shell';
+import { useGroupShape } from '#ui/lib/group-shape';
 import { partContext } from '#ui/lib/part-context';
 import { useControllable } from '#ui/lib/use-controllable';
 
@@ -22,6 +23,7 @@ interface FieldContext {
   size: ControlSize | undefined;
   value: string;
   setValue: (next: string) => void;
+  setFocused: (focused: boolean) => void;
 }
 
 const [Context, useField] = partContext<FieldContext>('Field.Root');
@@ -61,15 +63,17 @@ function Root({
   ...box
 }: Readonly<FieldRootProps>) {
   const [value, setValue] = useControllable(valueProp, defaultValue, onValueChange);
+  const [focused, setFocused] = useState(false);
   const message = error || undefined;
   const field = useMemo<FieldContext>(
-    () => ({ label, invalid, error: message, size, value, setValue }),
+    () => ({ label, invalid, error: message, size, value, setValue, setFocused }),
     [label, invalid, message, size, value, setValue],
   );
   const at = useMemo(() => sort(children), [children]);
+  const group = useGroupShape(focused);
   return (
     <Context.Provider value={field}>
-      <Box gap={8} {...box}>
+      <Box gap={8} {...box} style={[group, box.style]}>
         {hideLabel ? null : (
           <Text variant="meta" color="textMuted">
             {label}
@@ -91,6 +95,11 @@ function sort(children: ReactNode): { control: ReactNode[]; note: ReactNode[] } 
   return at;
 }
 
+interface FocusHandlers {
+  onFocus?: () => void;
+  onBlur?: () => void;
+}
+
 interface EntryValue {
   /** Held by the entry itself. Given none of the three, it binds to the Root's. */
   value?: string;
@@ -98,14 +107,25 @@ interface EntryValue {
   onValueChange?: (next: string) => void;
 }
 
-function useEntry(part: string, own: Readonly<EntryValue>) {
+function useEntry(part: string, own: Readonly<EntryValue>, focus?: FocusHandlers) {
   const field = useField(part);
+  const { setFocused } = field;
+  const onFocus = useCallback(() => {
+    setFocused(true);
+    focus?.onFocus?.();
+  }, [setFocused, focus?.onFocus]);
+  const onBlur = useCallback(() => {
+    setFocused(false);
+    focus?.onBlur?.();
+  }, [setFocused, focus?.onBlur]);
   const owned =
     own.value !== undefined || own.defaultValue !== undefined || own.onValueChange !== undefined;
   return {
     label: field.label,
     invalid: field.invalid,
     size: field.size,
+    onFocus,
+    onBlur,
     ...(owned
       ? { value: own.value, defaultValue: own.defaultValue, onValueChange: own.onValueChange }
       : { value: field.value, onValueChange: field.setValue }),
@@ -119,7 +139,11 @@ interface FieldInputProps
 /** The single-line entry. `type` wires the keyboard, the autofill and the
  *  masking; the label, the invalid tint and the shell size come from the Root. */
 function Input({ value, defaultValue, onValueChange, ...props }: Readonly<FieldInputProps>) {
-  const entry = useEntry('Input', { value, defaultValue, onValueChange });
+  const entry = useEntry(
+    'Input',
+    { value, defaultValue, onValueChange },
+    { onFocus: props.onFocus, onBlur: props.onBlur },
+  );
   return <TextField {...props} {...entry} />;
 }
 
@@ -130,7 +154,11 @@ interface FieldTextareaProps
 /** The multi-line entry: it opens `rows` tall and grows to `maxRows`. One of its
  *  lines is one line of a <Field.Input>, so the two align in a form. */
 function Textarea({ value, defaultValue, onValueChange, ...props }: Readonly<FieldTextareaProps>) {
-  const entry = useEntry('Textarea', { value, defaultValue, onValueChange });
+  const entry = useEntry(
+    'Textarea',
+    { value, defaultValue, onValueChange },
+    { onFocus: props.onFocus, onBlur: props.onBlur },
+  );
   return <TextArea {...props} {...entry} />;
 }
 

--- a/packages/ui/src/components/molecules/list/list.tsx
+++ b/packages/ui/src/components/molecules/list/list.tsx
@@ -44,9 +44,7 @@ function Root({ ordered = false, label, children }: Readonly<ListRootProps>) {
   return (
     <Box role="list" aria-label={label} style={s.list}>
       {items.map((child, at) => (
-        // The document order is fixed: the position IS the identity.
-        // biome-ignore lint/suspicious/noArrayIndexKey: the position IS what the provider carries
-        <ListContext.Provider key={at} value={places[at] as Context}>
+        <ListContext.Provider key={child.key ?? at} value={places[at] as Context}>
           {child}
         </ListContext.Provider>
       ))}

--- a/packages/ui/src/components/molecules/timeline/timeline.tsx
+++ b/packages/ui/src/components/molecules/timeline/timeline.tsx
@@ -80,10 +80,7 @@ function Root({ size, children }: Readonly<TimelineRootProps>) {
   return (
     <Box>
       {items.map((child, at) => (
-        // The position is the identity here: this is the caller's own list of
-        // children, in the order it was written, and nothing reorders it.
-        // biome-ignore lint/suspicious/noArrayIndexKey: the position IS what the provider carries
-        <TimelineContext.Provider key={at} value={rail[at] as Context}>
+        <TimelineContext.Provider key={child.key ?? at} value={rail[at] as Context}>
           {child}
         </TimelineContext.Provider>
       ))}

--- a/packages/ui/src/lib/group-shape.test.ts
+++ b/packages/ui/src/lib/group-shape.test.ts
@@ -3,13 +3,17 @@
 import { renderHook } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import { describe, expect, it } from 'vitest';
-import { GroupSlotContext, groupSlot, useGroupShape } from './group-shape';
+import { type GroupPosition, GroupSlotContext, groupSlot, useGroupShape } from './group-shape';
 
-const inGroup = ({ children }: { children: ReactNode }) =>
-  createElement(GroupSlotContext.Provider, {
-    value: groupSlot('horizontal', 'first', 12, 'md'),
-    children,
-  });
+const at =
+  (position: GroupPosition) =>
+  ({ children }: { children: ReactNode }) =>
+    createElement(GroupSlotContext.Provider, {
+      value: groupSlot('horizontal', position, 12, 'md'),
+      children,
+    });
+
+const inGroup = at('first');
 
 describe('useGroupShape', () => {
   it('is null outside a group, so an ungrouped control keeps its own shape', () => {
@@ -24,5 +28,17 @@ describe('useGroupShape', () => {
       borderTopRightRadius: 0,
       borderBottomRightRadius: 0,
     });
+  });
+
+  it('rises above its neighbours while focused, so its ring is not painted over', () => {
+    const { result } = renderHook(() => useGroupShape(true), { wrapper: at('first') });
+
+    expect(result.current).toMatchObject({ zIndex: 1 });
+  });
+
+  it('sits back down when it is not, so it does not cover the member after it', () => {
+    const { result } = renderHook(() => useGroupShape(false), { wrapper: at('first') });
+
+    expect(result.current).not.toHaveProperty('zIndex');
   });
 });

--- a/packages/ui/src/lib/group-shape.ts
+++ b/packages/ui/src/lib/group-shape.ts
@@ -78,10 +78,10 @@ function corners(
   };
 }
 
-// The focus ring is a boxShadow painted OUTSIDE the box, and a group collapses
-// the borders, so a focused member is otherwise overpainted by the one after it.
-// Only the member knows it is focused, which is why the group cannot lift it,
-// and why the group must never clip: an `overflow` there would cut the ring.
+// The ring is drawn OUTSIDE the box, and a group collapses the borders, so a
+// focused member would otherwise be overpainted by the one after it. Only the
+// member knows it is focused, which is why the group cannot lift it, and why the
+// group must never clip: an `overflow` there would cut the ring.
 const RAISED = { zIndex: 1 };
 
 function shapeOf(slot: GroupSlot, focused: boolean): ViewStyle {


### PR DESCRIPTION
## What

Five independent shape fixes in the kit's controls, grouped because each is a few lines and none is worth its own PR:

- `Badge` and `Chip` ellipsize inside their pill instead of spilling out of it, and keep their width in a row that scrolls.
- `Button` takes the shell's control size from `lib/field-shell` like every other control, instead of carrying its own paddings.
- A `Field` inside a `ButtonGroup` raises its stacking order so its focus ring is not painted over by the neighbour that follows it.
- `List` and `Timeline` keep a reordered child mounted rather than remounting it, by keying on identity instead of index.

## Closes

No issue — fallout found while building the queue UI that sits at the top of this stack.

## Checks

- [x] `bun run typecheck`, `bun run test` and `bunx biome check` pass on this layer
- [ ] n/a — no server change
- [x] Follows `CODE_STYLE.md` — no comments narrating the work, exported API only
- [x] One idea. If it grew a second, it was split.

## Risk

Visual, and contained to four atoms plus two molecules. If the ellipsis rule is wrong a Badge truncates text that used to fit; if the stacking fix is wrong a focus ring is clipped again. Both are visible in the kit workbench (`bun run dev:kit`) on the Badge, Chip, Button and Field stories.

The `List`/`Timeline` key change is the one with real behaviour behind it: a reordered child now keeps its state. A reviewer would notice a regression as a row losing input state when the list reorders.
