### PR TITLE
feat(ui): the kit Table sorts, and scrolls sideways instead of losing a column

### DIFF
--- a/packages/ui/src/components/organisms/index.ts
+++ b/packages/ui/src/components/organisms/index.ts
@@ -82,7 +82,10 @@ export { Resizable, useResizablePanel } from './resizable';
 export type { SplashBackdropProps, SplashCover } from './splash-backdrop';
 export { SplashBackdrop } from './splash-backdrop';
 export type {
+  SortColumn,
+  SortDirection,
   TableCellProps,
+  TableColumn,
   TableRootProps,
   TableRowProps,
   TableSectionProps,

--- a/packages/ui/src/components/organisms/table/table-cell.tsx
+++ b/packages/ui/src/components/organisms/table/table-cell.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from 'react';
+import { Box } from '#ui/components/atoms/box';
+import { Text } from '#ui/components/atoms/text';
+import { styles } from '#ui/core';
+import { space } from '#ui/core/tokens';
+import { drawn, FILL, useTableGrid } from './table-columns';
+import { useTable } from './table-context';
+import { useTableSort } from './table-sort';
+import { SortCell } from './table-sort-cell';
+
+interface TableCellProps {
+  /** A string is set in the table's own type, in the head's ink or the body's;
+   *  anything else is drawn as it was written. */
+  children?: ReactNode;
+}
+
+function Cell({ children }: Readonly<TableCellProps>) {
+  const { head, variant, at } = useTable('Cell');
+  const grid = useTableGrid();
+  const sorting = useTableSort();
+  const column = grid?.columns[at];
+  if (!drawn(column, grid?.step ?? 0)) return null;
+  const pad = variant === 'framed' ? s.cell : s.cellPlain;
+  const sortsBy = head && sorting ? column?.column : undefined;
+  const box = grid?.boxes[at] ?? FILL;
+  const body =
+    typeof children === 'string' ? (
+      <Text variant={head ? 'label' : 'body'} color={head ? 'text' : 'textMuted'}>
+        {children}
+      </Text>
+    ) : (
+      children
+    );
+  if (sortsBy !== undefined && sorting) {
+    return (
+      <SortCell column={sortsBy} align={column?.align} sort={sorting} box={box} pad={pad}>
+        {body}
+      </SortCell>
+    );
+  }
+  return (
+    <Box
+      role={head ? 'columnheader' : 'cell'}
+      style={[box, column?.align === 'end' ? s.end : null, pad]}
+    >
+      {body}
+    </Box>
+  );
+}
+
+const s = styles({
+  cell: { px: space[3], py: space[2] },
+  cellPlain: { py: space[3] },
+  end: { align: 'flex-end' },
+});
+
+export type { TableCellProps };
+export { Cell };

--- a/packages/ui/src/components/organisms/table/table-columns.ts
+++ b/packages/ui/src/components/organisms/table/table-columns.ts
@@ -1,0 +1,85 @@
+import { createContext, useContext } from 'react';
+import type { ViewStyle } from 'react-native';
+import { BREAKPOINTS, type BreakpointName } from '#ui/core/tokens';
+
+interface TableColumn {
+  /** The name this column answers to in the Root's `sort`. Without one it is
+   *  not a sort control. */
+  column?: string;
+  /** Fixed px. A column stating one neither grows nor shrinks. */
+  width?: number;
+  /** Share of the width the fixed columns leave, defaulting to 1. */
+  flex?: number;
+  /** The px a `flex` column stops shrinking at. */
+  min?: number;
+  /** Drawn from this breakpoint up, and absent below it: not narrowed, not
+   *  clipped, and not read out. */
+  from?: BreakpointName;
+  /** Defaults to `start`. */
+  align?: 'start' | 'end';
+}
+
+interface TableGrid {
+  columns: readonly TableColumn[];
+  boxes: readonly ViewStyle[];
+  step: number;
+  minWidth: number;
+}
+
+const GridContext = createContext<TableGrid | null>(null);
+
+function useTableGrid(): TableGrid | null {
+  return useContext(GridContext);
+}
+
+const NO_COLUMNS: readonly TableColumn[] = [];
+
+const FILL: ViewStyle = { flexGrow: 1, flexShrink: 1, flexBasis: 0, minWidth: 0 };
+
+function columnBox(column: TableColumn): ViewStyle {
+  if (column.width !== undefined) {
+    return { width: column.width, flexGrow: 0, flexShrink: 0 };
+  }
+  return {
+    flexGrow: column.flex ?? 1,
+    flexShrink: 1,
+    flexBasis: 0,
+    minWidth: column.min ?? 0,
+  };
+}
+
+function stepOf(name: BreakpointName): number {
+  return BREAKPOINTS.indexOf(name);
+}
+
+function breakpointMask(columns: readonly TableColumn[]): number {
+  let bits = 0;
+  for (const column of columns) {
+    if (column.from) bits |= 1 << stepOf(column.from);
+  }
+  return bits;
+}
+
+function drawn(column: TableColumn | undefined, step: number): boolean {
+  return !column?.from || step >= stepOf(column.from);
+}
+
+function minWidthOf(columns: readonly TableColumn[], step: number): number {
+  let total = 0;
+  for (const column of columns) {
+    if (drawn(column, step)) total += column.width ?? column.min ?? 0;
+  }
+  return total;
+}
+
+export type { TableColumn, TableGrid };
+export {
+  breakpointMask,
+  columnBox,
+  drawn,
+  FILL,
+  GridContext,
+  minWidthOf,
+  NO_COLUMNS,
+  useTableGrid,
+};

--- a/packages/ui/src/components/organisms/table/table-context.ts
+++ b/packages/ui/src/components/organisms/table/table-context.ts
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react';
+import { partContext } from '#ui/lib/part-context';
+
+/** How a table meets the page: as a card of its own (`framed`), or as ruled
+ * rows flush with the column of text around it (`plain`). */
+type TableVariant = 'framed' | 'plain';
+
+interface Place {
+  variant: TableVariant;
+  head: boolean;
+  ruled: boolean;
+  at: number;
+}
+
+interface TableSectionProps {
+  /** A DIRECT <Table.Row> child. */
+  children?: ReactNode;
+}
+
+const [TableContext, useTable] = partContext<Place>('Table.Root');
+
+export type { Place, TableSectionProps, TableVariant };
+export { TableContext, useTable };

--- a/packages/ui/src/components/organisms/table/table-frame.tsx
+++ b/packages/ui/src/components/organisms/table/table-frame.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from 'react';
+import { ScrollView } from 'react-native';
+import { Box } from '#ui/components/atoms/box';
+import { styles } from '#ui/core';
+import { useTableGrid } from './table-columns';
+import type { TableVariant } from './table-context';
+
+interface FrameProps {
+  variant: TableVariant;
+  label?: string;
+  children: ReactNode;
+}
+
+// The scroller sits OUTSIDE `role="table"`, so a reader still walks
+// table -> rowgroup -> row -> cell with nothing of ours in between.
+function Frame({ variant, label, children }: Readonly<FrameProps>) {
+  const grid = useTableGrid();
+  const floor = grid?.minWidth ?? 0;
+  const frame = variant === 'framed' ? s.framed : undefined;
+  if (floor === 0) {
+    return (
+      <Box role="table" aria-label={label} style={frame}>
+        {children}
+      </Box>
+    );
+  }
+  return (
+    <Box style={frame}>
+      <ScrollView horizontal style={s.scroller} contentContainerStyle={s.track}>
+        <Box role="table" aria-label={label} minW={floor} style={s.wide}>
+          {children}
+        </Box>
+      </ScrollView>
+    </Box>
+  );
+}
+
+const s = styles({
+  framed: { border: 'border', radius: 'md', bg: 'surface1', overflow: 'hidden' },
+  // A table is as tall as its rows: without this the scroller takes the height
+  // of whatever it was given and scrolls the rows vertically too.
+  scroller: { grow: 0, shrink: 1 },
+  track: { grow: 1 },
+  wide: { grow: 1 },
+});
+
+export { Frame };

--- a/packages/ui/src/components/organisms/table/table-sort-cell.tsx
+++ b/packages/ui/src/components/organisms/table/table-sort-cell.tsx
@@ -1,0 +1,61 @@
+import type { ReactNode } from 'react';
+import type { StyleProp, ViewStyle } from 'react-native';
+import { Box } from '#ui/components/atoms/box';
+import { Focusable } from '#ui/components/atoms/focusable';
+import { Icon } from '#ui/components/atoms/icon';
+import { Text } from '#ui/components/atoms/text';
+import { styles } from '#ui/core';
+import type { TableColumn } from './table-columns';
+import { SORT_GLYPH, sortClaim, sortPlace, type TableSort } from './table-sort';
+
+interface SortCellProps {
+  column: string;
+  align?: NonNullable<TableColumn['align']>;
+  sort: TableSort;
+  box: StyleProp<ViewStyle>;
+  pad: StyleProp<ViewStyle>;
+  children?: ReactNode;
+}
+
+function SortCell({ column, align, sort, box, pad, children }: Readonly<SortCellProps>) {
+  const place = sortPlace(sort.columns, column);
+  const state = place?.direction ?? 'none';
+  const press = sort.press;
+  const face = (
+    <>
+      {children}
+      <Icon name={SORT_GLYPH[state]} size={14} thickness={2.2} color={place ? 'text' : 'textDim'} />
+      {place && sort.columns.length > 1 ? (
+        <Text variant="overline" color="accentText">
+          {place.rank}
+        </Text>
+      ) : null}
+    </>
+  );
+  const inside = [s.head, pad, align === 'end' ? s.end : null];
+  return (
+    <Box role="columnheader" style={box} {...sortClaim(state)}>
+      {press ? (
+        <Focusable
+          ring="focusEdge"
+          states={HEAD_STATES}
+          style={inside}
+          onPress={() => press(column)}
+        >
+          {face}
+        </Focusable>
+      ) : (
+        <Box style={inside}>{face}</Box>
+      )}
+    </Box>
+  );
+}
+
+const HEAD_STATES = { hover: { bg: 'tint/10' }, press: { bg: 'tint/18' } } as const;
+
+const s = styles({
+  head: { flex: true, row: true, align: 'center', gap: 6, minW: 0 },
+  end: { justify: 'flex-end' },
+});
+
+export { SortCell };

--- a/packages/ui/src/components/organisms/table/table-sort.native.test.ts
+++ b/packages/ui/src/components/organisms/table/table-sort.native.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { nextSort, sortClaim } from './table-sort';
+
+describe('sortClaim', () => {
+  it('claims nothing on a platform with no sort semantics to claim it in', () => {
+    expect(sortClaim('asc')).toEqual({});
+  });
+});
+
+describe('nextSort', () => {
+  it('walks one column ascending, then descending, then out of the sort', () => {
+    const first = nextSort([], 'port', false);
+    const second = nextSort(first, 'port', false);
+
+    expect(first).toEqual([{ column: 'port', direction: 'asc' }]);
+    expect(second).toEqual([{ column: 'port', direction: 'desc' }]);
+    expect(nextSort(second, 'port', false)).toEqual([]);
+  });
+
+  it('appends a column as the last tiebreak when the table takes several', () => {
+    const sort = nextSort([{ column: 'state', direction: 'asc' }], 'date', true);
+
+    expect(sort).toEqual([
+      { column: 'state', direction: 'asc' },
+      { column: 'date', direction: 'asc' },
+    ]);
+  });
+
+  it('turns a column already in the sort instead of sending it to the back', () => {
+    const sort = [
+      { column: 'state', direction: 'asc' },
+      { column: 'date', direction: 'asc' },
+    ] as const;
+
+    expect(nextSort(sort, 'state', true)).toEqual([
+      { column: 'state', direction: 'desc' },
+      { column: 'date', direction: 'asc' },
+    ]);
+  });
+
+  it('leaves the columns around it where they are when one drops out', () => {
+    const sort = [
+      { column: 'state', direction: 'desc' },
+      { column: 'date', direction: 'desc' },
+      { column: 'size', direction: 'asc' },
+    ] as const;
+
+    expect(nextSort(sort, 'date', true)).toEqual([
+      { column: 'state', direction: 'desc' },
+      { column: 'size', direction: 'asc' },
+    ]);
+  });
+});

--- a/packages/ui/src/components/organisms/table/table-sort.ts
+++ b/packages/ui/src/components/organisms/table/table-sort.ts
@@ -1,0 +1,78 @@
+import { createContext, useContext } from 'react';
+import type { IconName } from '#ui/lib/glyph';
+import { WEB } from '#ui/lib/platform';
+
+type SortDirection = 'asc' | 'desc';
+
+/**
+ * One column of the sort, and which way it runs. The array's ORDER is the
+ * priority: the first entry orders the rows, the next breaks its ties.
+ */
+interface SortColumn {
+  column: string;
+  direction: SortDirection;
+}
+
+type SortState = SortDirection | 'none';
+
+interface SortPlace {
+  direction: SortDirection;
+  rank: number;
+}
+
+interface TableSort {
+  columns: readonly SortColumn[];
+  press: ((column: string) => void) | null;
+}
+
+const SortContext = createContext<TableSort | null>(null);
+
+function useTableSort(): TableSort | null {
+  return useContext(SortContext);
+}
+
+const NEXT_DIRECTION = {
+  none: 'asc',
+  asc: 'desc',
+  desc: null,
+} as const satisfies Record<SortState, SortDirection | null>;
+
+const SORT_GLYPH = {
+  none: 'arrows-sort',
+  asc: 'arrow-narrow-up',
+  desc: 'arrow-narrow-down',
+} as const satisfies Record<SortState, IconName>;
+
+const ARIA_SORT = {
+  none: 'none',
+  asc: 'ascending',
+  desc: 'descending',
+} as const satisfies Record<SortState, string>;
+
+function sortPlace(columns: readonly SortColumn[], column: string): SortPlace | null {
+  const at = columns.findIndex((entry) => entry.column === column);
+  const found = columns[at];
+  return found ? { direction: found.direction, rank: at + 1 } : null;
+}
+
+function nextSort(
+  columns: readonly SortColumn[],
+  column: string,
+  multiple: boolean,
+): readonly SortColumn[] {
+  const place = sortPlace(columns, column);
+  const direction = NEXT_DIRECTION[place?.direction ?? 'none'];
+  if (!multiple) return direction ? [{ column, direction }] : [];
+  if (!direction) return columns.filter((entry) => entry.column !== column);
+  if (!place) return [...columns, { column, direction }];
+  return columns.map((entry) => (entry.column === column ? { column, direction } : entry));
+}
+
+/** React Native has no sort claim and no screen reader on those platforms reads
+ *  one, so the rank a heading DRAWS is what reaches assistive tech there. */
+function sortClaim(state: SortState): { 'aria-sort'?: string } {
+  return WEB ? { 'aria-sort': ARIA_SORT[state] } : {};
+}
+
+export type { SortColumn, SortDirection, TableSort };
+export { nextSort, SORT_GLYPH, SortContext, sortClaim, sortPlace, useTableSort };

--- a/packages/ui/src/components/organisms/table/table.fixtures.tsx
+++ b/packages/ui/src/components/organisms/table/table.fixtures.tsx
@@ -1,5 +1,178 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Box } from '#ui/components/atoms/box';
+import { Chip } from '#ui/components/atoms/chip';
+import { Text } from '#ui/components/atoms/text';
+import type { ColorValue } from '#ui/core';
+import { type SortColumn, Table, type TableColumn, type TableVariant } from './table';
+
 export const MODULES = [
   { id: 'tv.kroma.torrents', port: '41310', state: 'Running' },
   { id: 'tv.kroma.whisper', port: '41311', state: 'Running' },
   { id: 'tv.kroma.vpn', port: '41312', state: 'Stopped' },
 ];
