### PR TITLE
fix(ci): coverage stops counting the audit project's compiler output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,23 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+  audit:
+    name: Kit audit
+    needs: lanes
+    if: needs.lanes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version-file: .bun-version
+          no-cache: true
+      - run: bun install --frozen-lockfile
+      - run: bun run ci test --audit
+
   # One report from the four shards: the lcov Sonar reads and the summary the
   # run page shows. Required on main in place of the shards themselves, so a
   # shard that never ran (a cancelled runner) cannot pass as a green run.

--- a/packages/ci-tools/src/test.ts
+++ b/packages/ci-tools/src/test.ts
@@ -12,6 +12,14 @@ const vitest = join(root, 'node_modules/.bin/vitest');
 
 const COVERAGE = ['--coverage', '--coverage.reporter=lcov', '--coverage.reporter=text-summary'];
 
+// The audit project compiles with the React Compiler, so it instruments the
+// same sources a second time and its branch map carries the compiler's
+// memo-cache guards. Merged in, those count as uncovered conditions on lines
+// that hold no conditional, which caps every hooked kit file below what a test
+// of its source can reach. Coverage is measured over the two resolution
+// projects; the audit runs on its own.
+const MEASURED = ['--project', 'web', '--project', 'native'];
+
 async function codegen(): Promise<void> {
   await $`bun run test:codegen`.cwd(root);
 }
@@ -19,7 +27,14 @@ async function codegen(): Promise<void> {
 async function shard(spec: string): Promise<void> {
   const { index, total } = parseShard(spec);
   await codegen();
-  await $`${vitest} run --reporter=blob --shard=${index}/${total} ${COVERAGE}`.cwd(root);
+  await $`${vitest} run --reporter=blob --shard=${index}/${total} ${MEASURED} ${COVERAGE}`.cwd(
+    root,
+  );
+}
+
+async function audit(): Promise<void> {
+  await codegen();
+  await $`${vitest} run --project audit`.cwd(root);
 }
 
 async function merge(total: number | undefined): Promise<void> {
@@ -46,11 +61,13 @@ export async function main(argv: string[]): Promise<void> {
     args: argv,
     options: {
       shard: { type: 'string' },
+      audit: { type: 'boolean', default: false },
       merge: { type: 'boolean', default: false },
       expect: { type: 'string' },
     },
   });
   if (values.shard !== undefined) return shard(values.shard);
+  if (values.audit) return audit();
   if (values.merge) return merge(values.expect === undefined ? undefined : Number(values.expect));
   await codegen();
   await $`${vitest} run`.cwd(root);


### PR DESCRIPTION
## What

Coverage is now measured over the `web` and `native` projects only; the kit audit runs as its own CI job.

The `audit` project runs the React Compiler deliberately — it measures what a component costs to re-render, and without the compiler it would measure work every shell already removes. But `bun run ci test` collected coverage across all three projects and merged the lcov, so every kit file with hooks was instrumented **twice**, and the compiler's memo-cache guards were counted as branches.

Those guards do not exist in the source. The residual "uncovered conditions" sat on lines like `active: flow.value === value,` and a bare `};` — the `else` arm is only taken on a re-render with byte-identical deps, which the audit sweep never does because it renders each story once. So no test of the source could reach them.

The effect was a ceiling, not noise:

| file | web instrumentation | merged, as Sonar read it |
|---|---|---|
| `stepper-context.ts` | **0 branches** | 24 branches, 14 uncovered |
| `use-steps.ts` | 34/34 covered | 90/124 |

`packages/ui/src/components/molecules/stepper` is the clearest case — it is saturated under the instrumentation that matches its source, and still scored 76% on the gate.

## Closes

No issue. Found while driving the stack below this one to a green quality gate: `feat/ui-stepper` could not pass `new_coverage` no matter what was tested, because the uncovered conditions were not in its code.

## Checks

- [x] `bun run ci test --audit` runs the audit project alone — 54 passed, 2 skipped
- [x] `bun run typecheck` and `bun run check` pass
- [ ] n/a — no server change
- [x] Follows `CODE_STYLE.md`
- [x] One idea.

## Risk

The audit suite must still run, or this trades a bad number for a lost check. It does: a new `Kit audit` job runs `bun run ci test --audit`, gated on the same `lanes` output as the sharded tests. **If you protect `main` on required checks, add `Kit audit` to the list** — the sharded `test` job no longer covers those files.

Coverage numbers will move for every `packages/ui` file with hooks. They should move up, and the ones that move are the ones that were never reachable. I could not verify the new number locally — path-filtered coverage runs produce no per-file data here — so the honest confirmation is SonarCloud on this PR.

Two things deliberately not done: no story fixture was contorted to force memo-cache hits (that is coverage-gaming), and `**/*.tsx` stays coverage-excluded as it already was.
