### PR TITLE
feat(ui): a Dropzone, with a web surface that reads the dropped file

### DIFF
--- a/packages/ui/src/components/molecules/dropzone/dropzone-parts.tsx
+++ b/packages/ui/src/components/molecules/dropzone/dropzone-parts.tsx
@@ -1,0 +1,64 @@
+// The faces a <Dropzone> shows, and the contract both halves are written to.
+//
+// Their own file because the two Roots are platform variants of each OTHER:
+// under web resolution `./dropzone` from inside `dropzone.web` is `dropzone.web`
+// itself, so anything shared has to sit outside that pair or the import is a
+// cycle that resolves to undefined.
+
+import type { ReactNode } from 'react';
+import { Icon, type IconName } from '#ui/components/atoms/icon';
+import { Text } from '#ui/components/atoms/text';
+
+export const SURFACE_SHAPE = {
+  borderWidth: 1.5,
+  borderRadius: 16,
+  paddingX: 24,
+  paddingY: 28,
+  gap: 8,
+} as const;
+
+/** A file the zone turned away, with the rule it broke. */
+export interface DropzoneRejection {
+  file: File;
+  reason: 'size' | 'type';
+}
+
+export interface DropzoneRootProps {
+  /** Names the surface to assistive tech, which cannot read a drawing. A zone
+   *  with a `<Dropzone.Title>` may leave it out: the title names it. */
+  label?: string;
+  /** Comma-separated types, as the native picker takes them (`.torrent`,
+   *  `image/*`). Also filters what a DROP is allowed to carry. */
+  accept?: string;
+  /** Take more than one file. Defaults to one. */
+  multiple?: boolean;
+  /** Turn away anything larger, in bytes. */
+  maxSize?: number;
+  disabled?: boolean;
+  /** Busy: the surface stops taking files and spins instead. */
+  loading?: boolean;
+  /** The files that got through. */
+  onDrop?: (files: File[]) => void;
+  onReject?: (rejections: DropzoneRejection[]) => void;
+  /** A `<Dropzone.Icon>`, a `<Dropzone.Title>`, a `<Dropzone.Description>`. */
+  children?: ReactNode;
+}
+
+/** The glyph above the title. Decorative: the title carries the meaning. */
+export function DropzoneIcon({ name = 'file-upload' }: Readonly<{ name?: IconName }>) {
+  return <Icon name={name} size={26} thickness={1.6} color="glyphDim" />;
+}
+
+/** What the surface takes, in the operator's words. */
+export function DropzoneTitle({ children }: Readonly<{ children: ReactNode }>) {
+  return <Text variant="label">{children}</Text>;
+}
+
+/** The quieter second line: the formats, the size ceiling, how many. */
+export function DropzoneDescription({ children }: Readonly<{ children: ReactNode }>) {
+  return (
+    <Text variant="meta" color="text/40">
+      {children}
+    </Text>
+  );
+}

