### PR TITLE
feat(server): a module can ask the host what a title's episodes are called

### DIFF
--- a/packages/client/src/client/module-api.test.ts
+++ b/packages/client/src/client/module-api.test.ts
@@ -51,6 +51,19 @@ describe('moduleApi', () => {
     expect(sent[1]?.init?.body).toBeUndefined();
   });
 
+  it('hands a raw request through for what a JSON body cannot carry', async () => {
+    const { ctx, sent } = makeCtx();
+    const upload = new FormData();
+    upload.append('file', new Blob(['x']), 'poster.png');
+
+    await moduleApi(ctx, 'tv.kroma.vpn').send('/import', { method: 'POST', body: upload });
+
+    expect(sent[0]?.path).toBe('/admin/m/tv.kroma.vpn/import');
+    expect(sent[0]?.init?.method).toBe('POST');
+    expect(sent[0]?.init?.body).toBe(upload);
+    expect(sent[0]?.init?.headers).toBeUndefined();
+  });
+
   it('URL-encodes the module id', async () => {
     const { ctx, sent } = makeCtx();
     await moduleApi(ctx, 'weird/id').get('/x');

--- a/packages/client/src/client/module-api.ts
+++ b/packages/client/src/client/module-api.ts
@@ -12,6 +12,7 @@ export interface ModuleApi {
   post<T>(path: string, body?: unknown): Promise<T>;
   put<T>(path: string, body?: unknown): Promise<T>;
   delete<T>(path: string): Promise<T>;
+  send<T>(path: string, init: RequestInit): Promise<T>;
 }
 
 const send = <T>(ctx: RequestContext, base: string, path: string, init?: RequestInit): Promise<T> =>
@@ -28,5 +29,6 @@ export function moduleApi(ctx: RequestContext, id: string): ModuleApi {
     post: (path, body) => send(ctx, base, path, withBody('POST', body)),
     put: (path, body) => send(ctx, base, path, withBody('PUT', body)),
     delete: (path) => send(ctx, base, path, { method: 'DELETE' }),
+    send: (path, init) => send(ctx, base, path, init),
   };
 }

--- a/server/crates/kroma-db/src/schema/ddl.rs
+++ b/server/crates/kroma-db/src/schema/ddl.rs
@@ -591,7 +591,10 @@ pub(crate) const SCHEMA: &str = "
         imported_at     INTEGER,
         details_url     TEXT,
         only_files      TEXT,
-        upgrade         INTEGER NOT NULL DEFAULT 0
+        upgrade         INTEGER NOT NULL DEFAULT 0,
+        downloaded_bytes INTEGER NOT NULL DEFAULT 0,
+        uploaded_bytes  INTEGER NOT NULL DEFAULT 0,
+        match_source    TEXT
     );
     CREATE INDEX IF NOT EXISTS idx_downloads_status ON downloads(status, grabbed_at DESC);
     CREATE INDEX IF NOT EXISTS idx_downloads_req    ON downloads(request_id);

--- a/server/crates/kroma-db/src/schema/migrations.rs
+++ b/server/crates/kroma-db/src/schema/migrations.rs
@@ -148,4 +148,17 @@ pub(crate) const MIGRATIONS: &[&str] = &[
     "INSERT OR IGNORE INTO my_list (user_id, item_id, added_at) SELECT user_id, item_id, added_at FROM watch_later",
     "DROP INDEX IF EXISTS idx_watch_later_user",
     "DROP TABLE IF EXISTS watch_later",
+    // Per-download byte counters, so the queue can show a seeding ratio and an
+    // all-time up/down total that outlives the engine session (librqbit's own
+    // counters reset with the process).
+    "ALTER TABLE downloads ADD COLUMN downloaded_bytes INTEGER NOT NULL DEFAULT 0",
+    "ALTER TABLE downloads ADD COLUMN uploaded_bytes INTEGER NOT NULL DEFAULT 0",
+    // How `tmdb_id` was decided: 'auto' from the release name, 'manual' from an
+    // operator correction. NULL is a row from before the column, which the
+    // automatic pass treats as unpinned. A 'manual' row is never re-matched.
+    "ALTER TABLE downloads ADD COLUMN match_source TEXT",
+    // Paging the queue orders by grabbed_at across every filter, and filtering
+    // by client is a full scan without this.
+    "CREATE INDEX IF NOT EXISTS idx_downloads_grabbed ON downloads(grabbed_at DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_downloads_client ON downloads(client_id, grabbed_at DESC)",
 ];

--- a/server/crates/kroma-domain/src/metadata.rs
+++ b/server/crates/kroma-domain/src/metadata.rs
@@ -144,9 +144,20 @@ pub fn build_doc(title: &str, year: Option<u32>, meta: &Metadata) -> String {
     parts.join(". ")
 }
 
+/// One episode of a season, as the provider names it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EpisodeInfo {
+    pub episode: u32,
+    pub name: Option<String>,
+    pub overview: Option<String>,
+    pub air_date: Option<String>,
+    pub still_url: Option<String>,
+}
+
 /// One TMDB title offered by the "fix the match" picker, with the confidence
 /// [`crate::matching`] gives it against what the filename parsed to.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MatchCandidate {
     pub tmdb_id: u64,

--- a/server/crates/kroma-engine/src/host_ctx.rs
+++ b/server/crates/kroma-engine/src/host_ctx.rs
@@ -147,6 +147,49 @@ impl HostCtx for AppState {
         crate::services::settings::metadata_language(&self.settings, &self.config)
     }
 
