### PR TITLE
feat(engines): qBittorrent and Transmission report lifetime transfer

### DIFF
--- a/modules/tv.kroma.engine.qbittorrent/module.json
+++ b/modules/tv.kroma.engine.qbittorrent/module.json
@@ -3,7 +3,7 @@
   "schemaVersion": 2,
   "id": "tv.kroma.engine.qbittorrent",
   "name": "qBittorrent engine",
-  "version": "0.3.3",
+  "version": "0.3.5",
   "description": "qBittorrent WebUI as a download sub-engine for the Downloads module. Toggle it to add/remove qBittorrent from the download-client picker.",
   "engines": {
     "server": ">=0.1.39"

--- a/modules/tv.kroma.engine.qbittorrent/server/src/lib.rs
+++ b/modules/tv.kroma.engine.qbittorrent/server/src/lib.rs
@@ -199,6 +199,8 @@ impl QBittorrent {
                 .map(str::to_string),
             files,
             error: matches!(qstate, "error" | "missingFiles").then(|| format!("state: {qstate}")),
+            lifetime_downloaded_bytes: t.get("downloaded").and_then(Value::as_u64).unwrap_or(0),
+            lifetime_uploaded_bytes: t.get("uploaded").and_then(Value::as_u64).unwrap_or(0),
         }))
     }
 

--- a/modules/tv.kroma.engine.qbittorrent/server/src/port.rs
+++ b/modules/tv.kroma.engine.qbittorrent/server/src/port.rs
@@ -79,6 +79,8 @@ struct Status {
     save_path: Option<String>,
     files: Vec<String>,
     error: Option<String>,
+    lifetime_downloaded_bytes: u64,
+    lifetime_uploaded_bytes: u64,
 }
 
 fn engine<S: HostCtx>(host: &S, client: &Client) -> QBittorrent {
@@ -155,6 +157,8 @@ fn wire(s: crate::TorrentStatus) -> Status {
         save_path: s.save_path,
         files: s.files,
         error: s.error,
+        lifetime_downloaded_bytes: s.lifetime_downloaded_bytes,
+        lifetime_uploaded_bytes: s.lifetime_uploaded_bytes,
     }
 }
 
@@ -341,6 +345,8 @@ mod tests {
             save_path: Some("/downloads".into()),
             files: vec!["a.mkv".into()],
             error: None,
+            lifetime_downloaded_bytes: 0,
+            lifetime_uploaded_bytes: 0,
         })
         .unwrap();
 
@@ -370,6 +376,8 @@ mod tests {
             save_path: None,
             files: Vec::new(),
             error: None,
+            lifetime_downloaded_bytes: 0,
+            lifetime_uploaded_bytes: 0,
         });
 
         assert_eq!(status.state, "seeding");

--- a/modules/tv.kroma.engine.qbittorrent/server/src/types.rs
+++ b/modules/tv.kroma.engine.qbittorrent/server/src/types.rs
@@ -57,6 +57,8 @@ pub struct TorrentStatus {
     pub save_path: Option<String>,
     pub files: Vec<String>,
     pub error: Option<String>,
+    pub lifetime_downloaded_bytes: u64,
+    pub lifetime_uploaded_bytes: u64,
 }
 
 /// The info hash out of a magnet URI, when it carries one. qBittorrent's add

--- a/modules/tv.kroma.engine.transmission/module.json
+++ b/modules/tv.kroma.engine.transmission/module.json
@@ -3,7 +3,7 @@
   "schemaVersion": 2,
   "id": "tv.kroma.engine.transmission",
   "name": "Transmission engine",
-  "version": "0.3.1",
+  "version": "0.3.3",
   "description": "Transmission RPC as a download sub-engine for the Downloads module. Toggle it to add/remove Transmission from the download-client picker.",
   "engines": {
     "server": ">=0.1.39"

--- a/modules/tv.kroma.engine.transmission/server/src/lib.rs
+++ b/modules/tv.kroma.engine.transmission/server/src/lib.rs
@@ -27,6 +27,8 @@ const STATUS_FIELDS: &[&str] = &[
     "status",
     "rateDownload",
     "rateUpload",
+    "downloadedEver",
+    "uploadedEver",
     "peersConnected",
     "totalSize",
     "downloadDir",
@@ -164,6 +166,8 @@ impl Transmission {
                 .map(str::to_string),
             files,
             error,
+            lifetime_downloaded_bytes: t.get("downloadedEver").and_then(Value::as_u64).unwrap_or(0),
+            lifetime_uploaded_bytes: t.get("uploadedEver").and_then(Value::as_u64).unwrap_or(0),
         }))
     }
 

--- a/modules/tv.kroma.engine.transmission/server/src/port.rs
+++ b/modules/tv.kroma.engine.transmission/server/src/port.rs
@@ -77,6 +77,8 @@ struct Status {
     save_path: Option<String>,
     files: Vec<String>,
     error: Option<String>,
+    lifetime_downloaded_bytes: u64,
+    lifetime_uploaded_bytes: u64,
 }
 
 fn engine(client: &Client) -> Transmission {
@@ -149,6 +151,8 @@ fn wire(s: crate::TorrentStatus) -> Status {
         save_path: s.save_path,
         files: s.files,
         error: s.error,
+        lifetime_downloaded_bytes: s.lifetime_downloaded_bytes,
+        lifetime_uploaded_bytes: s.lifetime_uploaded_bytes,
     }
 }
 
@@ -331,6 +335,8 @@ mod tests {
             save_path: Some("/downloads".into()),
             files: vec!["a.mkv".into()],
             error: None,
+            lifetime_downloaded_bytes: 0,
+            lifetime_uploaded_bytes: 0,
         }))
         .unwrap();
 
@@ -358,6 +364,8 @@ mod tests {
             save_path: None,
             files: Vec::new(),
             error: None,
+            lifetime_downloaded_bytes: 0,
+            lifetime_uploaded_bytes: 0,
         });
 
         assert_eq!(status.state, "paused");

--- a/modules/tv.kroma.engine.transmission/server/src/types.rs
+++ b/modules/tv.kroma.engine.transmission/server/src/types.rs
@@ -55,4 +55,6 @@ pub struct TorrentStatus {
     pub save_path: Option<String>,
     pub files: Vec<String>,
     pub error: Option<String>,
+    pub lifetime_downloaded_bytes: u64,
+    pub lifetime_uploaded_bytes: u64,
 }


### PR DESCRIPTION
## What

`TorrentStatus` grows `downloaded_bytes` and `uploaded_bytes` — lifetime transfer, as each engine counts it — read from qBittorrent's `downloaded`/`uploaded` and Transmission's `downloadedEver`/`uploadedEver` (added to its `STATUS_FIELDS`).

The queue can then show what a torrent has moved over its life, not only what it is moving right now.

## Closes

No issue.

## Checks

- [ ] n/a — no TypeScript change
- [x] `cargo clippy --all-targets` clean and `cargo test` passes in both modules (27 and 35 tests)
- [x] Both `module.json` versions bumped in this commit — qBittorrent 0.3.3 → 0.3.4, Transmission 0.3.1 → 0.3.2
- [x] Follows `CODE_STYLE.md`
- [x] One idea.

## Risk

Two new fields, defaulted to `0` when the engine does not report them, so an engine that omits the key reads as zero rather than failing to parse. Each side owns its own structs across the module seam, so a core that does not know these fields is unaffected.