--- a/packages/ui/src/components/molecules/dropzone/dropzone-sift.test.ts
+++ b/packages/ui/src/components/molecules/dropzone/dropzone-sift.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { sift } from './dropzone-sift';
+
+const file = (name: string, size: number, type = '') => {
+  const made = new File(['x'], name, { type });
+  Object.defineProperty(made, 'size', { value: size });
+  return made;
+};
+
+describe('what a zone takes and what it turns away', () => {
+  it('turns away a file bigger than the ceiling, and says which rule it broke', () => {
+    const { taken, turned } = sift([file('big.torrent', 2000)], { maxSize: 1000 });
+
+    expect(taken).toEqual([]);
+    expect(turned).toEqual([
+      { file: expect.objectContaining({ name: 'big.torrent' }), reason: 'size' },
+    ]);
+  });
+
+  it('matches an extension rule the way the native picker does', () => {
+    const { taken, turned } = sift([file('a.torrent', 10), file('b.png', 10)], {
+      accept: '.torrent',
+    });
+
+    expect(taken.map((f) => f.name)).toEqual(['a.torrent']);
+    expect(turned[0]).toMatchObject({ reason: 'type' });
+  });
+
+  it('matches an extension whatever case it arrived in', () => {
+    const { taken } = sift([file('A.TORRENT', 10)], { accept: '.torrent' });
+
+    expect(taken.map((f) => f.name)).toEqual(['A.TORRENT']);
+  });
+
+  it('matches a type family', () => {
+    const { taken } = sift([file('a.png', 10, 'image/png')], { accept: 'image/*', multiple: true });
+
+    expect(taken).toHaveLength(1);
+  });
+
+  it('matches one exact type without taking its neighbours in the family', () => {
+    const dropped = [file('a.png', 10, 'image/png'), file('b.jpg', 10, 'image/jpeg')];
+
+    const { taken, turned } = sift(dropped, { accept: 'image/png', multiple: true });
+
+    expect(taken.map((f) => f.name)).toEqual(['a.png']);
+    expect(turned).toMatchObject([{ reason: 'type' }]);
+  });
+
+  it('takes a file that satisfies any one rule of several', () => {
+    const { taken } = sift([file('a.nfo', 10), file('b.png', 10, 'image/png')], {
+      accept: '.torrent, image/*',
+      multiple: true,
+    });
+
+    expect(taken.map((f) => f.name)).toEqual(['b.png']);
+  });
+
+  it('lets a file through on size when it sits exactly on the ceiling', () => {
+    const { taken } = sift([file('a.torrent', 1000)], { maxSize: 1000 });
+
+    expect(taken).toHaveLength(1);
+  });
+
+  it('reports the type rule and stops, so one file is never turned away twice', () => {
+    const { turned } = sift([file('big.png', 2000)], { accept: '.torrent', maxSize: 1000 });
+
+    expect(turned).toMatchObject([{ reason: 'type' }]);
+  });
+
+  it('takes only the first when the zone is not multiple, without calling the rest rejected', () => {
+    const { taken, turned } = sift([file('a.torrent', 10), file('b.torrent', 10)], {});
+
+    expect(taken.map((f) => f.name)).toEqual(['a.torrent']);
+    expect(turned).toEqual([]);
+  });
+
+  it('still reports what broke a rule in a single-file zone', () => {
+    const { taken, turned } = sift([file('big.torrent', 2000), file('a.torrent', 10)], {
+      maxSize: 1000,
+    });
+
+    expect(taken.map((f) => f.name)).toEqual(['a.torrent']);
+    expect(turned).toMatchObject([{ reason: 'size' }]);
+  });
+
+  it('takes everything when nothing narrows it', () => {
+    const { taken } = sift([file('a', 1), file('b', 1)], { multiple: true });
+
+    expect(taken).toHaveLength(2);
+  });
+
+  it('ignores the empty rule a trailing comma leaves behind', () => {
+    const { taken } = sift([file('a.torrent', 10)], { accept: '.torrent,' });
+
+    expect(taken).toHaveLength(1);
+  });
+});

--- a/packages/ui/src/components/molecules/dropzone/dropzone-sift.ts
+++ b/packages/ui/src/components/molecules/dropzone/dropzone-sift.ts
@@ -1,0 +1,38 @@
+import type { DropzoneRejection, DropzoneRootProps } from './dropzone-parts';
+
+function accepts(file: File, accept: string | undefined): boolean {
+  if (!accept) return true;
+  const name = file.name.toLowerCase();
+  return accept
+    .split(',')
+    .map((rule) => rule.trim().toLowerCase())
+    .filter(Boolean)
+    .some((rule) => {
+      if (rule.startsWith('.')) return name.endsWith(rule);
+      if (rule.endsWith('/*')) return file.type.startsWith(rule.slice(0, -1));
+      return file.type === rule;
+    });
+}
+
+/** Split what arrived into what the zone takes and what it turns away. */
+export function sift(
+  files: readonly File[],
+  { accept, maxSize, multiple }: Pick<DropzoneRootProps, 'accept' | 'maxSize' | 'multiple'>,
+): { taken: File[]; turned: DropzoneRejection[] } {
+  const taken: File[] = [];
+  const turned: DropzoneRejection[] = [];
+  for (const file of files) {
+    if (!accepts(file, accept)) {
+      turned.push({ file, reason: 'type' });
+      continue;
+    }
+    if (maxSize !== undefined && file.size > maxSize) {
+      turned.push({ file, reason: 'size' });
+      continue;
+    }
+    taken.push(file);
+  }
+  // A single-file zone takes the first and says nothing about the rest: they
+  // were not rejected by a rule, they were simply not asked for.
+  return { taken: multiple ? taken : taken.slice(0, 1), turned };
+}

