### PR TITLE
feat(ui): a Stepper, and the hooks to drive one from a caller's own chrome

### DIFF
--- a/packages/ui/src/components/molecules/index.ts
+++ b/packages/ui/src/components/molecules/index.ts
@@ -97,6 +97,20 @@ export type {
 export { Select, selectTriggerVariants } from './select';
 export type { StatCardRootProps, StatCardValueProps } from './stat-card';
 export { StatCard } from './stat-card';
+export type {
+  StepperFlow,
+  StepperFlowOptions,
+  StepperItemProps,
+  StepperItemState,
+  StepperListProps,
+  StepperMoveProps,
+  StepperOrientation,
+  StepperPanelProps,
+  StepperRootProps,
+  StepperStep,
+  StepperValueDetails,
+} from './stepper';
+export { Stepper, stepperVariants, useStepper, useStepperItem, useSteps } from './stepper';
 export type { ThemeSwitchProps } from './theme-switch';
 export { ThemeSwitch } from './theme-switch';
 export type { TimelineItemProps, TimelineRootProps, TimelineTone } from './timeline';

--- a/packages/ui/src/components/molecules/stepper/index.ts
+++ b/packages/ui/src/components/molecules/stepper/index.ts
@@ -1,0 +1,1 @@
+export * from './stepper';

--- a/packages/ui/src/components/molecules/stepper/stepper-context.ts
+++ b/packages/ui/src/components/molecules/stepper/stepper-context.ts
@@ -1,0 +1,71 @@
+import type { ControlMetrics, ControlSize } from '#ui/lib/field-shell';
+import { partContext } from '#ui/lib/part-context';
+import { useStableCallback } from '#ui/lib/stable-callback';
+import type { StepperFlow } from './use-steps';
+
+type StepperOrientation = 'horizontal' | 'vertical';
+
+interface StepperStep {
+  /** One-based. */
+  position: number;
+  count: number;
+  title?: string;
+  complete: boolean;
+}
+
+interface StepperState {
+  flow: StepperFlow;
+  size: ControlSize;
+  orientation: StepperOrientation;
+  label: string;
+  stepLabel: (step: StepperStep) => string;
+  join: (value: string) => () => void;
+  mark: (value: string, disabled: boolean) => void;
+}
+
+const [Context, useStepperPart] = partContext<StepperState>('Stepper.Root');
+
+/**
+ * The flow the surrounding `<Stepper.Root>` is running. Its callbacks keep one
+ * identity for the life of the flow.
+ */
+function useStepper(): StepperFlow {
+  return useStepperPart('useStepper').flow;
+}
+
+interface StepperItemState {
+  index: number;
+  active: boolean;
+  complete: boolean;
+  reachable: boolean;
+  last: boolean;
+  select: () => void;
+}
+
+/** One step's own state, for a caller drawing an indicator of its own. It
+ *  reports; what puts a step IN the flow is rendering a `<Stepper.Item>`. */
+function useStepperItem(value: string): StepperItemState {
+  const { flow } = useStepperPart('useStepperItem');
+  const select = useStableCallback(() => flow.goTo(value));
+  const index = flow.steps.indexOf(value);
+  return {
+    index,
+    active: flow.value === value,
+    complete: flow.complete(value),
+    reachable: flow.reachable(value),
+    last: index === flow.count - 1,
+    select,
+  };
+}
+
+function stepShape(metrics: ControlMetrics) {
+  return {
+    marker: metrics.line + 4,
+    gap: Math.round(metrics.gap / 2),
+    step: metrics.gap,
+    connector: 2,
+  };
+}
+
+export type { StepperItemState, StepperOrientation, StepperState, StepperStep };
+export { Context, stepShape, useStepper, useStepperItem, useStepperPart };

--- a/packages/ui/src/components/molecules/stepper/stepper-item.tsx
+++ b/packages/ui/src/components/molecules/stepper/stepper-item.tsx
@@ -1,0 +1,226 @@
+import { type ReactNode, useLayoutEffect } from 'react';
+import { Box } from '#ui/components/atoms/box';
+import { Focusable } from '#ui/components/atoms/focusable';
+import { Icon, type IconName, type IconProps } from '#ui/components/atoms/icon';
+import { Text } from '#ui/components/atoms/text';
+import { type StyleDecl, svFor } from '#ui/core';
+import { bySize, CONTROL } from '#ui/lib/field-shell';
+import { nameOf } from '#ui/lib/name-of';
+import { partContext } from '#ui/lib/part-context';
+import { stepShape, useStepperItem, useStepperPart } from './stepper-context';
+
+type StepState = 'ahead' | 'current' | 'complete';
+
+const stepperVariants = svFor<{
+  root: StyleDecl;
+  marker: StyleDecl;
+  number: StyleDecl;
+  label: StyleDecl;
+  hint: StyleDecl;
+  glyph: Pick<IconProps, 'color' | 'size'>;
+}>()({
+  slots: {
+    root: { row: true, align: 'center', _hover: { bg: 'tint/8' }, _press: { bg: 'tint/14' } },
+    marker: { center: true, radius: 'pill', borderWidth: 1.5, border: 'transparent', shrink: 0 },
+    number: { font: 'ui', fontWeight: '700' },
+    label: { font: 'ui', fontWeight: '600' },
+    hint: { font: 'ui', color: 'textDim' },
+    glyph: { color: 'text' },
+  },
+  variants: {
+    size: bySize((metrics) => {
+      const shape = stepShape(metrics);
+      return {
+        root: {
+          gap: shape.gap,
+          px: Math.round(metrics.px / 2),
+          py: Math.round(metrics.py / 2),
+          radius: metrics.radius,
+        },
+        marker: { w: shape.marker, h: shape.marker },
+        number: { fontSize: Math.round(metrics.fontSize * 0.8), lineHeight: shape.marker },
+        label: { fontSize: metrics.fontSize, lineHeight: metrics.line },
+        hint: { fontSize: metrics.fontSize - 3, lineHeight: metrics.line - 4 },
+        glyph: { size: Math.round(metrics.fontSize * 0.9) },
+      };
+    }),
+    state: {
+      ahead: {
+        marker: { border: 'borderStrong' },
+        number: { color: 'text/35' },
+        label: { color: 'text/40' },
+        glyph: { color: 'text/35' },
+      },
+      current: {
+        marker: { bg: 'accent' },
+        number: { color: 'accentInk' },
+        label: { color: 'text' },
+        glyph: { color: 'accentInk' },
+      },
+      complete: {
+        marker: { bg: 'accentSoft' },
+        number: { color: 'accentText' },
+        label: { color: 'text/75' },
+        glyph: { color: 'accentText' },
+      },
+    },
+  },
+  defaults: { size: 'md', state: 'ahead' },
+});
+
+type StepSlots = ReturnType<typeof stepperVariants>;
+
+const [ItemContext, useStepperFace] = partContext<StepSlots>('Stepper.Item');
+
+function stepStateOf(active: boolean, complete: boolean): StepState {
+  if (active) return 'current';
+  return complete ? 'complete' : 'ahead';
+}
+
+function Marker({
+  position,
+  icon,
+  complete,
+  slots,
+}: Readonly<{ position: number; icon?: IconName; complete: boolean; slots: StepSlots }>) {
+  return (
+    <Box style={slots.marker}>
+      <MarkerFace position={position} icon={icon} complete={complete} slots={slots} />
+    </Box>
+  );
+}
+
+function MarkerFace({
+  position,
+  icon,
+  complete,
+  slots,
+}: Readonly<{ position: number; icon?: IconName; complete: boolean; slots: StepSlots }>) {
+  if (complete) return <Icon name="check" {...slots.glyph} />;
+  if (icon) return <Icon name={icon} {...slots.glyph} />;
+  return <Text style={slots.number}>{position}</Text>;
+}
+
+interface StepperItemProps {
+  value: string;
+  /** A glyph in the marker instead of the step's number. A complete step draws
+   *  the tick whatever this says. */
+  icon?: IconName;
+  /** Names the step to assistive tech. It draws NOTHING, and the position and
+   *  the state are added to it: reach for it only where the children carry no
+   *  plain text. */
+  label?: string;
+  /** A step nothing may enter: `Previous`, `Next` and the arrow keys pass over
+   *  it rather than stopping on it. */
+  disabled?: boolean;
+  children?: ReactNode;
+}
+
+/** The WHOLE row is the control: one D-pad stop, and the marker is a face
+ *  rather than a second target. Rendering one is what puts the step in the
+ *  flow, at whatever depth it sits. */
+function Item({ value, icon, label, disabled, children }: Readonly<StepperItemProps>) {
+  const { flow, size, orientation, stepLabel, join, mark } = useStepperPart('Item');
+  const step = useStepperItem(value);
+  // Layout effects, not passive ones: they run before the first paint, so the
+  // flow is whole by the time anything is drawn.
+  useLayoutEffect(() => join(value), [join, value]);
+  useLayoutEffect(() => mark(value, disabled === true), [mark, value, disabled]);
+
+  const state = stepStateOf(step.active, step.complete);
+  const slots = stepperVariants({ size, state });
+  const metrics = CONTROL[size];
+  const shape = stepShape(metrics);
+  const vertical = orientation === 'vertical';
+  return (
+    <>
+      <ItemContext.Provider value={slots}>
+        <Focusable
+          role="tab"
+          selected={step.active}
+          current={step.active ? 'step' : undefined}
+          disabled={disabled || !step.reachable}
+          label={stepLabel({
+            position: step.index + 1,
+            count: flow.count,
+            title: label ?? nameOf(children),
+            complete: step.complete,
+          })}
+          onPress={step.select}
+          ring="focusInset"
+          sv={stepperVariants}
+          vars={{ size, state }}
+          style={vertical ? STRETCH : undefined}
+        >
+          <Marker position={step.index + 1} icon={icon} complete={step.complete} slots={slots} />
+          {children ? (
+            <Box gap={2} shrink={1}>
+              {children}
+            </Box>
+          ) : null}
+        </Focusable>
+      </ItemContext.Provider>
+      {step.last ? null : (
+        <Connector
+          vertical={vertical}
+          thickness={shape.connector}
+          length={shape.step}
+          indent={Math.round(metrics.px / 2 + (shape.marker - shape.connector) / 2)}
+          stepPaddingY={Math.round(metrics.py / 2)}
+          complete={step.complete}
+        />
+      )}
+    </>
+  );
+}
+
+// Drawn by the step rather than the list, which cannot see which of its
+// children are steps once they are one component deep.
+function Connector({
+  vertical,
+  thickness,
+  length,
+  indent,
+  stepPaddingY,
+  complete,
+}: Readonly<{
+  vertical: boolean;
+  thickness: number;
+  length: number;
+  indent: number;
+  stepPaddingY: number;
+  complete: boolean;
+}>) {
+  const paint = complete ? 'accent' : 'border';
+  if (vertical) {
+    return (
+      <Box
+        w={thickness}
+        h={length + stepPaddingY * 2}
+        mt={-stepPaddingY}
+        mb={-stepPaddingY}
+        ml={indent}
+        radius="pill"
+        bg={paint}
+        aria-hidden
+      />
+    );
+  }
+  return <Box grow={1} h={thickness} minW={length} radius="pill" bg={paint} aria-hidden />;
+}
+
+/** The step's drawn title; its plain text is the step's accessible name. */
+function Label({ children }: Readonly<{ children: ReactNode }>) {
+  const slots = useStepperFace('Label');
+  return <Text style={slots.label}>{children}</Text>;
+}
+
+function Hint({ children }: Readonly<{ children: ReactNode }>) {
+  const slots = useStepperFace('Hint');
+  return <Text style={slots.hint}>{children}</Text>;
+}
+
+const STRETCH = { alignSelf: 'stretch' } as const;
+
+export type { StepperItemProps };
+export { Hint, Item, Label, stepperVariants };

--- a/packages/ui/src/components/molecules/stepper/stepper-list.tsx
+++ b/packages/ui/src/components/molecules/stepper/stepper-list.tsx
@@ -1,0 +1,59 @@
+import type { ReactNode } from 'react';
+import type { StyleProp, ViewStyle } from 'react-native';
+import { Box } from '#ui/components/atoms/box';
+import { CONTROL } from '#ui/lib/field-shell';
+import { FocusColumn, FocusRegion } from '#ui/lib/focus-scope';
+import { stepShape, useStepperPart } from './stepper-context';
+
+interface StepperListProps {
+  /** The steps, at any depth: a `<Stepper.Item>` joins the flow by rendering,
+   *  so a component of your own holding them works. */
+  children?: ReactNode;
+  style?: StyleProp<ViewStyle>;
+}
+
+/** The indicator: the steps in order, with the rule between them. */
+function List({ children, style }: Readonly<StepperListProps>) {
+  const { flow, size, orientation, label } = useStepperPart('List');
+  const vertical = orientation === 'vertical';
+  const shape = stepShape(CONTROL[size]);
+
+  // Stops at the ends rather than wrapping the way <SegmentGroup> does: a
+  // sequence has a first step and a last one.
+  const walk = (delta: -1 | 1) => {
+    for (let at = flow.index + delta; at >= 0 && at < flow.count; at += delta) {
+      const key = flow.steps[at];
+      if (key === undefined || !flow.reachable(key)) continue;
+      flow.goTo(key);
+      return;
+    }
+  };
+
+  const Group = vertical ? FocusColumn : FocusRegion;
+  return (
+    <Group>
+      <Box
+        row={!vertical}
+        align={vertical ? 'stretch' : 'center'}
+        // The row fills what holds it, so the rules between the steps have
+        // something to stretch into: a <FocusRegion> lays its children out in a
+        // row, where a shrink-wrapped list leaves them at their minimum.
+        grow={vertical ? undefined : 1}
+        gap={vertical ? 0 : shape.gap}
+        role="tablist"
+        accessibilityLabel={label}
+        onKeyDown={(event) => {
+          const key = event.nativeEvent.key;
+          if (key === 'ArrowLeft' || key === 'ArrowUp') walk(-1);
+          else if (key === 'ArrowRight' || key === 'ArrowDown') walk(1);
+        }}
+        style={style}
+      >
+        {children}
+      </Box>
+    </Group>
+  );
+}
+
+export type { StepperListProps };
+export { List };

--- a/packages/ui/src/components/molecules/stepper/stepper.fixtures.tsx
+++ b/packages/ui/src/components/molecules/stepper/stepper.fixtures.tsx
@@ -1,0 +1,167 @@
+import { useState } from 'react';
+import { Box, Row } from '#ui/components/atoms/box';
+import { Button } from '#ui/components/atoms/button';
+import { Switch } from '#ui/components/atoms/switch';
+import { Text } from '#ui/components/atoms/text';
+import { SegmentGroup } from '#ui/components/molecules/segment-group';
+import type { ControlSize } from '#ui/lib/field-shell';
+import { Stepper, type StepperOrientation, useStepper } from './stepper';
+
+export interface DemoProps {
+  orientation?: StepperOrientation;
+  size?: ControlSize;
+}
+
+function Panels() {
+  return (
+    <>
+      <Stepper.Panel value="account">
+        <Text color="textDim">Une adresse et un mot de passe.</Text>
+      </Stepper.Panel>
+      <Stepper.Panel value="library">
+        <Text color="textDim">Les dossiers à parcourir.</Text>
+      </Stepper.Panel>
+      <Stepper.Panel value="done">
+        <Text color="textDim">Tout est prêt.</Text>
+      </Stepper.Panel>
+    </>
+  );
+}
+
+function Steps() {
+  return (
+    <Stepper.List>
+      <Stepper.Item value="account" icon="user">
+        <Stepper.Label>Compte</Stepper.Label>
+        <Stepper.Hint>Adresse et mot de passe</Stepper.Hint>
+      </Stepper.Item>
+      <Stepper.Item value="library" icon="folder">
+        <Stepper.Label>Bibliothèque</Stepper.Label>
+        <Stepper.Hint>Où sont les films</Stepper.Hint>
+      </Stepper.Item>
+      <Stepper.Item value="done" icon="rocket">
+        <Stepper.Label>Fin</Stepper.Label>
+      </Stepper.Item>
+    </Stepper.List>
+  );
+}
+
+export function Walkthrough({ orientation, size }: Readonly<DemoProps>) {
+  return (
+    <Box w={orientation === 'vertical' ? 360 : 640}>
+      <Stepper.Root label="Configuration" orientation={orientation} size={size}>
+        <Steps />
+        <Panels />
+        <Row gap={12}>
+          <Stepper.Previous />
+          <Stepper.Next />
+        </Row>
+      </Stepper.Root>
+    </Box>
+  );
+}
+
+export function Validated({ size }: Readonly<DemoProps>) {
+  const [agreed, setAgreed] = useState(false);
+  return (
+    <Box w={640}>
+      <Stepper.Root label="Configuration" size={size} complete={agreed ? DONE : NONE}>
+        <Steps />
+        <Stepper.Panel value="account">
+          <Row gap={12}>
+            <Switch checked={agreed} onCheckedChange={setAgreed} label="Je confirme mon compte" />
+            <Text color="textDim">Je confirme mon compte</Text>
+          </Row>
+        </Stepper.Panel>
+        <Stepper.Panel value="library">
+          <Text color="textDim">Les dossiers à parcourir.</Text>
+        </Stepper.Panel>
+        <Stepper.Panel value="done">
+          <Text color="textDim">Tout est prêt.</Text>
+        </Stepper.Panel>
+        <Row gap={12}>
+          <Stepper.Previous />
+          <Stepper.Next disabled={!agreed} />
+        </Row>
+      </Stepper.Root>
+    </Box>
+  );
+}
+
+const DONE = ['account'];
+const NONE: string[] = [];
+
+function OwnFooter() {
+  const flow = useStepper();
+  return (
+    <Row gap={12}>
+      <Text variant="meta" color="textDim">
+        {`${flow.index + 1} / ${flow.count}`}
+      </Text>
+      <Box flex />
+      <Button variant="ghost" label="Recommencer" onPress={flow.reset} />
+      <Button
+        label={flow.last ? 'Terminer' : 'Continuer'}
+        disabled={!flow.canGoNext}
+        onPress={flow.next}
+      />
+    </Row>
+  );
+}
+
+export function Footer({ size }: Readonly<DemoProps>) {
+  return (
+    <Box w={640}>
+      <Stepper.Root label="Configuration" size={size}>
+        <Steps />
+        <Panels />
+        <OwnFooter />
+      </Stepper.Root>
+    </Box>
+  );
+}
+
+function Quality() {
+  const [quality, setQuality] = useState('auto');
+  return (
+    <Box gap={10}>
+      <SegmentGroup.Root value={quality} onValueChange={setQuality} label="Qualité">
+        <SegmentGroup.Item value="auto">
+          <SegmentGroup.Label>Auto</SegmentGroup.Label>
+        </SegmentGroup.Item>
+        <SegmentGroup.Item value="1080p">
+          <SegmentGroup.Label>1080p</SegmentGroup.Label>
+        </SegmentGroup.Item>
+        <SegmentGroup.Item value="4k">
+          <SegmentGroup.Label>4K</SegmentGroup.Label>
+        </SegmentGroup.Item>
+      </SegmentGroup.Root>
+      <Text variant="meta" color="textDim">
+        {`Choisi : ${quality}`}
+      </Text>
+    </Box>
+  );
+}
+
+export function Kept({ size }: Readonly<DemoProps>) {
+  return (
+    <Box w={640}>
+      <Stepper.Root label="Configuration" size={size}>
+        <Steps />
+        <Stepper.Panel value="account" keepMounted>
+          <Quality />
+        </Stepper.Panel>
+        <Stepper.Panel value="library">
+          <Text color="textDim">Repartez en arrière : le choix est encore là.</Text>
+        </Stepper.Panel>
+        <Stepper.Panel value="done">
+          <Text color="textDim">Tout est prêt.</Text>
+        </Stepper.Panel>
+        <Row gap={12}>
+          <Stepper.Previous />
+          <Stepper.Next />
+        </Row>
+      </Stepper.Root>
+    </Box>
+  );
+}

--- a/packages/ui/src/components/molecules/stepper/stepper.hooks.test.tsx
+++ b/packages/ui/src/components/molecules/stepper/stepper.hooks.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  renderHook,
+  render as renderRaw,
+  screen,
+} from '@testing-library/react';
+import type { ReactElement, ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Button } from '#ui/components/atoms/button';
+import { Text } from '#ui/components/atoms/text';
+import { onScreen } from '#ui/testing';
+import { Stepper, useStepper, useStepperItem } from './stepper';
+
+const render = (ui: ReactElement) => renderRaw(onScreen(ui));
+
+afterEach(cleanup);
+
+function Flow({ children }: Readonly<{ children?: ReactNode }>) {
+  return (
+    <Stepper.Root label="Configuration">
+      <Stepper.List>
+        <Stepper.Item value="account">
+          <Stepper.Label>Compte</Stepper.Label>
+        </Stepper.Item>
+        <Stepper.Item value="library">
+          <Stepper.Label>Bibliothèque</Stepper.Label>
+        </Stepper.Item>
+        <Stepper.Item value="done">
+          <Stepper.Label>Fin</Stepper.Label>
+        </Stepper.Item>
+      </Stepper.List>
+      <Stepper.Panel value="account">
+        <Text>Adresse</Text>
+      </Stepper.Panel>
+      {children}
+      <Stepper.Previous />
+      <Stepper.Next />
+    </Stepper.Root>
+  );
+}
+
+function Footer() {
+  const flow = useStepper();
+  return <Text>{`${flow.index + 1}/${flow.count}`}</Text>;
+}
+
+describe('useStepper', () => {
+  it('hands anything inside the Root the flow it is running', () => {
+    render(
+      <Flow>
+        <Footer />
+      </Flow>,
+    );
+
+    fireEvent.click(screen.getByLabelText('Suivant'));
+
+    expect(screen.getByText('2/3')).toBeTruthy();
+  });
+
+  it('names itself when it is called outside a Root', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => renderHook(() => useStepper())).toThrow(
+      '<Stepper.useStepper> must be used inside <Stepper.Root>',
+    );
+
+    vi.restoreAllMocks();
+  });
+});
+
+function Dot({ value }: Readonly<{ value: string }>) {
+  const step = useStepperItem(value);
+  return (
+    <Button
+      label={`${value} ${step.index} ${step.complete ? 'done' : 'todo'}`}
+      disabled={!step.reachable}
+      onPress={step.select}
+    />
+  );
+}
+
+function Tail({ value }: Readonly<{ value: string }>) {
+  const step = useStepperItem(value);
+  return <Text>{`${value} ${step.last ? 'last' : 'more'}`}</Text>;
+}
+
+describe('useStepperItem', () => {
+  it('calls only the final step the last one', () => {
+    render(
+      <Flow>
+        <Tail value="library" />
+        <Tail value="done" />
+      </Flow>,
+    );
+
+    expect(screen.getByText('library more')).toBeTruthy();
+    expect(screen.getByText('done last')).toBeTruthy();
+  });
+
+  it('hands back one select for the life of the flow', () => {
+    const { result, rerender } = renderHook(() => useStepperItem('account'), { wrapper: Flow });
+    const first = result.current.select;
+
+    rerender();
+
+    expect(result.current.select).toBe(first);
+  });
+
+  it('answers for one step, and goes to it when a hand-drawn indicator is pressed', () => {
+    render(
+      <Flow>
+        <Dot value="account" />
+      </Flow>,
+    );
+
+    fireEvent.click(screen.getByLabelText('Suivant'));
+    fireEvent.click(screen.getByLabelText('account 0 done'));
+
+    expect(screen.getByText('Adresse')).toBeTruthy();
+  });
+
+  it('names itself when it is called outside a Root', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => renderHook(() => useStepperItem('account'))).toThrow(
+      '<Stepper.useStepperItem> must be used inside <Stepper.Root>',
+    );
+
+    vi.restoreAllMocks();
+  });
+});

