### PR TITLE
feat(ui): Select takes several values

### DIFF
--- a/packages/ui/src/components/molecules/select/select-context.ts
+++ b/packages/ui/src/components/molecules/select/select-context.ts
@@ -30,8 +30,9 @@ interface SelectValueDetails {
 }
 
 interface SelectState {
-  value: string;
-  current: SelectOption | undefined;
+  values: readonly string[];
+  multiple: boolean;
+  picked: readonly SelectOption[];
   label: string | undefined;
   placeholder: string | undefined;
   open: boolean;
@@ -51,6 +52,7 @@ interface SelectRowState {
    *  past: the ring is the keyboard's, the wash is the pointer's. */
   keyed?: boolean;
   onHoverIn?: () => void;
+  onPicked?: () => void;
   onLayout?: (y: number, height: number) => void;
 }
 

--- a/packages/ui/src/components/molecules/select/select-item.tsx
+++ b/packages/ui/src/components/molecules/select/select-item.tsx
@@ -5,6 +5,7 @@
 import { type ReactNode, useMemo } from 'react';
 import { Pressable, type StyleProp, type TextStyle } from 'react-native';
 import { Box } from '#ui/components/atoms/box';
+import { CheckboxFace } from '#ui/components/atoms/checkbox';
 import { Focusable } from '#ui/components/atoms/focusable';
 import { Icon, type IconName } from '#ui/components/atoms/icon';
 import { Text } from '#ui/components/atoms/text';
@@ -73,10 +74,10 @@ function optionOf(props: Readonly<SelectItemProps>): SelectOption {
 
 function Item(props: Readonly<SelectItemProps>) {
   const { value, children, disabled = false } = props;
-  const { value: picked, pick } = useSelect('Item');
+  const { values, pick } = useSelect('Item');
   const row = useSelectRow();
   const option = optionOf(props);
-  const chosen = value === picked;
+  const chosen = values.includes(value);
   const state = useMemo(() => ({ value, chosen }), [value, chosen]);
   const composed = children !== undefined && textOf(children) === undefined;
   const body = (ink: StyleProp<TextStyle>) =>
@@ -94,7 +95,9 @@ function Item(props: Readonly<SelectItemProps>) {
           aria-disabled={disabled}
           tabIndex={-1}
           onPress={() => {
-            if (!disabled) pick(value);
+            if (disabled) return;
+            pick(value);
+            row.onPicked?.();
           }}
           onHoverIn={row.onHoverIn}
           onLayout={(event) => {
@@ -150,10 +153,13 @@ function ItemRow({ option, ink }: Readonly<{ option: SelectOption; ink: StylePro
   );
 }
 
-/** The tick on the picked row. <Select.Item> draws it for you; name it yourself
- *  only when the row's arrangement puts it somewhere else. */
+/** The picked row's face: a tick, or a checkbox where several rows can be
+ *  picked at once. <Select.Item> draws it for you; name it yourself only when
+ *  the row's arrangement puts it somewhere else. */
 function Indicator() {
+  const { multiple } = useSelect('Indicator');
   const { chosen } = useSelectItem('Indicator');
+  if (multiple) return <CheckboxFace checked={chosen} />;
   return (
     <Box w={18} align="center">
       {chosen ? <Icon name="check" size={16} color="accentText" /> : null}

--- a/packages/ui/src/components/molecules/select/select-options.tsx
+++ b/packages/ui/src/components/molecules/select/select-options.tsx
@@ -5,6 +5,7 @@
 import { useId, useState } from 'react';
 import { useListKeys, useRowInView } from '#ui/lib/anchored-keys';
 import {
+  focusTrigger,
   useActiveDescendant,
   useAnchoredPlacement,
   useTriggerFocus,
@@ -26,8 +27,8 @@ function SelectOptions(props: Readonly<SelectSurfaceProps>) {
 const MIN_WIDTH = 160;
 const MAX_HEIGHT = 320;
 
-function firstEnabled(options: readonly SelectOption[], value: string): number {
-  const chosen = options.findIndex((option) => option.value === value && !option.disabled);
+function firstEnabled(options: readonly SelectOption[], values: readonly string[]): number {
+  const chosen = options.findIndex((option) => values.includes(option.value) && !option.disabled);
   if (chosen >= 0) return chosen;
   return Math.max(
     0,
@@ -40,12 +41,13 @@ function SelectPopover({
   label,
   options,
   items,
-  value,
+  values,
+  multiple,
   onPick,
   anchor,
 }: Readonly<SelectSurfaceProps>) {
   const baseId = useId();
-  const [active, setActive] = useState(() => firstEnabled(options, value));
+  const [active, setActive] = useState(() => firstEnabled(options, values));
   const keyed = useFocusVisible(active);
   const { scroll, onRowLayout } = useRowInView(active);
 
@@ -78,6 +80,7 @@ function SelectPopover({
     active: index === active,
     keyed,
     onHoverIn: () => setActive(index),
+    onPicked: () => focusTrigger(anchor),
     onLayout: (y, height) => onRowLayout(index, y, height),
   });
 
@@ -88,6 +91,7 @@ function SelectPopover({
       at={at}
       role={LISTBOX}
       label={label}
+      multiselectable={multiple}
       listId={`${baseId}-list`}
       onDismiss={() => onDismiss('outside')}
       scroll={scroll}

--- a/packages/ui/src/components/molecules/select/select-selection.ts
+++ b/packages/ui/src/components/molecules/select/select-selection.ts
@@ -1,0 +1,68 @@
+import { useMemo } from 'react';
+import { useStableCallback } from '#ui/lib/stable-callback';
+import { useControllable } from '#ui/lib/use-controllable';
+import type { SelectOption, SelectValueDetails } from './select-context';
+
+const NONE: readonly string[] = [];
+
+interface SelectSingleValueProps {
+  multiple?: false;
+  /** '' is "nothing picked": no option may use it, or the placeholder never
+   *  shows. */
+  value?: string;
+  defaultValue?: string;
+  onValueChange?: (next: string, details: SelectValueDetails) => void;
+}
+
+interface SelectMultipleValueProps {
+  /** Every pick toggles a value and the surface stays open. */
+  multiple: true;
+  value?: readonly string[];
+  defaultValue?: readonly string[];
+  onValueChange?: (next: string[], details: SelectValueDetails) => void;
+}
+
+type SelectValueProps = SelectSingleValueProps | SelectMultipleValueProps;
+
+interface SelectSelection {
+  values: readonly string[];
+  choose: (value: string, item: SelectOption | undefined) => void;
+}
+
+function listOf(value: string | readonly string[]): readonly string[] {
+  if (typeof value !== 'string') return value;
+  return value === '' ? NONE : [value];
+}
+
+function toggled(values: readonly string[], value: string): string[] {
+  return values.includes(value) ? values.filter((v) => v !== value) : [...values, value];
+}
+
+function report(
+  props: Readonly<SelectValueProps>,
+  next: readonly string[],
+  item: SelectOption,
+): void {
+  if (props.multiple) props.onValueChange?.([...next], { item });
+  else props.onValueChange?.(next[0] ?? '', { item });
+}
+
+function useSelectSelection(props: Readonly<SelectValueProps>): SelectSelection {
+  const controlled = props.value;
+  const incoming = useMemo(
+    () => (controlled === undefined ? undefined : listOf(controlled)),
+    [controlled],
+  );
+  const [values, setValues] = useControllable(incoming, listOf(props.defaultValue ?? NONE));
+
+  const choose = useStableCallback((value: string, item: SelectOption | undefined) => {
+    const next = props.multiple ? toggled(values, value) : [value];
+    setValues(next);
+    if (item) report(props, next, item);
+  });
+
+  return { values, choose };
+}
+
+export type { SelectMultipleValueProps, SelectSingleValueProps, SelectValueProps };
+export { useSelectSelection };

--- a/packages/ui/src/components/molecules/select/select-surface.ts
+++ b/packages/ui/src/components/molecules/select/select-surface.ts
@@ -14,7 +14,8 @@ export interface SelectSurfaceProps {
   label: string | undefined;
   options: readonly SelectOption[];
   items: readonly ReactElement[];
-  value: string;
+  values: readonly string[];
+  multiple: boolean;
   onPick: (next: string) => void;
   onDismiss: (reason: SelectDismissReason) => void;
   anchor: RefObject<View | null>;

--- a/packages/ui/src/components/molecules/select/select.fixtures.tsx
+++ b/packages/ui/src/components/molecules/select/select.fixtures.tsx
@@ -1,6 +1,8 @@
-import { useState } from 'react';
+import { type ReactNode, useState } from 'react';
 
-import { Box } from '#ui/components/atoms/box';
+import { Box, Row } from '#ui/components/atoms/box';
+
+import { Button } from '#ui/components/atoms/button';
 
 import type { IconName } from '#ui/components/atoms/icon';
 
@@ -105,5 +107,109 @@ function Composed() {
       <Select.Item value="1080p" label="1080p" note="8 Mb/s" />
       <Select.Item value="720p" label="720p" note="4 Mb/s" disabled />
     </Select.Root>
+  );
+}
+
+const STATUSES = [
+  { value: 'active', label: 'Downloading', icon: 'download' },
+  { value: 'done', label: 'Done', icon: 'circle-check' },
+  { value: 'failed', label: 'Failed', icon: 'alert-triangle' },
+] as const satisfies readonly { value: string; label: string; icon: IconName }[];
+
+function StatusPicker({
+  start = [],
+  size,
+  presentation,
+  defaultOpen = false,
+}: Readonly<{
+  start?: readonly string[];
+  size?: ControlSize;
+  presentation?: SelectPresentation;
+  defaultOpen?: boolean;
+}>) {
+  const [picked, setPicked] = useState<readonly string[]>(start);
+  return (
+    <Select.Root
+      multiple
+      label="Status"
+      placeholder="Any status"
+      value={picked}
+      onValueChange={setPicked}
+      presentation={presentation}
+      defaultOpen={defaultOpen}
+    >
+      <Select.Trigger size={size} block />
+      {STATUSES.map((status) => (
+        <Select.Item key={status.value} value={status.value} icon={status.icon}>
+          {status.label}
+        </Select.Item>
+      ))}
+    </Select.Root>
+  );
+}
+
+function Labelled({ name, children }: Readonly<{ name: string; children: ReactNode }>) {
+  return (
+    <Box gap={6}>
+      <Text variant="overline" color="textDim">
+        {name}
+      </Text>
+      {children}
+    </Box>
+  );
+}
+
+export function Statuses({ presentation }: Readonly<{ presentation: SelectPresentation }>) {
+  return (
+    <Box h={presentation === 'panel' ? 260 : 0} w={280}>
+      <StatusPicker start={['active', 'failed']} presentation={presentation} defaultOpen />
+    </Box>
+  );
+}
+
+export function Summaries({ size }: Readonly<{ size?: ControlSize }>) {
+  return (
+    <Box gap={20} w={280}>
+      <Labelled name="nothing picked">
+        <StatusPicker size={size} />
+      </Labelled>
+      <Labelled name="one picked">
+        <StatusPicker size={size} start={['done']} />
+      </Labelled>
+      <Labelled name="several picked">
+        <StatusPicker size={size} start={['active', 'done', 'failed']} />
+      </Labelled>
+    </Box>
+  );
+}
+
+export function Clearable() {
+  const [picked, setPicked] = useState<readonly string[]>(['done', 'failed']);
+  return (
+    <Row gap={10} w={380}>
+      <Box flex>
+        <Select.Root
+          multiple
+          label="Status"
+          placeholder="Any status"
+          value={picked}
+          onValueChange={setPicked}
+        >
+          <Select.Trigger block />
+          {STATUSES.map((status) => (
+            <Select.Item key={status.value} value={status.value} icon={status.icon}>
+              {status.label}
+            </Select.Item>
+          ))}
+        </Select.Root>
+      </Box>
+      <Button
+        variant="ghost"
+        icon="x"
+        label="Clear"
+        disabled={picked.length === 0}
+        onPress={() => setPicked([])}
+      />
+    </Row>
   );
 }

--- a/packages/ui/src/components/molecules/select/select.keyboard.test.tsx
+++ b/packages/ui/src/components/molecules/select/select.keyboard.test.tsx
@@ -9,6 +9,7 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { act } from 'react';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { Box } from '#ui/components/atoms/box';
 import { Focusable } from '#ui/components/atoms/focusable';
 import { Text } from '#ui/components/atoms/text';
 import { activeTheme } from '#ui/core';
@@ -16,7 +17,7 @@ import { configureRemote } from '#ui/lib/focus-remote';
 import { FocusScope } from '#ui/lib/focus-scope';
 import { clearPressGuard } from '#ui/lib/press-guard';
 import { layout } from '#ui/testing';
-import { Select, type SelectRootProps } from './select';
+import { Select, type SelectSingleRootProps } from './select';
 
 beforeAll(() => configureRemote());
 
@@ -262,6 +263,33 @@ describe('the parts', () => {
     expect(screen.getByText('Qualité')).toBeTruthy();
   });
 
+  it('drops the pick when its value is handed back the empty string', () => {
+    const { rerender } = render(<Source value="server" />);
+
+    rerender(<Source value="" />);
+
+    expect(screen.getByRole('combobox').getAttribute('aria-label')).toBe('Source');
+    expect(screen.queryByText('kroma_server')).toBeNull();
+  });
+
+  it('reports nothing for a row it never collected as an option', () => {
+    const onValueChange = vi.fn();
+    render(
+      <Select.Root label="Source" defaultValue="all" onValueChange={onValueChange}>
+        <Select.Trigger />
+        <Select.Item value="all">Toutes les sources</Select.Item>
+        <Box>
+          <Select.Item value="server">kroma_server</Select.Item>
+        </Box>
+      </Select.Root>,
+    );
+
+    fireEvent.click(screen.getByLabelText('kroma_server'));
+
+    expect(onValueChange).not.toHaveBeenCalled();
+    expect(screen.getByRole('combobox').getAttribute('aria-label')).toBe('Source');
+  });
+
   it('opens in a dialog under a D-pad, and Back says so', () => {
     const onOpenChange = vi.fn();
     render(
@@ -352,7 +380,7 @@ const RATES = ['1080p', '720p', '480p', '360p', '240p'];
 const ROW_HEIGHT = 44;
 const FOLD = ROW_HEIGHT * 2;
 
-function Quality({ onValueChange }: Readonly<Pick<SelectRootProps, 'onValueChange'>>) {
+function Quality({ onValueChange }: Readonly<Pick<SelectSingleRootProps, 'onValueChange'>>) {
   return (
     <Select.Root label="Qualité" defaultValue="1080p" onValueChange={onValueChange}>
       <Select.Trigger />

--- a/packages/ui/src/components/molecules/select/select.multiple.test.tsx
+++ b/packages/ui/src/components/molecules/select/select.multiple.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { configureRemote } from '#ui/lib/focus-remote';
+import { clearPressGuard } from '#ui/lib/press-guard';
+import { Select, type SelectValueDetails } from './select';
+
+beforeAll(() => configureRemote());
+
+afterEach(() => {
+  cleanup();
+  clearPressGuard();
+});
+
+function Statuses({
+  picked = ['active'],
+  onValueChange,
+}: Readonly<{
+  picked?: readonly string[];
+  onValueChange?: (next: string[], details: SelectValueDetails) => void;
+}>) {
+  return (
+    <Select.Root
+      multiple
+      label="Statut"
+      defaultValue={picked}
+      presentation="panel"
+      defaultOpen
+      onValueChange={onValueChange}
+    >
+      <Select.Trigger />
+      <Select.Item value="active">En cours</Select.Item>
+      <Select.Item value="done">Terminés</Select.Item>
+      <Select.Item value="failed">Échecs</Select.Item>
+    </Select.Root>
+  );
+}
+
+function trigger(): string | null {
+  return screen.getByRole('combobox').getAttribute('aria-label');
+}
+
+function option(name: string): HTMLElement {
+  return screen.getByRole('option', { name });
+}
+
+describe('a <Select> that takes several values', () => {
+  it('adds a value to the picks and stays open for the next one', () => {
+    render(<Statuses />);
+    clearPressGuard();
+
+    fireEvent.click(option('Terminés'));
+
+    expect(screen.getByRole('listbox')).toBeTruthy();
+    expect(trigger()).toBe('Statut: En cours, Terminés');
+  });
+
+  it('drops a value that is picked a second time', () => {
+    render(<Statuses />);
+    clearPressGuard();
+
+    fireEvent.click(option('En cours'));
+
+    expect(trigger()).toBe('Statut');
+  });
+
+  it('hands its handler the whole list, not only the value that moved', () => {
+    const onValueChange = vi.fn();
+    render(<Statuses onValueChange={onValueChange} />);
+    clearPressGuard();
+
+    fireEvent.click(option('Terminés'));
+
+    expect(onValueChange).toHaveBeenCalledWith(['active', 'done'], {
+      item: expect.objectContaining({ value: 'done', label: 'Terminés' }),
+    });
+  });
+
+  it('takes the keyboard back from a row a pointer pressed, since the list outlives it', () => {
+    render(<Statuses />);
+    clearPressGuard();
+    const row = option('Terminés');
+
+    row.focus();
+    fireEvent.click(row);
+
+    expect(document.activeElement).toBe(screen.getByRole('combobox'));
+  });
+
+  it('announces the listbox as one several rows can be chosen from', () => {
+    render(<Statuses />);
+
+    expect(screen.getByRole('listbox').getAttribute('aria-multiselectable')).toBe('true');
+  });
+
+  it('counts the picks the trigger has no room to name', () => {
+    render(<Statuses picked={['active', 'done', 'failed']} />);
+
+    expect(screen.getByText('+2')).toBeTruthy();
+    expect(trigger()).toBe('Statut: En cours, Terminés, Échecs');
+  });
+
+  it('keeps the dialog a remote drives open as rows are ticked', () => {
+    render(
+      <Select.Root
+        multiple
+        label="Statut"
+        defaultValue={['active']}
+        presentation="dialog"
+        defaultOpen
+      >
+        <Select.Trigger />
+        <Select.Item value="active">En cours</Select.Item>
+        <Select.Item value="done">Terminés</Select.Item>
+      </Select.Root>,
+    );
+    clearPressGuard();
+
+    fireEvent.click(option('Terminés'));
+
+    expect(screen.getByRole('dialog')).toBeTruthy();
+    expect(trigger()).toBe('Statut: En cours, Terminés');
+  });
+
+  it('closes on the first pick when only one value is allowed', () => {
+    render(
+      <Select.Root label="Statut" defaultValue="active" presentation="panel" defaultOpen>
+        <Select.Trigger />
+        <Select.Item value="active">En cours</Select.Item>
+        <Select.Item value="done">Terminés</Select.Item>
+      </Select.Root>,
+    );
+    clearPressGuard();
+
+    fireEvent.click(option('Terminés'));
+
+    expect(screen.queryByRole('listbox')).toBeNull();
+    expect(trigger()).toBe('Statut: Terminés');
+  });
+});

--- a/packages/ui/src/components/molecules/select/select.story.mdx
+++ b/packages/ui/src/components/molecules/select/select.story.mdx
@@ -4,7 +4,7 @@ import { Box } from '#ui/components/atoms/box';
 import { Text } from '#ui/components/atoms/text';
 import { Field } from '#ui/components/molecules/field';
 import { Select, selectTriggerVariants } from './select';
-import { TRACKS, Tracks, Subtitles, Composed, Options } from './select.fixtures';
+import { TRACKS, Tracks, Subtitles, Composed, Options, Statuses, Summaries, Clearable } from './select.fixtures';
 
 export const story = defineStory({
   group: 'Input',
@@ -44,6 +44,64 @@ Pick one of a few, from a trigger that says what is picked. Composed rather than
   <Composed />
 </Scene>
 
+## Several values at once
+
+`multiple` turns the pick into a set. Each row toggles instead of replacing, the
+surface stays open so the next one is a press away, and every row wears a
+checkbox rather than the picked row wearing a tick. The value is an array both
+ways, empty when nothing is picked, and the listbox says `aria-multiselectable`
+so a screen reader announces a set rather than one choice.
+
+```tsx
+<Select.Root multiple label="Status" placeholder="Any status" value={picked} onValueChange={setPicked}>
+  <Select.Trigger />
+  <Select.Item value="active" icon="download">Downloading</Select.Item>
+  <Select.Item value="done" icon="circle-check">Done</Select.Item>
+  <Select.Item value="failed" icon="alert-triangle">Failed</Select.Item>
+</Select.Root>
+```
+
+Reach for it when the answer is a filter over a long list and the only room is a
+trigger: a set of statuses over a queue, a set of genres over a catalogue. Where
+the choices fit on the page, put them there instead. Three or four rows are a
+`<ChoiceList multiple>`, all readable at once, and a handful of one-word answers
+are `<Chip>`s, which show every state with nothing opened.
+
+<Scene name="Pick several">
+  Two statuses ticked. Pressing a row toggles it and leaves the list open for the
+  next one; pressing a ticked row unticks it.
+
+  <Statuses presentation="panel" />
+</Scene>
+
+<Scene name="Several under a D-pad">
+  The same set, in the presentation a remote gets: the dialog stays open as rows
+  are ticked, and Back is the way out. A television reaches a filter with the
+  same component and the same props.
+
+  <Statuses presentation="dialog" />
+</Scene>
+
+<Scene name="What the trigger says">
+  The summary at its three readings. Nothing picked reads as the placeholder, one
+  pick reads as that option with its icon, and several read as the first pick
+  plus a count. Assistive tech hears the whole list either way: the trigger's
+  name is `Status: Downloading, Failed`.
+
+  {story.take(({ size }) => (
+    <Summaries size={size} />
+  ))}
+</Scene>
+
+<Scene name="Clearing">
+  There is no clear button inside the control, because the value belongs to the
+  caller: emptying it is `onValueChange([])`. A filter bar with no room for a
+  second control can offer an "everything" row at the top of the list instead,
+  and clear from there.
+
+  <Clearable />
+</Scene>
+
 ## Where the options appear
 
 `presentation` decides, and its default asks the shell and then the platform: a
@@ -69,9 +127,13 @@ this device would have chosen.
 - Use a `note` for the fact that settles the choice: a bitrate, a codec, a count.
 - Wrap it in `<Field.Root>` for the label row. The select is the control, not the form row.
 - Give a composed row a `label`: it is what the trigger and assistive tech read.
+- Give a `multiple` select a `placeholder` that names the filter: it is what the trigger reads while nothing is picked.
 </Do>
 
 <Dont>
 - Reach for it with two options. Two Chips show both answers at once.
 - Put dozens of items in one: past a screenful it is a search problem, not a pick.
+- Give `multiple` a single string. The value is an array both ways, empty for nothing picked.
+- Use it for three rows that would fit on the page. That is a `<ChoiceList multiple>`, or a row of `<Chip>`s.
+- Add an option that means "all" and expect it to tick. A row that undoes the others is the caller's, and never part of the value.
 </Dont>

--- a/packages/ui/src/components/molecules/select/select.tsx
+++ b/packages/ui/src/components/molecules/select/select.tsx
@@ -1,8 +1,9 @@
-// <Select>: one value from a list. The trigger is shared; where the options
-// appear is the shell's decision (see ./select-options): a <Dialog> under a
-// D-pad (on tvOS a modal is its own view controller, so the remote is
-// confined to the options) and an anchored listbox popover under a pointer,
-// with the combobox keyboard the browser's native select taught everyone.
+// <Select>: one value from a list, or a set of them under `multiple`. The
+// trigger is shared; where the options appear is the shell's decision (see
+// ./select-options): a <Dialog> under a D-pad (on tvOS a modal is its own view
+// controller, so the remote is confined to the options) and an anchored listbox
+// popover under a pointer, with the combobox keyboard the browser's native
+// select taught everyone.
 
 import {
   Children,
@@ -35,6 +36,11 @@ import {
 } from './select-context';
 import { Indicator, Item, optionOf, type SelectItemProps } from './select-item';
 import { SelectOptions } from './select-options';
+import {
+  type SelectMultipleValueProps,
+  type SelectSingleValueProps,
+  useSelectSelection,
+} from './select-selection';
 import type { SelectPresentation } from './select-surface';
 
 // The trigger IS a field: same well, same metrics table, so a select and an
@@ -62,10 +68,7 @@ const triggerVariants = sv({
   defaults: { size: 'md', invalid: false, filled: false, block: false },
 });
 
-interface SelectRootProps {
-  value?: string;
-  defaultValue?: string;
-  onValueChange?: (next: string, details: SelectValueDetails) => void;
+interface SelectRootBase {
   open?: boolean;
   defaultOpen?: boolean;
   onOpenChange?: (open: boolean, details: SelectOpenDetails) => void;
@@ -85,32 +88,37 @@ interface SelectRootProps {
   children: ReactNode;
 }
 
+type SelectSingleRootProps = SelectRootBase & SelectSingleValueProps;
+type SelectMultipleRootProps = SelectRootBase & SelectMultipleValueProps;
+type SelectRootProps = SelectSingleRootProps | SelectMultipleRootProps;
+
 function isItem(node: ReactNode): node is ReactElement<SelectItemProps> {
   return isValidElement(node) && node.type === Item;
 }
 
-function Root({
-  value: valueProp,
-  defaultValue,
-  onValueChange,
-  open: openProp,
-  defaultOpen,
-  onOpenChange,
-  label,
-  placeholder,
-  presentation = 'auto',
-  disabled = false,
-  children,
-}: Readonly<SelectRootProps>) {
-  // '' is "nothing picked": no option may use it, or the placeholder never shows.
-  const [value, setValue] = useControllable(valueProp, defaultValue ?? '');
+function Root(props: Readonly<SelectRootProps>) {
+  const {
+    open: openProp,
+    defaultOpen,
+    onOpenChange,
+    label,
+    placeholder,
+    presentation = 'auto',
+    disabled = false,
+    children,
+  } = props;
+  const multiple = props.multiple === true;
+  const { values, choose } = useSelectSelection(props);
   const [open, setOpenState] = useControllable(openProp, defaultOpen ?? false);
   const anchor = useRef<View>(null);
 
   const kids = useMemo(() => Children.toArray(children), [children]);
   const items = useMemo(() => kids.filter(isItem), [kids]);
   const options = useMemo(() => items.map((item) => optionOf(item.props)), [items]);
-  const current = options.find((option) => option.value === value);
+  const picked = useMemo(
+    () => options.filter((option) => values.includes(option.value)),
+    [options, values],
+  );
 
   const setOpen = useCallback(
     (next: boolean, reason: SelectOpenReason) => {
@@ -122,17 +130,18 @@ function Root({
 
   const pick = useCallback(
     (next: string) => {
-      const item = options.find((option) => option.value === next);
-      setValue(next);
-      if (item) onValueChange?.(next, { item });
-      setOpen(false, 'select');
+      choose(
+        next,
+        options.find((option) => option.value === next),
+      );
+      if (!multiple) setOpen(false, 'select');
     },
-    [options, setValue, onValueChange, setOpen],
+    [options, choose, multiple, setOpen],
   );
 
   const state = useMemo<SelectState>(
-    () => ({ value, current, label, placeholder, open, disabled, anchor, setOpen, pick }),
-    [value, current, label, placeholder, open, disabled, setOpen, pick],
+    () => ({ values, multiple, picked, label, placeholder, open, disabled, anchor, setOpen, pick }),
+    [values, multiple, picked, label, placeholder, open, disabled, setOpen, pick],
   );
 
   return (
@@ -144,7 +153,8 @@ function Root({
         label={label ?? placeholder}
         options={options}
         items={items}
-        value={value}
+        values={values}
+        multiple={multiple}
         onPick={pick}
         onDismiss={(reason: SelectDismissReason) => setOpen(false, reason)}
         anchor={anchor}
@@ -177,7 +187,7 @@ function Trigger({
   children,
   ...focusProps
 }: Readonly<SelectTriggerProps>) {
-  const { label, placeholder, current, open, disabled, anchor, setOpen } = useSelect('Trigger');
+  const { label, placeholder, picked, open, disabled, anchor, setOpen } = useSelect('Trigger');
   const shell = size ?? entryDefaultSize();
   return (
     <Focusable
@@ -185,11 +195,11 @@ function Trigger({
       ref={anchor}
       role="combobox"
       expanded={open}
-      label={triggerName(label, placeholder, current)}
+      label={triggerName(label, placeholder, picked)}
       disabled={disabled}
       onPress={() => setOpen(true, 'trigger')}
       sv={triggerVariants}
-      vars={{ size: shell, invalid, filled: current !== undefined, block }}
+      vars={{ size: shell, invalid, filled: picked.length > 0, block }}
       style={style}
     >
       {(state) => (
@@ -208,23 +218,31 @@ function Trigger({
 function triggerName(
   label: string | undefined,
   placeholder: string | undefined,
-  current: SelectOption | undefined,
+  picked: readonly SelectOption[],
 ): string | undefined {
-  if (!current) return label ?? placeholder;
-  return label ? `${label}: ${current.label}` : current.label;
+  if (picked.length === 0) return label ?? placeholder;
+  const names = picked.map((option) => option.label).join(', ');
+  return label ? `${label}: ${names}` : names;
 }
 
 /** What is picked, rendered inside the trigger: the option's icon and label, or
- *  the placeholder while nothing is. */
+ *  the placeholder while nothing is. A `multiple` select names the first pick
+ *  and counts the rest; assistive tech hears them all. */
 function Value() {
-  const { current, placeholder } = useSelect('Value');
+  const { picked, placeholder } = useSelect('Value');
   const ink = useContext(SelectInkContext);
+  const [first, ...rest] = picked;
   return (
     <>
-      {current?.icon ? <Icon name={current.icon} size={18} color="textMuted" /> : null}
+      {first?.icon ? <Icon name={first.icon} size={18} color="textMuted" /> : null}
       <Text variant="body" lines={1} style={ink}>
-        {current?.label ?? placeholder ?? ''}
+        {first?.label ?? placeholder ?? ''}
       </Text>
+      {rest.length > 0 ? (
+        <Text variant="meta" color="textDim">
+          {`+${rest.length}`}
+        </Text>
+      ) : null}
     </>
   );
 }
@@ -234,11 +252,13 @@ const Select = { Root, Trigger, Value, Item, Indicator };
 export type {
   SelectDismissReason,
   SelectItemProps,
+  SelectMultipleRootProps,
   SelectOpenDetails,
   SelectOpenReason,
   SelectOption,
   SelectPresentation,
   SelectRootProps,
+  SelectSingleRootProps,
   SelectTriggerProps,
   SelectValueDetails,
 };

--- a/packages/ui/src/lib/anchored-panel.ts
+++ b/packages/ui/src/lib/anchored-panel.ts
@@ -129,6 +129,13 @@ export function useTriggerFocus(anchor: RefObject<unknown>): void {
   }, [anchor]);
 }
 
+/** Takes the focus back, for a panel that outlives the press that moved it onto
+ *  a row: a pointer focuses what it presses, and the trigger owns the keyboard
+ *  for as long as the panel is open. */
+export function focusTrigger(anchor: RefObject<unknown>): void {
+  (anchor.current as AnchorHandle | null)?.focus?.();
+}
+
 /**
  * Wires the trigger to a panel it does not contain: its keys reach the panel's
  * keyboard, and `aria-controls`/`aria-haspopup` say what it opens. The trigger

--- a/packages/ui/src/lib/anchored-popup.tsx
+++ b/packages/ui/src/lib/anchored-popup.tsx
@@ -2,7 +2,7 @@
 // is ./anchored-panel and how it takes the keyboard is ./anchored-keys.
 
 import type { ReactNode } from 'react';
-import { Pressable, type Role, ScrollView } from 'react-native';
+import { Pressable, type Role, ScrollView, type ViewProps } from 'react-native';
 import { Box } from '#ui/components/atoms/box';
 import type { AnchorPlacement } from '#ui/lib/anchor';
 import type { PanelScroll } from '#ui/lib/anchored-keys';
@@ -13,10 +13,15 @@ import { useTDefault } from '#ui/services/i18n';
 const PAD = 6;
 const RADIUS = 'xl';
 
+// react-native-web forwards the attribute; React Native's own accessibility
+// props stop short of it, which is why the shape is asserted rather than typed.
+const MULTISELECTABLE = { 'aria-multiselectable': true } as unknown as ViewProps;
+
 interface AnchoredPopupProps {
   at: AnchorPlacement;
   role: Role;
   label: string | undefined;
+  multiselectable?: boolean;
   listId: string;
   onDismiss: () => void;
   scroll?: PanelScroll;
@@ -27,6 +32,7 @@ function AnchoredPopup({
   at,
   role,
   label,
+  multiselectable = false,
   listId,
   onDismiss,
   scroll,
@@ -42,6 +48,7 @@ function AnchoredPopup({
         style={PANEL_BACKDROP}
       />
       <Box
+        {...(multiselectable ? MULTISELECTABLE : null)}
         nativeID={listId}
         role={role}
         accessibilityLabel={label}


### PR DESCRIPTION
## What

`Select` takes several values. With `multiple`, the panel stays open across picks, the value is reported as a list, and each option carries its own selected state.

Two supporting changes in `lib/`: `anchored-panel` and `anchored-popup` stop closing on the press that toggles an option, which single-select relied on and multi-select cannot.

## Closes

No issue — the download queue's filter row needs one control that filters on several statuses at once.

## Checks

- [x] `bun run typecheck`, `bun run test` and `bunx biome check` pass on this layer
- [ ] n/a — no server change
- [x] Follows `CODE_STYLE.md` — no comments narrating the work, exported API only
- [x] One idea. If it grew a second, it was split.

## Risk

`Select` is used across the web client and the kit, so the regression to watch for is single-select behaviour changing: a single Select must still close on pick. `select.keyboard.test.tsx` and `select.multiple.test.tsx` cover both modes, and the story has both.

The dismissal change in `anchored-popup` is the shared one — it also backs other anchored surfaces, so a mistake there shows up as a popup that will not close on outside press.
