### PR TITLE
fix(sonar): drop two exclusions that stopped matching anything

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -74,8 +74,6 @@ sonar.exclusions=\
   packages/modules-generated/**,\
   server/crates/kroma-modules-generated/**,\
   clients/synology/.cache/**,\
-  packages/ui/audit/paint/**,\
-  packages/ui/audit/a11y/**,\
   **/*.min.js,\
   **/vendor/**,\
   data/**,\


### PR DESCRIPTION
## What

Drops two `sonar.exclusions` patterns that had stopped matching anything:

```
packages/ui/audit/paint/**
packages/ui/audit/a11y/**
```

Those directories held the audit's per-component snapshot files — one `.txt` per component, genuinely "runtime data not authored here", which is what that exclusion block is for. The audit no longer writes snapshots to disk and both directories are gone, so the patterns matched nothing.

Deleted rather than repointed: there is nothing left for them to name. `git ls-files` finds no committed snapshot anywhere under `packages/ui`, and `report.ts`/`sweep.ts` make no disk writes.

## Closes

No issue. `bun run sonar:lint` fails on `main` today, and this is why.

## Checks

- [x] `bun run sonar:lint` now passes — it exits 1 on `main`
- [ ] n/a — no server change
- [x] Follows `CODE_STYLE.md`
- [x] One idea.

## Risk

Low, and self-checking. This is exactly the silent lapse `sonar-project.properties` warns about in its own header: Sonar does not treat a pattern matching nothing as an error, it just stops applying, so a renamed file drops out of an exclusion unnoticed. `packages/sonar-tools/src/config-lint.ts` is the guard, and it is what caught these.

Worth knowing: `bun run sonar:lint` is not wired into any workflow, so nothing enforced this.