+    fn metadata_candidates(
+        &self,
+        query: &str,
+        kind: &str,
+        year: Option<u32>,
+    ) -> Vec<kroma_domain::metadata::MatchCandidate> {
+        let scope = match kind {
+            "show" | "tv" | "season" | "episode" => {
+                crate::infra::metadata::discover::DiscoverScope::Shows
+            }
+            "movie" | "item" => crate::infra::metadata::discover::DiscoverScope::Movies,
+            _ => crate::infra::metadata::discover::DiscoverScope::All,
+        };
+        let target = crate::services::rematch::MatchTarget {
+            title: query.to_string(),
+            year,
+            current_tmdb_id: None,
+        };
+        crate::services::rematch::ranked(self, scope, query, &target).unwrap_or_default()
+    }
+
+    fn metadata_episodes(
+        &self,
+        tmdb_id: u64,
+        season: u32,
+    ) -> Vec<kroma_domain::metadata::EpisodeInfo> {
+        let Some(api_key) = self.config.tmdb_api_key.as_deref() else {
+            return Vec::new();
+        };
+        let lang = crate::services::settings::metadata_language(&self.settings, &self.config);
+        crate::infra::metadata::season_episodes(api_key, &lang, tmdb_id, season)
+            .episodes
+            .into_iter()
+            .map(|e| kroma_domain::metadata::EpisodeInfo {
+                episode: e.episode,
+                name: e.name,
+                overview: e.overview,
+                air_date: e.air_date,
+                still_url: e.still_url,
+            })
+            .collect()
+    }
+
     fn get_service(
         &self,
         type_id: std::any::TypeId,
@@ -166,10 +209,14 @@ mod tests {
     use serde_json::json;
 
     use super::*;
-    use crate::test_support::test_state;
+    use crate::test_support::{test_state, test_state_with_tmdb, FakeTmdb};
 
     fn body(env: &crate::infra::events::Envelope) -> serde_json::Value {
         serde_json::from_str(env.payload_unrouted()).unwrap()
+    }
+
+    fn page(results: serde_json::Value) -> serde_json::Value {
+        json!({ "page": 1, "total_pages": 1, "results": results })
     }
 
     fn user(state: &crate::state::SharedState, perms: &[Permission]) -> User {
@@ -414,5 +461,121 @@ mod tests {
     fn triggering_an_unknown_job_is_a_no_op_rather_than_a_panic() {
         let state = test_state();
         HostCtx::trigger_job(&*state, "no.such.job", "test");
+    }
+
+    #[test]
+    fn ranks_the_provider_titles_a_module_asked_about() {
+        let state = test_state_with_tmdb("test-key");
+
+        let _tmdb = FakeTmdb::start(|_| {
+            (
+                200,
+                page(json!([
+                    { "id": 605, "title": "The Matrix Revolutions", "release_date": "2003-11-05" },
+                    { "id": 603, "title": "The Matrix", "release_date": "1999-03-31" },
+                ])),
+            )
+        });
+
+        let found = HostCtx::metadata_candidates(&*state, "The Matrix", "movie", Some(1999));
+
+        assert_eq!(
+            found.iter().map(|c| c.tmdb_id).collect::<Vec<_>>(),
+            [603, 605],
+            "the 1999 title outranks the sequel because the module asked for 1999"
+        );
+        assert!(found[0].score > found[1].score);
+    }
+
+    #[test]
+    fn the_kind_a_module_names_picks_the_provider_scope() {
+        let state = test_state_with_tmdb("test-key");
+
+        let _tmdb = FakeTmdb::start(|path| match path {
+            "/search/movie" => (
+                200,
+                page(json!([{ "id": 841, "title": "Dune", "release_date": "1984-12-14" }])),
+            ),
+            "/search/tv" => (
+                200,
+                page(json!([{ "id": 87739, "name": "Dune", "first_air_date": "2025-01-01" }])),
+            ),
+            _ => (
+                200,
+                page(json!([{ "id": 1, "media_type": "movie", "title": "Dune" }])),
+            ),
+        });
+
+        let movies = HostCtx::metadata_candidates(&*state, "Dune", "movie", None);
+        let shows = HostCtx::metadata_candidates(&*state, "Dune", "show", None);
+        let anything = HostCtx::metadata_candidates(&*state, "Dune", "release", None);
+
+        assert_eq!(movies[0].tmdb_id, 841);
+        assert_eq!(shows[0].tmdb_id, 87739);
+        assert_eq!(anything[0].tmdb_id, 1);
+    }
+
+    #[test]
+    fn a_provider_that_answers_nothing_is_an_empty_candidate_list_not_an_error() {
+        let state = test_state_with_tmdb("test-key");
+
+        let _tmdb = FakeTmdb::start(|_| (500, json!({ "status_message": "boom" })));
+
+        let found = HostCtx::metadata_candidates(&*state, "Dune", "movie", None);
+
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn names_the_episodes_of_the_season_a_module_asked_for() {
+        let state = test_state_with_tmdb("test-key");
+
+        let tmdb = FakeTmdb::start(|_| {
+            (
+                200,
+                json!({ "episodes": [
+                    {
+                        "episode_number": 1,
+                        "name": "Winter Is Coming",
+                        "overview": "Ned takes the offer.",
+                        "air_date": "2011-04-17",
+                        "still_path": "/still1.jpg",
+                    },
+                    { "episode_number": 2, "name": "", "overview": "", "air_date": "" },
+                ]}),
+            )
+        });
+
+        let episodes = HostCtx::metadata_episodes(&*state, 1399, 2);
+
+        assert_eq!(
+            tmdb.requests()[0].split('?').next(),
+            Some("/tv/1399/season/2")
+        );
+        assert_eq!(episodes[0].episode, 1);
+        assert_eq!(episodes[0].name.as_deref(), Some("Winter Is Coming"));
+        assert_eq!(episodes[0].overview.as_deref(), Some("Ned takes the offer."));
+        assert_eq!(episodes[0].air_date.as_deref(), Some("2011-04-17"));
+        assert_eq!(
+            episodes[0].still_url.as_deref(),
+            Some("https://image.tmdb.org/t/p/w300/still1.jpg")
+        );
+        assert_eq!(episodes[1].episode, 2);
+        assert_eq!(episodes[1].name, None);
+        assert_eq!(episodes[1].still_url, None);
+    }
+
+    #[test]
+    fn asks_the_provider_nothing_at_all_without_a_key() {
+        let state = test_state();
+
+        let tmdb = FakeTmdb::start(|_| (200, json!({})));
+
+        let episodes = HostCtx::metadata_episodes(&*state, 1399, 1);
+        let candidates = HostCtx::metadata_candidates(&*state, "Dune", "movie", None);
+
+        assert!(episodes.is_empty());
+        assert!(candidates.is_empty());
+        assert!(tmdb.requests().is_empty());
     }
 }

--- a/server/crates/kroma-engine/src/services/rematch/mod.rs
+++ b/server/crates/kroma-engine/src/services/rematch/mod.rs
@@ -12,21 +12,18 @@
 
 use anyhow::{bail, Result};
 
-use kroma_domain::matching::{self, Candidate, Query};
-
 use crate::db;
 use crate::infra::metadata::discover;
-use crate::model::{MatchCandidate, MatchCandidates};
+use crate::model::MatchCandidates;
 use crate::services::jobs::now_ms;
-use crate::services::settings;
 use crate::state::SharedState;
+
+mod search;
+
+pub use search::{ranked, MatchTarget};
 
 // A correction jumps ahead of the nightly backlog (mirrors `pipeline::reprocess`).
 const HIGH: i64 = 100;
-
-// How many candidates the picker offers. One TMDB page is 20; more than that and
-// the right title was never going to be found by scrolling.
-const MAX_CANDIDATES: usize = 20;
 
 /// Which catalog subject is being rematched. The wire vocabulary is
 /// `movie` | `show`; everything downstream needs a different spelling of it.
@@ -97,7 +94,6 @@ fn load(state: &SharedState, subject: Subject, id: &str) -> Result<Local> {
         ..local
     })
 }
-
 /// The ranked TMDB candidates for one element. `query` overrides the search text
 /// when the operator types their own (the parsed title is often the reason the
 /// automatic match failed); scoring still compares against the *parsed* title and
@@ -118,79 +114,19 @@ pub fn candidates(
         .filter(|q| !q.is_empty())
         .unwrap_or(&local.title)
         .to_string();
-
-    let Some(api_key) = state.config.tmdb_api_key.clone() else {
-        bail!("metadata disabled: set KROMA_TMDB_API_KEY");
+    let target = search::MatchTarget {
+        title: local.title.clone(),
+        year: local.year,
+        current_tmdb_id: local.current_tmdb_id,
     };
-    let lang = settings::metadata_language(&state.settings, &state.config);
-    // macOS filenames are NFD, so a title parsed from disk carries decomposed
-    // accents (`é` as `e` + U+0301). TMDB's search returns nothing for those (it
-    // even mismatches "Amélie" to an unrelated title), so strip the combining
-    // marks first. This keeps a precomposed `é` and only fixes the decomposed case.
-    let primary = matching::strip_combining(&search_text);
-    let mut hits = discover::search(&api_key, &lang, subject.scope(), &primary, 1)
-        .map_err(|()| anyhow::anyhow!("TMDB search failed"))?
-        .hits;
-    // Still nothing? TMDB is also picky about apostrophes and leading articles:
-    // "L'Île aux chiens" comes back empty while "ile aux chiens" finds it. Retry
-    // once with the fully folded form (lowercased, de-accented, punctuation and a
-    // leading article dropped) before giving up.
-    if hits.is_empty() {
-        let folded = matching::normalize(&search_text);
-        if !folded.is_empty() && folded != primary {
-            hits = discover::search(&api_key, &lang, subject.scope(), &folded, 1)
-                .map_err(|()| anyhow::anyhow!("TMDB search failed"))?
-                .hits;
-        }
-    }
-
-    let scored = rank(&local, hits);
+    let results = search::ranked(state, subject.scope(), &search_text, &target)?;
     Ok(MatchCandidates {
         query: search_text,
         year: local.year,
         current_tmdb_id: local.current_tmdb_id,
         pinned,
-        results: scored,
+        results,
     })
-}
-
-// Score every hit against the parsed title/year and sort most-likely first.
-fn rank(local: &Local, hits: Vec<discover::DiscoverHit>) -> Vec<MatchCandidate> {
-    let query = Query {
-        title: &local.title,
-        year: local.year,
-    };
-    let mut out: Vec<MatchCandidate> = hits
-        .into_iter()
-        .map(|h| {
-            let score = matching::score(
-                &query,
-                &Candidate {
-                    tmdb_id: h.tmdb_id,
-                    title: h.title.clone(),
-                    original_title: h.original_title.clone(),
-                    year: h.year,
-                    // Votes are a tiebreaker for the automatic pick; the picker
-                    // shows a human the posters, so they add nothing here.
-                    votes: 0,
-                },
-            );
-            MatchCandidate {
-                tmdb_id: h.tmdb_id,
-                title: h.title,
-                original_title: Some(h.original_title).filter(|s| !s.is_empty()),
-                year: h.year,
-                poster_url: h.poster_url,
-                overview: h.overview,
-                rating: h.rating,
-                score,
-                current: Some(h.tmdb_id) == local.current_tmdb_id,
-            }
-        })
-        .collect();
-    out.sort_by(|a, b| b.score.total_cmp(&a.score));
-    out.truncate(MAX_CANDIDATES);
-    out
 }
 
 /// Pin `tmdb_id` to this element (or clear the pin with `None`, restoring
@@ -221,29 +157,6 @@ pub fn apply(state: &SharedState, subject: Subject, id: &str, tmdb_id: Option<u6
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::RequestKind;
-
-    fn local(title: &str, year: Option<u32>, current: Option<u64>) -> Local {
-        Local {
-            title: title.to_string(),
-            year,
-            current_tmdb_id: current,
-        }
-    }
-
-    fn hit(id: u64, title: &str, year: Option<u32>) -> discover::DiscoverHit {
-        discover::DiscoverHit {
-            kind: RequestKind::Movie,
-            tmdb_id: id,
-            title: title.to_string(),
-            original_title: title.to_string(),
-            year,
-            poster_url: None,
-            backdrop_url: None,
-            overview: None,
-            rating: None,
-        }
-    }
 
     #[test]
     fn subject_parses_every_accepted_spelling() {
@@ -282,56 +195,6 @@ mod tests {
             asked.iter().all(|r| r.starts_with("/search/tv")),
             "{asked:?}"
         );
-    }
-
-    #[test]
-    fn rank_puts_the_best_scoring_candidate_first() {
-        let local = local("It", Some(1990), None);
-        let ranked = rank(
-            &local,
-            vec![hit(474350, "It", Some(2017)), hit(437, "It", Some(1990))],
-        );
-        assert_eq!(ranked[0].tmdb_id, 437);
-        assert!(ranked[0].score > ranked[1].score);
-    }
-
-    #[test]
-    fn rank_flags_the_stored_match_as_current() {
-        let local = local("Dune", Some(2021), Some(438631));
-        let ranked = rank(
-            &local,
-            vec![
-                hit(438631, "Dune", Some(2021)),
-                hit(841, "Dune", Some(1984)),
-            ],
-        );
-        assert!(ranked.iter().find(|c| c.tmdb_id == 438631).unwrap().current);
-        assert!(!ranked.iter().find(|c| c.tmdb_id == 841).unwrap().current);
-    }
-
-    #[test]
-    fn rank_keeps_low_scoring_candidates_for_the_operator_to_pick() {
-        // Unlike the automatic path, nothing is filtered out: the whole point is
-        // that the operator can choose a title scoring below the accept cutoff.
-        let local = local("Some Local Recording", None, None);
-        let ranked = rank(&local, vec![hit(1, "Frozen", Some(2013))]);
-        assert_eq!(ranked.len(), 1);
-        assert!(ranked[0].score < matching::MIN_SCORE);
-    }
-
-    #[test]
-    fn rank_caps_the_list() {
-        let local = local("X", None, None);
-        let hits = (0..50).map(|i| hit(i, "X", None)).collect();
-        assert_eq!(rank(&local, hits).len(), MAX_CANDIDATES);
-    }
-
-    #[test]
-    fn rank_omits_an_empty_original_title() {
-        let local = local("Dune", None, None);
-        let mut h = hit(1, "Dune", None);
-        h.original_title = String::new();
-        assert_eq!(rank(&local, vec![h])[0].original_title, None);
     }
 
     use crate::test_support::{seed_movie, test_state_with_tmdb, FakeTmdb};
@@ -422,6 +285,19 @@ mod tests {
             "the apostrophe survived: {}",
             asked[1]
         );
+    }
+
+    #[test]
+    fn a_title_that_folds_to_the_query_already_sent_is_not_searched_twice() {
+        let state = test_state_with_tmdb("test-key");
+        seed_titled(&state, "itm-1", "dune", Some(2021));
+
+        let tmdb = FakeTmdb::start(|_| (200, page(serde_json::json!([]))));
+
+        let out = candidates(&state, Subject::Movie, "itm-1", None).unwrap();
+
+        assert!(out.results.is_empty());
+        assert_eq!(tmdb.requests().len(), 1, "{:?}", tmdb.requests());
     }
 
     #[test]

--- a/server/crates/kroma-engine/src/services/rematch/search.rs
+++ b/server/crates/kroma-engine/src/services/rematch/search.rs
@@ -1,0 +1,178 @@
+//! Asking the provider what a title could be, and ranking the answers.
+
+use anyhow::{bail, Result};
+
+use kroma_domain::matching::{self, Candidate, Query};
+
+use crate::infra::metadata::discover;
+use crate::model::MatchCandidate;
+use crate::services::settings;
+use crate::state::AppState;
+
+// How many candidates a picker offers. One TMDB page is 20; more than that and
+// the right title was never going to be found by scrolling.
+pub(super) const MAX_CANDIDATES: usize = 20;
+
+/// What a search is being scored against: the title and year the source parsed
+/// to, and the id already pinned to it (so the picker can mark it).
+#[derive(Debug, Clone, Default)]
+pub struct MatchTarget {
+    pub title: String,
+    pub year: Option<u32>,
+    pub current_tmdb_id: Option<u64>,
+}
+
+/// Search the provider for `search_text` and rank every hit against `target`.
+///
+/// `search_text` is what goes to the provider (an operator's own words, when
+/// they typed some); `target` is what the score is measured against, so the
+/// confidence stays honest about the thing on disk rather than about the query.
+pub fn ranked(
+    state: &AppState,
+    scope: discover::DiscoverScope,
+    search_text: &str,
+    target: &MatchTarget,
+) -> Result<Vec<MatchCandidate>> {
+    let Some(api_key) = state.config.tmdb_api_key.clone() else {
+        bail!("metadata disabled: set KROMA_TMDB_API_KEY");
+    };
+    let lang = settings::metadata_language(&state.settings, &state.config);
+    // macOS filenames are NFD, so a title parsed from disk carries decomposed
+    // accents (`é` as `e` + U+0301). TMDB's search returns nothing for those (it
+    // even mismatches "Amélie" to an unrelated title), so strip the combining
+    // marks first. This keeps a precomposed `é` and only fixes the decomposed case.
+    let primary = matching::strip_combining(search_text);
+    let mut hits = discover::search(&api_key, &lang, scope, &primary, 1)
+        .map_err(|()| anyhow::anyhow!("TMDB search failed"))?
+        .hits;
+    // Still nothing? TMDB is also picky about apostrophes and leading articles:
+    // "L'Île aux chiens" comes back empty while "ile aux chiens" finds it. Retry
+    // once with the fully folded form (lowercased, de-accented, punctuation and a
+    // leading article dropped) before giving up.
+    if hits.is_empty() {
+        let folded = matching::normalize(search_text);
+        if !folded.is_empty() && folded != primary {
+            hits = discover::search(&api_key, &lang, scope, &folded, 1)
+                .map_err(|()| anyhow::anyhow!("TMDB search failed"))?
+                .hits;
+        }
+    }
+    Ok(rank(target, hits))
+}
+
+// Score every hit against the parsed title/year and sort most-likely first.
+fn rank(target: &MatchTarget, hits: Vec<discover::DiscoverHit>) -> Vec<MatchCandidate> {
+    let query = Query {
+        title: &target.title,
+        year: target.year,
+    };
+    let mut out: Vec<MatchCandidate> = hits
+        .into_iter()
+        .map(|h| {
+            let score = matching::score(
+                &query,
+                &Candidate {
+                    tmdb_id: h.tmdb_id,
+                    title: h.title.clone(),
+                    original_title: h.original_title.clone(),
+                    year: h.year,
+                    // Votes are a tiebreaker for the automatic pick; the picker
+                    // shows a human the posters, so they add nothing here.
+                    votes: 0,
+                },
+            );
+            MatchCandidate {
+                tmdb_id: h.tmdb_id,
+                title: h.title,
+                original_title: Some(h.original_title).filter(|s| !s.is_empty()),
+                year: h.year,
+                poster_url: h.poster_url,
+                overview: h.overview,
+                rating: h.rating,
+                score,
+                current: Some(h.tmdb_id) == target.current_tmdb_id,
+            }
+        })
+        .collect();
+    out.sort_by(|a, b| b.score.total_cmp(&a.score));
+    out.truncate(MAX_CANDIDATES);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kroma_domain::requests::RequestKind;
+
+    fn target(title: &str, year: Option<u32>, current: Option<u64>) -> MatchTarget {
+        MatchTarget {
+            title: title.to_string(),
+            year,
+            current_tmdb_id: current,
+        }
+    }
+
+    fn hit(id: u64, title: &str, year: Option<u32>) -> discover::DiscoverHit {
+        discover::DiscoverHit {
+            kind: RequestKind::Movie,
+            tmdb_id: id,
+            title: title.to_string(),
+            original_title: title.to_string(),
+            year,
+            poster_url: None,
+            backdrop_url: None,
+            overview: None,
+            rating: None,
+        }
+    }
+
+    #[test]
+    fn rank_puts_the_best_scoring_candidate_first() {
+        let local = target("It", Some(1990), None);
+        let ranked = rank(
+            &local,
+            vec![hit(474350, "It", Some(2017)), hit(437, "It", Some(1990))],
+        );
+        assert_eq!(ranked[0].tmdb_id, 437);
+        assert!(ranked[0].score > ranked[1].score);
+    }
+
+    #[test]
+    fn rank_flags_the_stored_match_as_current() {
+        let local = target("Dune", Some(2021), Some(438631));
+        let ranked = rank(
+            &local,
+            vec![
+                hit(438631, "Dune", Some(2021)),
+                hit(841, "Dune", Some(1984)),
+            ],
+        );
+        assert!(ranked.iter().find(|c| c.tmdb_id == 438631).unwrap().current);
+        assert!(!ranked.iter().find(|c| c.tmdb_id == 841).unwrap().current);
+    }
+
+    #[test]
+    fn rank_keeps_low_scoring_candidates_for_the_operator_to_pick() {
+        // Unlike the automatic path, nothing is filtered out: the whole point is
+        // that the operator can choose a title scoring below the accept cutoff.
+        let local = target("Some Local Recording", None, None);
+        let ranked = rank(&local, vec![hit(1, "Frozen", Some(2013))]);
+        assert_eq!(ranked.len(), 1);
+        assert!(ranked[0].score < matching::MIN_SCORE);
+    }
+
+    #[test]
+    fn rank_caps_the_list() {
+        let local = target("X", None, None);
+        let hits = (0..50).map(|i| hit(i, "X", None)).collect();
+        assert_eq!(rank(&local, hits).len(), MAX_CANDIDATES);
+    }
+
+    #[test]
+    fn rank_omits_an_empty_original_title() {
+        let local = target("Dune", None, None);
+        let mut h = hit(1, "Dune", None);
+        h.original_title = String::new();
+        assert_eq!(rank(&local, vec![h])[0].original_title, None);
+    }
+}

--- a/server/crates/kroma-engine/src/services/settings/store.rs
+++ b/server/crates/kroma-engine/src/services/settings/store.rs
@@ -204,6 +204,9 @@ fn defaults() -> BTreeMap<String, Value> {
     m.insert("rqbitPort".into(), json!(0));
     m.insert("rqbitDownKbps".into(), json!(0));
     m.insert("rqbitUpKbps".into(), json!(0));
+    // How many downloads may hold an engine slot at once (0 = no cap); the rest
+    // wait in the queue.
+    m.insert("torrentMaxActive".into(), json!(0));
     // `vpnWgConfig` is a secret: written via /api/admin/vpn, never returned in a
     // settings view.
     m.insert("vpnWgConfig".into(), json!(""));

--- a/server/crates/kroma-module-host/src/host_ctx.rs
+++ b/server/crates/kroma-module-host/src/host_ctx.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use axum::http::StatusCode;
 use axum::response::Response;
 
+use kroma_domain::metadata::{EpisodeInfo, MatchCandidate};
 use kroma_domain::{Audience, NotificationSpec, Permission, User};
 
 use super::{Contribution, Event, LibraryFolders};
@@ -70,6 +71,17 @@ pub trait HostCtx: Send + Sync + 'static {
 
     // The metadata language tag (e.g. `"fr-FR"`) for TMDB lookups.
     fn metadata_language(&self) -> String;
+
+    // Provider titles matching `query`, ranked most-likely-first against
+    // `(query, year)` by the same scoring the automatic path uses. `kind` is
+    // `movie` | `show`. Empty when no provider is configured, so a caller
+    // degrades to "nothing matched" rather than failing.
+    fn metadata_candidates(&self, query: &str, kind: &str, year: Option<u32>)
+        -> Vec<MatchCandidate>;
+
+    // One season's episodes, as the provider names them. Best-effort: an empty
+    // list is "nothing to add", never an error.
+    fn metadata_episodes(&self, tmdb_id: u64, season: u32) -> Vec<EpisodeInfo>;
 
     // Prefer the typed [`service`] helper.
     fn get_service(&self, type_id: TypeId) -> Option<Arc<dyn Any + Send + Sync>>;
@@ -140,6 +152,19 @@ impl<T: HostCtx + ?Sized> HostCtx for std::sync::Arc<T> {
     }
     fn metadata_language(&self) -> String {
         (**self).metadata_language()
+    }
+
+    fn metadata_candidates(
+        &self,
+        query: &str,
+        kind: &str,
+        year: Option<u32>,
+    ) -> Vec<MatchCandidate> {
+        (**self).metadata_candidates(query, kind, year)
+    }
+
+    fn metadata_episodes(&self, tmdb_id: u64, season: u32) -> Vec<EpisodeInfo> {
+        (**self).metadata_episodes(tmdb_id, season)
     }
     fn get_service(&self, type_id: TypeId) -> Option<Arc<dyn Any + Send + Sync>> {
         (**self).get_service(type_id)
@@ -265,6 +290,19 @@ mod tests {
             self.note("metadata_language");
             "fr-FR".into()
         }
+        fn metadata_candidates(
+            &self,
+            query: &str,
+            _kind: &str,
+            _year: Option<u32>,
+        ) -> Vec<MatchCandidate> {
+            self.note(&format!("metadata_candidates:{query}"));
+            Vec::new()
+        }
+        fn metadata_episodes(&self, tmdb_id: u64, season: u32) -> Vec<EpisodeInfo> {
+            self.note(&format!("metadata_episodes:{tmdb_id}:{season}"));
+            Vec::new()
+        }
         fn contributions(&self, _point: &str) -> Vec<Contribution> {
             Vec::new()
         }
@@ -313,6 +351,8 @@ mod tests {
         assert!(host.library_folders().is_empty());
         assert_eq!(host.secret("tmdb").as_deref(), Some("key"));
         assert_eq!(host.metadata_language(), "fr-FR");
+        assert!(host.metadata_candidates("Dune", "movie", Some(2021)).is_empty());
+        assert!(host.metadata_episodes(1399, 2).is_empty());
         assert!(host.get_service(TypeId::of::<u8>()).is_none());
 
         assert_eq!(
@@ -333,6 +373,8 @@ mod tests {
                 "library_folders",
                 "secret:tmdb",
                 "metadata_language",
+                "metadata_candidates:Dune",
+                "metadata_episodes:1399:2",
                 "get_service",
             ]
         );

--- a/server/crates/kroma-module-host/src/testing/mod.rs
+++ b/server/crates/kroma-module-host/src/testing/mod.rs
@@ -20,7 +20,32 @@ pub use stub::StubHost;
 
 #[cfg(test)]
 mod fixtures {
+    use kroma_domain::metadata::{EpisodeInfo, MatchCandidate};
     use kroma_domain::{NotificationEvent, NotificationSpec, User};
+
+    pub fn candidate() -> MatchCandidate {
+        MatchCandidate {
+            tmdb_id: 438631,
+            title: "Dune".into(),
+            original_title: None,
+            year: Some(2021),
+            poster_url: None,
+            overview: None,
+            rating: None,
+            score: 0.98,
+            current: false,
+        }
+    }
+
+    pub fn episode() -> EpisodeInfo {
+        EpisodeInfo {
+            episode: 1,
+            name: Some("Winter Is Coming".into()),
+            overview: None,
+            air_date: Some("2011-04-17".into()),
+            still_url: None,
+        }
+    }
 
     pub fn spec() -> NotificationSpec {
         NotificationSpec::new(

--- a/server/crates/kroma-module-host/src/testing/recording.rs
+++ b/server/crates/kroma-module-host/src/testing/recording.rs
@@ -108,6 +108,23 @@ impl<H: HostCtx> HostCtx for Recording<H> {
     fn metadata_language(&self) -> String {
         self.inner.metadata_language()
     }
+
+    fn metadata_candidates(
+        &self,
+        query: &str,
+        kind: &str,
+        year: Option<u32>,
+    ) -> Vec<kroma_domain::metadata::MatchCandidate> {
+        self.inner.metadata_candidates(query, kind, year)
+    }
+
+    fn metadata_episodes(
+        &self,
+        tmdb_id: u64,
+        season: u32,
+    ) -> Vec<kroma_domain::metadata::EpisodeInfo> {
+        self.inner.metadata_episodes(tmdb_id, season)
+    }
     fn contributions(&self, point: &str) -> Vec<crate::Contribution> {
         self.inner.contributions(point)
     }
@@ -121,7 +138,7 @@ impl<H: HostCtx> HostCtx for Recording<H> {
 mod tests {
     use serde_json::json;
 
-    use super::super::fixtures::{spec, user};
+    use super::super::fixtures::{candidate, episode, spec, user};
     use super::super::StubHost;
     use super::*;
 
@@ -129,12 +146,19 @@ mod tests {
     fn recording_forwards_everything_but_the_bus() {
         let inner = StubHost::new()
             .with_tmdb_key("k")
-            .with_metadata_language("fr-FR");
+            .with_metadata_language("fr-FR")
+            .with_metadata_candidates(vec![candidate()])
+            .with_metadata_episodes(vec![episode()]);
         let host = Recording::new(inner);
 
         // Forwarded, so the test still sees the real host's answers.
         assert_eq!(host.secret("tmdb").as_deref(), Some("k"));
         assert_eq!(host.metadata_language(), "fr-FR");
+        assert_eq!(
+            host.metadata_candidates("Dune", "movie", Some(2021))[0].tmdb_id,
+            438631
+        );
+        assert_eq!(host.metadata_episodes(1399, 2)[0].episode, 1);
         assert_eq!(host.setting_str("k", "fallback"), "fallback");
         assert!(host.require(&user(), Permission::LibraryManage).is_ok());
         assert!(host.require_any_admin(&user()).is_ok());

--- a/server/crates/kroma-module-host/src/testing/stub.rs
+++ b/server/crates/kroma-module-host/src/testing/stub.rs
@@ -9,6 +9,7 @@ use std::sync::{Arc, Mutex};
 use axum::http::StatusCode;
 use axum::response::Response;
 use kroma_db::Pool;
+use kroma_domain::metadata::{EpisodeInfo, MatchCandidate};
 use kroma_domain::{Audience, NotificationSpec, Permission, User};
 use kroma_testing::TempDir;
 
@@ -45,6 +46,8 @@ pub struct StubHost {
     data_dir: Arc<TempDir>,
     tmdb_key: Option<String>,
     metadata_language: String,
+    metadata_candidates: Vec<MatchCandidate>,
+    metadata_episodes: Vec<EpisodeInfo>,
     module_enabled: bool,
     libraries: Vec<LibraryFolders>,
     settings: Arc<Mutex<BTreeMap<String, serde_json::Value>>>,
@@ -91,6 +94,8 @@ impl StubHost {
             data_dir: Arc::new(data_dir),
             tmdb_key: None,
             metadata_language: "en".into(),
+            metadata_candidates: Vec::new(),
+            metadata_episodes: Vec::new(),
             module_enabled: true,
             libraries: Vec::new(),
             settings: Arc::new(Mutex::new(BTreeMap::new())),
@@ -145,6 +150,19 @@ impl StubHost {
     /// Answer `secret("tmdb")` with `key`.
     pub fn with_tmdb_key(mut self, key: &str) -> Self {
         self.tmdb_key = Some(key.into());
+        self
+    }
+
+    /// Answer `metadata_episodes()` with `episodes` (default: none).
+    pub fn with_metadata_episodes(mut self, episodes: Vec<EpisodeInfo>) -> Self {
+        self.metadata_episodes = episodes;
+        self
+    }
+
+    /// Answer `metadata_candidates()` with `candidates`, whatever is asked
+    /// (default: none, i.e. nothing matched).
+    pub fn with_metadata_candidates(mut self, candidates: Vec<MatchCandidate>) -> Self {
+        self.metadata_candidates = candidates;
         self
     }
 
@@ -328,6 +346,19 @@ impl HostCtx for StubHost {
     fn metadata_language(&self) -> String {
         self.metadata_language.clone()
     }
+
+    fn metadata_candidates(
+        &self,
+        _query: &str,
+        _kind: &str,
+        _year: Option<u32>,
+    ) -> Vec<MatchCandidate> {
+        self.metadata_candidates.clone()
+    }
+
+    fn metadata_episodes(&self, _tmdb_id: u64, _season: u32) -> Vec<EpisodeInfo> {
+        self.metadata_episodes.clone()
+    }
     fn contributions(&self, point: &str) -> Vec<crate::Contribution> {
         let prefix = format!("test.{point}");
         self.points
@@ -353,7 +384,7 @@ impl HostCtx for StubHost {
 mod tests {
     use serde_json::json;
 
-    use super::super::fixtures::user;
+    use super::super::fixtures::{candidate, episode, user};
     use super::*;
 
     // Every crate that tests against the seam now leans on these answers, so a
@@ -380,6 +411,8 @@ mod tests {
         assert!(host.library_folders().is_empty());
         assert!(host.secret("tmdb").is_none());
         assert_eq!(host.metadata_language(), "en");
+        assert!(host.metadata_candidates("Dune", "movie", None).is_empty());
+        assert!(host.metadata_episodes(1399, 1).is_empty());
         assert!(host.get_service(TypeId::of::<u32>()).is_none());
         assert!(host.data_dir().is_dir());
     }
@@ -389,6 +422,8 @@ mod tests {
         let host = StubHost::new()
             .with_tmdb_key("k")
             .with_metadata_language("fr-FR")
+            .with_metadata_candidates(vec![candidate()])
+            .with_metadata_episodes(vec![episode()])
             .with_module_enabled(false)
             .with_libraries(vec![LibraryFolders {
                 id: "lib1".into(),
@@ -402,6 +437,11 @@ mod tests {
 
         assert_eq!(host.secret("tmdb").as_deref(), Some("k"));
         assert_eq!(host.metadata_language(), "fr-FR");
+        assert_eq!(
+            host.metadata_candidates("anything", "movie", None)[0].tmdb_id,
+            438631
+        );
+        assert_eq!(host.metadata_episodes(1399, 2)[0].episode, 1);
         assert!(!host.module_enabled("tv.kroma.anything"));
         assert_eq!(host.library_folders()[0].folders, ["/media/films"]);
         assert_eq!(host.setting_str("str", "fallback"), "set");

--- a/server/crates/kroma-module-runtime/src/lib.rs
+++ b/server/crates/kroma-module-runtime/src/lib.rs
@@ -313,6 +313,35 @@ impl HostCtx for RemoteHost {
         }
     }
 
+    // Asked of the core, which holds the provider credential.
+    fn metadata_candidates(
+        &self,
+        query: &str,
+        kind: &str,
+        year: Option<u32>,
+    ) -> Vec<kroma_domain::metadata::MatchCandidate> {
+        let mut call = self.callback().query("q", query).query("kind", kind);
+        if let Some(year) = year {
+            call = call.query("year", year.to_string());
+        }
+        call.get_json::<Vec<kroma_domain::metadata::MatchCandidate>>(
+            &self.host_url("metadata-search"),
+        )
+        .unwrap_or_default()
+    }
+
+    fn metadata_episodes(
+        &self,
+        tmdb_id: u64,
+        season: u32,
+    ) -> Vec<kroma_domain::metadata::EpisodeInfo> {
+        self.callback()
+            .query("tmdbId", tmdb_id.to_string())
+            .query("season", season.to_string())
+            .get_json::<Vec<kroma_domain::metadata::EpisodeInfo>>(&self.host_url("metadata-episodes"))
+            .unwrap_or_default()
+    }
+
     // Asked of the core, which owns the supervisor: a sidecar cannot see which
     // of its peers is installed or running, and must not care.
     fn contributions(&self, point: &str) -> Vec<kroma_module_host::Contribution> {

--- a/server/crates/kroma-module-runtime/tests/host_metadata.rs
+++ b/server/crates/kroma-module-runtime/tests/host_metadata.rs
@@ -1,0 +1,137 @@
+use std::sync::{mpsc, Arc, Mutex};
+use std::time::Duration;
+
+use axum::extract::State;
+use axum::http::Uri;
+use axum::routing::get;
+use axum::{Json, Router};
+use kroma_domain::metadata::{EpisodeInfo, MatchCandidate};
+use kroma_module_host::HostCtx;
+
+#[derive(Clone, Default)]
+struct Asked(Arc<Mutex<Vec<String>>>);
+
+impl Asked {
+    fn note(&self, uri: &Uri) {
+        self.0.lock().unwrap().push(uri.to_string());
+    }
+
+    fn seen(&self) -> Vec<String> {
+        self.0.lock().unwrap().clone()
+    }
+}
+
+fn dune() -> MatchCandidate {
+    MatchCandidate {
+        tmdb_id: 438631,
+        title: "Dune".into(),
+        original_title: None,
+        year: Some(2021),
+        poster_url: None,
+        overview: None,
+        rating: None,
+        score: 0.98,
+        current: false,
+    }
+}
+
+fn winter_is_coming() -> EpisodeInfo {
+    EpisodeInfo {
+        episode: 1,
+        name: Some("Winter Is Coming".into()),
+        overview: None,
+        air_date: Some("2011-04-17".into()),
+        still_url: None,
+    }
+}
+
+async fn search(State(asked): State<Asked>, uri: Uri) -> Json<Vec<MatchCandidate>> {
+    asked.note(&uri);
+    Json(vec![dune()])
+}
+
+async fn episodes(State(asked): State<Asked>, uri: Uri) -> Json<Vec<EpisodeInfo>> {
+    asked.note(&uri);
+    Json(vec![winter_is_coming()])
+}
+
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind")
+        .local_addr()
+        .expect("addr")
+        .port()
+}
+
+fn start_core(asked: Asked) -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    listener.set_nonblocking(true).expect("non-blocking");
+    let port = listener.local_addr().expect("addr").port();
+    std::thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        rt.block_on(async move {
+            let listener = tokio::net::TcpListener::from_std(listener).expect("listener");
+            let app = Router::new()
+                .route("/api/_host/metadata-search", get(search))
+                .route("/api/_host/metadata-episodes", get(episodes))
+                .with_state(asked);
+            axum::serve(listener, app).await.expect("serve");
+        });
+    });
+    port
+}
+
+#[test]
+fn a_sidecar_asks_the_core_what_a_title_and_its_episodes_are_called() {
+    let dir = std::path::PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join("host-metadata");
+    std::fs::create_dir_all(&dir).expect("tmp dir");
+    let asked = Asked::default();
+    let core = start_core(asked.clone());
+    std::env::set_var("KROMA_MODULE_ID", "tv.kroma.metadata-test");
+    std::env::set_var("KROMA_MODULE_PORT", free_port().to_string());
+    std::env::set_var("KROMA_CORE_URL", format!("http://127.0.0.1:{core}/"));
+    std::env::set_var("KROMA_HOST_TOKEN", "host-token");
+    std::env::set_var("KROMA_DB_PATH", dir.join("core.db").display().to_string());
+    std::env::set_var("KROMA_DATA_DIR", dir.display().to_string());
+    let (tx, rx) = mpsc::channel();
+
+    std::thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let wire = move |host: &kroma_module_runtime::RemoteHost| {
+            tx.send((
+                host.metadata_candidates("Dune", "movie", Some(2021)),
+                host.metadata_episodes(1399, 2),
+            ))
+            .expect("the lookups answered");
+            Router::new()
+        };
+        rt.block_on(kroma_module_runtime::serve(wire, vec![]))
+            .expect("serve");
+    });
+
+    let (candidates, episodes) = rx
+        .recv_timeout(Duration::from_secs(30))
+        .expect("the module reached the core");
+
+    assert_eq!(candidates[0].tmdb_id, 438631);
+    assert_eq!(candidates[0].title, "Dune");
+    assert_eq!(episodes[0].episode, 1);
+    assert_eq!(episodes[0].name.as_deref(), Some("Winter Is Coming"));
+    let seen = asked.seen();
+    assert!(
+        seen[0].contains("q=Dune")
+            && seen[0].contains("kind=movie")
+            && seen[0].contains("year=2021"),
+        "{seen:?}"
+    );
+    assert!(
+        seen[1].contains("tmdbId=1399") && seen[1].contains("season=2"),
+        "{seen:?}"
+    );
+}

--- a/server/crates/kroma-module-supervisor/src/host_api.rs
+++ b/server/crates/kroma-module-supervisor/src/host_api.rs
@@ -29,6 +29,8 @@ where
         .route("/_host/enabled", get(module_enabled::<S>))
         .route("/_host/libraries", get(library_folders::<S>))
         .route("/_host/metadata-language", get(metadata_language::<S>))
+        .route("/_host/metadata-search", get(metadata_search::<S>))
+        .route("/_host/metadata-episodes", get(metadata_episodes::<S>))
         // By NAME: a sidecar asks for the credential it needs, and this route
         // never learns which vendors exist.
         .route("/_host/secret", get(secret::<S>))
@@ -239,6 +241,36 @@ async fn secret<S: HostCtx>(
 
 async fn metadata_language<S: HostCtx>(State(host): State<S>) -> Json<String> {
     Json(host.metadata_language())
+}
+
+#[derive(serde::Deserialize)]
+struct MetadataSearchQuery {
+    q: String,
+    #[serde(default)]
+    kind: String,
+    #[serde(default)]
+    year: Option<u32>,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EpisodesQuery {
+    tmdb_id: u64,
+    season: u32,
+}
+
+async fn metadata_episodes<S: HostCtx>(
+    State(host): State<S>,
+    axum::extract::Query(params): axum::extract::Query<EpisodesQuery>,
+) -> Json<Vec<kroma_domain::metadata::EpisodeInfo>> {
+    Json(host.metadata_episodes(params.tmdb_id, params.season))
+}
+
+async fn metadata_search<S: HostCtx>(
+    State(host): State<S>,
+    axum::extract::Query(params): axum::extract::Query<MetadataSearchQuery>,
+) -> Json<Vec<kroma_domain::metadata::MatchCandidate>> {
+    Json(host.metadata_candidates(&params.q, &params.kind, params.year))
 }
 
 #[cfg(test)]

--- a/server/crates/kroma-module-supervisor/tests/host_metadata.rs
+++ b/server/crates/kroma-module-supervisor/tests/host_metadata.rs
@@ -1,0 +1,135 @@
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use kroma_domain::metadata::{EpisodeInfo, MatchCandidate};
+use kroma_module_host::testing::StubHost;
+use tower::ServiceExt;
+
+const TOKEN: &str = "host-token";
+
+fn dune() -> MatchCandidate {
+    MatchCandidate {
+        tmdb_id: 438631,
+        title: "Dune".into(),
+        original_title: None,
+        year: Some(2021),
+        poster_url: None,
+        overview: None,
+        rating: None,
+        score: 0.98,
+        current: false,
+    }
+}
+
+fn winter_is_coming() -> EpisodeInfo {
+    EpisodeInfo {
+        episode: 1,
+        name: Some("Winter Is Coming".into()),
+        overview: None,
+        air_date: Some("2011-04-17".into()),
+        still_url: None,
+    }
+}
+
+async fn get(host: StubHost, uri: &str, token: Option<&str>) -> (StatusCode, String) {
+    let mut req = Request::builder().method("GET").uri(uri);
+    if let Some(t) = token {
+        req = req.header("authorization", format!("Bearer {t}"));
+    }
+    let res = kroma_module_supervisor::host_router::<StubHost>(TOKEN.into())
+        .with_state(host)
+        .oneshot(req.body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let status = res.status();
+    let bytes = axum::body::to_bytes(res.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    (status, String::from_utf8(bytes.to_vec()).unwrap())
+}
+
+#[tokio::test]
+async fn a_search_comes_back_as_the_candidates_the_core_ranked() {
+    let host = StubHost::new().with_metadata_candidates(vec![dune()]);
+
+    let (status, body) = get(
+        host,
+        "/_host/metadata-search?q=Dune&kind=movie&year=2021",
+        Some(TOKEN),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    let found: Vec<MatchCandidate> = serde_json::from_str(&body).expect("candidates came back");
+    assert_eq!(found[0].tmdb_id, 438631);
+    assert_eq!(found[0].year, Some(2021));
+    assert!((found[0].score - 0.98).abs() < f32::EPSILON);
+}
+
+#[tokio::test]
+async fn a_search_needs_only_the_query_text() {
+    let host = StubHost::new().with_metadata_candidates(vec![dune()]);
+
+    let (status, body) = get(host, "/_host/metadata-search?q=Dune", Some(TOKEN)).await;
+
+    assert_eq!(status, StatusCode::OK);
+    let found: Vec<MatchCandidate> = serde_json::from_str(&body).expect("candidates came back");
+    assert_eq!(found.len(), 1);
+}
+
+#[tokio::test]
+async fn a_search_with_no_query_text_is_rejected() {
+    let (status, _) = get(
+        StubHost::new(),
+        "/_host/metadata-search?kind=movie",
+        Some(TOKEN),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn a_season_comes_back_as_the_episodes_the_provider_names() {
+    let host = StubHost::new().with_metadata_episodes(vec![winter_is_coming()]);
+
+    let (status, body) = get(
+        host,
+        "/_host/metadata-episodes?tmdbId=1399&season=1",
+        Some(TOKEN),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    let episodes: Vec<EpisodeInfo> = serde_json::from_str(&body).expect("episodes came back");
+    assert_eq!(episodes[0].episode, 1);
+    assert_eq!(episodes[0].name.as_deref(), Some("Winter Is Coming"));
+    assert_eq!(episodes[0].air_date.as_deref(), Some("2011-04-17"));
+}
+
+#[tokio::test]
+async fn a_season_lookup_takes_its_title_id_in_camel_case_only() {
+    let host = StubHost::new().with_metadata_episodes(vec![winter_is_coming()]);
+
+    let (status, _) = get(
+        host,
+        "/_host/metadata-episodes?tmdb_id=1399&season=1",
+        Some(TOKEN),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn neither_lookup_answers_a_caller_without_the_host_token() {
+    let searched = get(StubHost::new(), "/_host/metadata-search?q=Dune", None).await;
+    let listed = get(
+        StubHost::new(),
+        "/_host/metadata-episodes?tmdbId=1399&season=1",
+        None,
+    )
+    .await;
+
+    assert_eq!(searched.0, StatusCode::UNAUTHORIZED);
+    assert_eq!(listed.0, StatusCode::UNAUTHORIZED);
+}


### PR DESCRIPTION
## What

A module can now ask the host what a title's episodes are called.

The host context grows two lookups — `metadata_search` and `metadata_episodes` — reachable by a sidecar over the token-authed `/api/_host/*` API. A module that has a TMDB id and a season can turn a torrent's file list into episode names without shipping its own catalog client or its own API key.

The mechanism carries no module's meaning: nothing added here names a module's domain. `kroma-engine` implements it, `kroma-module-host` declares it, `kroma-module-runtime` calls it, `kroma-module-supervisor` routes it.

`services/rematch.rs` becomes `services/rematch/` with the search half split into `search.rs`, because the file crossed the 300-line hard split and the search is what the new lookup reuses.

## Closes

No issue — the file list in the torrents PR at the top of this stack reads as episode names, and that data has to come from the core.

## Checks

- [ ] n/a — no TypeScript behaviour change beyond a client type
- [x] `cargo clippy --workspace --all-targets` and `cargo test --workspace` both exit 0 (2138 tests)
- [x] Follows `CODE_STYLE.md`
- [x] One idea.

## Risk

New host endpoints, so the surface to review is authorization: these are behind the same module token as the rest of `/api/_host/*`, and a module that does not call them is unaffected.

The `rematch` rename is the mechanical risk — a stale `services/rematch.rs` left beside the new `services/rematch/` directory is a hard rustc error. Verified there is exactly one, and the workspace compiles.