+
+export const DOWNLOADS = [
+  { name: 'Arrival', state: 'Seeding', added: '2026-08-19', bytes: 8_100_000_000 },
+  { name: 'Blade Runner 2049', state: 'Downloading', added: '2026-08-24', bytes: 24_600_000_000 },
+  { name: 'Dune', state: 'Seeding', added: '2026-08-24', bytes: 31_200_000_000 },
+  { name: 'Heat', state: 'Paused', added: '2026-08-11', bytes: 12_400_000_000 },
+  { name: 'Sicario', state: 'Downloading', added: '2026-08-19', bytes: 9_800_000_000 },
+];
+
+type Download = (typeof DOWNLOADS)[number];
+
+type Take = { variant?: TableVariant };
+
+const FIELD: Record<string, (row: Download) => string | number> = {
+  name: (row) => row.name,
+  state: (row) => row.state,
+  added: (row) => row.added,
+  bytes: (row) => row.bytes,
+};
+
+const DOT: Record<string, ColorValue> = {
+  Downloading: 'accent',
+  Seeding: 'success',
+  Paused: 'textDim',
+};
+
+function compare(a: string | number, b: string | number): number {
+  if (typeof a === 'number' && typeof b === 'number') return a - b;
+  return String(a).localeCompare(String(b));
+}
+
+export function ordered(rows: readonly Download[], sort: readonly SortColumn[]): Download[] {
+  return [...rows].sort((a, b) => {
+    for (const { column, direction } of sort) {
+      const read = FIELD[column];
+      const side = read ? compare(read(a), read(b)) : 0;
+      if (side !== 0) return direction === 'asc' ? side : -side;
+    }
+    return 0;
+  });
+}
+
+export function query(sort: readonly SortColumn[]): string {
+  const order = sort.map((entry) => `${entry.column}:${entry.direction}`).join(',');
+  return order ? `GET /api/downloads?sort=${order}` : 'GET /api/downloads';
+}
+
+export const COLUMNS: readonly TableColumn[] = [
+  { column: 'name', flex: 2, min: 160 },
+  { column: 'state', width: 172 },
+  { column: 'added', width: 128, from: 'md' },
+  { column: 'bytes', width: 92, align: 'end' },
+];
+
+function Head() {
+  return (
+    <Table.Header>
+      <Table.Row>
+        <Table.Cell>Title</Table.Cell>
+        <Table.Cell>State</Table.Cell>
+        <Table.Cell>Added</Table.Cell>
+        <Table.Cell>Size</Table.Cell>
+      </Table.Row>
+    </Table.Header>
+  );
+}
+
+function Rows({ rows }: Readonly<{ rows: readonly Download[] }>) {
+  return (
+    <Table.Body>
+      {rows.map((row) => (
+        <Table.Row key={row.name}>
+          <Table.Cell>{row.name}</Table.Cell>
+          <Table.Cell>
+            <Chip label={row.state} size="sm" dot={DOT[row.state]} />
+          </Table.Cell>
+          <Table.Cell>{row.added}</Table.Cell>
+          <Table.Cell>{`${(row.bytes / 1e9).toFixed(1)} GB`}</Table.Cell>
+        </Table.Row>
+      ))}
+    </Table.Body>
+  );
+}
+
+export function Columned({ variant, width }: Readonly<Take & { width: number }>) {
+  return (
+    <Box w={width}>
+      <Table.Root variant={variant} label="Downloads" columns={COLUMNS}>
+        <Head />
+        <Rows rows={DOWNLOADS.slice(0, 3)} />
+      </Table.Root>
+    </Box>
+  );
+}
+
+export function SortedByOne({ variant }: Readonly<Take>) {
+  const [sort, setSort] = useState<readonly SortColumn[]>([{ column: 'name', direction: 'asc' }]);
+  const rows = useMemo(() => ordered(DOWNLOADS, sort), [sort]);
+  return (
+    <Table.Root
+      variant={variant}
+      label="Downloads"
+      columns={COLUMNS}
+      sort={sort}
+      onSortChange={setSort}
+    >
+      <Head />
+      <Rows rows={rows} />
+    </Table.Root>
+  );
+}
+
+export function SortedByTwo({ variant }: Readonly<Take>) {
+  const [sort, setSort] = useState<readonly SortColumn[]>([
+    { column: 'state', direction: 'asc' },
+    { column: 'added', direction: 'desc' },
+  ]);
+  const rows = useMemo(() => ordered(DOWNLOADS, sort), [sort]);
+  return (
+    <Table.Root
+      variant={variant}
+      label="Downloads"
+      columns={COLUMNS}
+      multiple
+      sort={sort}
+      onSortChange={setSort}
+    >
+      <Head />
+      <Rows rows={rows} />
+    </Table.Root>
+  );
+}
+
+export function ServerSorted({ variant }: Readonly<Take>) {
+  const [sort, setSort] = useState<readonly SortColumn[]>([{ column: 'added', direction: 'desc' }]);
+  const [rows, setRows] = useState<readonly Download[]>([]);
+  const [waiting, setWaiting] = useState(true);
+  useEffect(() => {
+    setWaiting(true);
+    const answer = setTimeout(() => {
+      setRows(ordered(DOWNLOADS, sort));
+      setWaiting(false);
+    }, 450);
+    return () => clearTimeout(answer);
+  }, [sort]);
+  return (
+    <Box gap={10}>
+      <Text variant="meta" font="mono" color={waiting ? 'accentText' : 'textDim'}>
+        {query(sort)}
+      </Text>
+      <Table.Root
+        variant={variant}
+        label="Downloads"
+        columns={COLUMNS}
+        multiple
+        sort={sort}
+        onSortChange={setSort}
+      >
+        <Head />
+        <Box opacity={waiting ? 0.35 : 1}>
+          <Rows rows={rows} />
+        </Box>
+      </Table.Root>
+    </Box>
+  );
+}