--- a/packages/ui/src/components/molecules/dropzone/dropzone.fixtures.tsx
+++ b/packages/ui/src/components/molecules/dropzone/dropzone.fixtures.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react';
+
+import { Box } from '#ui/components/atoms/box';
+
+import { Text } from '#ui/components/atoms/text';
+
+import { Dropzone, type DropzoneRejection, type DropzoneRootProps } from './dropzone';
+
+export function Demo(props: Readonly<Partial<DropzoneRootProps>>) {
+  const [picked, setPicked] = useState<string | null>(null);
+  return (
+    <Box w={420} gap={10}>
+      <Dropzone.Root
+        label="Upload a file"
+        {...props}
+        onDrop={(files) => setPicked(files[0]?.name ?? null)}
+      >
+        <Dropzone.Icon />
+        <Dropzone.Title>Drop a file here</Dropzone.Title>
+        <Dropzone.Description>or click to browse</Dropzone.Description>
+      </Dropzone.Root>
+      {picked ? (
+        <Text variant="meta" color="text/50">
+          {picked}
+        </Text>
+      ) : null}
+    </Box>
+  );
+}
+
+export function OneKind() {
+  return (
+    <Box w={420}>
+      <Dropzone.Root label="Upload a torrent" accept=".torrent">
+        <Dropzone.Icon name="file-upload" />
+        <Dropzone.Title>Drop a .torrent here</Dropzone.Title>
+        <Dropzone.Description>Nothing else is taken</Dropzone.Description>
+      </Dropzone.Root>
+    </Box>
+  );
+}
+
+export function Bounded() {
+  const [turned, setTurned] = useState<DropzoneRejection[]>([]);
+  return (
+    <Box w={420} gap={10}>
+      <Dropzone.Root
+        label="Upload a file under 1 MB"
+        maxSize={1_000_000}
+        onDrop={() => setTurned([])}
+        onReject={setTurned}
+      >
+        <Dropzone.Icon />
+        <Dropzone.Title>Drop a file here</Dropzone.Title>
+        <Dropzone.Description>1 MB at most</Dropzone.Description>
+      </Dropzone.Root>
+      {turned.length > 0 ? (
+        <Text variant="meta" color="danger">
+          {`${turned[0]?.file.name} is too big`}
+        </Text>
+      ) : null}
+    </Box>
+  );
+}
+
+export function Busy() {
+  return (
+    <Box w={420}>
+      <Dropzone.Root label="Uploading" loading>
+        <Dropzone.Icon />
+        <Dropzone.Title>Drop a file here</Dropzone.Title>
+      </Dropzone.Root>
+    </Box>
+  );
+}

--- a/packages/ui/src/components/molecules/dropzone/dropzone.story.mdx
+++ b/packages/ui/src/components/molecules/dropzone/dropzone.story.mdx
@@ -1,0 +1,44 @@
+import { defineStory } from '@kroma/workbench/story';
+import { Bounded, Busy, Demo, OneKind } from './dropzone.fixtures';
+
+export const story = defineStory({
+  group: 'Input',
+  component: Demo,
+  args: {
+    label: 'Upload a file',
+    accept: '.torrent',
+    multiple: false,
+    disabled: false,
+    loading: false,
+  },
+});
+
+The surface a file arrives on. It takes one two ways, dragged from the desktop or picked through the OS dialog when it is clicked, and it is the same control either way: the click opens a real hidden `<input type="file">`, so a keyboard or a screen reader is never shut out of a pattern that looks like it needs a mouse. The dashed edge is the whole point of the shape, because a filled control reads as something that DOES a thing when pressed rather than somewhere a thing goes. It highlights while a file is over it, and both of its rules are enforced before anything reaches the caller: `accept` filters the drop as well as the picker, `maxSize` turns away what is too big, and what was refused comes back through `onReject` with the rule it broke so the screen can SAY so instead of appearing to ignore the file. A zone that is `loading` stops taking anything and spins in place of its faces, which is what stops a slow upload being started twice.
+
+Dragging a file is a pointer-and-filesystem idea and a television has neither, so the native build draws the same surface as a plain focusable and opens nothing; a shell that wants a file there reaches for the platform's own picker.
+
+```tsx
+<Dropzone.Root accept=".torrent" maxSize={1024 * 1024} onDrop={([file]) => queue(file)}>
+  <Dropzone.Icon />
+  <Dropzone.Title>Drop a .torrent here</Dropzone.Title>
+  <Dropzone.Description>or click to browse</Dropzone.Description>
+</Dropzone.Root>
+```
+
+<Demo />
+
+## Only one kind of file
+
+`accept` filters the drop as well as the picker, so a dragged file that does not match is refused with `reason: 'type'` rather than quietly accepted.
+
+<OneKind />
+
+## A ceiling
+
+`maxSize` is in bytes, and what it turns away arrives in `onReject`. That is where the message an operator reads comes from.
+
+<Bounded />
+
+## While it works
+
+<Busy />