--- a/packages/ui/src/components/molecules/stepper/stepper.panel.test.tsx
+++ b/packages/ui/src/components/molecules/stepper/stepper.panel.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render as renderRaw, screen } from '@testing-library/react';
+import { type ReactElement, type ReactNode, useState } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Text } from '#ui/components/atoms/text';
+import { onScreen } from '#ui/testing';
+import { Stepper } from './stepper';
+
+const render = (ui: ReactElement) => renderRaw(onScreen(ui));
+
+afterEach(cleanup);
+
+function Flow({ children }: Readonly<{ children?: ReactNode }>) {
+  return (
+    <Stepper.Root label="Configuration">
+      <Stepper.List>
+        <Stepper.Item value="account">
+          <Stepper.Label>Compte</Stepper.Label>
+        </Stepper.Item>
+        <Stepper.Item value="library">
+          <Stepper.Label>Bibliothèque</Stepper.Label>
+        </Stepper.Item>
+      </Stepper.List>
+      {children}
+      <Stepper.Previous />
+      <Stepper.Next />
+    </Stepper.Root>
+  );
+}
+
+let built = 0;
+
+function Counted() {
+  const [seen] = useState(() => {
+    built += 1;
+    return built;
+  });
+  return <Text>{`built ${seen}`}</Text>;
+}
+
+describe('a panel that has to survive the trip', () => {
+  afterEach(() => {
+    built = 0;
+  });
+
+  it('builds its children again every time by default', () => {
+    render(
+      <Flow>
+        <Stepper.Panel value="account">
+          <Counted />
+        </Stepper.Panel>
+      </Flow>,
+    );
+
+    fireEvent.click(screen.getByLabelText('Suivant'));
+    fireEvent.click(screen.getByLabelText('Précédent'));
+
+    expect(screen.getByText('built 2')).toBeTruthy();
+  });
+
+  it('takes a kept panel off the page while another step is showing', () => {
+    render(
+      <Flow>
+        <Stepper.Panel value="account" keepMounted>
+          <Counted />
+        </Stepper.Panel>
+      </Flow>,
+    );
+
+    fireEvent.click(screen.getByLabelText('Suivant'));
+
+    const kept = screen.getByText('built 1').closest('[role="tabpanel"]');
+    expect(kept?.getAttribute('style')).toBe('display: none !important;');
+  });
+
+  it('keeps what was typed in it when it asks to stay mounted', () => {
+    render(
+      <Flow>
+        <Stepper.Panel value="account" keepMounted>
+          <Counted />
+        </Stepper.Panel>
+      </Flow>,
+    );
+
+    fireEvent.click(screen.getByLabelText('Suivant'));
+    fireEvent.click(screen.getByLabelText('Précédent'));
+
+    expect(screen.getByText('built 1')).toBeTruthy();
+  });
+});

