### PR TITLE
feat(i18n): a dev-only key inspector, added by one line in a vite config

### DIFF
--- a/apps/kit/package.json
+++ b/apps/kit/package.json
@@ -50,6 +50,8 @@
     "@babel/core": "^7.29.7",
     "@kroma/build-info": "workspace:*",
     "@kroma/bundler": "workspace:*",
+    "@kroma/i18n": "workspace:*",
+    "@kroma/i18n-devtools": "workspace:*",
     "@react-native-tvos/config-tv": "^0.1.6",
     "@types/node": "^22.20.1",
     "@types/react": "^19.2.18",

--- a/apps/kit/vite.config.ts
+++ b/apps/kit/vite.config.ts
@@ -10,6 +10,7 @@ import {
   webResolve,
 } from '@kroma/bundler/rnw';
 import { storyCode } from '@kroma/bundler/story-code';
+import { kromaI18nDevtools } from '@kroma/i18n/vite';
 import { kromaUI } from '@kroma/ui/vite';
 import { kromaIconCatalog } from '@kroma/ui/vite/icon-catalog';
 import react from '@vitejs/plugin-react';
@@ -23,6 +24,7 @@ export default defineConfig({
   plugins: [
     kromaUI(),
     kromaIconCatalog(),
+    kromaI18nDevtools(),
     // Before react(): a story's `.docs.mdx` has to be JSX before the React
     // transform sees it.
     kromaMdx(),

--- a/bun.lock
+++ b/bun.lock
@@ -56,6 +56,8 @@
         "@babel/core": "^7.29.7",
         "@kroma/build-info": "workspace:*",
         "@kroma/bundler": "workspace:*",
+        "@kroma/i18n": "workspace:*",
+        "@kroma/i18n-devtools": "workspace:*",
         "@react-native-tvos/config-tv": "^0.1.6",
         "@types/node": "^22.20.1",
         "@types/react": "^19.2.18",
@@ -366,6 +368,8 @@
       "devDependencies": {
         "@babel/core": "^8.0.1",
         "@kroma/bundler": "workspace:*",
+        "@kroma/i18n": "workspace:*",
+        "@kroma/i18n-devtools": "workspace:*",
         "@rolldown/plugin-babel": "^0.2.3",
         "@tanstack/react-query-devtools": "^5.101.4",
         "@tanstack/router-cli": "^1.167.30",
@@ -508,6 +512,8 @@
         "@babel/plugin-transform-classes": "^7.29.7",
         "@babel/preset-env": "^7.29.7",
         "@kroma/build-info": "workspace:*",
+        "@kroma/i18n": "workspace:*",
+        "@kroma/i18n-devtools": "workspace:*",
         "@kroma/ui": "workspace:*",
         "@mdx-js/mdx": "^3.1.1",
         "@mdx-js/rollup": "^3.1.1",
@@ -586,6 +592,7 @@
         "@types/react": "^19.2.18",
         "react": "19.2.8",
         "typescript": "^7.0.2",
+        "vite": "^8.2.1",
       },
       "peerDependencies": {
         "react": ">=18",
@@ -593,6 +600,27 @@
       "optionalPeers": [
         "react",
       ],
+    },
+    "packages/i18n-devtools": {
+      "name": "@kroma/i18n-devtools",
+      "version": "0.0.0",
+      "dependencies": {
+        "@kroma/core": "workspace:*",
+        "@kroma/i18n": "workspace:*",
+        "@kroma/ui": "workspace:*",
+        "zod": "^4.4.3",
+      },
+      "devDependencies": {
+        "@types/react": "^19.2.18",
+        "@types/react-dom": "^19.2.4",
+        "react": "19.2.8",
+        "react-dom": "19.2.8",
+        "typescript": "^7.0.2",
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18",
+      },
     },
     "packages/lan-beacon": {
       "name": "@kroma/lan-beacon",
@@ -1434,6 +1462,8 @@
     "@kroma/desktop": ["@kroma/desktop@workspace:clients/desktop"],
 
     "@kroma/i18n": ["@kroma/i18n@workspace:packages/i18n"],
+
+    "@kroma/i18n-devtools": ["@kroma/i18n-devtools@workspace:packages/i18n-devtools"],
 
     "@kroma/kit": ["@kroma/kit@workspace:apps/kit"],
 

--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -44,6 +44,8 @@
   "devDependencies": {
     "@babel/core": "^8.0.1",
     "@kroma/bundler": "workspace:*",
+    "@kroma/i18n": "workspace:*",
+    "@kroma/i18n-devtools": "workspace:*",
     "@rolldown/plugin-babel": "^0.2.3",
     "@tanstack/react-query-devtools": "^5.101.4",
     "@tanstack/router-cli": "^1.167.30",

--- a/clients/web/vite.config.ts
+++ b/clients/web/vite.config.ts
@@ -8,6 +8,7 @@ import {
   webResolve,
 } from '@kroma/bundler/rnw';
 import { standaloneScript } from '@kroma/bundler/standalone-script';
+import { kromaI18nDevtools } from '@kroma/i18n/vite';
 import { kromaModule } from '@kroma/module-sdk/vite';
 import { kromaUI } from '@kroma/ui/vite';
 import babel from '@rolldown/plugin-babel';
@@ -25,6 +26,7 @@ export default defineConfig({
   plugins: [
     kromaUI(),
     kromaModule(),
+    kromaI18nDevtools(),
     buildInfoPlugin({ projectRoot: fileURLToPath(new URL('.', import.meta.url)) }),
     standaloneScript(swScript),
     tanstackStart({ spa: { enabled: true } }),

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -41,6 +41,8 @@
     "@babel/plugin-transform-classes": "^7.29.7",
     "@babel/preset-env": "^7.29.7",
     "@kroma/build-info": "workspace:*",
+    "@kroma/i18n": "workspace:*",
+    "@kroma/i18n-devtools": "workspace:*",
     "@kroma/ui": "workspace:*",
     "@mdx-js/mdx": "^3.1.1",
     "@mdx-js/rollup": "^3.1.1",

--- a/packages/bundler/src/shell.ts
+++ b/packages/bundler/src/shell.ts
@@ -15,6 +15,7 @@ import {
 } from '@kroma/bundler/rnw';
 import { tvFrame } from '@kroma/bundler/tv-frame';
 import { tvShellHead } from '@kroma/bundler/tv-shell-head';
+import { kromaI18nDevtools } from '@kroma/i18n/vite';
 import { kromaUI } from '@kroma/ui/vite';
 import babel from '@rolldown/plugin-babel';
 import react, { reactCompilerPreset } from '@vitejs/plugin-react';
@@ -78,6 +79,7 @@ export function tvShellConfig(shellUrl: string, target: TvTarget) {
     // browser; off in device mode, where the panel already is that canvas.
     plugins: [
       kromaUI(),
+      kromaI18nDevtools(),
       // Before react(): the workbench behind `?workbench` reads the kit's
       // `.docs.mdx` files, which have to be JSX before the React transform.
       kromaMdx(),

--- a/packages/i18n-devtools/package.json
+++ b/packages/i18n-devtools/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@kroma/i18n-devtools",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "KROMA's in-app i18n dev tools: a floating badge that opens a panel to switch the locale for the session and to render every message as the key and the catalog that answered it. Loaded only by the dev server, through @kroma/i18n/vite.",
+  "author": "Maxime Scharwath <maxscharwath@gmail.com>",
+  "license": "GPL-2.0-or-later",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "directory": "packages/i18n-devtools"
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@kroma/core": "workspace:*",
+    "@kroma/i18n": "workspace:*",
+    "@kroma/ui": "workspace:*",
+    "zod": "^4.4.3"
+  },
+  "peerDependencies": {
+    "react": ">=18",
+    "react-dom": ">=18"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.4",
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
+    "typescript": "^7.0.2"
+  }
+}

--- a/packages/i18n-devtools/src/devtools.test.tsx
+++ b/packages/i18n-devtools/src/devtools.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+
+import { act, render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Devtools } from './devtools';
+import { readSession, writeSession } from './session';
+
+function press(code: string): void {
+  act(() => {
+    window.dispatchEvent(new KeyboardEvent('keydown', { code, ctrlKey: true, altKey: true }));
+  });
+}
+
+afterEach(() => {
+  sessionStorage.clear();
+});
+
+describe('the dev tools', () => {
+  it('keeps the corner a drag stored, which it does not own, when the panel opens', () => {
+    render(<Devtools />);
+    writeSession({ x: 40, y: 60 });
+
+    press('KeyI');
+
+    expect(readSession()).toMatchObject({ open: true, x: 40, y: 60 });
+  });
+
+  it('remembers the switches it does own', () => {
+    render(<Devtools />);
+
+    press('KeyK');
+
+    expect(readSession()).toMatchObject({ keys: true, open: false });
+  });
+});

--- a/packages/i18n-devtools/src/devtools.tsx
+++ b/packages/i18n-devtools/src/devtools.tsx
@@ -1,0 +1,62 @@
+import { activeLocale } from '@kroma/core';
+import { installKeyInspector, installLocaleOverride } from '@kroma/i18n';
+import { keyLabel } from '@kroma/i18n/devtools';
+import { Button } from '@kroma/ui/kit';
+import { useEffect, useState } from 'react';
+import { Panel } from './panel';
+import { type DevtoolsSession, readSession, writeSession } from './session';
+import { chordLabel, isApplePlatform } from './shortcut';
+import { useShortcut } from './use-shortcut';
+
+const KEYS_CODE = 'KeyK';
+const PANEL_CODE = 'KeyI';
+
+export function Devtools() {
+  const [{ open, keys, locale }, setSession] = useState<DevtoolsSession>(readSession);
+
+  const patch = (fields: Partial<DevtoolsSession>) => {
+    setSession((current) => ({ ...current, ...fields }));
+    writeSession(fields);
+  };
+
+  useEffect(() => {
+    installKeyInspector(keys ? keyLabel : null);
+    installLocaleOverride(locale);
+  }, [keys, locale]);
+
+  useShortcut(
+    [
+      { code: KEYS_CODE, run: () => patch({ keys: !keys }) },
+      { code: PANEL_CODE, run: () => patch({ open: !open }) },
+    ],
+    () => {
+      if (open) patch({ open: false });
+    },
+  );
+
+  if (!open) {
+    return (
+      <Button
+        size="sm"
+        variant="glass"
+        icon="language"
+        label="i18n"
+        onPress={() => patch({ open: true })}
+      />
+    );
+  }
+
+  const apple = isApplePlatform(navigator.platform);
+  return (
+    <Panel
+      locale={locale}
+      appLocale={activeLocale()}
+      keys={keys}
+      onLocale={(next) => patch({ locale: next })}
+      onKeys={(next) => patch({ keys: next })}
+      onClose={() => patch({ open: false })}
+      keysChord={chordLabel(KEYS_CODE, apple)}
+      panelChord={chordLabel(PANEL_CODE, apple)}
+    />
+  );
+}

--- a/packages/i18n-devtools/src/drag.test.ts
+++ b/packages/i18n-devtools/src/drag.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { draggable, place } from './drag';
+
+function host(): HTMLElement {
+  const element = document.createElement('div');
+  document.body.append(element);
+  return element;
+}
+
+function pointer(type: string, x: number, y: number): PointerEvent {
+  return new MouseEvent(type, { clientX: x, clientY: y, bubbles: true }) as PointerEvent;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  window.innerWidth = 1000;
+  window.innerHeight = 800;
+});
+
+describe('dragging the tools', () => {
+  it('anchors to a corner by coordinates, inside the viewport', () => {
+    const element = host();
+
+    place(element, 20_000, -50);
+
+    expect(element.style.left).toBe('872px');
+    expect(element.style.top).toBe('8px');
+    expect(element.style.right).toBe('auto');
+  });
+
+  it('reports where it was dropped, once, at the end of the drag', () => {
+    const element = host();
+    const dropped = vi.fn();
+    draggable(element, dropped);
+
+    element.dispatchEvent(pointer('pointerdown', 100, 100));
+    window.dispatchEvent(pointer('pointermove', 160, 140));
+    window.dispatchEvent(pointer('pointerup', 160, 140));
+
+    expect(dropped).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves a press alone, so the badge still opens the panel', () => {
+    const element = host();
+    const dropped = vi.fn();
+    const clicked = vi.fn();
+    element.addEventListener('click', clicked);
+    draggable(element, dropped);
+
+    element.dispatchEvent(pointer('pointerdown', 100, 100));
+    window.dispatchEvent(pointer('pointermove', 101, 101));
+    window.dispatchEvent(pointer('pointerup', 101, 101));
+    element.dispatchEvent(pointer('click', 101, 101));
+
+    expect(dropped).not.toHaveBeenCalled();
+    expect(clicked).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows the click a real drag would otherwise become', () => {
+    const element = host();
+    const clicked = vi.fn();
+    element.addEventListener('click', clicked);
+    draggable(element, vi.fn());
+
+    element.dispatchEvent(pointer('pointerdown', 100, 100));
+    window.dispatchEvent(pointer('pointermove', 200, 200));
+    window.dispatchEvent(pointer('pointerup', 200, 200));
+    element.dispatchEvent(pointer('click', 200, 200));
+
+    expect(clicked).not.toHaveBeenCalled();
+  });
+
+  it('stops listening once disposed', () => {
+    const element = host();
+    const dropped = vi.fn();
+
+    draggable(element, dropped)();
+    element.dispatchEvent(pointer('pointerdown', 100, 100));
+    window.dispatchEvent(pointer('pointermove', 200, 200));
+    window.dispatchEvent(pointer('pointerup', 200, 200));
+
+    expect(dropped).not.toHaveBeenCalled();
+  });
+});

--- a/packages/i18n-devtools/src/drag.ts
+++ b/packages/i18n-devtools/src/drag.ts
@@ -1,0 +1,87 @@
+const THRESHOLD_PX = 4;
+const MARGIN_PX = 8;
+const FALLBACK_WIDTH_PX = 120;
+const FALLBACK_HEIGHT_PX = 40;
+
+interface Grab {
+  pointerX: number;
+  pointerY: number;
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+function moveTo(host: HTMLElement, x: number, y: number, width: number, height: number): void {
+  host.style.right = 'auto';
+  host.style.bottom = 'auto';
+  host.style.left = `${Math.min(Math.max(x, MARGIN_PX), window.innerWidth - width - MARGIN_PX)}px`;
+  host.style.top = `${Math.min(Math.max(y, MARGIN_PX), window.innerHeight - height - MARGIN_PX)}px`;
+}
+
+export function place(host: HTMLElement, x: number, y: number): void {
+  const width = host.offsetWidth || FALLBACK_WIDTH_PX;
+  const height = host.offsetHeight || FALLBACK_HEIGHT_PX;
+  moveTo(host, x, y, width, height);
+}
+
+/** Drag `host` from anywhere inside it. A press that never passes the threshold
+ *  stays a press, so the badge under the pointer still opens the panel; one that
+ *  does swallows the click it would otherwise have become. */
+export function draggable(host: HTMLElement, onDrop: (x: number, y: number) => void): () => void {
+  let grab: Grab | null = null;
+  let dragged = false;
+
+  const move = (event: PointerEvent) => {
+    if (!grab) return;
+    const dx = event.clientX - grab.pointerX;
+    const dy = event.clientY - grab.pointerY;
+    if (!dragged && Math.hypot(dx, dy) < THRESHOLD_PX) return;
+    dragged = true;
+    moveTo(host, grab.left + dx, grab.top + dy, grab.width, grab.height);
+  };
+
+  const release = () => {
+    grab = null;
+    window.removeEventListener('pointermove', move);
+    window.removeEventListener('pointerup', up);
+  };
+
+  function up(): void {
+    if (grab && dragged) {
+      const box = host.getBoundingClientRect();
+      onDrop(box.left, box.top);
+    }
+    release();
+  }
+
+  const down = (event: PointerEvent) => {
+    const box = host.getBoundingClientRect();
+    grab = {
+      pointerX: event.clientX,
+      pointerY: event.clientY,
+      left: box.left,
+      top: box.top,
+      width: box.width || FALLBACK_WIDTH_PX,
+      height: box.height || FALLBACK_HEIGHT_PX,
+    };
+    dragged = false;
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', up);
+  };
+
+  const click = (event: MouseEvent) => {
+    if (!dragged) return;
+    dragged = false;
+    event.stopPropagation();
+    event.preventDefault();
+  };
+
+  host.addEventListener('pointerdown', down);
+  host.addEventListener('click', click, true);
+  return () => {
+    host.removeEventListener('pointerdown', down);
+    host.removeEventListener('click', click, true);
+    release();
+  };
+}

--- a/packages/i18n-devtools/src/index.ts
+++ b/packages/i18n-devtools/src/index.ts
@@ -1,0 +1,1 @@
+export { mount } from './mount';

--- a/packages/i18n-devtools/src/mount.tsx
+++ b/packages/i18n-devtools/src/mount.tsx
@@ -1,0 +1,41 @@
+import { createRoot } from 'react-dom/client';
+import { Devtools } from './devtools';
+import { draggable, place } from './drag';
+import { readSession, writeSession } from './session';
+
+const HOST_STYLE = {
+  position: 'fixed',
+  right: '16px',
+  bottom: '16px',
+  zIndex: '2147483000',
+  display: 'flex',
+  touchAction: 'none',
+} as const;
+
+/** Put the dev tools on the page: a badge in the bottom-right corner that opens
+ *  the panel. Its own React root in its own element, so it never joins the
+ *  layout it is inspecting. Returns a disposer, and does nothing where there is
+ *  no document. */
+export function mount(): () => void {
+  if (typeof document === 'undefined') return () => {};
+  const host = document.createElement('div');
+  host.dataset.kromaI18nDevtools = '';
+  Object.assign(host.style, HOST_STYLE);
+  document.body.append(host);
+
+  const { x, y } = readSession();
+  if (x !== null && y !== null) place(host, x, y);
+  const stopDrag = draggable(host, (left, top) => writeSession({ x: left, y: top }));
+
+  const root = createRoot(host);
+  root.render(<Devtools />);
+
+  return () => {
+    stopDrag();
+    // A hot reload disposes while React may still be rendering the tree above.
+    queueMicrotask(() => {
+      root.unmount();
+      host.remove();
+    });
+  };
+}

--- a/packages/i18n-devtools/src/panel.tsx
+++ b/packages/i18n-devtools/src/panel.tsx
@@ -1,0 +1,84 @@
+import { LOCALES } from '@kroma/core';
+import { Button, Column, IconButton, Row, Surface, Text } from '@kroma/ui/kit';
+
+export interface PanelProps {
+  locale: string | null;
+  appLocale: string;
+  keys: boolean;
+  onLocale: (locale: string | null) => void;
+  onKeys: (keys: boolean) => void;
+  onClose: () => void;
+  keysChord: string;
+  panelChord: string;
+}
+
+const WIDTH_PX = 300;
+
+export function Panel({
+  locale,
+  appLocale,
+  keys,
+  onLocale,
+  onKeys,
+  onClose,
+  keysChord,
+  panelChord,
+}: Readonly<PanelProps>) {
+  const active = locale ?? appLocale;
+  return (
+    <Surface tone="raised" pad="md" elevated gap={14} style={{ width: WIDTH_PX }}>
+      <Row align="center" justify="space-between">
+        <Text variant="label">i18n devtools</Text>
+        <Text variant="meta" color="textDim">
+          {panelChord}
+        </Text>
+        <IconButton icon="x" label="Close" control="sm" variant="ghost" onPress={onClose} />
+      </Row>
+
+      <Column gap={6}>
+        <Text variant="overline" color="textDim">
+          Locale
+        </Text>
+        <Row gap={6}>
+          {LOCALES.map(({ code }) => (
+            <Button
+              key={code}
+              size="sm"
+              variant={locale === code ? 'primary' : 'ghost'}
+              label={code.toUpperCase()}
+              onPress={() => onLocale(code)}
+            />
+          ))}
+          <Button
+            size="sm"
+            variant={locale === null ? 'primary' : 'ghost'}
+            label={`Auto (${appLocale})`}
+            onPress={() => onLocale(null)}
+          />
+        </Row>
+        <Text variant="meta" color="textDim">
+          This tab only. Nothing is saved and the account keeps its language, so text the server
+          writes stays in {appLocale}.
+        </Text>
+      </Column>
+
+      <Column gap={6}>
+        <Text variant="overline" color="textDim">
+          Message keys
+        </Text>
+        <Button
+          size="sm"
+          block
+          icon="language"
+          variant={keys ? 'primary' : 'glass'}
+          label={keys ? 'Showing keys' : 'Show keys'}
+          onPress={() => onKeys(!keys)}
+        />
+        <Text variant="meta" color="textDim">
+          Every message becomes [catalog/key], so {active} text with no brackets did not come from a
+          catalog. {keysChord} does the same.
+        </Text>
+      </Column>
+    </Surface>
+  );
+}

--- a/packages/i18n-devtools/src/session.test.ts
+++ b/packages/i18n-devtools/src/session.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { readSession, writeSession } from './session';
+
+const KEY = 'kroma:i18n-devtools';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  sessionStorage.clear();
+});
+
+describe('the dev-tools session', () => {
+  it('starts closed, with nothing overridden', () => {
+    expect(readSession()).toEqual({ open: false, keys: false, locale: null, x: null, y: null });
+  });
+
+  it('remembers a switch across a reload, which is what a hot reload is', () => {
+    writeSession({ open: true, keys: true, locale: 'fr' });
+
+    expect(readSession()).toMatchObject({ open: true, keys: true, locale: 'fr' });
+  });
+
+  it('merges a patch over what is stored rather than replacing it', () => {
+    writeSession({ open: true, locale: 'fr' });
+    writeSession({ x: 40, y: 60 });
+
+    expect(readSession()).toMatchObject({ open: true, locale: 'fr', x: 40, y: 60 });
+  });
+
+  it('falls back to closed when the stored blob is not what it claims', () => {
+    sessionStorage.setItem(KEY, '{"open":"yes"}');
+
+    expect(readSession().open).toBe(false);
+  });
+
+  it('falls back to closed when the stored blob is not JSON at all', () => {
+    sessionStorage.setItem(KEY, 'not json');
+
+    expect(readSession().open).toBe(false);
+  });
+
+  it('ignores a blob too large to be its own', () => {
+    sessionStorage.setItem(KEY, JSON.stringify({ open: true, locale: 'x'.repeat(600) }));
+
+    expect(readSession().open).toBe(false);
+  });
+
+  it('reads as closed where the platform has no session storage', () => {
+    vi.stubGlobal('sessionStorage', undefined);
+
+    expect(readSession()).toEqual({ open: false, keys: false, locale: null, x: null, y: null });
+  });
+
+  it('still answers a patch where there is no session storage to keep it in', () => {
+    vi.stubGlobal('sessionStorage', undefined);
+
+    expect(writeSession({ open: true, locale: 'fr' })).toMatchObject({ open: true, locale: 'fr' });
+  });
+});

--- a/packages/i18n-devtools/src/session.ts
+++ b/packages/i18n-devtools/src/session.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+
+const KEY = 'kroma:i18n-devtools';
+const MAX_CHARS = 512;
+
+const Session = z.object({
+  open: z.boolean().default(false),
+  keys: z.boolean().default(false),
+  locale: z.string().max(16).nullable().default(null),
+  x: z.number().finite().nullable().default(null),
+  y: z.number().finite().nullable().default(null),
+});
+
+export type DevtoolsSession = z.infer<typeof Session>;
+
+const CLOSED: DevtoolsSession = { open: false, keys: false, locale: null, x: null, y: null };
+
+export function readSession(): DevtoolsSession {
+  try {
+    const stored = sessionStorage.getItem(KEY);
+    if (!stored || stored.length > MAX_CHARS) return CLOSED;
+    const parsed = Session.safeParse(JSON.parse(stored));
+    return parsed.success ? parsed.data : CLOSED;
+  } catch {
+    return CLOSED;
+  }
+}
+
+/** Merge `patch` over what the tab already holds, and answer the result even
+ *  where there is no storage to keep it in. */
+export function writeSession(patch: Partial<DevtoolsSession>): DevtoolsSession {
+  const next = { ...readSession(), ...patch };
+  try {
+    sessionStorage.setItem(KEY, JSON.stringify(next));
+  } catch {}
+  return next;
+}

--- a/packages/i18n-devtools/src/shortcut.test.ts
+++ b/packages/i18n-devtools/src/shortcut.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { chordLabel, isApplePlatform, isChord, isEditableTarget } from './shortcut';
+
+const chord = (init: KeyboardEventInit) =>
+  new KeyboardEvent('keydown', { code: 'KeyK', ctrlKey: true, altKey: true, ...init });
+
+describe('isChord', () => {
+  it('matches the physical key so a layout that moves the letter still fires', () => {
+    expect(isChord(chord({ key: '˚' }), 'KeyK')).toBe(true);
+  });
+
+  it('ignores a chord aimed at another key', () => {
+    expect(isChord(chord({}), 'KeyI')).toBe(false);
+  });
+
+  it('refuses AltGr, which Windows and Linux report as ctrl+alt', () => {
+    const altGr = chord({ modifierAltGraph: true } as KeyboardEventInit);
+
+    expect(isChord(altGr, 'KeyK')).toBe(false);
+  });
+
+  it('refuses a key held down so the state does not flip at the repeat rate', () => {
+    expect(isChord(chord({ repeat: true }), 'KeyK')).toBe(false);
+  });
+
+  it('refuses a richer chord that happens to contain this one', () => {
+    expect(isChord(chord({ shiftKey: true }), 'KeyK')).toBe(false);
+    expect(isChord(chord({ metaKey: true }), 'KeyK')).toBe(false);
+  });
+
+  it('refuses either modifier on its own', () => {
+    expect(isChord(chord({ altKey: false }), 'KeyK')).toBe(false);
+    expect(isChord(chord({ ctrlKey: false }), 'KeyK')).toBe(false);
+  });
+});
+
+describe('isEditableTarget', () => {
+  it('reports a field the reader could be typing in', () => {
+    for (const tag of ['input', 'textarea', 'select']) {
+      expect(isEditableTarget(document.createElement(tag))).toBe(true);
+    }
+  });
+
+  it('reports a contenteditable element, and anything nested inside one', () => {
+    const host = document.createElement('div');
+    host.setAttribute('contenteditable', 'true');
+    const inner = document.createElement('span');
+    host.append(inner);
+    document.body.append(host);
+
+    expect(isEditableTarget(host)).toBe(true);
+    expect(isEditableTarget(inner)).toBe(true);
+  });
+
+  it('reports nothing for ordinary content or a missing target', () => {
+    expect(isEditableTarget(document.createElement('div'))).toBe(false);
+    expect(isEditableTarget(null)).toBe(false);
+  });
+});
+
+describe('chordLabel', () => {
+  it('spells the chord the way each platform writes it', () => {
+    expect(chordLabel('KeyK', false)).toBe('Ctrl+Alt+K');
+    expect(chordLabel('KeyK', true)).toBe('⌃⌥K');
+  });
+});
+
+describe('isApplePlatform', () => {
+  it('knows the platforms whose readers expect the symbols', () => {
+    expect(isApplePlatform('MacIntel')).toBe(true);
+    expect(isApplePlatform('iPhone')).toBe(true);
+    expect(isApplePlatform('Win32')).toBe(false);
+    expect(isApplePlatform('Linux x86_64')).toBe(false);
+  });
+});

--- a/packages/i18n-devtools/src/shortcut.ts
+++ b/packages/i18n-devtools/src/shortcut.ts
@@ -1,0 +1,31 @@
+export interface Shortcut {
+  code: string;
+  run: () => void;
+}
+
+const EDITABLE = /^(?:INPUT|TEXTAREA|SELECT)$/;
+const APPLE = /mac|iphone|ipad|ipod/i;
+
+export function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (EDITABLE.test(target.tagName)) return true;
+  return target.isContentEditable === true || target.closest('[contenteditable="true"]') !== null;
+}
+
+export function isChord(event: KeyboardEvent, code: string): boolean {
+  if (event.repeat || event.metaKey || event.shiftKey) return false;
+  if (!event.ctrlKey || !event.altKey) return false;
+  // Windows and Linux report AltGr as ctrl+alt, so every AltGr character on a
+  // Swiss, German or French layout would otherwise land here as a chord.
+  if (event.getModifierState('AltGraph')) return false;
+  return event.code === code;
+}
+
+export function isApplePlatform(platform: string): boolean {
+  return APPLE.test(platform);
+}
+
+export function chordLabel(code: string, apple: boolean): string {
+  const key = code.replace(/^Key/, '');
+  return apple ? `⌃⌥${key}` : `Ctrl+Alt+${key}`;
+}

--- a/packages/i18n-devtools/src/use-shortcut.ts
+++ b/packages/i18n-devtools/src/use-shortcut.ts
@@ -1,0 +1,24 @@
+import { useEffect, useRef } from 'react';
+import { isChord, isEditableTarget, type Shortcut } from './shortcut';
+
+export function useShortcut(shortcuts: readonly Shortcut[], onDismiss?: () => void): void {
+  const latest = useRef({ shortcuts, onDismiss });
+  latest.current = { shortcuts, onDismiss };
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.repeat) return;
+      if (event.key === 'Escape') {
+        latest.current.onDismiss?.();
+        return;
+      }
+      if (isEditableTarget(event.target)) return;
+      const hit = latest.current.shortcuts.find((shortcut) => isChord(event, shortcut.code));
+      if (!hit) return;
+      event.preventDefault();
+      hit.run();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, []);
+}

--- a/packages/i18n-devtools/tsconfig.json
+++ b/packages/i18n-devtools/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["react", "react-dom"]
+  },
+  "include": ["src"]
+}

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -16,6 +16,8 @@
   "exports": {
     ".": "./src/index.ts",
     "./react": "./src/react/index.ts",
+    "./devtools": "./src/devtools/index.ts",
+    "./vite": "./vite/index.ts",
     "./schema": "./schema/catalog.schema.json"
   },
   "scripts": {
@@ -24,7 +26,8 @@
   "devDependencies": {
     "@types/react": "^19.2.18",
     "react": "19.2.8",
-    "typescript": "^7.0.2"
+    "typescript": "^7.0.2",
+    "vite": "^8.2.1"
   },
   "keywords": [
     "i18n",

--- a/packages/i18n/src/chain.ts
+++ b/packages/i18n/src/chain.ts
@@ -25,3 +25,22 @@ export function translateChain(
   }
   return undefined;
 }
+
+/** Where in `chain` {@link translateChain} would take the message from, or `-1`
+ *  when nothing answers. Pairs with `CatalogStore.sources` to say which catalog
+ *  spoke, which is what the key inspector reports. */
+export function answeringIndex(
+  chain: Chain,
+  locale: string,
+  key: string,
+  vars?: TVars,
+  plural?: PluralRule,
+): number {
+  let index = 0;
+  for (const catalog of chain) {
+    const lookup = vars ? resolvePluralKey(catalog, locale, key, vars, plural) : key;
+    if (catalog[lookup] !== undefined) return index;
+    index += 1;
+  }
+  return -1;
+}

--- a/packages/i18n/src/dev-overrides.ts
+++ b/packages/i18n/src/dev-overrides.ts
@@ -1,0 +1,53 @@
+import type { CatalogSource } from './types';
+
+/** Renders a message as something that names its key rather than its text.
+ *  `from` is the catalog that would have answered, or `undefined` when none
+ *  does: the engine has already walked the chain, so an inspector only formats. */
+export type KeyInspector = (key: string, from: CatalogSource | undefined, locale: string) => string;
+
+let inspector: KeyInspector | null = null;
+let locale: string | null = null;
+let revision = 0;
+const listeners = new Set<() => void>();
+
+function changed(): void {
+  revision += 1;
+  for (const listener of listeners) listener();
+}
+
+export function activeKeyInspector(): KeyInspector | null {
+  return inspector;
+}
+
+/** Route every message every instance renders through `next`, or `null` to
+ *  stop. Process-wide on purpose: the dev tools are one switch for the page,
+ *  and they reach an instance they were never handed. */
+export function installKeyInspector(next: KeyInspector | null): void {
+  if (inspector === next) return;
+  inspector = next;
+  changed();
+}
+
+export function activeLocaleOverride(): string | null {
+  return locale;
+}
+
+/** Render every provider in `next` instead of the locale the app resolved, or
+ *  `null` to give it back. Nothing is persisted and no account preference
+ *  moves: this lasts as long as the page does. */
+export function installLocaleOverride(next: string | null): void {
+  if (locale === next) return;
+  locale = next;
+  changed();
+}
+
+export function overridesRevision(): number {
+  return revision;
+}
+
+export function onOverridesChange(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}

--- a/packages/i18n/src/devtools/index.ts
+++ b/packages/i18n/src/devtools/index.ts
@@ -1,0 +1,1 @@
+export { keyLabel } from './key-label';

--- a/packages/i18n/src/devtools/key-label.test.ts
+++ b/packages/i18n/src/devtools/key-label.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { installKeyInspector } from '../dev-overrides';
+import { createI18n } from '../i18n';
+import { keyLabel } from './key-label';
+
+function build() {
+  return createI18n({
+    catalogs: {
+      en: { greeting: 'Hi', only: 'English only', item: '{count} items', item_one: '{count} item' },
+      fr: { greeting: 'Bonjour' },
+    },
+    defaultLocale: 'en',
+  });
+}
+
+afterEach(() => {
+  installKeyInspector(null);
+});
+
+describe('the key label', () => {
+  it('names the core catalog when the app answered', () => {
+    const i18n = build();
+
+    installKeyInspector(keyLabel);
+
+    expect(i18n.translate('fr', 'greeting')).toBe('[core/greeting]');
+  });
+
+  it('names the module whose catalog answered, so ownership is readable', () => {
+    const i18n = build();
+    i18n.add('tv.kroma.torrents', { fr: { greeting: 'Salut' } });
+
+    installKeyInspector(keyLabel);
+
+    expect(i18n.translator('fr', 'tv.kroma.torrents')('greeting')).toBe(
+      '[tv.kroma.torrents/greeting]',
+    );
+  });
+
+  it('marks a key no catalog answers', () => {
+    const i18n = build();
+
+    installKeyInspector(keyLabel);
+
+    expect(i18n.translate('fr', 'nope' as 'greeting')).toBe('[missing/nope]');
+  });
+
+  it('names the locale that answered when it is not the one asked for', () => {
+    const i18n = build();
+
+    installKeyInspector(keyLabel);
+
+    expect(i18n.translate('fr', 'only')).toBe('[core@en/only]');
+  });
+
+  it('labels a plural message with the key as written, not the variant', () => {
+    const i18n = build();
+
+    installKeyInspector(keyLabel);
+
+    expect(i18n.translate('en', 'item', { count: 1 })).toBe('[core/item]');
+  });
+
+  it('leaves the message alone again once it is uninstalled', () => {
+    const i18n = build();
+
+    installKeyInspector(keyLabel);
+    installKeyInspector(null);
+
+    expect(i18n.translate('fr', 'greeting')).toBe('Bonjour');
+  });
+});

--- a/packages/i18n/src/devtools/key-label.ts
+++ b/packages/i18n/src/devtools/key-label.ts
@@ -1,0 +1,14 @@
+import type { KeyInspector } from '../dev-overrides';
+
+const BASE = 'core';
+const UNANSWERED = 'missing';
+
+/** What a message renders as while the key inspector is installed:
+ *  `[core/player.play]` for an app key, `[tv.kroma.torrents/queue.title]` for one
+ *  a module's own catalog answered, `[missing/foo]` for one nothing answers, and
+ *  `[core@en/foo]` when the answer came from the fallback locale. */
+export const keyLabel: KeyInspector = (key, from, locale) => {
+  if (!from) return `[${UNANSWERED}/${key}]`;
+  const scope = from.scope ?? BASE;
+  return `[${from.locale === locale ? scope : `${scope}@${from.locale}`}/${key}]`;
+};

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -1,4 +1,5 @@
-import { translateChain } from './chain';
+import { answeringIndex, translateChain } from './chain';
+import { activeKeyInspector, onOverridesChange, overridesRevision } from './dev-overrides';
 import { CatalogStore, type SCHEMA_KEY } from './store';
 import type { Catalog, Catalogs, PluralRule, TVars } from './types';
 
@@ -65,21 +66,33 @@ export function createI18n<
   const { catalogs, defaultLocale, plural } = config;
   const store = new CatalogStore<L>(catalogs as unknown as Catalogs<L>, defaultLocale as L);
 
-  const render = (locale: L, scope: string | undefined, key: string, vars?: TVars): string =>
-    translateChain(store.chain(locale, scope), locale, key, vars, plural) ?? key;
+  type Bound = (key: K | (string & {}), vars?: TVars) => string;
 
   // One translator per locale and scope, forever. The closure reads the chain
   // on every call rather than capturing it, so an added catalog still reaches
-  // it and the cache never needs clearing. Identity matters: a React hook hands
-  // this straight to callers who put it in a `useMemo` dependency list, and a
-  // fresh closure per render would quietly defeat all of them.
-  const bound = new Map<string, (key: K | (string & {}), vars?: TVars) => string>();
+  // it. Identity matters: a React hook hands this straight to callers who put
+  // it in a `useMemo` dependency list, and a fresh closure per render would
+  // quietly defeat all of them.
+  const bound = new Map<string, Bound>();
+  let revision = overridesRevision();
 
   const translator = (locale: L, scope?: string) => {
+    const current = overridesRevision();
+    if (current !== revision) {
+      bound.clear();
+      revision = current;
+    }
     const cacheKey = scope === undefined ? locale : `${locale}\u0000${scope}`;
     let fn = bound.get(cacheKey);
     if (!fn) {
-      fn = (key, vars) => render(locale, scope, key, vars);
+      const inspector = activeKeyInspector();
+      fn = inspector
+        ? (key, vars) => {
+            const at = answeringIndex(store.chain(locale, scope), locale, key, vars, plural);
+            return inspector(key, at === -1 ? undefined : store.sources(locale, scope)[at], locale);
+          }
+        : (key, vars) =>
+            translateChain(store.chain(locale, scope), locale, key, vars, plural) ?? key;
       bound.set(cacheKey, fn);
     }
     return fn;
@@ -87,11 +100,18 @@ export function createI18n<
 
   return {
     defaultLocale: defaultLocale as L,
-    translate: (locale, key, vars) => render(locale, undefined, key, vars),
+    translate: (locale, key, vars) => translator(locale)(key, vars),
     translator,
     add: (scope, added) => store.add(scope, added),
     has: (key) => store.has(key),
-    version: () => store.version(),
-    subscribe: (listener) => store.subscribe(listener),
+    version: () => store.version() + overridesRevision(),
+    subscribe: (listener) => {
+      const stopStore = store.subscribe(listener);
+      const stopInspector = onOverridesChange(listener);
+      return () => {
+        stopStore();
+        stopInspector();
+      };
+    },
   } as I18n<L, CatalogMessages<C[D]>>;
 }

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -1,5 +1,10 @@
 export { type DefineI18nConfig, defineI18n } from './define';
 export {
+  installKeyInspector,
+  installLocaleOverride,
+  type KeyInspector,
+} from './dev-overrides';
+export {
   createI18n,
   type I18n,
   type I18nConfig,
@@ -12,4 +17,12 @@ export { expandRefs, hasUnresolvedRef } from './nest';
 export { resolvePluralKey, selectCategory } from './plural';
 export type { Locale, MessageKey, Messages, Register, Translate } from './registry';
 export { SCHEMA_KEY } from './store';
-export type { Catalog, Catalogs, LocaleSet, PluralCategory, PluralRule, TVars } from './types';
+export type {
+  Catalog,
+  CatalogSource,
+  Catalogs,
+  LocaleSet,
+  PluralCategory,
+  PluralRule,
+  TVars,
+} from './types';

--- a/packages/i18n/src/react/provider.test.tsx
+++ b/packages/i18n/src/react/provider.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+
+import { act, render } from '@testing-library/react';
+import { useState } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { installKeyInspector, installLocaleOverride } from '../dev-overrides';
+import { keyLabel } from '../devtools/key-label';
+import { createI18n } from '../i18n';
+import { useLocale, useT } from './context';
+import { I18nProvider } from './provider';
+
+const KEYS = ['screen.title', 'screen.subtitle', 'screen.action'] as const;
+const DATA = 'Alien: Earth';
+
+function build() {
+  return createI18n({
+    catalogs: {
+      en: { 'screen.title': 'Downloads', 'screen.subtitle': 'Queue', 'screen.action': 'Add' },
+      fr: {
+        'screen.title': 'Téléchargements',
+        'screen.subtitle': 'File',
+        'screen.action': 'Ajouter',
+      },
+    },
+    defaultLocale: 'en',
+  });
+}
+
+// Holds the first string it is handed, which is what the React Compiler does to
+// a component whose memoised value depends on nothing that moved.
+function Frozen({ text }: Readonly<{ text: string }>) {
+  const [first] = useState(text);
+  return <li>{first}</li>;
+}
+
+function Screen() {
+  const t = useT();
+  const locale = useLocale();
+  return (
+    <ul>
+      {KEYS.map((key) => (
+        <Frozen key={key} text={t(key)} />
+      ))}
+      <Frozen text={DATA} />
+      <Frozen text={new Intl.NumberFormat(locale).format(1234.5)} />
+    </ul>
+  );
+}
+
+function texts(container: HTMLElement): string[] {
+  return [...container.querySelectorAll('li')].map((li) => li.textContent ?? '');
+}
+
+afterEach(() => {
+  installKeyInspector(null);
+  installLocaleOverride(null);
+});
+
+describe('a dev switch over a rendered screen', () => {
+  it('turns every message into its key, and leaves what no catalog wrote alone', () => {
+    const { container } = render(
+      <I18nProvider i18n={build()} locale="en">
+        <Screen />
+      </I18nProvider>,
+    );
+    const before = texts(container);
+
+    act(() => installKeyInspector(keyLabel));
+
+    const after = texts(container);
+    expect(after.filter((text, i) => text !== before[i])).toHaveLength(KEYS.length);
+    expect(after.slice(0, KEYS.length)).toEqual(KEYS.map((key) => `[core/${key}]`));
+    expect(after.at(-2)).toBe(DATA);
+    expect(after.at(-1)).toBe(before.at(-1));
+  });
+
+  it('moves every message AND every formatter when the locale is the switch', () => {
+    const { container } = render(
+      <I18nProvider i18n={build()} locale="en">
+        <Screen />
+      </I18nProvider>,
+    );
+    const before = texts(container);
+
+    act(() => installLocaleOverride('fr'));
+
+    const after = texts(container);
+    expect(after.slice(0, KEYS.length)).toEqual(['Téléchargements', 'File', 'Ajouter']);
+    expect(after.at(-2)).toBe(DATA);
+    expect(after.at(-1)).not.toBe(before.at(-1));
+  });
+
+  it('gives the locale back when the switch does', () => {
+    const { container } = render(
+      <I18nProvider i18n={build()} locale="en">
+        <Screen />
+      </I18nProvider>,
+    );
+
+    act(() => installLocaleOverride('fr'));
+    act(() => installLocaleOverride(null));
+
+    expect(texts(container).slice(0, KEYS.length)).toEqual(['Downloads', 'Queue', 'Add']);
+  });
+});

--- a/packages/i18n/src/react/provider.tsx
+++ b/packages/i18n/src/react/provider.tsx
@@ -1,8 +1,12 @@
 import { type ReactNode, useMemo, useSyncExternalStore } from 'react';
+import { activeLocaleOverride, onOverridesChange, overridesRevision } from '../dev-overrides';
 import type { I18n } from '../i18n';
 import type { Locale } from '../registry';
 import type { Catalog } from '../types';
 import { I18nContext, type I18nValue } from './context';
+
+const revisionOnServer = () => 0;
+const localeOverrideOnServer = () => null;
 
 export interface I18nProviderProps {
   /** The instance built by `createI18n`. */
@@ -24,9 +28,22 @@ export function I18nProvider({
   // components, and a store watch in each of them would mean a set insert per
   // mount for something that changes only when a module registers a catalog.
   const version = useSyncExternalStore(i18n.subscribe, i18n.version, i18n.version);
-  const value = useMemo<I18nValue>(
-    () => ({ i18n, locale, version, setLocale: (next) => onLocaleChange?.(next) }),
-    [i18n, locale, version, onLocaleChange],
+  const revision = useSyncExternalStore(onOverridesChange, overridesRevision, revisionOnServer);
+  const override = useSyncExternalStore(
+    onOverridesChange,
+    activeLocaleOverride,
+    localeOverrideOnServer,
   );
-  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
+  const active = (override as Locale | null) ?? locale;
+  const value = useMemo<I18nValue>(
+    () => ({ i18n, locale: active, version, setLocale: (next) => onLocaleChange?.(next) }),
+    [i18n, active, version, onLocaleChange],
+  );
+  // React Compiler memoisation is per mount, so a component that already
+  // resolved a string would keep showing it without a remount.
+  return (
+    <I18nContext.Provider key={revision} value={value}>
+      {children}
+    </I18nContext.Provider>
+  );
 }

--- a/packages/i18n/src/store.ts
+++ b/packages/i18n/src/store.ts
@@ -1,9 +1,13 @@
 import type { Chain } from './chain';
 import { expandRefs } from './nest';
-import type { Catalog, Catalogs } from './types';
+import type { Catalog, CatalogSource, Catalogs } from './types';
 
 /** `$schema` points an editor at the catalog schema; it is not a message. */
 export const SCHEMA_KEY = '$schema' as const;
+
+function lookupKey(locale: string, scope: string | undefined): string {
+  return scope === undefined ? locale : `${locale}\u0000${scope}`;
+}
 
 function withoutSchema(catalogs: Record<string, Catalog | undefined>): Record<string, Catalog> {
   const out: Record<string, Catalog> = {};
@@ -30,6 +34,7 @@ export class CatalogStore<L extends string> {
   private readonly base: Record<string, Catalog>;
   private readonly scopes = new Map<string, Record<string, Catalog>>();
   private readonly chains = new Map<string, Chain>();
+  private readonly origins = new Map<string, readonly CatalogSource[]>();
   private readonly listeners = new Set<() => void>();
   private revision = 0;
 
@@ -46,17 +51,35 @@ export class CatalogStore<L extends string> {
    *  changes when a scope is added or removed, and building a fresh array per
    *  translation is a measurable share of the cheapest path. */
   chain(locale: string, scope?: string): Chain {
-    const key = scope === undefined ? locale : `${locale}\u0000${scope}`;
-    let chain = this.chains.get(key);
-    if (!chain) {
-      const own = scope ? this.scopes.get(scope) : undefined;
-      const codes = locale === this.defaultLocale ? [locale] : [locale, this.defaultLocale];
-      chain = [own, this.base]
-        .flatMap((source) => codes.map((code) => source?.[code]))
-        .filter((catalog): catalog is Catalog => catalog !== undefined);
-      this.chains.set(key, chain);
-    }
-    return chain;
+    const key = lookupKey(locale, scope);
+    return this.chains.get(key) ?? this.build(key, locale, scope).chain;
+  }
+
+  /** Where each catalog of {@link chain} came from, at the same indices. Kept
+   *  beside the chain rather than in it so that rendering a message never
+   *  walks provenance it does not read. */
+  sources(locale: string, scope?: string): readonly CatalogSource[] {
+    const key = lookupKey(locale, scope);
+    return this.origins.get(key) ?? this.build(key, locale, scope).sources;
+  }
+
+  private build(key: string, locale: string, scope: string | undefined) {
+    const codes = locale === this.defaultLocale ? [locale] : [locale, this.defaultLocale];
+    const chain: Catalog[] = [];
+    const sources: CatalogSource[] = [];
+    const add = (from: string | null, source: Record<string, Catalog> | undefined) => {
+      for (const code of codes) {
+        const catalog = source?.[code];
+        if (!catalog) continue;
+        chain.push(catalog);
+        sources.push({ scope: from, locale: code });
+      }
+    };
+    if (scope) add(scope, this.scopes.get(scope));
+    add(null, this.base);
+    this.chains.set(key, chain);
+    this.origins.set(key, sources);
+    return { chain, sources };
   }
 
   /** Whether the base catalogs declare `key`, which is what "is this a message
@@ -95,6 +118,7 @@ export class CatalogStore<L extends string> {
 
   private changed(): void {
     this.chains.clear();
+    this.origins.clear();
     this.revision += 1;
     for (const listener of this.listeners) listener();
   }

--- a/packages/i18n/src/types.ts
+++ b/packages/i18n/src/types.ts
@@ -9,6 +9,13 @@ export type Catalog = Readonly<Record<string, string>>;
  *  it fall through to the default locale. */
 export type Catalogs<L extends string = string> = Readonly<Partial<Record<L, Catalog>>>;
 
+/** Where a catalog in a lookup came from: the scope that added it, or `null` for
+ *  the base catalogs the app was built with, and the locale it speaks. */
+export interface CatalogSource {
+  readonly scope: string | null;
+  readonly locale: string;
+}
+
 /** A CLDR plural category. Catalogs carry it as a key suffix (`key_one`). */
 export type PluralCategory = Intl.LDMLPluralRule;
 

--- a/packages/i18n/vite/index.test.ts
+++ b/packages/i18n/vite/index.test.ts
@@ -1,0 +1,98 @@
+import type { Plugin } from 'vite';
+import { resolveConfig } from 'vite';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { kromaI18nDevtools } from './index.ts';
+
+const PROVIDER = '/repo/packages/i18n/src/react/provider.tsx';
+
+function inject(plugin: Plugin, id: string, options?: { ssr: boolean }): string | null {
+  if (typeof plugin.transform !== 'function') throw new Error('the plugin lost its transform');
+  const result = plugin.transform.call({} as never, 'export const x = 1;', id, options);
+  if (result === null || result === undefined || typeof result === 'string') return null;
+  return 'code' in result ? (result.code ?? null) : null;
+}
+
+function transform(id: string, options?: { ssr: boolean }): string | null {
+  return inject(kromaI18nDevtools(), id, options);
+}
+
+async function withoutPanel(): Promise<Plugin> {
+  vi.doMock('node:module', () => ({
+    createRequire: () => ({
+      resolve: () => {
+        throw new Error('Cannot find module');
+      },
+    }),
+  }));
+  vi.doMock('node:fs', () => ({ existsSync: () => false }));
+  vi.resetModules();
+
+  const { kromaI18nDevtools: uninstalled } = await import('./index.ts');
+  return uninstalled();
+}
+
+async function pluginNames(command: 'build' | 'serve'): Promise<string[]> {
+  const config = await resolveConfig(
+    { configFile: false, plugins: [kromaI18nDevtools()] },
+    command,
+  );
+  return config.plugins.map((plugin) => plugin.name);
+}
+
+async function aliases(plugin: Plugin): Promise<Record<string, string>> {
+  if (typeof plugin.config !== 'function') throw new Error('the plugin lost its config');
+  const config = await plugin.config.call(
+    {} as never,
+    {},
+    { command: 'serve', mode: 'development' },
+  );
+  const alias = config?.resolve?.alias;
+  return alias === undefined || Array.isArray(alias) ? {} : alias;
+}
+
+afterEach(() => {
+  vi.doUnmock('node:fs');
+  vi.doUnmock('node:module');
+  vi.resetModules();
+});
+
+describe('kromaI18nDevtools', () => {
+  it('mounts the dev tools from the provider, which every shell renders', () => {
+    expect(transform(PROVIDER)).toContain('@kroma/i18n-devtools');
+  });
+
+  it('disposes on a hot reload rather than binding the shortcut twice', () => {
+    expect(transform(PROVIDER)).toContain('import.meta.hot.dispose');
+  });
+
+  it('leaves every other module alone', () => {
+    expect(transform('/repo/packages/i18n/src/react/context.ts')).toBeNull();
+    expect(transform('/repo/clients/web/src/routes/__root.tsx')).toBeNull();
+  });
+
+  it('reaches the provider through the query a dev server appends', () => {
+    expect(transform(`${PROVIDER}?t=1735689600000`)).toContain('@kroma/i18n-devtools');
+  });
+
+  it('leaves the server pass alone, so a prerender renders the real copy', () => {
+    expect(transform(PROVIDER, { ssr: true })).toBeNull();
+  });
+
+  it('is dropped by Vite itself on a production build', async () => {
+    expect(await pluginNames('serve')).toContain('kroma-i18n-devtools');
+
+    expect(await pluginNames('build')).not.toContain('kroma-i18n-devtools');
+  });
+
+  it('resolves the panel itself, since the module it injects into cannot', async () => {
+    expect(await aliases(kromaI18nDevtools())).toHaveProperty('@kroma/i18n-devtools');
+  });
+
+  it('adds no alias where the panel is not installed beside the shell', async () => {
+    expect(await aliases(await withoutPanel())).toEqual({});
+  });
+
+  it('injects nothing without the panel, so a shell that lacks it still starts', async () => {
+    expect(inject(await withoutPanel(), PROVIDER)).toBeNull();
+  });
+});

--- a/packages/i18n/vite/index.ts
+++ b/packages/i18n/vite/index.ts
@@ -1,0 +1,46 @@
+import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import type { Plugin } from 'vite';
+
+const PROVIDER = /[\\/]i18n[\\/]src[\\/]react[\\/]provider\.tsx$/;
+
+const INJECTED = `
+import { mount as __kromaI18nDevtools } from '@kroma/i18n-devtools';
+const __kromaI18nDevtoolsStop = __kromaI18nDevtools();
+if (import.meta.hot) import.meta.hot.dispose(__kromaI18nDevtoolsStop);
+`;
+
+const PANEL = '@kroma/i18n-devtools';
+
+// The injection lands in @kroma/i18n, which does not depend on the panel: only
+// a shell does. So the bare specifier is resolved here, against the shell that
+// loaded this plugin, and handed to Vite as an alias.
+function panelEntry(): string | null {
+  for (const from of [`${process.cwd()}/`, import.meta.url]) {
+    try {
+      return createRequire(from).resolve(PANEL);
+    } catch {}
+  }
+  const sibling = fileURLToPath(new URL('../../i18n-devtools/src/index.ts', import.meta.url));
+  return existsSync(sibling) ? sibling : null;
+}
+
+/** The i18n dev tools, for a shell's `plugins`. Dev server only. */
+export function kromaI18nDevtools(): Plugin {
+  const entry = panelEntry();
+  return {
+    name: 'kroma-i18n-devtools',
+    apply: 'serve',
+    enforce: 'pre',
+    config() {
+      return entry ? { resolve: { alias: { [PANEL]: entry } } } : {};
+    },
+    transform(code, id, options) {
+      if (entry === null || options?.ssr) return null;
+      const query = id.indexOf('?');
+      if (!PROVIDER.test(query === -1 ? id : id.slice(0, query))) return null;
+      return { code: code + INJECTED, map: null };
+    },
+  };
+}

--- a/packages/ui/src/services/format.ts
+++ b/packages/ui/src/services/format.ts
@@ -43,13 +43,17 @@ export interface Format {
   timecode: (ms: number) => string;
 }
 
-// One set per locale for the whole app, not one per mounted component: these
-// are called from table cells and download rows, where fifty of them would mean
-// fifty identical objects and four hundred identical closures.
-const BOUND = new Map<Locale, Format>();
+// One set per translator for the whole app, not one per mounted component:
+// these are called from table cells and download rows, where fifty of them
+// would mean fifty identical objects and four hundred identical closures. The
+// translator rather than the locale is the key because `elapsed` and `uptime`
+// render their unit through it, so a Format built against an older one keeps
+// saying what that one said; one translator is handed out per locale, so this
+// is no coarser.
+const BOUND = new WeakMap<Translate, Format>();
 
 function formatFor(locale: Locale, t: Translate): Format {
-  const cached = BOUND.get(locale);
+  const cached = BOUND.get(t);
   if (cached) return cached;
   const bound: Format = {
     bytes: (bytes) => formatBytes(bytes, locale),
@@ -61,7 +65,7 @@ function formatFor(locale: Locale, t: Translate): Format {
     mbps: (n) => formatMbps(n, locale),
     timecode: formatTimecodeMs,
   };
-  BOUND.set(locale, bound);
+  BOUND.set(t, bound);
   return bound;
 }
 


### PR DESCRIPTION
## What

A dev-only translation-key inspector, turned on by one line in a vite config.

`kromaI18nDevtools()` (from `@kroma/i18n/vite`) mounts a draggable panel that names the key behind any string on the page and lets a translator override it in place, without a rebuild. It is added to `packages/bundler/src/shell.ts` (so every TV shell gets one), `clients/web/vite.config.ts` and `apps/kit/vite.config.ts`.

The panel itself is a new workspace package, `@kroma/i18n-devtools`, kept separate from `@kroma/i18n` so the runtime library does not carry React UI. The plugin resolves the panel against either the shell or the package, so a shell that does not depend on it directly still gets one.

One correctness fix rides along, in `packages/ui/src/services/format.ts`: the bound formatter cache now keys on the translator as well as the locale. `elapsed` and `uptime` render their unit through `t`, so a `Format` built against an older translator kept saying what that one said, and a catalog registered later never reached it.

## Closes

No issue — every user-visible string in this repo is a translation key, and finding which key produced a given string on screen meant grepping the catalog.

## Checks

- [x] `bun run typecheck` (40 workspaces), `bun run test` and `bunx biome check` pass
- [x] `bun install --frozen-lockfile` passes — the lockfile matches this layer's `package.json` files exactly
- [ ] n/a — no server change
- [x] Follows `CODE_STYLE.md`
- [x] One idea.

## Risk

The panel is dev-only and must not reach a production bundle — that is the thing to check. It is gated in the vite plugin, so a mistake would show as `@kroma/i18n-devtools` appearing in a production build's module graph.

The `format.ts` cache-key change touches every formatted number and duration in the app. If it were wrong the symptom would be the opposite of the bug it fixes: a formatter rebuilt on every render. It is one `Map` lookup, and the cache still keys on locale first.