--- a/packages/ui/src/components/molecules/dropzone/dropzone.test.tsx
+++ b/packages/ui/src/components/molecules/dropzone/dropzone.test.tsx
@@ -1,0 +1,195 @@
+// @vitest-environment jsdom
+
+import { fireEvent, isInaccessible, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { Dropzone } from './dropzone.web';
+
+const file = (name: string, size: number, type = '') => {
+  const made = new File(['x'], name, { type });
+  Object.defineProperty(made, 'size', { value: size });
+  return made;
+};
+
+const picker = (container: HTMLElement) => container.querySelector('input') as HTMLInputElement;
+
+describe('the surface', () => {
+  it('hands over what was dropped on it', () => {
+    const onDrop = vi.fn();
+    render(
+      <Dropzone.Root label="Upload" accept=".torrent" onDrop={onDrop}>
+        <Dropzone.Title>Drop it</Dropzone.Title>
+      </Dropzone.Root>,
+    );
+
+    fireEvent.drop(screen.getByRole('button'), {
+      dataTransfer: { files: [file('a.torrent', 10)] },
+    });
+
+    expect(onDrop).toHaveBeenCalledWith([expect.objectContaining({ name: 'a.torrent' })]);
+  });
+
+  it('reports what it turned away rather than swallowing it', () => {
+    const onDrop = vi.fn();
+    const onReject = vi.fn();
+    render(
+      <Dropzone.Root label="Upload" maxSize={100} onDrop={onDrop} onReject={onReject}>
+        <Dropzone.Title>Drop it</Dropzone.Title>
+      </Dropzone.Root>,
+    );
+
+    fireEvent.drop(screen.getByRole('button'), {
+      dataTransfer: { files: [file('big.torrent', 900)] },
+    });
+
+    expect(onDrop).not.toHaveBeenCalled();
+    expect(onReject).toHaveBeenCalledWith([expect.objectContaining({ reason: 'size' })]);
+  });
+
+  it('takes nothing while it is busy', () => {
+    const onDrop = vi.fn();
+    render(
+      <Dropzone.Root label="Upload" loading onDrop={onDrop}>
+        <Dropzone.Title>Drop it</Dropzone.Title>
+      </Dropzone.Root>,
+    );
+
+    fireEvent.drop(screen.getByRole('button'), {
+      dataTransfer: { files: [file('a.torrent', 10)] },
+    });
+
+    expect(onDrop).not.toHaveBeenCalled();
+  });
+
+  it('highlights while a file is over it, and stops when it leaves', () => {
+    render(
+      <Dropzone.Root label="Upload">
+        <Dropzone.Title>Drop it</Dropzone.Title>
+      </Dropzone.Root>,
+    );
+    const zone = screen.getByRole('button');
+
+    fireEvent.dragOver(zone);
+    expect(zone.getAttribute('data-drag-active')).not.toBeNull();
+
+    fireEvent.dragLeave(zone);
+    expect(zone.getAttribute('data-drag-active')).toBeNull();
+  });
+
+  it('is a real button, so picking a file never needs a pointer', () => {
+    render(
+      <Dropzone.Root label="Upload">
+        <Dropzone.Title>Drop it</Dropzone.Title>
+      </Dropzone.Root>,
+    );
+
+    expect(screen.getByRole('button').tagName).toBe('BUTTON');
+  });
+
+  it('keeps the picker out of the accessibility tree, so the surface is the only control', () => {
+    const { container } = render(
+      <Dropzone.Root label="Upload">
+        <Dropzone.Title>Drop it</Dropzone.Title>
+      </Dropzone.Root>,
+    );
+
+    expect(isInaccessible(picker(container))).toBe(true);
+    expect(screen.getByRole('button').getAttribute('aria-label')).toBe('Upload');
+  });
+
+  it('opens the picker when the surface is clicked', () => {
+    const { container } = render(
+      <Dropzone.Root label="Upload">
+        <Dropzone.Title>Drop it</Dropzone.Title>
+      </Dropzone.Root>,
+    );
+
+    const click = vi.spyOn(picker(container), 'click').mockImplementation(() => {});
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(click).toHaveBeenCalled();
+  });
+
+  it.each(['Enter', ' '])('opens the picker from the keyboard with %s', (key) => {
+    const { container } = render(
+      <Dropzone.Root label="Upload">
+        <Dropzone.Title>Drop it</Dropzone.Title>
+      </Dropzone.Root>,
+    );
+
+    const click = vi.spyOn(picker(container), 'click').mockImplementation(() => {});
+
+    fireEvent.keyDown(screen.getByRole('button'), { key });
+
+    expect(click).toHaveBeenCalled();
+  });
+
+  it('leaves any other key to the browser', () => {
+    const { container } = render(
+      <Dropzone.Root label="Upload">
+        <Dropzone.Title>Drop it</Dropzone.Title>
+      </Dropzone.Root>,
+    );
+
+    const click = vi.spyOn(picker(container), 'click').mockImplementation(() => {});
+
+    fireEvent.keyDown(screen.getByRole('button'), { key: 'Tab' });
+
+    expect(click).not.toHaveBeenCalled();
+  });
+
+  it('hands over what was picked, and clears the input so the same file picks again', () => {
+    const onDrop = vi.fn();
+    const { container } = render(
+      <Dropzone.Root label="Upload" onDrop={onDrop}>
+        <Dropzone.Title>Drop it</Dropzone.Title>
+      </Dropzone.Root>,
+    );
+
+    fireEvent.change(picker(container), { target: { files: [file('a.torrent', 10)] } });
+
+    expect(onDrop).toHaveBeenCalledWith([expect.objectContaining({ name: 'a.torrent' })]);
+    expect(picker(container).value).toBe('');
+  });
+
+  it('says nothing when the picker is dismissed without a file', () => {
+    const onDrop = vi.fn();
+    const onReject = vi.fn();
+    const { container } = render(
+      <Dropzone.Root label="Upload" onDrop={onDrop} onReject={onReject}>
+        <Dropzone.Title>Drop it</Dropzone.Title>
+      </Dropzone.Root>,
+    );
+
+    fireEvent.change(picker(container), { target: { files: [] } });
+
+    expect(onDrop).not.toHaveBeenCalled();
+    expect(onReject).not.toHaveBeenCalled();
+  });
+
+  it('shrugs off a drop that carries no transfer at all', () => {
+    const onDrop = vi.fn();
+    render(
+      <Dropzone.Root label="Upload" onDrop={onDrop}>
+        <Dropzone.Title>Drop it</Dropzone.Title>
+      </Dropzone.Root>,
+    );
+
+    fireEvent.drop(screen.getByRole('button'));
+
+    expect(onDrop).not.toHaveBeenCalled();
+  });
+
+  it('does not highlight while it is disabled', () => {
+    render(
+      <Dropzone.Root label="Upload" disabled>
+        <Dropzone.Title>Drop it</Dropzone.Title>
+      </Dropzone.Root>,
+    );
+    const zone = screen.getByRole('button');
+
+    fireEvent.dragOver(zone);
+
+    expect(zone.getAttribute('data-drag-active')).toBeNull();
+  });
+});

--- a/packages/ui/src/components/molecules/dropzone/dropzone.tsx
+++ b/packages/ui/src/components/molecules/dropzone/dropzone.tsx
@@ -1,0 +1,59 @@
+// <Dropzone>: the surface a file is dropped on, or clicked to browse for.
+//
+// Dragging a file from the desktop is a POINTER-and-filesystem idea, and a
+// television has neither, so the native targets render the surface as a plain
+// pressable that reports its press and nothing else: a shell that wants to open
+// a picker there does it with the platform's own. The half that listens for
+// drags, reads the files and enforces `accept` / `maxSize` is in ./dropzone.web.
+
+import { Box } from '#ui/components/atoms/box';
+import { Focusable } from '#ui/components/atoms/focusable';
+import { HAND } from '#ui/lib/cursor';
+import {
+  DropzoneDescription,
+  DropzoneIcon,
+  type DropzoneRootProps,
+  DropzoneTitle,
+  SURFACE_SHAPE,
+} from './dropzone-parts';
+
+const SURFACE = {
+  alignItems: 'center',
+  justifyContent: 'center',
+  borderWidth: SURFACE_SHAPE.borderWidth,
+  borderStyle: 'dashed',
+  borderRadius: SURFACE_SHAPE.borderRadius,
+  paddingHorizontal: SURFACE_SHAPE.paddingX,
+  paddingVertical: SURFACE_SHAPE.paddingY,
+} as const;
+
+function Root({ label, disabled = false, children }: Readonly<DropzoneRootProps>) {
+  return (
+    <Focusable role="button" label={label} disabled={disabled} style={[SURFACE, HAND]}>
+      <Box center gap={SURFACE_SHAPE.gap}>
+        {children}
+      </Box>
+    </Focusable>
+  );
+}
+
+/**
+ * A surface files are dropped on, or clicked to browse for.
+ *
+ * ```tsx
+ * <Dropzone.Root accept=".torrent" maxSize={1024 * 1024} onDrop={([file]) => queue(file)}>
+ *   <Dropzone.Icon />
+ *   <Dropzone.Title>Drop a .torrent here</Dropzone.Title>
+ *   <Dropzone.Description>or click to browse</Dropzone.Description>
+ * </Dropzone.Root>
+ * ```
+ */
+const Dropzone = {
+  Root,
+  Icon: DropzoneIcon,
+  Title: DropzoneTitle,
+  Description: DropzoneDescription,
+};
+
+export type { DropzoneRejection, DropzoneRootProps } from './dropzone-parts';
+export { Dropzone };

--- a/packages/ui/src/components/molecules/dropzone/dropzone.web.tsx
+++ b/packages/ui/src/components/molecules/dropzone/dropzone.web.tsx
@@ -1,0 +1,129 @@
+// The pointer-and-filesystem half of <Dropzone>: the drag listeners and the
+// hidden native input that does the actual picking. The two rules a zone
+// enforces are in ./dropzone-sift.
+
+import { type DragEvent, type KeyboardEvent, useCallback, useRef, useState } from 'react';
+import { Box } from '#ui/components/atoms/box';
+import { Spinner } from '#ui/components/atoms/spinner';
+import { color } from '#ui/core';
+import {
+  DropzoneDescription,
+  DropzoneIcon,
+  type DropzoneRootProps,
+  DropzoneTitle,
+  SURFACE_SHAPE,
+} from './dropzone-parts';
+import { sift } from './dropzone-sift';
+
+const HIDDEN = { display: 'none' } as const;
+
+function Root({
+  label,
+  accept,
+  multiple = false,
+  maxSize,
+  disabled = false,
+  loading = false,
+  onDrop,
+  onReject,
+  children,
+}: Readonly<DropzoneRootProps>) {
+  const input = useRef<HTMLInputElement>(null);
+  const [over, setOver] = useState(false);
+  const inert = disabled || loading;
+
+  const take = useCallback(
+    (files: FileList | null) => {
+      if (!files || files.length === 0) return;
+      const { taken, turned } = sift([...files], { accept, maxSize, multiple });
+      if (turned.length > 0) onReject?.(turned);
+      if (taken.length > 0) onDrop?.(taken);
+    },
+    [accept, maxSize, multiple, onDrop, onReject],
+  );
+
+  const onDropped = (e: DragEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    setOver(false);
+    if (!inert) take(e.dataTransfer?.files ?? null);
+  };
+
+  const onKey = (e: KeyboardEvent<HTMLButtonElement>) => {
+    if (inert || (e.key !== 'Enter' && e.key !== ' ')) return;
+    // Space would scroll the dialog under the zone.
+    e.preventDefault();
+    input.current?.click();
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-label={label}
+        disabled={inert}
+        data-drag-active={over || undefined}
+        onClick={() => input.current?.click()}
+        onKeyDown={onKey}
+        onDragOver={(e) => {
+          e.preventDefault();
+          if (!inert) setOver(true);
+        }}
+        onDragLeave={() => setOver(false)}
+        onDrop={onDropped}
+        style={{
+          ...SURFACE_CSS,
+          borderColor: color(over ? 'accent' : 'border'),
+          background: over ? color('accentSoft') : 'transparent',
+          cursor: inert ? 'default' : 'pointer',
+          opacity: disabled ? 0.5 : 1,
+        }}
+      >
+        <Box center gap={SURFACE_SHAPE.gap}>
+          {loading ? <Spinner /> : children}
+        </Box>
+      </button>
+      {/* Beside the button, not inside it: nesting one interactive element in
+          another is invalid, and this one is what actually opens the picker. */}
+      <input
+        ref={input}
+        type="file"
+        accept={accept}
+        multiple={multiple}
+        disabled={inert}
+        aria-label={label}
+        tabIndex={-1}
+        style={HIDDEN}
+        onChange={(e) => {
+          take(e.target.files);
+          // Cleared so picking the SAME file again still fires a change.
+          e.target.value = '';
+        }}
+      />
+    </>
+  );
+}
+
+const SURFACE_CSS = {
+  display: 'flex',
+  width: '100%',
+  flexDirection: 'column' as const,
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: SURFACE_SHAPE.gap,
+  borderWidth: SURFACE_SHAPE.borderWidth,
+  borderStyle: 'dashed' as const,
+  borderRadius: SURFACE_SHAPE.borderRadius,
+  padding: `${SURFACE_SHAPE.paddingY}px ${SURFACE_SHAPE.paddingX}px`,
+  transition: 'border-color 140ms ease, background 140ms ease',
+};
+
+/** A surface files are dropped on, or clicked to browse for. See ./dropzone. */
+const Dropzone = {
+  Root,
+  Icon: DropzoneIcon,
+  Title: DropzoneTitle,
+  Description: DropzoneDescription,
+};
+
+export type { DropzoneRejection, DropzoneRootProps } from './dropzone-parts';
+export { Dropzone };

--- a/packages/ui/src/components/molecules/dropzone/index.ts
+++ b/packages/ui/src/components/molecules/dropzone/index.ts
@@ -1,0 +1,1 @@
+export * from './dropzone';

--- a/packages/ui/src/components/molecules/index.ts
+++ b/packages/ui/src/components/molecules/index.ts
@@ -29,6 +29,8 @@ export type { DataFieldRootProps, DataFieldValueProps } from './data-field';
 export { DataField } from './data-field';
 export type { DisclosureRootProps, DisclosureTriggerProps } from './disclosure';
 export { Disclosure } from './disclosure';
+export type { DropzoneRejection, DropzoneRootProps } from './dropzone';
+export { Dropzone } from './dropzone';
 export type { EmptyStateLayout, EmptyStateRootProps, EmptyStateSize } from './empty-state';
 export { EmptyState } from './empty-state';
 export type { FieldInputProps, FieldRootProps, FieldTextareaProps } from './field';


### PR DESCRIPTION
## What

A `Dropzone` molecule: `Dropzone.Root` with the zone's faces as parts, plus a `.web.tsx` surface that does the real file reading through the DOM drag-and-drop API. On native the Root renders the same faces without the web-only wiring.

A rejection says which rule the file broke (type, size, count) via `DropzoneRejection`, rather than silently refusing the drop.

## Closes

No issue — needed by the manual-add wizard at the top of this stack, which takes an uploaded `.torrent`.

## Checks

- [x] `bun run typecheck`, `bun run test` and `bunx biome check` pass on this layer
- [ ] n/a — no server change
- [x] Follows `CODE_STYLE.md` — no comments narrating the work, exported API only
- [x] One idea. If it grew a second, it was split.

## Risk

New component, no consumer in this layer. The platform split is the thing to check: `dropzone.web.tsx` wins under the `web` vitest project and the shells' Vite config, the plain file wins under Metro. If that split were wrong the native build would pull DOM APIs — the `native` vitest project would fail, and it does not.