--- a/packages/ui/src/components/molecules/stepper/stepper.story.mdx
+++ b/packages/ui/src/components/molecules/stepper/stepper.story.mdx
@@ -1,0 +1,76 @@
+import { defineStory } from '@kroma/workbench/story';
+import { stepperVariants } from './stepper';
+import { Footer, Kept, Validated, Walkthrough } from './stepper.fixtures';
+
+export const story = defineStory({
+  group: 'Actions',
+  variants: stepperVariants,
+  omit: ['state'],
+  component: Walkthrough,
+  args: { orientation: 'horizontal' },
+  controls: { orientation: ['horizontal', 'vertical'] },
+});
+
+A flow walked one step at a time: an account being set up, a television being paired. A **tablist** to assistive tech, named by `label`, where each step is a tab carrying its position (`Étape 2 sur 4 : Compte`) and the step being shown claims `aria-current="step"`. Composed, in Radix's shape: **Root** owns the flow, **List** is the indicator, **Item** is one step with **Label** and **Hint** inside it, **Panel** is the region a step owns, and **Previous** and **Next** are the two moves.
+
+A step joins the flow by RENDERING, not by being typed as a direct child, so pulling the steps out into a component of your own or building them with a `map` works. A Root that ends up with no steps at all throws instead of drawing an indicator nothing can move.
+
+The sequence is the rule. The Root remembers the furthest step the flow has been, and everything at or before that point can be gone back to while everything past it is disabled, so nobody skips ahead through the indicator. A flow whose owner decides what counts as done says so instead, with `complete`.
+
+```tsx
+<Stepper.Root label="Configuration" defaultValue="account">
+  <Stepper.List>
+    <Stepper.Item value="account" icon="user">
+      <Stepper.Label>Compte</Stepper.Label>
+      <Stepper.Hint>Adresse et mot de passe</Stepper.Hint>
+    </Stepper.Item>
+    <Stepper.Item value="library" icon="folder">
+      <Stepper.Label>Bibliothèque</Stepper.Label>
+    </Stepper.Item>
+  </Stepper.List>
+  <Stepper.Panel value="account">…</Stepper.Panel>
+  <Stepper.Panel value="library">…</Stepper.Panel>
+  <Row gap={12}>
+    <Stepper.Previous />
+    <Stepper.Next />
+  </Row>
+</Stepper.Root>
+```
+
+<Scene name="Down a column">
+  The same flow on its side, for a page with a sidebar rather than a header. The rule between two steps runs the other way and lands under the markers.
+
+  {story.take((props) => <Walkthrough {...props} orientation="vertical" />)}
+</Scene>
+
+<Scene name="A step that has to be earned">
+  `complete` is the caller's own answer to which steps are done, for a flow that validates: here the first step is done once the switch is on, and until then next is held back with `disabled`. Without `complete`, having been past a step is what makes it done.
+
+  <Validated />
+</Scene>
+
+<Scene name="Your own footer">
+  `useStepper()` hands anything inside the Root the flow it is running: where it is, how many steps there are, whether it may move, and `next`, `previous`, `goTo` and `reset`. `reset` puts it back at the first step and forgets how far it went, which is the other half of a wizard that ends in "Recommencer". Every one of those callbacks keeps its identity for the life of the flow, so it can sit in a dependency array. `<Stepper.Previous>` and `<Stepper.Next>` are thin wrappers over the same hook, which is why writing the row by hand costs nothing.
+
+  <Footer />
+</Scene>
+
+<Scene name="Coming back to what was typed">
+  A panel unmounts when its step is not the one showing, so what was in it starts again. `keepMounted` is the opt-out, and it is React's `<Activity>` underneath: the panel keeps its state, drops its effects, and so leaves the tab order and the D-pad ring while it is away. Pick a quality, step forward, step back.
+
+  <Kept />
+</Scene>
+
+<Do>
+- Name it: `label` is what a screen reader announces for the indicator.
+- Give a step a `<Stepper.Hint>` when its title alone does not say what it wants.
+- Pull the steps into a component of your own when two flows share them. That is what registration is for.
+- Reach for `useStepper()` before reaching for another prop on the Root.
+- Lift the values a flow collects. `keepMounted` keeps a panel's own state, not your form's.
+</Do>
+
+<Dont>
+- Add a step in the middle after the flow has mounted. Steps take their order from the order they render in, so a late arrival lands at the end.
+- Hide previous and next at the ends. They go dim and keep their place.
+- Use it for two steps. That is a form with a confirmation, not a flow.
+</Dont>

