### PR TITLE
feat(scene): a release name searches on its title

### DIFF
--- a/modules/tv.kroma.scene/module.json
+++ b/modules/tv.kroma.scene/module.json
@@ -3,7 +3,7 @@
   "schemaVersion": 2,
   "id": "tv.kroma.scene",
   "name": "Release parser",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "description": "Scene / P2P release-name parsing and scoring for the acquisition stack.",
   "engines": {
     "server": ">=0.1.39"

--- a/modules/tv.kroma.scene/server/src/parse.rs
+++ b/modules/tv.kroma.scene/server/src/parse.rs
@@ -32,8 +32,53 @@ pub fn parse_release_name(name: &str) -> ParsedRelease {
     }
 
     let title_end = first_marker.unwrap_or(tokens.len());
-    out.title = tokens[..title_end].join(" ");
+    out.title = strip_trailing_noise(&tokens[..title_end]).join(" ");
     out
+}
+
+const TRAILING_NOISE: &[&str] = &[
+    "complete",
+    "completa",
+    "integrale",
+    "intégrale",
+    "integral",
+    "series",
+    "serie",
+    "multi",
+    "multi3",
+    "multi5",
+    "dual",
+    "dualaudio",
+    "french",
+    "truefrench",
+    "vf",
+    "vf2",
+    "vff",
+    "vfi",
+    "vfq",
+    "vo",
+    "vost",
+    "vostfr",
+    "subfrench",
+    "stfr",
+    "english",
+    "eng",
+];
+
+fn strip_trailing_noise(run: &[String]) -> &[String] {
+    let Some((_, rest)) = run.split_first() else {
+        return run;
+    };
+    let noise = rest
+        .iter()
+        .rev()
+        .take_while(|token| {
+            TRAILING_NOISE
+                .iter()
+                .any(|word| token.eq_ignore_ascii_case(word))
+        })
+        .count();
+    &run[..run.len() - noise]
 }
 
 // Remembers the earliest structural-marker index (the title ends before it).

--- a/modules/tv.kroma.scene/server/src/tests.rs
+++ b/modules/tv.kroma.scene/server/src/tests.rs
@@ -19,6 +19,31 @@ fn parses_classic_movie_names() {
 }
 
 #[test]
+fn a_language_or_completeness_tag_trailing_the_title_is_not_part_of_it() {
+    assert_eq!(p("Stargate Atlantis iNTEGRALE MULTi").title, "Stargate Atlantis");
+    assert_eq!(
+        p("Stargate.Atlantis.INTEGRALE.MULTi.1080p.BluRay.x265").title,
+        "Stargate Atlantis"
+    );
+    assert_eq!(p("Stargate Atlantis COMPLETE SERIES MULTI").title, "Stargate Atlantis");
+    assert_eq!(p("Kaamelott.Integrale.FRENCH.1080p").title, "Kaamelott");
+    assert_eq!(p("Le.Bureau.des.Legendes.S01.MULTi.1080p").title, "Le Bureau des Legendes");
+}
+
+#[test]
+fn the_same_words_inside_a_title_are_left_alone() {
+    assert_eq!(p("A.Complete.Unknown.2024.1080p.WEB-DL").title, "A Complete Unknown");
+    assert_eq!(p("The.French.Dispatch.2021.1080p.BluRay").title, "The French Dispatch");
+    assert_eq!(p("The French Connection 1971 1080p").title, "The French Connection");
+    assert_eq!(p("The.Complete.Unknown").title, "The Complete Unknown");
+}
+
+#[test]
+fn a_name_that_is_nothing_but_tags_keeps_a_title_rather_than_matching_everything() {
+    assert_eq!(p("MULTi.FRENCH.1080p").title, "MULTi");
+}
+
+#[test]
 fn parses_modern_web_names_with_hdr_and_dv() {
     let r = p("Dune Part Two 2024 2160p WEB-DL DV HDR10 HEVC DDP5.1-GRP");
     assert_eq!(r.title, "Dune Part Two");


### PR DESCRIPTION
## What

`parse()` now yields the title a search should use, stripped of the tags a tracker appends to a release name. A grab looks for the show rather than for the release string, so `Some.Show.S02E04.1080p.WEB-DL.x265-GROUP` searches for `Some Show`.

## Closes

No issue.

## Checks

- [ ] n/a — no TypeScript change
- [x] `cargo clippy --all-targets` clean (zero warnings) and `cargo test` passes (35 tests)
- [x] `module.json` version bumped 0.3.0 → 0.3.1, in this commit
- [x] Follows `CODE_STYLE.md`
- [x] One idea.

## Risk

Contained to `tv.kroma.scene`'s parser. If the stripping is too aggressive a search loses a word that was part of the real title (a show whose name genuinely contains a year, say); too timid and the search still carries release tags and finds nothing. `tests.rs` gains cases for both directions.