--- a/packages/ui/src/components/organisms/table/table.story.mdx
+++ b/packages/ui/src/components/organisms/table/table.story.mdx
@@ -1,9 +1,10 @@
 import { defineStory } from '@kroma/workbench/story';
 import { Badge } from '#ui/components/atoms/badge';
+import { Box } from '#ui/components/atoms/box';
 import { Chip } from '#ui/components/atoms/chip';
 import { Text } from '#ui/components/atoms/text';
 import { Table } from './table';
-import { MODULES } from './table.fixtures';
+import { Columned, MODULES, ServerSorted, SortedByOne, SortedByTwo } from './table.fixtures';
 
 export const story = defineStory({
   group: 'Layout',
@@ -50,6 +51,80 @@ Rows of the same shape, read down a column as much as across a row. There is no 
   </Table.Body>
 </Table.Root>
 ```
+
+`columns` declares one entry per column, in the order the cells are written, and the Root publishes each entry's box for every row to apply to its nth cell. That is what makes a column a column: Yoga has no grid and cannot align two rows any other way. A column states a fixed `width`, or a `flex` share of what the fixed ones leave with a `min` it stops shrinking at. `from` drops it below a breakpoint, `align` sends its content to the other end, and `column` is the name it answers to in the sort. Left out entirely, every cell takes an equal share, which is what a two-column table of labels and readouts wants.
+
+```tsx
+columns={[
+  { column: 'name', flex: 2, min: 160 },
+  { column: 'state', width: 172 },
+  { column: 'added', width: 128, from: 'md' },
+  { column: 'bytes', width: 92, align: 'end' },
+]}
+```
+
+A heading sorts when its column names one and the Root takes an `onSortChange`. The sort is an ordered list, first key first, and a press is handed the whole next one, so the usual call site is `onSortChange={setSort}`. The table never reorders anything itself. The rows are the caller's children, in whatever order the caller put them, which for a table of any size is the order a server sent. That is also why there is no `defaultSort`: a sort the table owned would move the arrows and leave the rows where they were.
+
+```tsx
+const [sort, setSort] = useState([{ column: 'added', direction: 'desc' }]);
+const rows = ordered(downloads, sort);   // or the server's answer to `sort`
+
+<Table.Root label="Downloads" columns={COLUMNS} multiple sort={sort} onSortChange={setSort}>
+  <Table.Header>
+    <Table.Row>
+      <Table.Cell>Title</Table.Cell>
+      <Table.Cell>Added</Table.Cell>
+      <Table.Cell>Size</Table.Cell>
+    </Table.Row>
+  </Table.Header>
+  ...
+</Table.Root>
+```
+
+The whole heading is the control, so it is one D-pad stop with a hit area the size of the cell, and the arrow and the rank are faces inside it rather than targets of their own. On the browser targets it carries `aria-sort`, which a screen reader announces in its own language. React Native has no sort claim and no reader on those platforms reads one, so the rank is drawn rather than only announced, which also puts it in the heading's accessible name on both.
+
+<Scene name="Columns that hold, then scroll">
+  The same four columns at two widths. State, Added and Size state a `width` and keep it to the pixel; Title takes what is left and stops at its `min` of 160 rather than squeezing to nothing. Size sits at the end of its cell, where a number is read against the ones above it. Added names `from: 'md'` and is gone below that breakpoint, which follows the WINDOW rather than this canvas, so narrow the browser to watch it leave the header and every row at once.
+
+  The second table is narrower than those columns will shrink to, so it scrolls sideways. Drag it. The floor is the sum of every DRAWN column's `width` or `min`, which is why a column that dropped out below its breakpoint does not hold the table open, and why a table declaring no columns has no floor and no scroller. Without one, the last column is simply cut off by the frame, which is the bug this replaces.
+
+  {story.take(({ variant }) => (
+    <Box gap={24}>
+      <Box gap={8}>
+        <Text variant="overline" color="textDim">
+          620
+        </Text>
+        <Columned variant={variant} width={620} />
+      </Box>
+      <Box gap={8}>
+        <Text variant="overline" color="textDim">
+          440
+        </Text>
+        <Columned variant={variant} width={440} />
+      </Box>
+    </Box>
+  ))}
+</Scene>
+
+<Scene name="Sorting one column">
+  A press walks ascending, then descending, then out of the sort. The arrow says which way, and a column that can sort but is not sorting shows the idle glyph, so a reader knows the heading is a control before pressing it. Only one column sorts here: pressing another takes the sort with it.
+
+  {story.take(({ variant }) => <SortedByOne variant={variant} />)}
+</Scene>
+
+<Scene name="Two columns, and the rank that reads them">
+  `multiple` makes a press add its column to the sort as the last tiebreak instead of replacing it, so sorting by state and then by date within state is two presses in that order. The numeral after the arrow is the column's place in the list. It is drawn only once a second column joins, because a rank of one out of one says nothing.
+
+  There is no modifier key. Shift-click is a pointer's idea and a remote has none, so `multiple` is the whole mechanism and a press does the same thing under either hand. Cycling a column past descending drops it and leaves the ranks around it in order.
+
+  {story.take(({ variant }) => <SortedByTwo variant={variant} />)}
+</Scene>
+
+<Scene name="Sorted by the server">
+  What a real screen does with it. The press changes the query, the query is refetched, and the rows arrive already in order. The heading reports the new sort at once while the body is still the old answer, dimmed, so it is always clear which half has caught up. The line above the table is the request the sort becomes, and it moves as you press.
+
+  {story.take(({ variant }) => <ServerSorted variant={variant} />)}
+</Scene>
 
 <Scene name="Composed cells">
   A cell holds whatever it is about. Only a plain string is set in the table's own type; anything else is drawn as it was written, which is how a badge or a chip lands in a column.
@@ -142,10 +217,17 @@ Rows of the same shape, read down a column as much as across a row. There is no 
 - Write the same number of cells in every row: a column is as wide as the cells in it, and nothing else lines them up.
 - Name the table on the Root with `label`, so a reader who lands in the middle of it hears what it is.
 - Use `variant="plain"` where the table sits in a column of text: it has no frame to be inset from, so it lines up with the paragraph above it.
+- Order the rows yourself, in the same render that reports the sort. The table draws the sort; it never applies one.
+- Declare `columns` wherever a column has to hold its width: without one, a cell is as wide as its share of the row and nothing else.
+- Name a `column` only where sorting by it means something: one without a name is not a control and takes no stop.
+- Give a `flex` column a `min`, so a long title stops shrinking rather than squeezing to nothing. It is also what the table refuses to scroll narrower than.
 </Do>
 
 <Dont>
 - Reach for it for a long collection. A table materialises every row, so windowing is `<VirtualGrid>`.
 - Rule a row by hand: the seam belongs to the row under it, which is what keeps the last one from doubling the frame.
 - Put a control in a cell where the whole row is the thing being chosen. That is `<ListRow>`.
+- Ask for a modifier key to add a column to the sort. Set `multiple` and let each press build it, or the remote cannot reach it.
+- Write a different number of cells in the header and the body. The nth cell of every row is the nth column, and nothing else lines them up.
+- Give the arrow a press of its own. The heading is the control, and a target inside it is a second D-pad stop for the same act.
 </Dont>

--- a/packages/ui/src/components/organisms/table/table.test.tsx
+++ b/packages/ui/src/components/organisms/table/table.test.tsx
@@ -1,11 +1,18 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { useEffect, useState } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Badge } from '#ui/components/atoms/badge';
-import { Table } from './table';
+import { pinDesignWidth } from '#ui/core';
+import { clearPressGuard } from '#ui/lib/press-guard';
+import { type SortColumn, Table, type TableColumn } from './table';
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  clearPressGuard();
+  pinDesignWidth();
+});
 
 function Grid({ variant }: Readonly<{ variant?: 'framed' | 'plain' }>) {
   return (
@@ -115,5 +122,344 @@ describe('<Table>', () => {
       ),
     ).toThrow(/Table.Root/);
     quiet.mockRestore();
+  });
+});
+
+const headings = () => screen.getAllByRole('columnheader');
+
+const heading = (at: number) => headings()[at] as HTMLElement;
+
+const rank = (at: number) => within(heading(at)).queryByText(/^\d+$/)?.textContent ?? null;
+
+const press = (name: string) =>
+  fireEvent.click(screen.getByRole('button', { name: new RegExp(`^${name}`) }));
+
+const SORTABLE: readonly TableColumn[] = [{ column: 'id' }, { column: 'port' }, {}];
+
+function Sortable({
+  multiple = false,
+  onSortChange,
+}: Readonly<{ multiple?: boolean; onSortChange?: (next: readonly SortColumn[]) => void }>) {
+  const [sort, setSort] = useState<readonly SortColumn[]>([]);
+  return (
+    <Table.Root
+      label="Modules"
+      columns={SORTABLE}
+      multiple={multiple}
+      sort={sort}
+      onSortChange={(next) => {
+        setSort(next);
+        onSortChange?.(next);
+      }}
+    >
+      <Table.Header>
+        <Table.Row>
+          <Table.Cell>Module</Table.Cell>
+          <Table.Cell>Port</Table.Cell>
+          <Table.Cell>State</Table.Cell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell>tv.kroma.torrents</Table.Cell>
+          <Table.Cell>41310</Table.Cell>
+          <Table.Cell>Running</Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table.Root>
+  );
+}
+
+describe('a heading that sorts', () => {
+  it('cycles ascending, then descending, then out of the sort', () => {
+    render(<Sortable />);
+
+    const cycle = [0, 1, 2].map(() => {
+      press('Module');
+      return heading(0).getAttribute('aria-sort');
+    });
+
+    expect(cycle).toEqual(['ascending', 'descending', 'none']);
+  });
+
+  it('hands the caller the whole next sort rather than one direction', () => {
+    const reported = vi.fn();
+    render(<Sortable onSortChange={reported} />);
+
+    press('Port');
+
+    expect(reported).toHaveBeenCalledWith([{ column: 'port', direction: 'asc' }]);
+  });
+
+  it('is one control carrying its own direction, not a name beside a second target', () => {
+    render(<Sortable />);
+
+    const module = heading(0);
+
+    expect(within(module).getAllByRole('button')).toHaveLength(1);
+    expect(within(module).getByRole('button').querySelector('svg')).toBeTruthy();
+  });
+
+  it('presses over the whole cell, whose padding it takes', () => {
+    render(<Sortable />);
+
+    const module = heading(0);
+
+    expect(getComputedStyle(module).paddingLeft).toBe('0px');
+    expect(getComputedStyle(within(module).getByRole('button')).paddingLeft).toBe('12px');
+  });
+
+  it('leaves a heading whose column names no key out of the sort and out of the tab order', () => {
+    render(<Sortable />);
+
+    const state = heading(2);
+
+    expect(within(state).queryByRole('button')).toBeNull();
+    expect(state.getAttribute('aria-sort')).toBeNull();
+  });
+
+  it('drops the columns already sorted, unless the table takes several', () => {
+    render(<Sortable />);
+    press('Module');
+
+    press('Port');
+
+    expect(headings().map((head) => head.getAttribute('aria-sort'))).toEqual([
+      'none',
+      'ascending',
+      null,
+    ]);
+  });
+
+  it('ranks a column behind the ones already sorting when the table takes several', () => {
+    render(<Sortable multiple />);
+    press('Module');
+
+    press('Port');
+
+    expect(headings().map((head) => head.getAttribute('aria-sort'))).toEqual([
+      'ascending',
+      'ascending',
+      null,
+    ]);
+    expect([rank(0), rank(1)]).toEqual(['1', '2']);
+  });
+
+  it('turns a stacked column where it stands, keeping the rank it was given', () => {
+    render(<Sortable multiple />);
+    press('Module');
+    press('Port');
+
+    press('Module');
+
+    expect(headings().map((head) => head.getAttribute('aria-sort'))).toEqual([
+      'descending',
+      'ascending',
+      null,
+    ]);
+    expect([rank(0), rank(1)]).toEqual(['1', '2']);
+  });
+
+  it('draws no rank while one column carries the whole sort', () => {
+    render(<Sortable multiple />);
+
+    press('Module');
+
+    expect(rank(0)).toBeNull();
+  });
+
+  it('draws a sort the caller only reports, without offering a control', () => {
+    render(
+      <Table.Root
+        label="Modules"
+        columns={[{ column: 'port' }]}
+        sort={[{ column: 'port', direction: 'desc' }]}
+      >
+        <Table.Header>
+          <Table.Row>
+            <Table.Cell>Port</Table.Cell>
+          </Table.Row>
+        </Table.Header>
+      </Table.Root>,
+    );
+
+    const port = heading(0);
+
+    expect(port.getAttribute('aria-sort')).toBe('descending');
+    expect(within(port).queryByRole('button')).toBeNull();
+  });
+});
+
+const COLUMNS: readonly TableColumn[] = [
+  { flex: 2, min: 160 },
+  { width: 148 },
+  { width: 128, from: 'md' },
+  { align: 'end' },
+];
+
+function Declared() {
+  return (
+    <Table.Root label="Downloads" columns={COLUMNS}>
+      <Table.Header>
+        <Table.Row>
+          <Table.Cell>Title</Table.Cell>
+          <Table.Cell>State</Table.Cell>
+          <Table.Cell>Added</Table.Cell>
+          <Table.Cell>Size</Table.Cell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell>Dune</Table.Cell>
+          <Table.Cell>Seeding</Table.Cell>
+          <Table.Cell>2026-08-24</Table.Cell>
+          <Table.Cell>31.2 GB</Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table.Root>
+  );
+}
+
+const boxOf = (node: Element) => {
+  const style = getComputedStyle(node as HTMLElement);
+  return { width: style.width, grow: style.flexGrow, min: style.minWidth };
+};
+
+describe('a declared column', () => {
+  it('gives the same box to the nth cell of every row', () => {
+    pinDesignWidth(1200);
+    render(<Declared />);
+
+    const state = [heading(1), screen.getByText('Seeding').closest('[role="cell"]') as Element];
+
+    expect(state.map(boxOf)).toEqual([
+      { width: '148px', grow: '0', min: '0px' },
+      { width: '148px', grow: '0', min: '0px' },
+    ]);
+  });
+
+  it('shares what the fixed columns leave in the proportion each asks for', () => {
+    pinDesignWidth(1200);
+    render(<Declared />);
+
+    expect(boxOf(heading(0))).toEqual({ width: 'auto', grow: '2', min: '160px' });
+  });
+
+  it('drops a column below the breakpoint it names rather than narrowing it', () => {
+    pinDesignWidth(480);
+    render(<Declared />);
+
+    expect(headings().map((head) => head.textContent)).toEqual(['Title', 'State', 'Size']);
+  });
+
+  it('sits a column at the end when it asks for one', () => {
+    pinDesignWidth(1200);
+    render(<Declared />);
+
+    expect(getComputedStyle(heading(3)).alignItems).toBe('flex-end');
+  });
+
+  it('keeps every cell equal when the table declares no columns', () => {
+    render(<Grid />);
+
+    expect(headings().map(boxOf)).toEqual([
+      { width: 'auto', grow: '1', min: '0px' },
+      { width: 'auto', grow: '1', min: '0px' },
+    ]);
+  });
+});
+
+let mounts = 0;
+
+function Beat() {
+  useEffect(() => {
+    mounts += 1;
+  }, []);
+  return null;
+}
+
+const beating = (names: readonly string[]) => (
+  <Table.Root label="Modules">
+    <Table.Body>
+      {names.map((name) => (
+        <Table.Row key={name}>
+          <Table.Cell>
+            <Beat />
+          </Table.Cell>
+        </Table.Row>
+      ))}
+    </Table.Body>
+  </Table.Root>
+);
+
+describe('a row the caller reorders', () => {
+  it('keeps its identity rather than being remounted under its old position', () => {
+    mounts = 0;
+    const { rerender } = render(beating(['a', 'b']));
+
+    rerender(beating(['b', 'a']));
+
+    expect(mounts).toBe(2);
+  });
+});
+
+const grid = () => screen.getByRole('table') as HTMLElement;
+
+const scroller = () => grid().parentElement?.parentElement as HTMLElement;
+
+describe('a table wider than the room it is given', () => {
+  it('scrolls sideways rather than clipping, and will not shrink past its columns', () => {
+    pinDesignWidth(1200);
+    render(<Declared />);
+
+    expect(getComputedStyle(scroller()).overflowX).toBe('auto');
+    expect(getComputedStyle(grid()).minWidth).toBe('436px');
+  });
+
+  it('leaves a dropped column out of the width it refuses to shrink past', () => {
+    pinDesignWidth(480);
+    render(<Declared />);
+
+    expect(getComputedStyle(grid()).minWidth).toBe('308px');
+  });
+
+  it('keeps the rows directly under the table, with the scroller outside it', () => {
+    pinDesignWidth(1200);
+    render(<Declared />);
+
+    expect(grid().firstElementChild?.getAttribute('role')).toBe('rowgroup');
+    expect(scroller().getAttribute('role')).toBeNull();
+  });
+
+  it('is not wrapped in a scroller at all when nothing can overflow', () => {
+    render(<Grid />);
+
+    expect(getComputedStyle(scroller()).overflowX).not.toBe('auto');
+  });
+});
+
+describe('a sorting heading in a column that reads from the end', () => {
+  it('keeps the whole cell as the control and moves its face instead', () => {
+    render(
+      <Table.Root
+        label="Modules"
+        columns={[{ column: 'port', align: 'end' }, { align: 'end' }]}
+        sort={[]}
+        onSortChange={() => undefined}
+      >
+        <Table.Header>
+          <Table.Row>
+            <Table.Cell>Port</Table.Cell>
+            <Table.Cell>State</Table.Cell>
+          </Table.Row>
+        </Table.Header>
+      </Table.Root>,
+    );
+
+    const control = within(heading(0)).getByRole('button');
+
+    expect(getComputedStyle(heading(0)).alignItems).not.toBe('flex-end');
+    expect(getComputedStyle(control).justifyContent).toBe('flex-end');
+    expect(getComputedStyle(heading(1)).alignItems).toBe('flex-end');
   });
 });

--- a/packages/ui/src/components/organisms/table/table.tsx
+++ b/packages/ui/src/components/organisms/table/table.tsx
@@ -1,50 +1,36 @@
-// <Table>: rows of the same shape, read down a column as much as across a row.
-//
-// There is no <table> on a television, so the grid is Yoga's: a row is a flex
-// row and a cell is a flex child of it. That has one consequence worth knowing
-// before writing one - a column is as wide as the cells in it, and the cells of
-// two different rows do not agree with each other unless every row holds the
-// same number of them.
-//
-// Nothing here can ask a child where it sits: Yoga has no `order` and there is
-// no `:first-child`. So each level hands its own direct children their position
-// once, and a rule is drawn by the row UNDER the seam rather than by the one
-// above it, which is what keeps a table from doubling its own bottom border.
-
-import { Children, isValidElement, type ReactNode, useMemo } from 'react';
+import { Children, isValidElement, type ReactElement, type ReactNode, useMemo } from 'react';
+import type { ViewStyle } from 'react-native';
 import { Box } from '#ui/components/atoms/box';
-import { Text } from '#ui/components/atoms/text';
-import { styles } from '#ui/core';
-import { space } from '#ui/core/tokens';
-import { partContext } from '#ui/lib/part-context';
+import { styles, useBreakpointStep } from '#ui/core';
+import { useStableCallback } from '#ui/lib/stable-callback';
+import { Cell } from './table-cell';
+import {
+  breakpointMask,
+  columnBox,
+  GridContext,
+  minWidthOf,
+  NO_COLUMNS,
+  type TableColumn,
+} from './table-columns';
+import {
+  type Place,
+  TableContext,
+  type TableSectionProps,
+  type TableVariant,
+  useTable,
+} from './table-context';
+import { Frame } from './table-frame';
+import { nextSort, type SortColumn, SortContext, type TableSort } from './table-sort';
 
-/** How a table meets the page: as a card of its own (`framed`), or as ruled
- * rows flush with the column of text around it (`plain`). */
-type TableVariant = 'framed' | 'plain';
-
-interface Context {
-  variant: TableVariant;
-  head: boolean;
-  /** Nothing is drawn above this part inside the table, so it carries no rule. */
-  top: boolean;
+function parts(children: ReactNode): ReactElement[] {
+  return Children.toArray(children).filter(isValidElement);
 }
 
-const [TableContext, useTable] = partContext<Context>('Table.Root');
-
-// Only an element can be handed a position, and a table's children are always
-// parts: anything else is dropped rather than left to shift the grid.
-function parts(children: ReactNode): ReactNode[] {
-  return Children.toArray(children).filter((child) => isValidElement(child));
-}
-
-function Placed({ items, places }: Readonly<{ items: ReactNode[]; places: Context[] }>) {
+function Placed({ items, places }: Readonly<{ items: ReactElement[]; places: Place[] }>) {
   return (
     <>
       {items.map((child, at) => (
-        // The position is the identity: this is the caller's own list, in the
-        // order it was written, and nothing reorders it.
-        // biome-ignore lint/suspicious/noArrayIndexKey: the position IS what the provider carries
-        <TableContext.Provider key={at} value={places[at] as Context}>
+        <TableContext.Provider key={child.key ?? at} value={places[at] as Place}>
           {child}
         </TableContext.Provider>
       ))}
@@ -57,35 +43,84 @@ interface TableRootProps {
   variant?: TableVariant;
   /** Names the table to assistive tech. Draws nothing. */
   label?: string;
-  /** A DIRECT <Table.Header>, <Table.Body> or <Table.Row> child: only a direct
-   *  child is given its position, and only a part that reads it is ruled. */
+  /** One entry per column, in the order the cells are written. Left out, every
+   *  cell takes an equal share. */
+  columns?: readonly TableColumn[];
+  /** The columns the rows are ordered by, first key first. The table never
+   *  reorders its own rows: they are the caller's. */
+  sort?: readonly SortColumn[];
+  /** Given, every heading whose column names one becomes the sort control. */
+  onSortChange?: (next: readonly SortColumn[], details: { column: string }) => void;
+  /** A press adds its column to the sort as the last tiebreak instead of
+   *  replacing it. */
+  multiple?: boolean;
+  /** A DIRECT <Table.Header>, <Table.Body> or <Table.Row> child. */
   children?: ReactNode;
 }
 
-function Root({ variant = 'framed', label, children }: Readonly<TableRootProps>) {
+function Root({
+  variant = 'framed',
+  label,
+  columns,
+  sort,
+  onSortChange,
+  multiple = false,
+  children,
+}: Readonly<TableRootProps>) {
   const sections = useMemo(() => parts(children), [children]);
   const places = useMemo(
-    () => sections.map((_, at) => ({ variant, head: false, top: at === 0 })),
+    () => sections.map((_, at) => ({ variant, head: false, ruled: at !== 0, at })),
     [variant, sections],
   );
+  const declared = useMemo(() => {
+    const list = columns ?? NO_COLUMNS;
+    return { list, boxes: list.map(columnBox), breakpoints: breakpointMask(list) };
+  }, [columns]);
+  const press = useStableCallback((column: string) => {
+    onSortChange?.(nextSort(sort ?? NO_SORT, column, multiple), { column });
+  });
+  const sorting = useMemo<TableSort | null>(() => {
+    if (!sort && !onSortChange) return null;
+    return { columns: sort ?? NO_SORT, press: onSortChange ? press : null };
+  }, [sort, onSortChange, press]);
   return (
-    <Box role="table" aria-label={label} style={variant === 'framed' ? s.framed : undefined}>
-      <Placed places={places} items={sections} />
-    </Box>
+    <SortContext.Provider value={sorting}>
+      <GridScope columns={declared.list} boxes={declared.boxes} breakpoints={declared.breakpoints}>
+        <Frame variant={variant} label={label}>
+          <Placed places={places} items={sections} />
+        </Frame>
+      </GridScope>
+    </SortContext.Provider>
   );
 }
 
-interface TableSectionProps {
-  /** A DIRECT <Table.Row> child. */
-  children?: ReactNode;
+function GridScope({
+  columns,
+  boxes,
+  breakpoints,
+  children,
+}: Readonly<{
+  columns: readonly TableColumn[];
+  boxes: readonly ViewStyle[];
+  breakpoints: number;
+  children: ReactNode;
+}>) {
+  const step = useBreakpointStep(breakpoints);
+  const value = useMemo(
+    () => ({ columns, boxes, step, minWidth: minWidthOf(columns, step) }),
+    [columns, boxes, step],
+  );
+  return <GridContext.Provider value={value}>{children}</GridContext.Provider>;
 }
 
+const NO_SORT: readonly SortColumn[] = [];
+
 function Section({ head, children }: Readonly<{ head: boolean } & TableSectionProps>) {
-  const { variant, top } = useTable(head ? 'Header' : 'Body');
+  const { variant, ruled } = useTable(head ? 'Header' : 'Body');
   const rows = useMemo(() => parts(children), [children]);
   const places = useMemo(
-    () => rows.map((_, at) => ({ variant, head, top: top && at === 0 })),
-    [variant, head, top, rows],
+    () => rows.map((_, at) => ({ variant, head, ruled: ruled || at !== 0, at })),
+    [variant, head, ruled, rows],
   );
   return (
     <Box role="rowgroup" bg={head && variant === 'framed' ? 'surface2' : undefined}>
@@ -94,12 +129,10 @@ function Section({ head, children }: Readonly<{ head: boolean } & TableSectionPr
   );
 }
 
-/** The heading row: its cells name their columns rather than filling them. */
 function Header({ children }: Readonly<TableSectionProps>) {
   return <Section head>{children}</Section>;
 }
 
-/** The rows the table is about. */
 function Body({ children }: Readonly<TableSectionProps>) {
   return <Section head={false}>{children}</Section>;
 }
@@ -110,56 +143,28 @@ interface TableRowProps {
 }
 
 function Row({ children }: Readonly<TableRowProps>) {
-  const { top } = useTable('Row');
-  return (
-    <Box row role="row" style={top ? undefined : s.rule}>
-      {children}
-    </Box>
+  const { variant, head, ruled } = useTable('Row');
+  const cells = useMemo(() => parts(children), [children]);
+  const places = useMemo(
+    () => cells.map((_, at) => ({ variant, head, ruled, at })),
+    [variant, head, ruled, cells],
   );
-}
-
-interface TableCellProps {
-  /** A string is set in the table's own type, in the head's ink or the body's;
-   *  anything else is drawn as it was written. */
-  children?: ReactNode;
-}
-
-function Cell({ children }: Readonly<TableCellProps>) {
-  const { head, variant } = useTable('Cell');
   return (
-    // `minW: 0` is what lets a long cell wrap inside its column instead of
-    // widening it past the ones beside it.
-    <Box
-      flex
-      minW={0}
-      role={head ? 'columnheader' : 'cell'}
-      style={variant === 'framed' ? s.cell : s.cellPlain}
-    >
-      {typeof children === 'string' ? (
-        <Text variant={head ? 'label' : 'body'} color={head ? 'text' : 'textMuted'}>
-          {children}
-        </Text>
-      ) : (
-        children
-      )}
+    <Box row role="row" style={ruled ? s.rule : undefined}>
+      <Placed places={places} items={cells} />
     </Box>
   );
 }
 
 const s = styles({
-  framed: { border: 'border', radius: 'md', bg: 'surface1', overflow: 'hidden' },
   rule: { borderTopWidth: 1, borderTopColor: 'border' },
-  cell: { px: space[3], py: space[2] },
-  // Flush with the text around it: a plain table has no frame to be inset from,
-  // and its first column has to line up with the paragraph above it.
-  cellPlain: { py: space[3] },
 });
 
 /**
  * Rows of the same shape.
  *
  * ```tsx
- * <Table.Root label="Modules">
+ * <Table.Root label="Modules" columns={[{ column: 'id' }, { width: 90 }]}>
  *   <Table.Header>
  *     <Table.Row>
  *       <Table.Cell>Module</Table.Cell>
@@ -177,5 +182,14 @@ const s = styles({
  */
 const Table = { Root, Header, Body, Row, Cell };
 
-export type { TableCellProps, TableRootProps, TableRowProps, TableSectionProps, TableVariant };
+export type { TableCellProps } from './table-cell';
+export type { SortDirection } from './table-sort';
+export type {
+  SortColumn,
+  TableColumn,
+  TableRootProps,
+  TableRowProps,
+  TableSectionProps,
+  TableVariant,
+};
 export { Table };


### PR DESCRIPTION
## What

The kit `Table` sorts and scrolls sideways.

Sorting is declared per column and can stack on as many columns as a reader asks for, so a queue can be ordered by status then by age. `table-sort.ts` holds the comparison, `table-columns.ts` the column model, `table-sort-cell.tsx` the heading control.

A narrow viewport now scrolls the table frame (`table-frame.tsx`) rather than dropping the columns that did not fit.

## Closes

No issue — the download queue needs a sortable table, and the kit's Table was the right place for it.

## Checks

- [x] `bun run typecheck`, `bun run test` and `bunx biome check` pass on this layer
- [ ] n/a — no server change
- [x] Follows `CODE_STYLE.md` — no comments narrating the work, exported API only
- [x] One idea. If it grew a second, it was split.

## Risk

`Table` has existing callers, so the regression to watch for is an unsorted table changing layout: a Table with no sort declared must render as before. The horizontal scroll is the more visible change — the frame must scroll inside itself and not make the page scroll sideways.

Covered by `table.test.tsx` (276 lines added) and `table-sort.native.test.ts`, which pins the comparison under Metro resolution too.