--- a/packages/ui/src/components/molecules/stepper/stepper.test.tsx
+++ b/packages/ui/src/components/molecules/stepper/stepper.test.tsx
@@ -1,0 +1,255 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render as renderRaw, screen } from '@testing-library/react';
+import type { ReactElement, ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Text } from '#ui/components/atoms/text';
+import { onScreen } from '#ui/testing';
+import { Stepper, type StepperRootProps } from './stepper';
+
+const render = (ui: ReactElement) => renderRaw(onScreen(ui));
+
+afterEach(cleanup);
+
+function Flow({
+  children,
+  ...root
+}: Readonly<Partial<StepperRootProps> & { children?: ReactNode }>) {
+  return (
+    <Stepper.Root label="Configuration" {...root}>
+      <Stepper.List>
+        <Stepper.Item value="account">
+          <Stepper.Label>Compte</Stepper.Label>
+        </Stepper.Item>
+        <Stepper.Item value="library" disabled={root.value === 'skip'}>
+          <Stepper.Label>Bibliothèque</Stepper.Label>
+        </Stepper.Item>
+        <Stepper.Item value="done">
+          <Stepper.Label>Fin</Stepper.Label>
+        </Stepper.Item>
+      </Stepper.List>
+      <Stepper.Panel value="account">
+        <Text>Adresse</Text>
+      </Stepper.Panel>
+      <Stepper.Panel value="library">
+        <Text>Dossiers</Text>
+      </Stepper.Panel>
+      <Stepper.Panel value="done">
+        <Text>Prêt</Text>
+      </Stepper.Panel>
+      {children}
+      <Stepper.Previous />
+      <Stepper.Next />
+    </Stepper.Root>
+  );
+}
+
+function step(name: RegExp): HTMLElement {
+  return screen.getByRole('tab', { name });
+}
+
+function disabled(node: HTMLElement): boolean {
+  return node.getAttribute('aria-disabled') === 'true';
+}
+
+describe('Stepper', () => {
+  it('is a named tablist whose current step says so', () => {
+    render(<Flow />);
+
+    expect(screen.getByRole('tablist', { name: 'Configuration' })).toBeTruthy();
+    expect(step(/Compte/).getAttribute('aria-selected')).toBe('true');
+    expect(step(/Compte/).getAttribute('aria-current')).toBe('step');
+    expect(step(/Bibliothèque/).getAttribute('aria-current')).toBeNull();
+  });
+
+  it('names each step by its position, and says so once it is done', () => {
+    render(<Flow />);
+
+    fireEvent.click(screen.getByLabelText('Suivant'));
+
+    expect(screen.getByRole('tab', { name: 'Étape 1 sur 3 : Compte, terminée' })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: 'Étape 2 sur 3 : Bibliothèque' })).toBeTruthy();
+  });
+
+  it('opens at the first step and draws only its panel', () => {
+    render(<Flow />);
+
+    expect(screen.getByText('Adresse')).toBeTruthy();
+    expect(screen.queryByText('Dossiers')).toBeNull();
+    expect(screen.queryByText('Prêt')).toBeNull();
+  });
+
+  it('runs itself from a default step and reports why it moved', () => {
+    const onValueChange = vi.fn();
+    render(<Flow defaultValue="library" onValueChange={onValueChange} />);
+
+    fireEvent.click(screen.getByLabelText('Suivant'));
+
+    expect(onValueChange).toHaveBeenCalledWith('done', { reason: 'next' });
+    expect(screen.getByText('Prêt')).toBeTruthy();
+  });
+
+  it('leaves the step where it is when the caller owns the value', () => {
+    const onValueChange = vi.fn();
+    render(<Flow value="account" onValueChange={onValueChange} />);
+
+    fireEvent.click(screen.getByLabelText('Suivant'));
+
+    expect(onValueChange).toHaveBeenCalledWith('library', { reason: 'next' });
+    expect(screen.getByText('Adresse')).toBeTruthy();
+  });
+
+  it('dims the step back on the first step and the step forward on the last', () => {
+    render(<Flow />);
+
+    expect(disabled(screen.getByLabelText('Précédent'))).toBe(true);
+    expect(disabled(screen.getByLabelText('Suivant'))).toBe(false);
+
+    fireEvent.click(screen.getByLabelText('Suivant'));
+    fireEvent.click(screen.getByLabelText('Suivant'));
+
+    expect(disabled(screen.getByLabelText('Suivant'))).toBe(true);
+    expect(disabled(screen.getByLabelText('Précédent'))).toBe(false);
+  });
+
+  it('goes back to a step the flow has already been past', () => {
+    render(<Flow />);
+
+    fireEvent.click(screen.getByLabelText('Suivant'));
+    fireEvent.click(step(/Compte/));
+
+    expect(screen.getByText('Adresse')).toBeTruthy();
+    expect(disabled(step(/Bibliothèque/))).toBe(false);
+  });
+
+  it('refuses a step the flow has not reached yet', () => {
+    render(<Flow />);
+
+    fireEvent.click(step(/Fin/));
+
+    expect(disabled(step(/Fin/))).toBe(true);
+    expect(screen.getByText('Adresse')).toBeTruthy();
+  });
+
+  it('takes the caller word for which steps are done', () => {
+    render(<Flow complete={['done']} />);
+
+    expect(disabled(step(/Fin/))).toBe(false);
+    expect(disabled(step(/Bibliothèque/))).toBe(true);
+  });
+
+  it('steps over a step nothing may enter', () => {
+    const onValueChange = vi.fn();
+    render(<Flow value="skip" onValueChange={onValueChange} />);
+
+    fireEvent.click(screen.getByLabelText('Suivant'));
+
+    expect(onValueChange).toHaveBeenCalledWith('done', { reason: 'next' });
+  });
+
+  it('walks the reachable steps with the arrow keys, and stops at the end', () => {
+    render(<Flow defaultValue="library" />);
+
+    fireEvent.keyDown(screen.getByRole('tablist', { name: 'Configuration' }), {
+      key: 'ArrowRight',
+    });
+
+    expect(screen.getByText('Dossiers')).toBeTruthy();
+
+    fireEvent.keyDown(screen.getByRole('tablist', { name: 'Configuration' }), { key: 'ArrowLeft' });
+
+    expect(screen.getByText('Adresse')).toBeTruthy();
+  });
+
+  it('refuses to render a part outside its Root', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => render(<Stepper.Item value="account" />)).toThrow(
+      '<Stepper.Item> must be used inside <Stepper.Root>',
+    );
+
+    vi.restoreAllMocks();
+  });
+});
+
+function OwnSteps() {
+  return (
+    <Stepper.List>
+      <Stepper.Item value="account">
+        <Stepper.Label>Compte</Stepper.Label>
+      </Stepper.Item>
+      <Stepper.Item value="library">
+        <Stepper.Label>Bibliothèque</Stepper.Label>
+      </Stepper.Item>
+    </Stepper.List>
+  );
+}
+
+function OwnPanels() {
+  return (
+    <>
+      <Stepper.Panel value="account">
+        <Text>Adresse</Text>
+      </Stepper.Panel>
+      <Stepper.Panel value="library">
+        <Text>Dossiers</Text>
+      </Stepper.Panel>
+    </>
+  );
+}
+
+function MappedSteps({ steps }: Readonly<{ steps: readonly string[] }>) {
+  return (
+    <Stepper.List>
+      {steps.map((step) => (
+        <Stepper.Item key={step} value={step}>
+          <Stepper.Label>{step}</Stepper.Label>
+        </Stepper.Item>
+      ))}
+    </Stepper.List>
+  );
+}
+
+describe('where a step comes from', () => {
+  it('runs a flow whose steps sit inside a component the caller wrote', () => {
+    render(
+      <Stepper.Root label="Configuration">
+        <OwnSteps />
+        <OwnPanels />
+        <Stepper.Next />
+      </Stepper.Root>,
+    );
+
+    expect(step(/Compte/).getAttribute('aria-current')).toBe('step');
+    expect(screen.getByText('Adresse')).toBeTruthy();
+
+    fireEvent.click(screen.getByLabelText('Suivant'));
+
+    expect(screen.getByText('Dossiers')).toBeTruthy();
+    expect(disabled(screen.getByLabelText('Suivant'))).toBe(true);
+  });
+
+  it('counts the steps a map rendered, in the order they were rendered', () => {
+    render(
+      <Stepper.Root label="Configuration">
+        <MappedSteps steps={['un', 'deux', 'trois']} />
+      </Stepper.Root>,
+    );
+
+    expect(screen.getByRole('tab', { name: 'Étape 3 sur 3 : trois' })).toBeTruthy();
+  });
+
+  it('says so rather than drawing a dead control when no step joined the flow', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() =>
+      render(
+        <Stepper.Root label="Configuration">
+          <Stepper.List />
+        </Stepper.Root>,
+      ),
+    ).toThrow('<Stepper.Root> has no steps');
+
+    vi.restoreAllMocks();
+  });
+});

