### PR TITLE
chore/ignore zed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ scripts/serve-nas.sh
 .idea/
 .vscode/*
 !.vscode/extensions.json
+.zed/
 
 # Logs
 *.log


### PR DESCRIPTION
## What

Adds `.zed/` to `.gitignore`, in the "Editor / OS" block beside `.idea/` and `.vscode/*`.

Zed writes a `.zed/` next to the other editor directories. An empty `.zed/tasks.json` — which is what Zed leaves after you open its task picker once — is enough to fail `bun run check`, because `biome check .` walks it and cannot parse an empty file.

## Closes

No issue. Found while running the checks for this stack: `bun run check` failed locally on a file no one had authored.

## Checks

- [x] `bun run check` passes with the file present (it did not before)
- [ ] n/a — no server change
- [x] Follows `CODE_STYLE.md`
- [x] One idea.

## Risk

None. One ignore line; CI never saw the file because it is untracked.