--- a/packages/ui/src/components/molecules/stepper/stepper.tsx
+++ b/packages/ui/src/components/molecules/stepper/stepper.tsx
@@ -1,0 +1,232 @@
+import { Activity, type ReactNode, useLayoutEffect, useMemo, useState } from 'react';
+import type { StyleProp, ViewStyle } from 'react-native';
+import { Box } from '#ui/components/atoms/box';
+import { Button } from '#ui/components/atoms/button';
+import { CONTROL, type ControlSize, entryDefaultSize } from '#ui/lib/field-shell';
+import { useStableCallback } from '#ui/lib/stable-callback';
+import {
+  Context,
+  type StepperOrientation,
+  type StepperState,
+  type StepperStep,
+  useStepperPart,
+} from './stepper-context';
+import { Hint, Item, Label } from './stepper-item';
+import { List } from './stepper-list';
+import { type StepperValueDetails, useSteps } from './use-steps';
+
+function numberedStep({ position, count, title, complete }: StepperStep): string {
+  const at = `Étape ${position} sur ${count}`;
+  const named = title ? `${at} : ${title}` : at;
+  return complete ? `${named}, terminée` : named;
+}
+
+// Deliberately not the direct-children walk every other compound here uses: a
+// caller's own <Steps /> holding the items is the first thing anyone writes,
+// and no walk of the JSX can see through one.
+interface Member {
+  value: string;
+  disabled: boolean;
+}
+
+const NO_MEMBERS: readonly Member[] = [];
+
+function useStepRegistry() {
+  const [members, setMembers] = useState(NO_MEMBERS);
+
+  const join = useStableCallback((value: string) => {
+    setMembers((current) =>
+      current.some((member) => member.value === value)
+        ? current
+        : [...current, { value, disabled: false }],
+    );
+    return () => setMembers((current) => current.filter((member) => member.value !== value));
+  });
+
+  // Its own channel rather than part of the membership, so a step that turns
+  // disabled keeps its place instead of leaving and rejoining at the end.
+  const mark = useStableCallback((value: string, disabled: boolean) => {
+    setMembers((current) => {
+      const at = current.findIndex((member) => member.value === value);
+      if (at === -1 || current[at]?.disabled === disabled) return current;
+      const next = [...current];
+      next[at] = { value, disabled };
+      return next;
+    });
+  });
+
+  return { members, join, mark };
+}
+
+interface StepperRootProps {
+  /** Present: you own the step being shown (controlled). Absent: the flow runs
+   *  itself from `defaultValue` and reports through `onValueChange`. */
+  value?: string;
+  /** Where the flow opens, defaulting to the first step. It also seeds how far
+   *  the flow counts as having been. */
+  defaultValue?: string;
+  onValueChange?: (next: string, details: StepperValueDetails) => void;
+  /** The steps that are done, for a flow whose owner decides that. Left out, a
+   *  step is done once the flow has been past it, and a step ahead of its
+   *  furthest point cannot be gone to. */
+  complete?: readonly string[];
+  /** Names the indicator to assistive tech: what is being stepped through. */
+  label: string;
+  /** Defaults to `horizontal`. */
+  orientation?: StepperOrientation;
+  /** The control shell's size; see <TextField>. */
+  size?: ControlSize;
+  /** The accessible name of one step, defaulting to `Étape 2 sur 4 : Compte`
+   *  with `, terminée` on a step the flow is past. */
+  stepLabel?: (step: StepperStep) => string;
+  /** A `<Stepper.List>`, the `<Stepper.Panel>`s and whatever drives them. A
+   *  step joins the flow by RENDERING, at any depth and through a component of
+   *  your own, in the order the steps mount. A Root that ends up with none
+   *  throws rather than drawing a dead control. */
+  children?: ReactNode;
+  style?: StyleProp<ViewStyle>;
+}
+
+function Root({
+  value,
+  defaultValue,
+  onValueChange,
+  complete,
+  label,
+  orientation = 'horizontal',
+  size,
+  stepLabel = numberedStep,
+  children,
+  style,
+}: Readonly<StepperRootProps>) {
+  const shell = size ?? entryDefaultSize();
+  const { members, join, mark } = useStepRegistry();
+  const order = useMemo(() => members.map((member) => member.value), [members]);
+  const off = useMemo(
+    () => members.filter((member) => member.disabled).map((member) => member.value),
+    [members],
+  );
+  const flow = useSteps(order, { value, defaultValue, onValueChange, complete, disabled: off });
+
+  // The Root's own layout effect runs after every step's, so an empty flow here
+  // is a flow nothing joined rather than one that has not settled yet.
+  const [settled, setSettled] = useState(false);
+  useLayoutEffect(() => setSettled(true), []);
+  const state = useMemo<StepperState>(
+    () => ({ flow, size: shell, orientation, label, stepLabel, join, mark }),
+    [flow, shell, orientation, label, stepLabel, join, mark],
+  );
+  if (settled && order.length === 0) {
+    throw new Error('<Stepper.Root> has no steps: a step is a <Stepper.Item> rendered inside it.');
+  }
+
+  return (
+    <Context.Provider value={state}>
+      <Box gap={CONTROL[shell].gap} style={style}>
+        {children}
+      </Box>
+    </Context.Provider>
+  );
+}
+
+interface StepperPanelProps {
+  value: string;
+  /** Keep the panel mounted while another step is showing, so what was typed in
+   *  it is still there on the way back. Hidden through `<Activity>`: its effects
+   *  stop and it leaves the tab order and the D-pad ring. Defaults to false. */
+  keepMounted?: boolean;
+  children?: ReactNode;
+}
+
+/** Only the step being shown draws a panel. */
+function Panel({ value, keepMounted = false, children }: Readonly<StepperPanelProps>) {
+  const { flow, size, stepLabel } = useStepperPart('Panel');
+  const active = flow.value === value;
+  const at = flow.steps.indexOf(value);
+  if (!active && !keepMounted) return null;
+  const body = (
+    <Box
+      role="tabpanel"
+      accessibilityLabel={stepLabel({
+        position: at + 1,
+        count: flow.count,
+        complete: flow.complete(value),
+      })}
+      gap={CONTROL[size].gap}
+    >
+      {children}
+    </Box>
+  );
+  if (!keepMounted) return body;
+  return <Activity mode={active ? 'visible' : 'hidden'}>{body}</Activity>;
+}
+
+interface StepperMoveProps {
+  /** The word on the button, which is also its accessible name. Defaults to
+   *  `Précédent` and `Suivant`. */
+  label?: string;
+  /** The ends of the flow already disable themselves. */
+  disabled?: boolean;
+}
+
+function Previous({ label = 'Précédent', disabled = false }: Readonly<StepperMoveProps>) {
+  const { flow, size } = useStepperPart('Previous');
+  return (
+    <Button
+      variant="ghost"
+      size={size}
+      icon="chevron-left"
+      label={label}
+      disabled={disabled || !flow.canGoPrevious}
+      onPress={flow.previous}
+    />
+  );
+}
+
+function Next({ label = 'Suivant', disabled = false }: Readonly<StepperMoveProps>) {
+  const { flow, size } = useStepperPart('Next');
+  return (
+    <Button
+      size={size}
+      iconRight="chevron-right"
+      label={label}
+      disabled={disabled || !flow.canGoNext}
+      onPress={flow.next}
+    />
+  );
+}
+
+/**
+ * A flow walked one step at a time.
+ *
+ * ```tsx
+ * <Stepper.Root label="Configuration" defaultValue="account">
+ *   <Stepper.List>
+ *     <Stepper.Item value="account">
+ *       <Stepper.Label>Compte</Stepper.Label>
+ *       <Stepper.Hint>Adresse et mot de passe</Stepper.Hint>
+ *     </Stepper.Item>
+ *     <Stepper.Item value="library">
+ *       <Stepper.Label>Bibliothèque</Stepper.Label>
+ *     </Stepper.Item>
+ *   </Stepper.List>
+ *   <Stepper.Panel value="account">…</Stepper.Panel>
+ *   <Stepper.Panel value="library">…</Stepper.Panel>
+ *   <Box row gap={12}>
+ *     <Stepper.Previous />
+ *     <Stepper.Next />
+ *   </Box>
+ * </Stepper.Root>
+ * ```
+ */
+const Stepper = { Root, List, Item, Label, Hint, Panel, Previous, Next };
+
+export type { StepperItemState, StepperOrientation, StepperStep } from './stepper-context';
+export { useStepper, useStepperItem } from './stepper-context';
+export type { StepperItemProps } from './stepper-item';
+export { stepperVariants } from './stepper-item';
+export type { StepperListProps } from './stepper-list';
+export type { StepperFlow, StepperFlowOptions, StepperValueDetails } from './use-steps';
+export { useSteps } from './use-steps';
+export type { StepperMoveProps, StepperPanelProps, StepperRootProps };
+export { Stepper };

--- a/packages/ui/src/components/molecules/stepper/use-steps.options.test.ts
+++ b/packages/ui/src/components/molecules/stepper/use-steps.options.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { useSteps } from './use-steps';
+
+const steps = ['account', 'library', 'done'];
+
+describe('useSteps with steps nothing may enter', () => {
+  it('steps over a barred step on the way forward', () => {
+    const { result } = renderHook(() => useSteps(steps, { disabled: ['library'] }));
+
+    act(() => result.current.next());
+
+    expect(result.current.value).toBe('done');
+  });
+
+  it('steps over a barred step on the way back', () => {
+    const onValueChange = vi.fn();
+    const { result } = renderHook(() =>
+      useSteps(steps, { defaultValue: 'done', disabled: ['library'], onValueChange }),
+    );
+
+    act(() => result.current.previous());
+
+    expect(onValueChange).toHaveBeenCalledWith('account', { reason: 'previous' });
+    expect(result.current.value).toBe('account');
+  });
+
+  it('refuses to go to a barred step, and calls it unreachable', () => {
+    const { result } = renderHook(() => useSteps(steps, { disabled: ['library'] }));
+
+    act(() => result.current.goTo('library'));
+
+    expect(result.current.value).toBe('account');
+    expect(result.current.reachable('library')).toBe(false);
+  });
+
+  it('has nowhere left to go when every step ahead is barred', () => {
+    const { result } = renderHook(() => useSteps(steps, { disabled: ['library', 'done'] }));
+
+    expect(result.current.canGoNext).toBe(false);
+  });
+});
+
+describe('useSteps when its owner says which steps are done', () => {
+  it('takes that word rather than counting how far the flow went', () => {
+    const { result } = renderHook(() => useSteps(steps, { complete: ['done'] }));
+
+    act(() => result.current.next());
+
+    expect(result.current.complete('done')).toBe(true);
+    expect(result.current.complete('account')).toBe(false);
+  });
+
+  it('opens the step showing and the ones it was told are done, and no others', () => {
+    const { result } = renderHook(() => useSteps(steps, { complete: ['done'] }));
+
+    expect(result.current.reachable('account')).toBe(true);
+    expect(result.current.reachable('done')).toBe(true);
+    expect(result.current.reachable('library')).toBe(false);
+  });
+
+  it('re-reads which steps are done when its owner changes them', () => {
+    const { result, rerender } = renderHook(({ complete }) => useSteps(steps, { complete }), {
+      initialProps: { complete: [] as readonly string[] },
+    });
+
+    rerender({ complete: ['account'] });
+
+    expect(result.current.complete('account')).toBe(true);
+    expect(result.current.reachable('library')).toBe(false);
+  });
+});

--- a/packages/ui/src/components/molecules/stepper/use-steps.test.ts
+++ b/packages/ui/src/components/molecules/stepper/use-steps.test.ts
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { useSteps } from './use-steps';
+
+describe('useSteps', () => {
+  const steps = ['account', 'library', 'done'];
+
+  it('opens on the first step with nowhere to go back to', () => {
+    const { result } = renderHook(() => useSteps(steps));
+
+    expect(result.current).toMatchObject({ value: 'account', index: 0, count: 3, first: true });
+    expect(result.current.canGoPrevious).toBe(false);
+    expect(result.current.canGoNext).toBe(true);
+  });
+
+  it('opens every step it has been past, and none of the ones ahead', () => {
+    const { result } = renderHook(() => useSteps(steps));
+
+    act(() => result.current.next());
+
+    expect(result.current.complete('account')).toBe(true);
+    expect(result.current.reachable('account')).toBe(true);
+    expect(result.current.reachable('done')).toBe(false);
+  });
+
+  it('goes to a step ahead when its owner says so, rather than the indicator', () => {
+    const { result } = renderHook(() => useSteps(steps));
+
+    act(() => result.current.goTo('done'));
+
+    expect(result.current.value).toBe('done');
+    expect(result.current.reachable('library')).toBe(true);
+  });
+
+  it('goes back to the first step and forgets how far it went', () => {
+    const { result } = renderHook(() => useSteps(steps));
+
+    act(() => result.current.goTo('done'));
+    act(() => result.current.reset());
+
+    expect(result.current.value).toBe('account');
+    expect(result.current.reachable('library')).toBe(false);
+  });
+
+  it('keeps one identity for every callback a caller may depend on', () => {
+    const { result, rerender } = renderHook(() => useSteps(steps));
+    const first = result.current;
+
+    act(() => result.current.next());
+    rerender();
+
+    expect(result.current.next).toBe(first.next);
+    expect(result.current.previous).toBe(first.previous);
+    expect(result.current.goTo).toBe(first.goTo);
+    expect(result.current.reset).toBe(first.reset);
+  });
+
+  it('knows when it is on the last step, with nowhere further to go', () => {
+    const { result } = renderHook(() => useSteps(steps, { defaultValue: 'done' }));
+
+    expect(result.current).toMatchObject({ last: true, index: 2 });
+    expect(result.current.canGoNext).toBe(false);
+  });
+
+  it('holds nothing and goes nowhere when it is handed no steps', () => {
+    const { result } = renderHook(() => useSteps([]));
+
+    expect(result.current).toMatchObject({ value: '', count: 0, index: 0 });
+    expect(result.current.canGoNext).toBe(false);
+  });
+
+  it('falls back to the first step when the value it is handed is not one of them', () => {
+    const { result } = renderHook(() => useSteps(steps, { value: 'elsewhere' }));
+
+    expect(result.current).toMatchObject({ value: 'account', index: 0 });
+  });
+
+  it('stays where it is, and says nothing, when sent to the step already showing', () => {
+    const onValueChange = vi.fn();
+    const { result } = renderHook(() => useSteps(steps, { onValueChange }));
+
+    act(() => result.current.goTo('account'));
+
+    expect(result.current.value).toBe('account');
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+
+  it('ignores a step it does not hold', () => {
+    const onValueChange = vi.fn();
+    const { result } = renderHook(() => useSteps(steps, { onValueChange }));
+
+    act(() => result.current.goTo('elsewhere'));
+
+    expect(result.current.value).toBe('account');
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+
+  it('reports where it would go without moving when its owner holds the value', () => {
+    const onValueChange = vi.fn();
+    const { result } = renderHook(() => useSteps(steps, { value: 'account', onValueChange }));
+
+    act(() => result.current.next());
+
+    expect(onValueChange).toHaveBeenCalledWith('library', { reason: 'next' });
+    expect(result.current.value).toBe('account');
+  });
+
+  it('keeps the steps a controlled value opened once it comes back', () => {
+    const { result, rerender } = renderHook(({ value }) => useSteps(steps, { value }), {
+      initialProps: { value: 'account' },
+    });
+
+    rerender({ value: 'done' });
+    rerender({ value: 'account' });
+
+    expect(result.current.value).toBe('account');
+    expect(result.current.reachable('library')).toBe(true);
+  });
+
+  it('says it was reset when the flow goes back to the start', () => {
+    const onValueChange = vi.fn();
+    const { result } = renderHook(() => useSteps(steps, { defaultValue: 'done', onValueChange }));
+
+    act(() => result.current.reset());
+
+    expect(onValueChange).toHaveBeenCalledWith('account', { reason: 'reset' });
+    expect(result.current.value).toBe('account');
+  });
+});

--- a/packages/ui/src/components/molecules/stepper/use-steps.ts
+++ b/packages/ui/src/components/molecules/stepper/use-steps.ts
@@ -1,0 +1,132 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useStableCallback } from '#ui/lib/stable-callback';
+import { useControllable } from '#ui/lib/use-controllable';
+
+type StepReason = 'next' | 'previous' | 'goTo' | 'reset';
+
+interface StepperValueDetails {
+  reason: StepReason;
+}
+
+interface StepperFlowOptions {
+  value?: string;
+  /** Where an uncontrolled flow opens. Defaults to the first step, and seeds
+   *  how far the flow counts as having been. */
+  defaultValue?: string;
+  onValueChange?: (next: string, details: StepperValueDetails) => void;
+  /** The steps that are done, when the caller keeps that itself. Left out, a
+   *  step counts as done once the flow has been past it. */
+  complete?: readonly string[];
+  /** Steps nothing may enter: skipped by `next`, `previous` and the arrow keys
+   *  rather than stopped on. */
+  disabled?: readonly string[];
+}
+
+interface StepperFlow {
+  steps: readonly string[];
+  value: string;
+  index: number;
+  count: number;
+  first: boolean;
+  last: boolean;
+  canGoNext: boolean;
+  canGoPrevious: boolean;
+  next: () => void;
+  previous: () => void;
+  /** Goes to any step the flow holds, ahead of its furthest point included. */
+  goTo: (step: string) => void;
+  /** Back to the first step, forgetting how far the flow had been. */
+  reset: () => void;
+  complete: (step: string) => boolean;
+  reachable: (step: string) => boolean;
+}
+
+/** The wizard state machine, with no component around it: hand it the step ids
+ *  in order. */
+function useSteps(steps: readonly string[], options: StepperFlowOptions = {}): StepperFlow {
+  const { value, defaultValue, onValueChange, complete, disabled } = options;
+  const [held, setHeld] = useControllable(value, defaultValue ?? steps[0] ?? '');
+  const seat = steps.indexOf(held);
+  const index = seat === -1 ? 0 : seat;
+  const current = steps[index] ?? '';
+
+  // Raised in an effect so a controlled value that jumps forward and comes back
+  // does not take the steps it opened away again.
+  const [visited, setVisited] = useState(index);
+  const reached = Math.max(visited, index);
+  useEffect(() => {
+    setVisited((far) => Math.max(far, index));
+  }, [index]);
+
+  const off = useMemo(() => new Set(disabled), [disabled]);
+  const done = useMemo(() => (complete ? new Set(complete) : null), [complete]);
+
+  const seek = (from: number, delta: 1 | -1) => {
+    for (let at = from + delta; at >= 0 && at < steps.length; at += delta) {
+      const key = steps[at];
+      if (key !== undefined && !off.has(key)) return at;
+    }
+    return -1;
+  };
+
+  const land = useStableCallback((at: number, reason: StepReason) => {
+    const key = steps[at];
+    if (key === undefined || key === current) return;
+    setVisited((far) => Math.max(far, at));
+    setHeld(key);
+    onValueChange?.(key, { reason });
+  });
+
+  const next = useStableCallback(() => land(seek(index, 1), 'next'));
+  const previous = useStableCallback(() => land(seek(index, -1), 'previous'));
+
+  const goTo = useStableCallback((step: string) => {
+    if (!off.has(step)) land(steps.indexOf(step), 'goTo');
+  });
+
+  const reset = useStableCallback(() => {
+    setVisited(0);
+    land(0, 'reset');
+  });
+
+  // Plain callbacks, not stable ones: both are read while a part renders, and a
+  // frozen closure would answer from the render before the flow moved.
+  const isComplete = useCallback(
+    (step: string) => {
+      if (done) return done.has(step);
+      const at = steps.indexOf(step);
+      return at !== -1 && at < reached;
+    },
+    [done, steps, reached],
+  );
+
+  const isReachable = useCallback(
+    (step: string) => {
+      const at = steps.indexOf(step);
+      if (at === -1 || off.has(step)) return false;
+      if (done) return step === current || done.has(step);
+      return at <= reached;
+    },
+    [done, off, steps, reached, current],
+  );
+
+  return {
+    steps,
+    value: current,
+    index,
+    count: steps.length,
+    first: index === 0,
+    last: index === steps.length - 1,
+    canGoNext: seek(index, 1) !== -1,
+    canGoPrevious: seek(index, -1) !== -1,
+    next,
+    previous,
+    goTo,
+    reset,
+    complete: isComplete,
+    reachable: isReachable,
+  };
+}
+
+export type { StepperFlow, StepperFlowOptions, StepperValueDetails };
+export { useSteps };


### PR DESCRIPTION
## What

A `Stepper` molecule for multi-step flows, in the kit's part vocabulary: `Stepper.Root` owns the flow, `Stepper.List` draws the rail, `Stepper.Item` is one step and `Stepper.Panel` its body.

A step joins the flow **by rendering**, not by being a direct child of the list — so a caller can wrap steps in their own layout, or render them conditionally, without the Root losing count.

Alongside the components, three hooks expose the same flow to a caller who wants to draw the chrome themselves: `useSteps` (the flow, standalone), `useStepper` (the Root's flow from inside it) and `useStepperItem` (one step's state). The manual-add wizard at the top of this stack uses the components; the hooks exist because the same flow drives a footer that lives outside the Root.

## Closes

No issue — extracted from the torrents manual-add wizard, which needed a stepper and should not have grown a private one.

## Checks

- [x] `bun run typecheck`, `bun run test` and `bunx biome check` pass on this layer
- [ ] n/a — no server change
- [x] Follows `CODE_STYLE.md` — no comments narrating the work, exported API only
- [x] One idea. If it grew a second, it was split.

## Risk

New component, nothing consumes it yet in this layer, so the blast radius is the kit's barrel export. The part that would bite later is the join-by-rendering registration: if the ordering is wrong, steps appear out of order or a conditional step shifts its neighbours. Covered by `stepper.test.tsx`, `stepper.panel.test.tsx`, `stepper.hooks.test.tsx` and `use-steps.test.ts`, and visible in `stepper.story.mdx`.
