### PR TITLE
fix(player): a stalled playhead recovers, and a paused film stays paused

### DIFF
--- a/clients/mobile/src/player/engine/index.test.ts
+++ b/clients/mobile/src/player/engine/index.test.ts
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+import type { KromaClient, MediaItem } from '@kroma/core';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Listener = (payload: never) => void;
+
+const P = vi.hoisted(() => {
+  const make = () => {
+    const listeners = new Map<string, Set<Listener>>();
+    const player = {
+      playing: false,
+      duration: 7200,
+      currentTime: 0,
+      muted: false,
+      playbackRate: 1,
+      timeUpdateEventInterval: 0,
+      staysActiveInBackground: false,
+      showNowPlayingNotification: false,
+      availableAudioTracks: [] as unknown[],
+      audioTrack: null as unknown,
+      play: vi.fn(() => {
+        player.playing = true;
+      }),
+      pause: vi.fn(),
+      replaceAsync: vi.fn(async () => undefined),
+      addListener: (type: string, fn: Listener) => {
+        let set = listeners.get(type);
+        if (!set) {
+          set = new Set();
+          listeners.set(type, set);
+        }
+        set.add(fn);
+        return {
+          remove: () => {
+            set?.delete(fn);
+          },
+        };
+      },
+      emit: (type: string, payload: unknown) => {
+        for (const fn of listeners.get(type) ?? []) (fn as (p: unknown) => void)(payload);
+      },
+    };
+    return player;
+  };
+  const box = { current: make() };
+  return { box, fresh: () => (box.current = make()) };
+});
+
+vi.mock('expo-video', () => ({
+  useVideoPlayer: (_source: unknown, setup?: (p: unknown) => void) => {
+    setup?.(P.box.current);
+    return P.box.current;
+  },
+}));
+
+vi.mock('#mobile/player/caps', () => ({
+  decideSource: () => ({ direct: true, aacMaster: false }),
+}));
+
+import { useKromaEngine } from './index';
+
+const ITEM = {
+  id: 'itm_1',
+  title: 'A film',
+  durationMs: 7_200_000,
+  metadata: { title: 'A film' },
+} as unknown as MediaItem;
+
+const CLIENT = {
+  streamUrl: (id: string) => `stream://${id}`,
+  hlsMasterUrl: (id: string, _aac: boolean, anchor: number) => `hls://${id}@${anchor}`,
+  resolveArt: () => undefined,
+} as unknown as KromaClient;
+
+function open(startSec = 0) {
+  return renderHook(() => useKromaEngine(CLIENT, ITEM, startSec));
+}
+
+const player = () => P.box.current;
+
+async function reachReady() {
+  await act(async () => {
+    player().emit('statusChange', { status: 'readyToPlay' });
+  });
+}
+
+async function playFor(sec: number) {
+  await act(async () => {
+    player().emit('timeUpdate', { currentTime: sec, bufferedPosition: sec + 40 });
+  });
+}
+
+describe('useKromaEngine', () => {
+  beforeEach(() => {
+    P.fresh();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ headers: { get: () => '900' } })),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('starts the film on its first open', async () => {
+    open();
+    await waitFor(() => expect(player().replaceAsync).toHaveBeenCalledTimes(1));
+
+    await reachReady();
+
+    expect(player().play).toHaveBeenCalledTimes(1);
+  });
+
+  it('resumes a reload the viewer had left running', async () => {
+    const { result } = open();
+    await waitFor(() => expect(player().replaceAsync).toHaveBeenCalledTimes(1));
+    await reachReady();
+    await playFor(60);
+
+    act(() => result.current.setAudio(1));
+    await waitFor(() => expect(player().replaceAsync).toHaveBeenCalledTimes(2));
+    await reachReady();
+
+    expect(player().play).toHaveBeenCalledTimes(2);
+  });
+
+  it('leaves a reload alone under a viewer who had paused', async () => {
+    const { result } = open();
+    await waitFor(() => expect(player().replaceAsync).toHaveBeenCalledTimes(1));
+    await reachReady();
+    await playFor(60);
+    player().playing = false;
+
+    act(() => result.current.setAudio(1));
+    await waitFor(() => expect(player().replaceAsync).toHaveBeenCalledTimes(2));
+    await reachReady();
+
+    expect(player().play).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops the old source depth rather than drawing it against the new anchor', async () => {
+    const { result } = open();
+    await waitFor(() => expect(player().replaceAsync).toHaveBeenCalledTimes(1));
+    await reachReady();
+    await playFor(600);
+    expect(result.current.buffered).toBe(640);
+
+    act(() => result.current.setAudio(1));
+    await waitFor(() => expect(player().replaceAsync).toHaveBeenCalledTimes(2));
+
+    expect(result.current.buffered).toBe(900);
+  });
+});

--- a/clients/mobile/src/player/engine/index.ts
+++ b/clients/mobile/src/player/engine/index.ts
@@ -85,6 +85,10 @@ export function useKromaEngine(
   const load = useCallback(
     async (absSec: number) => {
       const id = ++core.loadId;
+      // Read before `started` is cleared below: a reload under a viewer who had
+      // paused (a far scrub, an audio track, the volume filter) must not start
+      // the film again. Nothing has played yet on the first open, so that autoplays.
+      const resume = !core.started || player.playing;
       setWaiting(true);
       setReady(false);
       let uri: string;
@@ -101,10 +105,12 @@ export function useKromaEngine(
       }
       if (id !== core.loadId) return;
       core.elSec = 0;
+      core.bufSec = 0;
       core.started = false;
-      core.resumeOnLoad = true;
+      core.resumeOnLoad = resume;
       setMode(core.mode);
       setCur(core.baseSec + (core.pendingSeek ?? 0));
+      setBuffered(core.baseSec + (core.pendingSeek ?? 0));
       const meta = item.metadata;
       await player
         .replaceAsync({

--- a/clients/mobile/src/player/engine/index.ts
+++ b/clients/mobile/src/player/engine/index.ts
@@ -9,7 +9,7 @@
 // copy-audio master retries once as AAC.
 
 import type { KromaClient, MediaItem } from '@kroma/core';
-import { type AudioTrack, useVideoPlayer } from 'expo-video';
+import { type AudioTrack, useVideoPlayer, type VideoPlayer } from 'expo-video';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { decideSource } from '#mobile/player/caps';
 import { useEngineControls } from './controls';
@@ -22,6 +22,11 @@ import {
 } from './types';
 
 export type { AudioFilterMode, Engine, EngineState } from './types';
+
+// Must be read before `started` is cleared for the new source.
+function resumeOnLoad(core: EngineCore, player: VideoPlayer): boolean {
+  return !core.started || player.playing;
+}
 
 export function useKromaEngine(
   client: KromaClient,
@@ -85,10 +90,7 @@ export function useKromaEngine(
   const load = useCallback(
     async (absSec: number) => {
       const id = ++core.loadId;
-      // Read before `started` is cleared below: a reload under a viewer who had
-      // paused (a far scrub, an audio track, the volume filter) must not start
-      // the film again. Nothing has played yet on the first open, so that autoplays.
-      const resume = !core.started || player.playing;
+      const resume = resumeOnLoad(core, player);
       setWaiting(true);
       setReady(false);
       let uri: string;

--- a/clients/web/src/features/playback/media-events.test.ts
+++ b/clients/web/src/features/playback/media-events.test.ts
@@ -141,6 +141,17 @@ describe('bindMediaEvents', () => {
     expect(fv.playCalls()).toBe(1);
   });
 
+  it('leaves a film the viewer had paused alone when the element is re-attached', () => {
+    const fv = fakeVideo();
+    const s = mkSetters();
+
+    bindMediaEvents(fv.el, item, s, 0, 0, false);
+    fv.fire('canplay');
+
+    expect(s.setReady).toHaveBeenCalledWith(true);
+    expect(fv.playCalls()).toBe(0);
+  });
+
   it('anchors at the element clock when no offset is given', () => {
     const fv = fakeVideo();
     const s = mkSetters();

--- a/clients/web/src/features/playback/media-events.ts
+++ b/clients/web/src/features/playback/media-events.ts
@@ -26,6 +26,10 @@ export function bindMediaEvents(
   // Preferred over the element's `duration`, which for a growing HLS EVENT
   // playlist is only the produced edge, not the whole movie. 0 = unknown.
   knownDurationMs = 0,
+  // False where the element is being re-attached under a viewer who had paused.
+  // Every binding is fresh, so without this a recovery reads its own first
+  // `canplay` as a reason to start a film nobody asked to resume.
+  autoplay = true,
 ): () => void {
   const {
     setCur,
@@ -62,7 +66,7 @@ export function bindMediaEvents(
   let started = false;
   const onReady = () => {
     setReady(true);
-    if (started || !v.paused) return;
+    if (started || !autoplay || !v.paused) return;
     const p = v.play();
     p?.catch(() => undefined);
   };

--- a/clients/web/src/features/playback/media-events.ts
+++ b/clients/web/src/features/playback/media-events.ts
@@ -16,8 +16,14 @@ export interface MediaEventSetters {
   setReady: (b: boolean) => void;
 }
 
-/** Subscribes the media element's events to the state setters and drives a
- * resilient, ready-gated autoplay. Returns the unsubscribe cleanup. */
+/**
+ * Subscribes the media element's events to the state setters and drives a
+ * resilient, ready-gated autoplay. Returns the unsubscribe cleanup.
+ *
+ * Every binding is fresh, so `autoplay` is what carries the viewer's own
+ * play/pause across a re-attach: pass `false` and the first `canplay` is not
+ * taken as a reason to start a film nobody asked to resume.
+ */
 export function bindMediaEvents(
   v: HTMLVideoElement,
   item: MovieView,
@@ -26,9 +32,6 @@ export function bindMediaEvents(
   // Preferred over the element's `duration`, which for a growing HLS EVENT
   // playlist is only the produced edge, not the whole movie. 0 = unknown.
   knownDurationMs = 0,
-  // False where the element is being re-attached under a viewer who had paused.
-  // Every binding is fresh, so without this a recovery reads its own first
-  // `canplay` as a reason to start a film nobody asked to resume.
   autoplay = true,
 ): () => void {
   const {

--- a/clients/web/src/features/playback/player.tsx
+++ b/clients/web/src/features/playback/player.tsx
@@ -110,7 +110,6 @@ export function Player({
     <video
       key={`${pb.anchor}:${pb.audioIndex}`}
       ref={videoRef}
-      autoPlay
       playsInline
       crossOrigin="anonymous"
       style={{ borderRadius: 'inherit' }}

--- a/clients/web/src/features/playback/use-stall-recovery.test.ts
+++ b/clients/web/src/features/playback/use-stall-recovery.test.ts
@@ -1,0 +1,165 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fakeVideo } from '#web/features/playback/fake-video.fixture';
+import {
+  type StallRecoveryOptions,
+  useStallRecovery,
+} from '#web/features/playback/use-stall-recovery';
+import type { HlsInstance, ShakaPlayerLike } from '#web/features/playback/video-engine';
+
+const POLL_MS = 500;
+const RUNG_MS = 2000;
+const WHOLE_LADDER_MS = 12_000;
+const BASE_SEC = 1000;
+
+function harness(over: Partial<StallRecoveryOptions> = {}) {
+  const fv = fakeVideo({ currentTime: 100, paused: false, readyState: 4 });
+  fv.setBuffered([[90, 160]]);
+  const shaka = { retryStreaming: vi.fn(() => true) } as unknown as ShakaPlayerLike;
+  const hls = { recoverMediaError: vi.fn() } as unknown as HlsInstance;
+  const onRestart = vi.fn();
+  const opts: StallRecoveryOptions = {
+    videoRef: { current: fv.el },
+    hlsRef: { current: hls },
+    shakaRef: { current: shaka },
+    baseSec: BASE_SEC,
+    active: true,
+    onRestart,
+    ...over,
+  };
+  return { fv, shaka, hls, onRestart, opts };
+}
+
+describe('useStallRecovery', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('nudges a playhead that stopped with buffer still ahead of it', () => {
+    const { fv, opts } = harness();
+
+    const { result } = renderHook(() => useStallRecovery(opts));
+    act(() => {
+      vi.advanceTimersByTime(RUNG_MS + POLL_MS);
+    });
+
+    expect(fv.get('currentTime')).toBeCloseTo(100.1, 5);
+    expect(result.current).toBe(true);
+  });
+
+  it('climbs to Shaka retrying the stream, then to a fresh source', () => {
+    const { shaka, hls, onRestart, opts } = harness();
+
+    renderHook(() => useStallRecovery(opts));
+    act(() => {
+      vi.advanceTimersByTime(WHOLE_LADDER_MS);
+    });
+
+    expect(shaka.retryStreaming).toHaveBeenCalledTimes(1);
+    expect(hls.recoverMediaError).not.toHaveBeenCalled();
+    expect(onRestart).toHaveBeenCalledTimes(1);
+    expect(onRestart.mock.calls[0]?.[0]).toBeCloseTo(BASE_SEC + 100.2, 5);
+  });
+
+  it('recovers through hls.js where Shaka is not the engine', () => {
+    const { hls, opts } = harness({ shakaRef: { current: null } });
+
+    renderHook(() => useStallRecovery(opts));
+    act(() => {
+      vi.advanceTimersByTime(WHOLE_LADDER_MS);
+    });
+
+    expect(hls.recoverMediaError).toHaveBeenCalledTimes(1);
+  });
+
+  it('survives a direct-play element with neither engine attached', () => {
+    const { onRestart, opts } = harness({
+      shakaRef: { current: null },
+      hlsRef: { current: null },
+    });
+
+    renderHook(() => useStallRecovery(opts));
+    act(() => {
+      vi.advanceTimersByTime(WHOLE_LADDER_MS);
+    });
+
+    expect(onRestart).toHaveBeenCalledTimes(1);
+  });
+
+  it('restarts once inside the cooldown, however often it stalls again', () => {
+    const { fv, onRestart, opts } = harness();
+
+    renderHook(() => useStallRecovery(opts));
+    act(() => {
+      vi.advanceTimersByTime(WHOLE_LADDER_MS);
+    });
+    act(() => {
+      fv.set('currentTime', 120);
+      vi.advanceTimersByTime(POLL_MS);
+      fv.set('currentTime', 125);
+      vi.advanceTimersByTime(POLL_MS);
+      vi.advanceTimersByTime(RUNG_MS * 4);
+    });
+
+    expect(onRestart).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves alone anything that is not meant to be advancing', () => {
+    for (const state of [{ paused: true }, { ended: true }, { seeking: true }, { readyState: 2 }]) {
+      const { fv, opts } = harness();
+      for (const [key, value] of Object.entries(state)) fv.set(key, value);
+
+      const { result } = renderHook(() => useStallRecovery(opts));
+      act(() => {
+        vi.advanceTimersByTime(RUNG_MS * 4);
+      });
+
+      expect(fv.get('currentTime')).toBe(100);
+      expect(result.current).toBe(false);
+    }
+  });
+
+  it('leaves a playhead that has genuinely run out to the engine', () => {
+    const { fv, opts } = harness();
+    fv.setBuffered([[90, 100.2]]);
+
+    const { result } = renderHook(() => useStallRecovery(opts));
+    act(() => {
+      vi.advanceTimersByTime(RUNG_MS * 4);
+    });
+
+    expect(fv.get('currentTime')).toBe(100);
+    expect(result.current).toBe(false);
+  });
+
+  it('watches nothing while it is not armed, or before an element is mounted', () => {
+    const idle = harness({ active: false });
+    const bare = harness({ videoRef: { current: null } });
+
+    const idleHook = renderHook(() => useStallRecovery(idle.opts));
+    const bareHook = renderHook(() => useStallRecovery(bare.opts));
+    act(() => {
+      vi.advanceTimersByTime(RUNG_MS * 4);
+    });
+
+    expect(idle.fv.get('currentTime')).toBe(100);
+    expect(idleHook.result.current).toBe(false);
+    expect(bareHook.result.current).toBe(false);
+  });
+
+  it('stops polling once it is unmounted', () => {
+    const { fv, opts } = harness();
+
+    const { unmount } = renderHook(() => useStallRecovery(opts));
+    unmount();
+    act(() => {
+      vi.advanceTimersByTime(RUNG_MS * 4);
+    });
+
+    expect(fv.get('currentTime')).toBe(100);
+  });
+});

--- a/clients/web/src/features/playback/use-stall-recovery.ts
+++ b/clients/web/src/features/playback/use-stall-recovery.ts
@@ -1,4 +1,4 @@
-import { driveStallRecovery, reachableBufferEnd, STALL_NUDGE_SEC } from '@kroma/core';
+import { driveStallRecovery, reachableBufferEnd, recoverMse, STALL_NUDGE_SEC } from '@kroma/core';
 import { useEffect, useState } from 'react';
 import type { HlsInstance, ShakaPlayerLike } from '#web/features/playback/video-engine';
 
@@ -36,12 +36,7 @@ export function useStallRecovery(opts: StallRecoveryOptions): boolean {
         nudge: () => {
           v.currentTime += STALL_NUDGE_SEC;
         },
-        recover: () => {
-          if (shakaRef.current) return shakaRef.current.retryStreaming();
-          if (!hlsRef.current) return false;
-          hlsRef.current.recoverMediaError();
-          return true;
-        },
+        recover: () => recoverMse(shakaRef.current, hlsRef.current),
         restart: () => onRestart(baseSec + v.currentTime),
       },
       setStalled,

--- a/clients/web/src/features/playback/use-stall-recovery.ts
+++ b/clients/web/src/features/playback/use-stall-recovery.ts
@@ -1,0 +1,81 @@
+import {
+  reachableBufferEnd,
+  STALL_NUDGE_SEC,
+  STALL_POLL_MS,
+  type StallStep,
+  stallWatch,
+} from '@kroma/core';
+import { useEffect, useRef, useState } from 'react';
+import type { HlsInstance, ShakaPlayerLike } from '#web/features/playback/video-engine';
+
+// A restart re-anchors the stream, which costs a fresh remux session: worth it
+// once for a picture that is otherwise frozen, not worth it in a loop.
+const RESTART_COOLDOWN_MS = 30_000;
+
+export interface StallRecoveryOptions {
+  videoRef: React.RefObject<HTMLVideoElement | null>;
+  hlsRef: { current: HlsInstance | null };
+  shakaRef: { current: ShakaPlayerLike | null };
+  /** The anchor the element's clock is relative to, so a restart can name the
+   * absolute position the picture froze at. */
+  baseSec: number;
+  active: boolean;
+  onRestart: (absSec: number) => void;
+}
+
+/**
+ * Works a stuck playhead back up: a nudge, then the engine's own recovery, then
+ * a fresh source at the same position. Returns whether it is stuck right now,
+ * which the chrome shows as buffering rather than as a healthy full bar.
+ */
+export function useStallRecovery(opts: StallRecoveryOptions): boolean {
+  const { videoRef, hlsRef, shakaRef, baseSec, active, onRestart } = opts;
+  const [stalled, setStalled] = useState(false);
+  const restartedAt = useRef(0);
+
+  useEffect(() => {
+    if (!active) return;
+    const watch = stallWatch();
+
+    const apply = (step: StallStep, v: HTMLVideoElement) => {
+      if (step === 'nudge') {
+        v.currentTime += STALL_NUDGE_SEC;
+        return;
+      }
+      if (step === 'recover') {
+        if (shakaRef.current) shakaRef.current.retryStreaming();
+        else hlsRef.current?.recoverMediaError();
+        return;
+      }
+      const now = Date.now();
+      if (now - restartedAt.current < RESTART_COOLDOWN_MS) return;
+      restartedAt.current = now;
+      onRestart(baseSec + v.currentTime);
+    };
+
+    const id = setInterval(() => {
+      const v = videoRef.current;
+      if (!v) return;
+      const step = watch.observe(
+        {
+          currentTime: v.currentTime,
+          bufferedEnd: reachableBufferEnd(v.buffered, v.currentTime),
+          paused: v.paused,
+          ended: v.ended,
+          seeking: v.seeking,
+          readyState: v.readyState,
+        },
+        Date.now(),
+      );
+      setStalled(watch.stalled());
+      if (step) apply(step, v);
+    }, STALL_POLL_MS);
+
+    return () => {
+      clearInterval(id);
+      setStalled(false);
+    };
+  }, [active, baseSec, onRestart, videoRef, hlsRef, shakaRef]);
+
+  return stalled;
+}

--- a/clients/web/src/features/playback/use-stall-recovery.ts
+++ b/clients/web/src/features/playback/use-stall-recovery.ts
@@ -1,9 +1,4 @@
-import {
-  driveStallRecovery,
-  reachableBufferEnd,
-  STALL_NUDGE_SEC,
-  type StallSample,
-} from '@kroma/core';
+import { driveStallRecovery, reachableBufferEnd, STALL_NUDGE_SEC } from '@kroma/core';
 import { useEffect, useState } from 'react';
 import type { HlsInstance, ShakaPlayerLike } from '#web/features/playback/video-engine';
 
@@ -26,24 +21,20 @@ export function useStallRecovery(opts: StallRecoveryOptions): boolean {
   const [stalled, setStalled] = useState(false);
 
   useEffect(() => {
-    if (!active) return;
+    const v = videoRef.current;
+    if (!active || !v) return;
     return driveStallRecovery(
       {
-        sample: (): StallSample | null => {
-          const v = videoRef.current;
-          if (!v) return null;
-          return {
-            currentTime: v.currentTime,
-            bufferedEnd: reachableBufferEnd(v.buffered, v.currentTime),
-            paused: v.paused,
-            ended: v.ended,
-            seeking: v.seeking,
-            readyState: v.readyState,
-          };
-        },
+        sample: () => ({
+          currentTime: v.currentTime,
+          bufferedEnd: reachableBufferEnd(v.buffered, v.currentTime),
+          paused: v.paused,
+          ended: v.ended,
+          seeking: v.seeking,
+          readyState: v.readyState,
+        }),
         nudge: () => {
-          const v = videoRef.current;
-          if (v) v.currentTime += STALL_NUDGE_SEC;
+          v.currentTime += STALL_NUDGE_SEC;
         },
         recover: () => {
           if (shakaRef.current) return shakaRef.current.retryStreaming();
@@ -51,10 +42,7 @@ export function useStallRecovery(opts: StallRecoveryOptions): boolean {
           hlsRef.current.recoverMediaError();
           return true;
         },
-        restart: () => {
-          const v = videoRef.current;
-          if (v) onRestart(baseSec + v.currentTime);
-        },
+        restart: () => onRestart(baseSec + v.currentTime),
       },
       setStalled,
     );

--- a/clients/web/src/features/playback/use-stall-recovery.ts
+++ b/clients/web/src/features/playback/use-stall-recovery.ts
@@ -1,23 +1,16 @@
 import {
+  driveStallRecovery,
   reachableBufferEnd,
   STALL_NUDGE_SEC,
-  STALL_POLL_MS,
-  type StallStep,
-  stallWatch,
+  type StallSample,
 } from '@kroma/core';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { HlsInstance, ShakaPlayerLike } from '#web/features/playback/video-engine';
-
-// A restart re-anchors the stream, which costs a fresh remux session: worth it
-// once for a picture that is otherwise frozen, not worth it in a loop.
-const RESTART_COOLDOWN_MS = 30_000;
 
 export interface StallRecoveryOptions {
   videoRef: React.RefObject<HTMLVideoElement | null>;
   hlsRef: { current: HlsInstance | null };
   shakaRef: { current: ShakaPlayerLike | null };
-  /** The anchor the element's clock is relative to, so a restart can name the
-   * absolute position the picture froze at. */
   baseSec: number;
   active: boolean;
   onRestart: (absSec: number) => void;
@@ -31,50 +24,40 @@ export interface StallRecoveryOptions {
 export function useStallRecovery(opts: StallRecoveryOptions): boolean {
   const { videoRef, hlsRef, shakaRef, baseSec, active, onRestart } = opts;
   const [stalled, setStalled] = useState(false);
-  const restartedAt = useRef(0);
 
   useEffect(() => {
     if (!active) return;
-    const watch = stallWatch();
-
-    const apply = (step: StallStep, v: HTMLVideoElement) => {
-      if (step === 'nudge') {
-        v.currentTime += STALL_NUDGE_SEC;
-        return;
-      }
-      if (step === 'recover') {
-        if (shakaRef.current) shakaRef.current.retryStreaming();
-        else hlsRef.current?.recoverMediaError();
-        return;
-      }
-      const now = Date.now();
-      if (now - restartedAt.current < RESTART_COOLDOWN_MS) return;
-      restartedAt.current = now;
-      onRestart(baseSec + v.currentTime);
-    };
-
-    const id = setInterval(() => {
-      const v = videoRef.current;
-      if (!v) return;
-      const step = watch.observe(
-        {
-          currentTime: v.currentTime,
-          bufferedEnd: reachableBufferEnd(v.buffered, v.currentTime),
-          paused: v.paused,
-          ended: v.ended,
-          seeking: v.seeking,
-          readyState: v.readyState,
+    return driveStallRecovery(
+      {
+        sample: (): StallSample | null => {
+          const v = videoRef.current;
+          if (!v) return null;
+          return {
+            currentTime: v.currentTime,
+            bufferedEnd: reachableBufferEnd(v.buffered, v.currentTime),
+            paused: v.paused,
+            ended: v.ended,
+            seeking: v.seeking,
+            readyState: v.readyState,
+          };
         },
-        Date.now(),
-      );
-      setStalled(watch.stalled());
-      if (step) apply(step, v);
-    }, STALL_POLL_MS);
-
-    return () => {
-      clearInterval(id);
-      setStalled(false);
-    };
+        nudge: () => {
+          const v = videoRef.current;
+          if (v) v.currentTime += STALL_NUDGE_SEC;
+        },
+        recover: () => {
+          if (shakaRef.current) return shakaRef.current.retryStreaming();
+          if (!hlsRef.current) return false;
+          hlsRef.current.recoverMediaError();
+          return true;
+        },
+        restart: () => {
+          const v = videoRef.current;
+          if (v) onRestart(baseSec + v.currentTime);
+        },
+      },
+      setStalled,
+    );
   }, [active, baseSec, onRestart, videoRef, hlsRef, shakaRef]);
 
   return stalled;

--- a/clients/web/src/features/playback/use-video-playback-engine.test.ts
+++ b/clients/web/src/features/playback/use-video-playback-engine.test.ts
@@ -242,6 +242,7 @@ describe('useVideoPlayback on Safari', () => {
 
 describe('useVideoPlayback stall recovery', () => {
   const lastBind = () => vi.mocked(bindMediaEvents).mock.calls.at(-1);
+  const boundAutoplay = () => lastBind()?.[5];
 
   async function attached() {
     H.decision = { kind: 'direct', aacMaster: false };
@@ -273,7 +274,7 @@ describe('useVideoPlayback stall recovery', () => {
     act(() => lastAttach().onGiveUp());
     await settle();
 
-    expect(lastBind()?.[5]).toBe(false);
+    expect(boundAutoplay()).toBe(false);
   });
 
   it('re-anchors at the anchor itself when the element is already gone', async () => {
@@ -305,6 +306,6 @@ describe('useVideoPlayback stall recovery', () => {
     act(() => lastAttach().onGiveUp());
     await settle();
 
-    expect(lastBind()?.[5]).toBe(true);
+    expect(boundAutoplay()).toBe(true);
   });
 });

--- a/clients/web/src/features/playback/use-video-playback-engine.test.ts
+++ b/clients/web/src/features/playback/use-video-playback-engine.test.ts
@@ -276,6 +276,26 @@ describe('useVideoPlayback stall recovery', () => {
     expect(lastBind()?.[5]).toBe(false);
   });
 
+  it('re-anchors at the anchor itself when the element is already gone', async () => {
+    const { result } = await attached();
+    result.current.videoRef.current = null;
+
+    act(() => lastAttach().onGiveUp());
+    await settle();
+
+    expect(result.current.anchor).toBe(0);
+  });
+
+  it('arms the watch once the element is ready and the source resolved', async () => {
+    const { result } = await attached();
+
+    act(() => lastBind()?.[2].setReady(true));
+    await settle();
+
+    expect(result.current.ready).toBe(true);
+    expect(result.current.waiting).toBe(false);
+  });
+
   it('lets a film the viewer had running start itself again', async () => {
     const { v } = await attached();
     act(() => lastBind()?.[2].setPlaying(false));

--- a/clients/web/src/features/playback/use-video-playback-engine.test.ts
+++ b/clients/web/src/features/playback/use-video-playback-engine.test.ts
@@ -39,6 +39,7 @@ vi.mock('#web/shared/lib/auth', () => ({
 
 const { useVideoPlayback } = await import('#web/features/playback/use-video-playback');
 const { attachMediaSource } = await import('#web/features/playback/video-engine');
+const { bindMediaEvents } = await import('#web/features/playback/media-events');
 
 const lastAttach = () => {
   const calls = vi.mocked(attachMediaSource).mock.calls;
@@ -236,5 +237,54 @@ describe('useVideoPlayback on Safari', () => {
     await settle();
     expect(lastAttach().useNativeHls).toBe(false);
     expect(lastAttach().useShaka).toBe(true);
+  });
+});
+
+describe('useVideoPlayback stall recovery', () => {
+  const lastBind = () => vi.mocked(bindMediaEvents).mock.calls.at(-1);
+
+  async function attached() {
+    H.decision = { kind: 'direct', aacMaster: false };
+    const { result } = render();
+    await settle();
+    const v = fakeVideo({ currentTime: 30 });
+    result.current.videoRef.current = v as unknown as HTMLVideoElement;
+    act(() => result.current.setEnginePref('direct'));
+    await settle();
+    return { result, v };
+  }
+
+  it('re-anchors where the engine gave up, at the position the picture froze at', async () => {
+    const { result, v } = await attached();
+    expect(result.current.anchor).toBe(30);
+    v.currentTime = 42;
+
+    act(() => lastAttach().onGiveUp());
+    await settle();
+
+    expect(result.current.anchor).toBe(42);
+  });
+
+  it('carries a viewer pause across the rebind a re-anchor causes', async () => {
+    const { v } = await attached();
+    act(() => lastBind()?.[2].setPlaying(false));
+    v.currentTime = 42;
+
+    act(() => lastAttach().onGiveUp());
+    await settle();
+
+    expect(lastBind()?.[5]).toBe(false);
+  });
+
+  it('lets a film the viewer had running start itself again', async () => {
+    const { v } = await attached();
+    act(() => lastBind()?.[2].setPlaying(false));
+    act(() => lastBind()?.[2].setPlaying(true));
+    v.currentTime = 42;
+
+    act(() => lastAttach().onGiveUp());
+    await settle();
+
+    expect(lastBind()?.[5]).toBe(true);
   });
 });

--- a/clients/web/src/features/playback/use-video-playback.ts
+++ b/clients/web/src/features/playback/use-video-playback.ts
@@ -39,8 +39,6 @@ export function useVideoPlayback(item: MovieView): VideoPlayback {
   const { anchor, setAnchor, bootAnchor } = useResumeAnchor(item, client, user);
   const audioIndexRef = useRef(0);
   audioIndexRef.current = audioIndex;
-  // Survives the remount a re-anchor causes, so a recovery resumes only what the
-  // viewer had left running.
   const wantPlay = useRef(true);
   const setPlayingIntent = useCallback((on: boolean) => {
     wantPlay.current = on;

--- a/clients/web/src/features/playback/use-video-playback.ts
+++ b/clients/web/src/features/playback/use-video-playback.ts
@@ -40,10 +40,6 @@ export function useVideoPlayback(item: MovieView): VideoPlayback {
   const audioIndexRef = useRef(0);
   audioIndexRef.current = audioIndex;
   const wantPlay = useRef(true);
-  const setPlayingIntent = useCallback((on: boolean) => {
-    wantPlay.current = on;
-    setPlaying(on);
-  }, []);
 
   const audioTracks = audioTracksOf(item);
 
@@ -121,7 +117,10 @@ export function useVideoPlayback(item: MovieView): VideoPlayback {
         setCur,
         setDur,
         setBufEnd,
-        setPlaying: setPlayingIntent,
+        setPlaying: (on: boolean) => {
+          wantPlay.current = on;
+          setPlaying(on);
+        },
         setWaiting,
         setVolume,
         setMuted,
@@ -132,13 +131,11 @@ export function useVideoPlayback(item: MovieView): VideoPlayback {
       knownDurationMs,
       wantPlay.current,
     );
-  }, [item, anchor, audioIndex, baseSec, knownDurationMs, setPlayingIntent]);
+  }, [item, anchor, audioIndex, baseSec, knownDurationMs]);
 
+  const absNow = useCallback(() => baseSec + (videoRef.current?.currentTime ?? 0), [baseSec]);
   const restartAt = useCallback((absSec: number) => setAnchor(Math.max(0, absSec)), [setAnchor]);
-  const giveUp = useCallback(
-    () => restartAt(baseSec + (videoRef.current?.currentTime ?? 0)),
-    [baseSec, restartAt],
-  );
+  const giveUp = useCallback(() => restartAt(absNow()), [absNow, restartAt]);
 
   // The chosen audio is muxed into the stream URL, so a language change remounts
   // the element rather than switching renditions in place.
@@ -169,7 +166,7 @@ export function useVideoPlayback(item: MovieView): VideoPlayback {
     hlsRef,
     shakaRef,
     baseSec,
-    active: ready && srcReady,
+    active: ready && srcReady && playing,
     onRestart: restartAt,
   });
 
@@ -213,12 +210,9 @@ export function useVideoPlayback(item: MovieView): VideoPlayback {
     (index: number) => {
       if (index === audioIndexRef.current) return;
       setAudioIndex(index);
-      if (decision.kind !== 'direct') {
-        const pos = baseSec + (videoRef.current?.currentTime ?? 0);
-        setAnchor(Math.max(0, Math.floor(pos)));
-      }
+      if (decision.kind !== 'direct') setAnchor(Math.max(0, Math.floor(absNow())));
     },
-    [decision.kind, baseSec, setAnchor],
+    [decision.kind, absNow, setAnchor],
   );
 
   const setEnginePref = useCallback(
@@ -226,9 +220,9 @@ export function useVideoPlayback(item: MovieView): VideoPlayback {
       setWebEnginePref(p);
       setForceHls(false);
       setEnginePrefState(p);
-      setAnchor(Math.max(0, Math.floor(baseSec + (videoRef.current?.currentTime ?? 0))));
+      setAnchor(Math.max(0, Math.floor(absNow())));
     },
-    [baseSec, setAnchor, setForceHls, setEnginePrefState],
+    [absNow, setAnchor, setForceHls, setEnginePrefState],
   );
 
   return {

--- a/clients/web/src/features/playback/use-video-playback.ts
+++ b/clients/web/src/features/playback/use-video-playback.ts
@@ -4,6 +4,7 @@ import { setWebEnginePref, type WebEnginePref } from '#web/features/playback/eng
 import { bindMediaEvents } from '#web/features/playback/media-events';
 import { useEngineDecision } from '#web/features/playback/use-engine-decision';
 import { useResumeAnchor } from '#web/features/playback/use-resume-anchor';
+import { useStallRecovery } from '#web/features/playback/use-stall-recovery';
 import { useVideoTransport } from '#web/features/playback/use-video-transport';
 import { attachMediaSource, type VideoPlayback } from '#web/features/playback/video-engine';
 import { kromaClient, type MovieView } from '#web/shared/lib/api';
@@ -38,6 +39,13 @@ export function useVideoPlayback(item: MovieView): VideoPlayback {
   const { anchor, setAnchor, bootAnchor } = useResumeAnchor(item, client, user);
   const audioIndexRef = useRef(0);
   audioIndexRef.current = audioIndex;
+  // Survives the remount a re-anchor causes, so a recovery resumes only what the
+  // viewer had left running.
+  const wantPlay = useRef(true);
+  const setPlayingIntent = useCallback((on: boolean) => {
+    wantPlay.current = on;
+    setPlaying(on);
+  }, []);
 
   const audioTracks = audioTracksOf(item);
 
@@ -115,7 +123,7 @@ export function useVideoPlayback(item: MovieView): VideoPlayback {
         setCur,
         setDur,
         setBufEnd,
-        setPlaying,
+        setPlaying: setPlayingIntent,
         setWaiting,
         setVolume,
         setMuted,
@@ -124,8 +132,15 @@ export function useVideoPlayback(item: MovieView): VideoPlayback {
       },
       baseSec,
       knownDurationMs,
+      wantPlay.current,
     );
-  }, [item, anchor, audioIndex, baseSec, knownDurationMs]);
+  }, [item, anchor, audioIndex, baseSec, knownDurationMs, setPlayingIntent]);
+
+  const restartAt = useCallback((absSec: number) => setAnchor(Math.max(0, absSec)), [setAnchor]);
+  const giveUp = useCallback(
+    () => restartAt(baseSec + (videoRef.current?.currentTime ?? 0)),
+    [baseSec, restartAt],
+  );
 
   // The chosen audio is muxed into the stream URL, so a language change remounts
   // the element rather than switching renditions in place.
@@ -147,8 +162,18 @@ export function useVideoPlayback(item: MovieView): VideoPlayback {
       shakaRef,
       setUseHls,
       setReady,
+      onGiveUp: giveUp,
     });
-  }, [item, decision, env.safari, enginePref, anchor, audioIndex, bootAnchor, srcReady]);
+  }, [item, decision, env.safari, enginePref, anchor, audioIndex, bootAnchor, srcReady, giveUp]);
+
+  const stalled = useStallRecovery({
+    videoRef,
+    hlsRef,
+    shakaRef,
+    baseSec,
+    active: ready && srcReady,
+    onRestart: restartAt,
+  });
 
   useEffect(() => {
     const onFs = () => setFs(Boolean(document.fullscreenElement));
@@ -215,7 +240,7 @@ export function useVideoPlayback(item: MovieView): VideoPlayback {
     enginePref,
     setEnginePref,
     playing,
-    waiting,
+    waiting: waiting || stalled,
     ready,
     cur,
     dur,

--- a/clients/web/src/features/playback/use-video-transport.ts
+++ b/clients/web/src/features/playback/use-video-transport.ts
@@ -1,4 +1,4 @@
-import type { EngineDecision } from '@kroma/core';
+import { type EngineDecision, isPlayableAt } from '@kroma/core';
 import { useCallback, useRef, useState } from 'react';
 import type { VideoPlayback } from '#web/features/playback/video-engine';
 
@@ -70,16 +70,7 @@ export function useVideoTransport(opts: VideoTransportOptions): VideoTransport {
         return;
       }
       const rel = target - baseSec;
-      // Native only if the target is actually buffered - `seekable` over-reports
-      // the full duration before it is produced, which would seek into a hole.
-      let buffered = false;
-      for (let i = 0; i < v.buffered.length; i += 1) {
-        if (rel >= v.buffered.start(i) - 0.5 && rel <= v.buffered.end(i) + 0.5) {
-          buffered = true;
-          break;
-        }
-      }
-      if (buffered) {
+      if (isPlayableAt(v.buffered, rel)) {
         v.currentTime = Math.max(0, rel);
       } else {
         setAnchor(target);

--- a/clients/web/src/features/playback/video-engine.test.ts
+++ b/clients/web/src/features/playback/video-engine.test.ts
@@ -17,9 +17,14 @@ const H = vi.hoisted(() => {
   }> = [];
   class FakeHls {
     static supported = true;
+    static Events = { ERROR: 'hlsError' };
+    static ErrorTypes = { NETWORK_ERROR: 'networkError', MEDIA_ERROR: 'mediaError' };
     static isSupported() {
       return FakeHls.supported;
     }
+    on = vi.fn();
+    startLoad = vi.fn();
+    recoverMediaError = vi.fn();
     loadSource = vi.fn();
     attachMedia = vi.fn();
     destroy = vi.fn();
@@ -45,6 +50,7 @@ const H = vi.hoisted(() => {
     );
     destroy = vi.fn(() => Promise.resolve());
     configure = vi.fn(() => true);
+    retryStreaming = vi.fn(() => true);
     constructor() {
       shakaInstances.push(this);
     }
@@ -87,6 +93,7 @@ describe('attachMediaSource direct-play', () => {
       shakaRef: { current: null },
       setUseHls: vi.fn(),
       setReady: vi.fn(),
+      onGiveUp: vi.fn(),
       ...over,
     };
   }
@@ -137,6 +144,7 @@ describe('attachMediaSource HLS master', () => {
       shakaRef: { current: null },
       setUseHls: vi.fn(),
       setReady: vi.fn(),
+      onGiveUp: vi.fn(),
       ...over,
     };
   }
@@ -206,6 +214,7 @@ describe('attachMediaSource HLS master via Shaka', () => {
       shakaRef: { current: null },
       setUseHls: vi.fn(),
       setReady: vi.fn(),
+      onGiveUp: vi.fn(),
       ...over,
     };
   }

--- a/clients/web/src/features/playback/video-engine.ts
+++ b/clients/web/src/features/playback/video-engine.ts
@@ -7,6 +7,7 @@
 
 import {
   type AudioTrack,
+  attachHlsRecovery,
   type EngineDecision,
   hlsBufferConfig,
   itemBufferPlan,
@@ -38,6 +39,7 @@ export interface ShakaPlayerLike {
   destroy(): Promise<void>;
   getStats(): ShakaStatsLike;
   configure(config: Record<string, unknown>): boolean;
+  retryStreaming(retryDelaySeconds?: number): boolean;
 }
 interface ShakaStatic {
   Player: { new (): ShakaPlayerLike; isBrowserSupported(): boolean };
@@ -100,6 +102,9 @@ export interface AttachSourceOptions {
   shakaRef: { current: ShakaPlayerLike | null };
   setUseHls: (b: boolean) => void;
   setReady: (b: boolean) => void;
+  /** Called when an engine has failed past its own recovery, so the caller can
+   * re-anchor onto a fresh stream at wherever the picture froze. */
+  onGiveUp: () => void;
 }
 
 function seekToAnchor(v: HTMLVideoElement, startSec: number): void {
@@ -136,6 +141,7 @@ export function attachMediaSource(opts: AttachSourceOptions): () => void {
     shakaRef,
     setUseHls,
     setReady,
+    onGiveUp,
   } = opts;
   setReady(false);
 
@@ -211,6 +217,7 @@ export function attachMediaSource(opts: AttachSourceOptions): () => void {
       ...hlsBufferConfig(plan),
     });
     hlsRef.current = hls;
+    attachHlsRecovery(Hls, hls, onGiveUp);
     hls.loadSource(url);
     hls.attachMedia(v);
   });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,7 @@ export * from './permissions';
 export * from './person-facts';
 export * from './platform';
 export * from './playback-buffer';
+export * from './playback-stall';
 export * from './player';
 export * from './push-labels';
 export * from './remote';

--- a/packages/core/src/playback-buffer.test.ts
+++ b/packages/core/src/playback-buffer.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   bufferPlan,
   hlsBufferConfig,
+  isPlayableAt,
   itemBufferPlan,
   reachableBufferEnd,
   shakaStreamingConfig,
@@ -194,5 +195,47 @@ describe('engine config', () => {
 
     expect(hlsBufferConfig(bufferPlan(4_000_000)).maxBufferHole).toBe(hole);
     expect(reachableBufferEnd(ranges([[hole, 90]]), 0)).toBe(90);
+  });
+});
+
+describe('isPlayableAt', () => {
+  it('takes a target well inside a buffered range', () => {
+    expect(isPlayableAt(ranges([[10, 60]]), 30)).toBe(true);
+  });
+
+  it('forgives a target a hair before a range, where a keyframe cut rounds', () => {
+    expect(isPlayableAt(ranges([[30, 90]]), 29.95)).toBe(true);
+    expect(isPlayableAt(ranges([[30, 90]]), 29)).toBe(false);
+  });
+
+  it('refuses the far edge, which is a stall at the production edge', () => {
+    expect(isPlayableAt(ranges([[10, 60]]), 59.9)).toBe(false);
+    expect(isPlayableAt(ranges([[10, 60]]), 60.4)).toBe(false);
+    expect(isPlayableAt(ranges([[10, 60]]), 59.5)).toBe(true);
+  });
+
+  it('reads every range, not only the first', () => {
+    expect(
+      isPlayableAt(
+        ranges([
+          [0, 10],
+          [40, 90],
+        ]),
+        50,
+      ),
+    ).toBe(true);
+    expect(
+      isPlayableAt(
+        ranges([
+          [0, 10],
+          [40, 90],
+        ]),
+        25,
+      ),
+    ).toBe(false);
+  });
+
+  it('has nothing to play when nothing is buffered', () => {
+    expect(isPlayableAt(ranges([]), 0)).toBe(false);
   });
 });

--- a/packages/core/src/playback-buffer.ts
+++ b/packages/core/src/playback-buffer.ts
@@ -95,6 +95,25 @@ export function reachableBufferEnd(ranges: TimeRanges, t: number): number {
   return Number.isNaN(end) ? 0 : end;
 }
 
+// A seek target may sit a hair before a range (rounding on a keyframe cut), but
+// must sit well inside its far edge: landing on the end leaves nothing to play
+// on from, which on a growing playlist is a stall at the production edge.
+const SEEK_HEAD_SEC = 0.1;
+const SEEK_TAIL_SEC = 0.3;
+
+/**
+ * Whether the playhead can be moved to `t` without waiting on a download. The
+ * question a seek asks before moving in place rather than re-anchoring, and the
+ * reason it is not `seekable`: that over-reports the whole runtime long before
+ * the remux has produced it.
+ */
+export function isPlayableAt(ranges: TimeRanges, t: number): boolean {
+  for (let i = 0; i < ranges.length; i += 1) {
+    if (t >= ranges.start(i) - SEEK_HEAD_SEC && t <= ranges.end(i) - SEEK_TAIL_SEC) return true;
+  }
+  return false;
+}
+
 /**
  * hls.js constructor options for `plan`. The gap numbers are the point: hls.js
  * defaults to a 0.1 s `maxBufferHole` and waits 2 s before nudging one, which on

--- a/packages/core/src/playback-stall.test.ts
+++ b/packages/core/src/playback-stall.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   attachHlsRecovery,
+  driveStallRecovery,
   type HlsClassLike,
   STALL_POLL_MS,
   type StallSample,
@@ -21,13 +22,15 @@ function playing(over: Partial<StallSample> = {}): StallSample {
   };
 }
 
-function hold(watch: StallWatch, from: number, polls: number, at = 100): StallStep[] {
+function hold(watch: StallWatch, from: number, polls: number, at = 100) {
   const steps: StallStep[] = [];
+  let stalled = false;
   for (let i = 1; i <= polls; i += 1) {
-    const step = watch.observe(playing({ currentTime: at }), from + i * STALL_POLL_MS);
-    if (step) steps.push(step);
+    const verdict = watch.observe(playing({ currentTime: at }), from + i * STALL_POLL_MS);
+    stalled = verdict.stalled;
+    if (verdict.step) steps.push(verdict.step);
   }
-  return steps;
+  return { steps, stalled };
 }
 
 const HLS_CLASS: HlsClassLike = {
@@ -55,29 +58,28 @@ describe('stallWatch', () => {
   it('asks for nothing while the picture is moving', () => {
     const watch = stallWatch();
 
-    const steps = [0, 1, 2, 3, 4].map((i) =>
+    const verdicts = [0, 1, 2, 3, 4].map((i) =>
       watch.observe(playing({ currentTime: 100 + i }), i * STALL_POLL_MS),
     );
 
-    expect(steps).toEqual([null, null, null, null, null]);
-    expect(watch.stalled()).toBe(false);
+    expect(verdicts.every((v) => v.step === null && !v.stalled)).toBe(true);
   });
 
   it('nudges a playhead that has stopped with buffer still ahead of it', () => {
     const watch = stallWatch();
     watch.observe(playing(), 0);
 
-    const steps = hold(watch, 0, 4);
+    const { steps, stalled } = hold(watch, 0, 4);
 
     expect(steps).toEqual(['nudge']);
-    expect(watch.stalled()).toBe(true);
+    expect(stalled).toBe(true);
   });
 
   it('climbs the ladder while the nudges do not take', () => {
     const watch = stallWatch();
     watch.observe(playing(), 0);
 
-    const steps = hold(watch, 0, 20);
+    const { steps } = hold(watch, 0, 20);
 
     expect(steps).toEqual(['nudge', 'nudge', 'recover', 'restart']);
   });
@@ -87,19 +89,19 @@ describe('stallWatch', () => {
     watch.observe(playing(), 0);
     hold(watch, 0, 20);
 
-    const steps = hold(watch, 20 * STALL_POLL_MS, 20);
+    const { steps, stalled } = hold(watch, 20 * STALL_POLL_MS, 20);
 
     expect(steps).toEqual([]);
-    expect(watch.stalled()).toBe(true);
+    expect(stalled).toBe(true);
   });
 
   it('does not read the jump a nudge itself makes as a recovery', () => {
     const watch = stallWatch();
     watch.observe(playing(), 0);
-    expect(hold(watch, 0, 4)).toEqual(['nudge']);
+    expect(hold(watch, 0, 4).steps).toEqual(['nudge']);
 
     watch.observe(playing({ currentTime: 100.1 }), 2500);
-    const steps = hold(watch, 2500, 5, 100.1);
+    const { steps } = hold(watch, 2500, 5, 100.1);
 
     expect(steps).toEqual(['nudge']);
   });
@@ -111,21 +113,20 @@ describe('stallWatch', () => {
 
     watch.observe(playing({ currentTime: 100.1 }), 2500);
     watch.observe(playing({ currentTime: 100.6 }), 3000);
-    const steps = hold(watch, 3000, 5, 100.6);
+    const { steps, stalled } = hold(watch, 3000, 5, 100.6);
 
     expect(steps).toEqual(['nudge']);
-    expect(watch.stalled()).toBe(true);
+    expect(stalled).toBe(true);
   });
 
   it('leaves a playhead that has genuinely run out to the engine', () => {
     const watch = stallWatch();
 
-    const steps = [0, 1, 2, 3, 4, 5, 6, 7, 8].map((i) =>
+    const verdicts = [0, 1, 2, 3, 4, 5, 6, 7, 8].map((i) =>
       watch.observe(playing({ bufferedEnd: 100.2 }), i * STALL_POLL_MS),
     );
 
-    expect(steps.every((s) => s === null)).toBe(true);
-    expect(watch.stalled()).toBe(false);
+    expect(verdicts.every((v) => v.step === null && !v.stalled)).toBe(true);
   });
 
   it('is not a stall when nothing is meant to be playing', () => {
@@ -139,12 +140,11 @@ describe('stallWatch', () => {
       watch.observe(playing(), 0);
       hold(watch, 0, 4);
 
-      const steps = [1, 2, 3, 4, 5, 6, 7, 8].map((i) =>
+      const verdicts = [1, 2, 3, 4, 5, 6, 7, 8].map((i) =>
         watch.observe(playing(over), 2000 + i * STALL_POLL_MS),
       );
 
-      expect(steps.every((s) => s === null)).toBe(true);
-      expect(watch.stalled()).toBe(false);
+      expect(verdicts.every((v) => v.step === null && !v.stalled)).toBe(true);
     }
   });
 });
@@ -202,5 +202,91 @@ describe('attachHlsRecovery', () => {
     expect(hls.recoverMediaError).toHaveBeenCalledTimes(3);
     expect(giveUp).not.toHaveBeenCalled();
     clock.mockRestore();
+  });
+});
+
+describe('driveStallRecovery', () => {
+  function target(over: Partial<Record<string, unknown>> = {}) {
+    let at = 100;
+    const calls = {
+      sample: () => ({ currentTime: at, bufferedEnd: at + 60, paused: false }),
+      nudge: vi.fn(() => {
+        at += 0.1;
+      }),
+      recover: vi.fn(() => true),
+      restart: vi.fn(),
+      ...over,
+    };
+    return { calls, move: (by: number) => (at += by) };
+  }
+
+  it('climbs the ladder in order and stops the interval when told', () => {
+    vi.useFakeTimers();
+    const t = target({ nudge: vi.fn() });
+
+    const stop = driveStallRecovery(t.calls, vi.fn());
+    vi.advanceTimersByTime(STALL_POLL_MS * 18);
+    stop();
+    vi.advanceTimersByTime(STALL_POLL_MS * 18);
+
+    expect(t.calls.nudge).toHaveBeenCalledTimes(2);
+    expect(t.calls.recover).toHaveBeenCalledTimes(1);
+    expect(t.calls.restart).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
+  it('falls through to a fresh source when the recovery declines', () => {
+    vi.useFakeTimers();
+    const t = target({ nudge: vi.fn(), recover: vi.fn(() => false) });
+
+    driveStallRecovery(t.calls, vi.fn());
+    vi.advanceTimersByTime(STALL_POLL_MS * 14);
+
+    expect(t.calls.recover).toHaveBeenCalledTimes(1);
+    expect(t.calls.restart).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
+  it('reports the stuck state, and clears it on the way out', () => {
+    vi.useFakeTimers();
+    const t = target({ nudge: vi.fn() });
+    const onStalled = vi.fn();
+
+    const stop = driveStallRecovery(t.calls, onStalled);
+    vi.advanceTimersByTime(STALL_POLL_MS * 6);
+    const whileStuck = onStalled.mock.calls.at(-1)?.[0];
+    stop();
+
+    expect(whileStuck).toBe(true);
+    expect(onStalled).toHaveBeenLastCalledWith(false);
+    vi.useRealTimers();
+  });
+
+  it('polls nothing into the watch while the target has no sample', () => {
+    vi.useFakeTimers();
+    const t = target({ sample: () => null, nudge: vi.fn() });
+
+    driveStallRecovery(t.calls, vi.fn());
+    vi.advanceTimersByTime(STALL_POLL_MS * 18);
+
+    expect(t.calls.nudge).not.toHaveBeenCalled();
+    expect(t.calls.restart).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it('holds a restart to one per cooldown', () => {
+    vi.useFakeTimers();
+    const t = target({ nudge: vi.fn() });
+
+    driveStallRecovery(t.calls, vi.fn());
+    vi.advanceTimersByTime(STALL_POLL_MS * 18);
+    t.move(5);
+    vi.advanceTimersByTime(STALL_POLL_MS);
+    t.move(5);
+    vi.advanceTimersByTime(STALL_POLL_MS);
+    vi.advanceTimersByTime(STALL_POLL_MS * 18);
+
+    expect(t.calls.restart).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
   });
 });

--- a/packages/core/src/playback-stall.test.ts
+++ b/packages/core/src/playback-stall.test.ts
@@ -147,18 +147,6 @@ describe('stallWatch', () => {
       expect(watch.stalled()).toBe(false);
     }
   });
-
-  it('starts the ladder again after a reset', () => {
-    const watch = stallWatch();
-    watch.observe(playing(), 0);
-    hold(watch, 0, 20);
-
-    watch.reset();
-    watch.observe(playing(), 0);
-    const steps = hold(watch, 0, 4);
-
-    expect(steps).toEqual(['nudge']);
-  });
 });
 
 describe('attachHlsRecovery', () => {

--- a/packages/core/src/playback-stall.test.ts
+++ b/packages/core/src/playback-stall.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  attachHlsRecovery,
+  type HlsClassLike,
+  STALL_POLL_MS,
+  type StallSample,
+  type StallStep,
+  type StallWatch,
+  stallWatch,
+} from './playback-stall';
+
+function playing(over: Partial<StallSample> = {}): StallSample {
+  return {
+    currentTime: 100,
+    bufferedEnd: 160,
+    paused: false,
+    ended: false,
+    seeking: false,
+    readyState: 4,
+    ...over,
+  };
+}
+
+function hold(watch: StallWatch, from: number, polls: number, at = 100): StallStep[] {
+  const steps: StallStep[] = [];
+  for (let i = 1; i <= polls; i += 1) {
+    const step = watch.observe(playing({ currentTime: at }), from + i * STALL_POLL_MS);
+    if (step) steps.push(step);
+  }
+  return steps;
+}
+
+const HLS_CLASS: HlsClassLike = {
+  Events: { ERROR: 'hlsError' },
+  ErrorTypes: { NETWORK_ERROR: 'networkError', MEDIA_ERROR: 'mediaError' },
+};
+
+function fakeHls() {
+  let listener: (event: string, data: { type: string; fatal: boolean }) => void = () => undefined;
+  const hls = {
+    on: (_event: string, fn: typeof listener) => {
+      listener = fn;
+    },
+    startLoad: vi.fn(),
+    recoverMediaError: vi.fn(),
+  };
+
+  return {
+    hls,
+    fire: (type: string, fatal = true) => listener('hlsError', { type, fatal }),
+  };
+}
+
+describe('stallWatch', () => {
+  it('asks for nothing while the picture is moving', () => {
+    const watch = stallWatch();
+
+    const steps = [0, 1, 2, 3, 4].map((i) =>
+      watch.observe(playing({ currentTime: 100 + i }), i * STALL_POLL_MS),
+    );
+
+    expect(steps).toEqual([null, null, null, null, null]);
+    expect(watch.stalled()).toBe(false);
+  });
+
+  it('nudges a playhead that has stopped with buffer still ahead of it', () => {
+    const watch = stallWatch();
+    watch.observe(playing(), 0);
+
+    const steps = hold(watch, 0, 4);
+
+    expect(steps).toEqual(['nudge']);
+    expect(watch.stalled()).toBe(true);
+  });
+
+  it('climbs the ladder while the nudges do not take', () => {
+    const watch = stallWatch();
+    watch.observe(playing(), 0);
+
+    const steps = hold(watch, 0, 20);
+
+    expect(steps).toEqual(['nudge', 'nudge', 'recover', 'restart']);
+  });
+
+  it('stops climbing once the ladder runs out, and stays stalled', () => {
+    const watch = stallWatch();
+    watch.observe(playing(), 0);
+    hold(watch, 0, 20);
+
+    const steps = hold(watch, 20 * STALL_POLL_MS, 20);
+
+    expect(steps).toEqual([]);
+    expect(watch.stalled()).toBe(true);
+  });
+
+  it('does not read the jump a nudge itself makes as a recovery', () => {
+    const watch = stallWatch();
+    watch.observe(playing(), 0);
+    expect(hold(watch, 0, 4)).toEqual(['nudge']);
+
+    watch.observe(playing({ currentTime: 100.1 }), 2500);
+    const steps = hold(watch, 2500, 5, 100.1);
+
+    expect(steps).toEqual(['nudge']);
+  });
+
+  it('clears the ladder once the playhead keeps moving', () => {
+    const watch = stallWatch();
+    watch.observe(playing(), 0);
+    hold(watch, 0, 4);
+
+    watch.observe(playing({ currentTime: 100.1 }), 2500);
+    watch.observe(playing({ currentTime: 100.6 }), 3000);
+    const steps = hold(watch, 3000, 5, 100.6);
+
+    expect(steps).toEqual(['nudge']);
+    expect(watch.stalled()).toBe(true);
+  });
+
+  it('leaves a playhead that has genuinely run out to the engine', () => {
+    const watch = stallWatch();
+
+    const steps = [0, 1, 2, 3, 4, 5, 6, 7, 8].map((i) =>
+      watch.observe(playing({ bufferedEnd: 100.2 }), i * STALL_POLL_MS),
+    );
+
+    expect(steps.every((s) => s === null)).toBe(true);
+    expect(watch.stalled()).toBe(false);
+  });
+
+  it('is not a stall when nothing is meant to be playing', () => {
+    for (const over of [
+      { paused: true },
+      { ended: true },
+      { seeking: true },
+      { readyState: 2 },
+    ] satisfies Partial<StallSample>[]) {
+      const watch = stallWatch();
+      watch.observe(playing(), 0);
+      hold(watch, 0, 4);
+
+      const steps = [1, 2, 3, 4, 5, 6, 7, 8].map((i) =>
+        watch.observe(playing(over), 2000 + i * STALL_POLL_MS),
+      );
+
+      expect(steps.every((s) => s === null)).toBe(true);
+      expect(watch.stalled()).toBe(false);
+    }
+  });
+
+  it('starts the ladder again after a reset', () => {
+    const watch = stallWatch();
+    watch.observe(playing(), 0);
+    hold(watch, 0, 20);
+
+    watch.reset();
+    watch.observe(playing(), 0);
+    const steps = hold(watch, 0, 4);
+
+    expect(steps).toEqual(['nudge']);
+  });
+});
+
+describe('attachHlsRecovery', () => {
+  it('reloads on a fatal network error and recovers a fatal media one', () => {
+    const giveUp = vi.fn();
+    const { hls, fire } = fakeHls();
+    attachHlsRecovery(HLS_CLASS, hls, giveUp);
+
+    fire('networkError');
+    fire('mediaError');
+
+    expect(hls.startLoad).toHaveBeenCalledTimes(1);
+    expect(hls.recoverMediaError).toHaveBeenCalledTimes(1);
+    expect(giveUp).not.toHaveBeenCalled();
+  });
+
+  it('leaves a non-fatal error to hls.js', () => {
+    const giveUp = vi.fn();
+    const { hls, fire } = fakeHls();
+    attachHlsRecovery(HLS_CLASS, hls, giveUp);
+
+    fire('mediaError', false);
+
+    expect(hls.recoverMediaError).not.toHaveBeenCalled();
+    expect(giveUp).not.toHaveBeenCalled();
+  });
+
+  it('gives up once the same failure has survived its recoveries', () => {
+    const giveUp = vi.fn();
+    const { hls, fire } = fakeHls();
+    attachHlsRecovery(HLS_CLASS, hls, giveUp);
+
+    fire('mediaError');
+    fire('mediaError');
+    fire('mediaError');
+
+    expect(hls.recoverMediaError).toHaveBeenCalledTimes(2);
+    expect(giveUp).toHaveBeenCalledTimes(1);
+  });
+
+  it('forgives a failure the film has since played through', () => {
+    const giveUp = vi.fn();
+    const { hls, fire } = fakeHls();
+    attachHlsRecovery(HLS_CLASS, hls, giveUp);
+    const clock = vi.spyOn(Date, 'now');
+
+    clock.mockReturnValue(0);
+    fire('mediaError');
+    fire('mediaError');
+    clock.mockReturnValue(120_000);
+    fire('mediaError');
+
+    expect(hls.recoverMediaError).toHaveBeenCalledTimes(3);
+    expect(giveUp).not.toHaveBeenCalled();
+    clock.mockRestore();
+  });
+});

--- a/packages/core/src/playback-stall.ts
+++ b/packages/core/src/playback-stall.ts
@@ -1,0 +1,162 @@
+// A playhead that stops while its own buffer runs on ahead: the freeze that
+// still reads as a full bar. Every engine nudges such a stall a few times and
+// then stops for good - hls.js raises a fatal `bufferStalledError` whose own
+// error policy is to do nothing at all - so what happens after that is the
+// application's to decide.
+
+const STALL_MS = 2000;
+// Under this the playhead has honestly run out, and the engine's own rebuffering
+// owns it. This watch is only for a stall with something left to play.
+const MIN_AHEAD_SEC = 0.5;
+// HAVE_FUTURE_DATA: the element itself saying it holds enough to advance.
+const READY_TO_ADVANCE = 3;
+const MOVED_SEC = 0.02;
+// A step moves the playhead exactly once, so a single sample of progress is not
+// a recovery; the ladder is only cleared once it keeps moving.
+const RESUMED_POLLS = 2;
+const RECOVERY_WINDOW_MS = 60_000;
+const MAX_RECOVERIES = 2;
+
+/** How often [`StallWatch.observe`] expects to be fed. */
+export const STALL_POLL_MS = 500;
+
+/** How far a `nudge` should move the playhead. */
+export const STALL_NUDGE_SEC = 0.1;
+
+/**
+ * One poll of a media element. `currentTime` and `bufferedEnd` need only share a
+ * clock, so either the element's own or an anchored absolute one will do.
+ */
+export interface StallSample {
+  currentTime: number;
+  bufferedEnd: number;
+  paused: boolean;
+  ended?: boolean;
+  seeking?: boolean;
+  /** The element's `readyState`, where the backend has one. A backend that
+   * exposes none is taken at its buffer's word. */
+  readyState?: number;
+}
+
+/** What to do about a stall, in ascending cost. */
+export type StallStep = 'nudge' | 'recover' | 'restart';
+
+const LADDER: readonly StallStep[] = ['nudge', 'nudge', 'recover', 'restart'];
+
+/** Watches one element for a playhead that has stopped with buffer ahead of it. */
+export interface StallWatch {
+  /** The step this sample calls for, or `null` while the picture still moves.
+   * Each rung is handed out once, `STALL_MS` apart, and the ladder resets only
+   * when playback actually resumes. */
+  observe(sample: StallSample, nowMs: number): StallStep | null;
+  /** Whether the playhead is stuck with something left to play. */
+  stalled(): boolean;
+  reset(): void;
+}
+
+/** A fresh watch, its ladder unclimbed. */
+export function stallWatch(): StallWatch {
+  let mark = Number.NaN;
+  let since = 0;
+  let taken = 0;
+  let advances = 0;
+  let stuck = false;
+
+  const reset = (): void => {
+    mark = Number.NaN;
+    since = 0;
+    taken = 0;
+    advances = 0;
+    stuck = false;
+  };
+
+  return {
+    reset,
+    stalled: () => stuck,
+    observe(sample, nowMs) {
+      const ahead = sample.bufferedEnd - sample.currentTime;
+      const idle =
+        sample.paused ||
+        sample.ended === true ||
+        sample.seeking === true ||
+        (sample.readyState ?? READY_TO_ADVANCE) < READY_TO_ADVANCE ||
+        ahead < MIN_AHEAD_SEC;
+      if (idle) {
+        reset();
+        return null;
+      }
+
+      const moved = Number.isNaN(mark) || Math.abs(sample.currentTime - mark) > MOVED_SEC;
+      mark = sample.currentTime;
+      if (moved) {
+        since = nowMs;
+        stuck = false;
+        advances += 1;
+        if (advances >= RESUMED_POLLS) taken = 0;
+        return null;
+      }
+
+      advances = 0;
+      if (nowMs - since < STALL_MS) return null;
+      stuck = true;
+      const step = LADDER[taken];
+      if (!step) return null;
+      taken += 1;
+      since = nowMs;
+      return step;
+    },
+  };
+}
+
+/** The `Hls` class itself, for the two error types worth recovering from. */
+export interface HlsClassLike {
+  Events: { ERROR: string };
+  ErrorTypes: { NETWORK_ERROR: string; MEDIA_ERROR: string };
+}
+
+/** The slice of an hls.js instance a recovery drives. */
+export interface HlsInstanceLike {
+  on(
+    event: string,
+    listener: (event: string, data: { type: string; fatal: boolean }) => void,
+  ): void;
+  startLoad(): void;
+  recoverMediaError(): void;
+}
+
+/**
+ * Recover the fatal errors hls.js hands back to its caller. Its own action for a
+ * stalled buffer is to do nothing, so an unhandled `bufferStalledError` is a
+ * frozen picture over a full buffer, permanently. `onGiveUp` runs once the same
+ * class of failure has survived `MAX_RECOVERIES` attempts inside a minute.
+ */
+export function attachHlsRecovery(
+  hlsClass: HlsClassLike,
+  hls: HlsInstanceLike,
+  onGiveUp: () => void,
+): void {
+  let network = 0;
+  let media = 0;
+  let last = 0;
+
+  hls.on(hlsClass.Events.ERROR, (_event, data) => {
+    if (!data.fatal) return;
+    const now = Date.now();
+    if (now - last > RECOVERY_WINDOW_MS) {
+      network = 0;
+      media = 0;
+    }
+    last = now;
+    if (data.type === hlsClass.ErrorTypes.NETWORK_ERROR && network < MAX_RECOVERIES) {
+      network += 1;
+      hls.startLoad();
+      return;
+    }
+    if (data.type === hlsClass.ErrorTypes.MEDIA_ERROR && media < MAX_RECOVERIES) {
+      media += 1;
+      hls.recoverMediaError();
+      return;
+    }
+    onGiveUp();
+  });
+}

--- a/packages/core/src/playback-stall.ts
+++ b/packages/core/src/playback-stall.ts
@@ -1,18 +1,8 @@
-// A playhead that stops while its own buffer runs on ahead: the freeze that
-// still reads as a full bar. Every engine nudges such a stall a few times and
-// then stops for good - hls.js raises a fatal `bufferStalledError` whose own
-// error policy is to do nothing at all - so what happens after that is the
-// application's to decide.
-
 const STALL_MS = 2000;
-// Under this the playhead has honestly run out, and the engine's own rebuffering
-// owns it. This watch is only for a stall with something left to play.
 const MIN_AHEAD_SEC = 0.5;
 // HAVE_FUTURE_DATA: the element itself saying it holds enough to advance.
 const READY_TO_ADVANCE = 3;
 const MOVED_SEC = 0.02;
-// A step moves the playhead exactly once, so a single sample of progress is not
-// a recovery; the ladder is only cleared once it keeps moving.
 const RESUMED_POLLS = 2;
 const RECOVERY_WINDOW_MS = 60_000;
 const MAX_RECOVERIES = 2;
@@ -20,7 +10,6 @@ const MAX_RECOVERIES = 2;
 /** How often [`StallWatch.observe`] expects to be fed. */
 export const STALL_POLL_MS = 500;
 
-/** How far a `nudge` should move the playhead. */
 export const STALL_NUDGE_SEC = 0.1;
 
 /**
@@ -49,12 +38,9 @@ export interface StallWatch {
    * Each rung is handed out once, `STALL_MS` apart, and the ladder resets only
    * when playback actually resumes. */
   observe(sample: StallSample, nowMs: number): StallStep | null;
-  /** Whether the playhead is stuck with something left to play. */
   stalled(): boolean;
-  reset(): void;
 }
 
-/** A fresh watch, its ladder unclimbed. */
 export function stallWatch(): StallWatch {
   let mark = Number.NaN;
   let since = 0;
@@ -71,7 +57,6 @@ export function stallWatch(): StallWatch {
   };
 
   return {
-    reset,
     stalled: () => stuck,
     observe(sample, nowMs) {
       const ahead = sample.bufferedEnd - sample.currentTime;
@@ -108,13 +93,68 @@ export function stallWatch(): StallWatch {
   };
 }
 
-/** The `Hls` class itself, for the two error types worth recovering from. */
+// A restart re-anchors the stream, which costs a fresh remux session on the
+// server (one ffmpeg per program + anchor).
+const RESTART_COOLDOWN_MS = 30_000;
+
+/**
+ * Whatever is playing, as a stall driver needs it: one sample per poll, and one
+ * way to carry out each rung of the ladder. `sample` answers `null` where there
+ * is nothing to read yet, or where the backend reports no buffered range and so
+ * cannot tell a stall from an honest rebuffer. `recover` answers `false` when it
+ * has no recovery of its own and the driver should restart instead.
+ */
+export interface StallTarget {
+  sample(): StallSample | null;
+  nudge(): void;
+  recover(): boolean;
+  restart(): void;
+}
+
+/**
+ * Polls `target` every [`STALL_POLL_MS`] and works a stuck playhead back up the
+ * ladder, holding a restart to one per 30 seconds. `onStalled` is handed whether
+ * the playhead is stuck with something left to play, which is what the chrome
+ * shows as buffering. Returns the stop function.
+ */
+export function driveStallRecovery(
+  target: StallTarget,
+  onStalled: (stalled: boolean) => void,
+): () => void {
+  const watch = stallWatch();
+  let restartedAt = 0;
+
+  const apply = (step: StallStep): void => {
+    if (step === 'nudge') {
+      target.nudge();
+      return;
+    }
+    if (step === 'recover' && target.recover()) return;
+    const now = Date.now();
+    if (now - restartedAt < RESTART_COOLDOWN_MS) return;
+    restartedAt = now;
+    target.restart();
+  };
+
+  const id = setInterval(() => {
+    const sample = target.sample();
+    if (!sample) return;
+    const step = watch.observe(sample, Date.now());
+    onStalled(watch.stalled());
+    if (step) apply(step);
+  }, STALL_POLL_MS);
+
+  return () => {
+    clearInterval(id);
+    onStalled(false);
+  };
+}
+
 export interface HlsClassLike {
   Events: { ERROR: string };
   ErrorTypes: { NETWORK_ERROR: string; MEDIA_ERROR: string };
 }
 
-/** The slice of an hls.js instance a recovery drives. */
 export interface HlsInstanceLike {
   on(
     event: string,

--- a/packages/core/src/playback-stall.ts
+++ b/packages/core/src/playback-stall.ts
@@ -1,11 +1,8 @@
 const STALL_MS = 2000;
 const MIN_AHEAD_SEC = 0.5;
-// HAVE_FUTURE_DATA: the element itself saying it holds enough to advance.
-const READY_TO_ADVANCE = 3;
+const HAVE_FUTURE_DATA = 3;
 const MOVED_SEC = 0.02;
 const RESUMED_POLLS = 2;
-const RECOVERY_WINDOW_MS = 60_000;
-const MAX_RECOVERIES = 2;
 
 /** How often [`StallWatch.observe`] expects to be fed. */
 export const STALL_POLL_MS = 500;
@@ -32,13 +29,20 @@ export type StallStep = 'nudge' | 'recover' | 'restart';
 
 const LADDER: readonly StallStep[] = ['nudge', 'nudge', 'recover', 'restart'];
 
-/** Watches one element for a playhead that has stopped with buffer ahead of it. */
+/** What one sample amounts to: whether the playhead is stuck with something left
+ * to play, and the rung to take about it. `step` is `null` on every sample but
+ * the one that hands a rung out, which is one per `STALL_MS`. */
+export interface StallVerdict {
+  step: StallStep | null;
+  stalled: boolean;
+}
+
+const MOVING: StallVerdict = { step: null, stalled: false };
+
+/** Watches one element for a playhead that has stopped with buffer ahead of it.
+ * The ladder resets only when playback actually resumes. */
 export interface StallWatch {
-  /** The step this sample calls for, or `null` while the picture still moves.
-   * Each rung is handed out once, `STALL_MS` apart, and the ladder resets only
-   * when playback actually resumes. */
-  observe(sample: StallSample, nowMs: number): StallStep | null;
-  stalled(): boolean;
+  observe(sample: StallSample, nowMs: number): StallVerdict;
 }
 
 export function stallWatch(): StallWatch {
@@ -57,18 +61,17 @@ export function stallWatch(): StallWatch {
   };
 
   return {
-    stalled: () => stuck,
     observe(sample, nowMs) {
       const ahead = sample.bufferedEnd - sample.currentTime;
       const idle =
         sample.paused ||
         sample.ended === true ||
         sample.seeking === true ||
-        (sample.readyState ?? READY_TO_ADVANCE) < READY_TO_ADVANCE ||
+        (sample.readyState ?? HAVE_FUTURE_DATA) < HAVE_FUTURE_DATA ||
         ahead < MIN_AHEAD_SEC;
       if (idle) {
         reset();
-        return null;
+        return MOVING;
       }
 
       const moved = Number.isNaN(mark) || Math.abs(sample.currentTime - mark) > MOVED_SEC;
@@ -78,17 +81,19 @@ export function stallWatch(): StallWatch {
         stuck = false;
         advances += 1;
         if (advances >= RESUMED_POLLS) taken = 0;
-        return null;
+        return MOVING;
       }
 
       advances = 0;
-      if (nowMs - since < STALL_MS) return null;
+      // A stall persists between rungs: only movement ends it.
+      if (nowMs - since < STALL_MS) return { step: null, stalled: stuck };
       stuck = true;
-      const step = LADDER[taken];
-      if (!step) return null;
-      taken += 1;
-      since = nowMs;
-      return step;
+      const step = LADDER[taken] ?? null;
+      if (step) {
+        taken += 1;
+        since = nowMs;
+      }
+      return { step, stalled: true };
     },
   };
 }
@@ -124,30 +129,53 @@ export function driveStallRecovery(
   const watch = stallWatch();
   let restartedAt = 0;
 
-  const apply = (step: StallStep): void => {
+  const apply = (step: StallStep, nowMs: number): void => {
     if (step === 'nudge') {
       target.nudge();
       return;
     }
     if (step === 'recover' && target.recover()) return;
-    const now = Date.now();
-    if (now - restartedAt < RESTART_COOLDOWN_MS) return;
-    restartedAt = now;
+    if (nowMs - restartedAt < RESTART_COOLDOWN_MS) return;
+    restartedAt = nowMs;
     target.restart();
   };
 
   const id = setInterval(() => {
     const sample = target.sample();
     if (!sample) return;
-    const step = watch.observe(sample, Date.now());
-    onStalled(watch.stalled());
-    if (step) apply(step);
+    const now = Date.now();
+    const { step, stalled } = watch.observe(sample, now);
+    onStalled(stalled);
+    if (step) apply(step, now);
   }, STALL_POLL_MS);
 
   return () => {
     clearInterval(id);
     onStalled(false);
   };
+}
+
+const RECOVERY_WINDOW_MS = 60_000;
+const MAX_RECOVERIES = 2;
+
+/** The Shaka slice a stall recovery drives. */
+export interface ShakaRecoverable {
+  retryStreaming(retryDelaySeconds?: number): boolean;
+}
+
+/**
+ * The MSE recovery rung, for whichever engine is attached: ask Shaka to retry
+ * the stream, else ask hls.js to recover its media error. `false` where neither
+ * is attached and the caller should reach for a fresh source instead.
+ */
+export function recoverMse(
+  shaka: ShakaRecoverable | null,
+  hls: Pick<HlsInstanceLike, 'recoverMediaError'> | null,
+): boolean {
+  if (shaka) return shaka.retryStreaming();
+  if (!hls) return false;
+  hls.recoverMediaError();
+  return true;
 }
 
 export interface HlsClassLike {

--- a/packages/tv/src/features/playback/player/avplayEngine.test.ts
+++ b/packages/tv/src/features/playback/player/avplayEngine.test.ts
@@ -296,6 +296,19 @@ describe('AvplayEngine visibility + destroy', () => {
     expect(lastArgs('restore')?.[2]).toBe('PLAYING');
   });
 
+  it('comes back paused where the viewer had paused it', () => {
+    const { e, names, lastArgs } = make({ direct: true, startSec: 0 });
+    e.pause();
+
+    Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+    Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(names()).toContain('restore');
+    expect(lastArgs('restore')?.[2]).toBe('PAUSED');
+  });
+
   it('destroy stops + closes the singleton and detaches the visibility listener', () => {
     const { e, names } = make();
     e.destroy();

--- a/packages/tv/src/features/playback/player/avplayEngine.test.ts
+++ b/packages/tv/src/features/playback/player/avplayEngine.test.ts
@@ -194,12 +194,15 @@ describe('AvplayEngine prepared (resume + audio mapping)', () => {
 });
 
 describe('AvplayEngine native listener events', () => {
-  it('current-play-time updates the absolute position + buffered', () => {
+  it('current-play-time moves the clock without calling the playhead a buffer', () => {
     const { e, a, listeners } = make({ direct: true, startSec: 0 });
+
     a.listener().oncurrentplaytime?.(5000);
+
     expect(e.position()).toBe(5);
     expect(listeners.onTime).toHaveBeenCalledWith(5);
-    expect(listeners.onBuffered).toHaveBeenCalledWith(5);
+    expect(listeners.onBuffered).not.toHaveBeenCalled();
+    expect(e.bufferedEnd()).toBeNull();
   });
 
   it('buffering + stream-completed + error map to the right callbacks', () => {

--- a/packages/tv/src/features/playback/player/avplayEngine.ts
+++ b/packages/tv/src/features/playback/player/avplayEngine.ts
@@ -119,7 +119,6 @@ export class AvplayEngine extends BaseTvEngine {
         oncurrentplaytime: (ms: number) => {
           this.elSec = ms / 1000;
           this.listeners.onTime(this.baseSec + this.elSec);
-          this.listeners.onBuffered(this.baseSec + this.elSec);
         },
         onstreamcompleted: () => this.listeners.onEnded(),
         onerror: () => this.fail(),
@@ -185,7 +184,7 @@ export class AvplayEngine extends BaseTvEngine {
         // Direct sources restore at the ABSOLUTE position; anchored masters at
         // the relative one (their clock restarts at the anchor).
         const ms = Math.round((this.mode === 'direct' ? this.position() : this.elSec) * 1000);
-        this.api.restore(this.sourceUrl(), ms, 'PLAYING');
+        this.api.restore(this.sourceUrl(), ms, this.paused ? 'PAUSED' : 'PLAYING');
       }
     } catch {
       /* best effort */

--- a/packages/tv/src/features/playback/player/baseEngine.test.ts
+++ b/packages/tv/src/features/playback/player/baseEngine.test.ts
@@ -222,3 +222,13 @@ describe('BaseTvEngine fail / direct->master fallback', () => {
     expect(e.reanchorCalls).toEqual([]);
   });
 });
+
+describe('BaseTvEngine restart', () => {
+  it('hands a fresh source at the given position to the backend re-anchor', () => {
+    const e = make({ direct: false, startSec: 0 });
+
+    e.restart(1800);
+
+    expect(e.reanchorCalls).toEqual([1800]);
+  });
+});

--- a/packages/tv/src/features/playback/player/baseEngine.test.ts
+++ b/packages/tv/src/features/playback/player/baseEngine.test.ts
@@ -37,6 +37,7 @@ const item = { id: 'm1' } as unknown as MediaItem;
 class TestEngine extends BaseTvEngine {
   readonly kind = 'mpv' as const;
   readonly reanchorCalls: number[] = [];
+  readonly seekCalls: number[] = [];
 
   // biome-ignore lint/complexity/noUselessConstructor: exposes the protected base constructor for the test
   constructor(o: EngineOptions) {
@@ -51,7 +52,9 @@ class TestEngine extends BaseTvEngine {
   bufferedEnd(): number {
     return 0;
   }
-  seekTo(): void {}
+  seekTo(absSec: number): void {
+    this.seekCalls.push(absSec);
+  }
   setAudioRendition(): void {}
   destroy(): void {
     this.destroyed = true;
@@ -220,6 +223,17 @@ describe('BaseTvEngine fail / direct->master fallback', () => {
     expect(listeners.onError).not.toHaveBeenCalled();
     expect(listeners.onWaiting).not.toHaveBeenCalled();
     expect(e.reanchorCalls).toEqual([]);
+  });
+});
+
+describe('BaseTvEngine nudge', () => {
+  it('moves the playhead a hair through the backend seek', () => {
+    const e = make({ direct: true, startSec: 42 });
+
+    e.nudge();
+
+    expect(e.seekCalls).toHaveLength(1);
+    expect(e.seekCalls[0]).toBeCloseTo(42.1, 5);
   });
 });
 

--- a/packages/tv/src/features/playback/player/baseEngine.ts
+++ b/packages/tv/src/features/playback/player/baseEngine.ts
@@ -3,7 +3,12 @@
 // timeline, and a `master` mode on the server's HLS remux anchored at `baseSec`
 // (its clock restarts at 0, so the absolute position is `baseSec + elSec`).
 
-import { decodableAudioCodecs, type KromaClient, type MediaItem } from '@kroma/core';
+import {
+  decodableAudioCodecs,
+  type KromaClient,
+  type MediaItem,
+  STALL_NUDGE_SEC,
+} from '@kroma/core';
 import type { AudioFilterMode } from '@kroma/ui';
 import type { EngineListeners, TvEngine } from '#tv/features/playback/player/engine';
 
@@ -121,6 +126,9 @@ export abstract class BaseTvEngine implements TvEngine {
   }
   isPaused(): boolean {
     return this.paused;
+  }
+  nudge(): void {
+    this.seekTo(this.position() + STALL_NUDGE_SEC);
   }
   restart(absSec: number): void {
     this.reanchor(absSec);

--- a/packages/tv/src/features/playback/player/baseEngine.ts
+++ b/packages/tv/src/features/playback/player/baseEngine.ts
@@ -122,6 +122,9 @@ export abstract class BaseTvEngine implements TvEngine {
   isPaused(): boolean {
     return this.paused;
   }
+  restart(absSec: number): void {
+    this.reanchor(absSec);
+  }
 
   protected abstract reanchor(absSec: number): void;
 

--- a/packages/tv/src/features/playback/player/engine.ts
+++ b/packages/tv/src/features/playback/player/engine.ts
@@ -53,12 +53,16 @@ export interface TvEngine {
    *  up as one. */
   bufferedEnd(): number | null;
   seekTo(absSec: number): void;
+  // Move the playhead a hair to unstick a decoder. Never a seek: a seek carries
+  // policy (the HTML engine re-anchors a target it cannot reach), and the point
+  // of this rung is that it is the cheap one.
+  nudge(): void;
   // Unstick a playhead that has stopped with buffer still ahead of it, without
   // rebuilding the source. `false` where the backend has no such recovery and
   // the caller should reach for `restart` instead.
   recoverStall?(): boolean;
   // Rebuild the source at `absSec`, discarding whatever the backend still holds.
-  restart?(absSec: number): void;
+  restart(absSec: number): void;
   setAudioRendition(rendition: number): void;
   // Resize the native video plane to a fraction-rect, or `null` for fullscreen. Only AVPlay/mpv
   // implement it; the HTML `<video>` engine CSS-transforms its element instead.

--- a/packages/tv/src/features/playback/player/engine.ts
+++ b/packages/tv/src/features/playback/player/engine.ts
@@ -53,6 +53,12 @@ export interface TvEngine {
    *  up as one. */
   bufferedEnd(): number | null;
   seekTo(absSec: number): void;
+  // Unstick a playhead that has stopped with buffer still ahead of it, without
+  // rebuilding the source. `false` where the backend has no such recovery and
+  // the caller should reach for `restart` instead.
+  recoverStall?(): boolean;
+  // Rebuild the source at `absSec`, discarding whatever the backend still holds.
+  restart?(absSec: number): void;
   setAudioRendition(rendition: number): void;
   // Resize the native video plane to a fraction-rect, or `null` for fullscreen. Only AVPlay/mpv
   // implement it; the HTML `<video>` engine CSS-transforms its element instead.

--- a/packages/tv/src/features/playback/player/expoVideoEngine.ts
+++ b/packages/tv/src/features/playback/player/expoVideoEngine.ts
@@ -186,6 +186,9 @@ export class ExpoVideoEngine extends BaseTvEngine implements TvEngine {
     // VideoPlayer would black the picture out for the handover.
     if (player && !this.destroyed) {
       this.pendingSeek = this.mode === 'direct' && absSec > 0 ? absSec : null;
+      // `teardown` is the only other place this is cleared, and `replace` skips
+      // it: the old source's depth would otherwise be drawn against the new anchor.
+      this.bufSec = null;
       try {
         player.replace({ uri: this.sourceUrl() });
         if (!this.paused) player.play();

--- a/packages/tv/src/features/playback/player/expoVideoEngine.ts
+++ b/packages/tv/src/features/playback/player/expoVideoEngine.ts
@@ -174,21 +174,25 @@ export class ExpoVideoEngine extends BaseTvEngine implements TvEngine {
     if (retiring) retire(retiring, now);
   }
 
-  /** In master mode, re-anchors at `absSec` on the server; in direct mode, seeks
-   * within the file. */
-  protected reanchor(absSec: number): void {
+  // Every path that moves the anchor comes through here, so none can leave the
+  // previous source's buffered depth to be drawn against the new one.
+  private resetClock(absSec: number): void {
     if (this.mode === 'master') {
       this.baseSec = absSec;
       this.elSec = 0;
     }
+    this.pendingSeek = this.mode === 'direct' && absSec > 0 ? absSec : null;
+    this.bufSec = null;
+  }
+
+  /** In master mode, re-anchors at `absSec` on the server; in direct mode, seeks
+   * within the file. */
+  protected reanchor(absSec: number): void {
+    this.resetClock(absSec);
     const player = this.player;
     // `replace` keeps the existing player and <VideoView>; swapping the whole
     // VideoPlayer would black the picture out for the handover.
     if (player && !this.destroyed) {
-      this.pendingSeek = this.mode === 'direct' && absSec > 0 ? absSec : null;
-      // `teardown` is the only other place this is cleared, and `replace` skips
-      // it: the old source's depth would otherwise be drawn against the new anchor.
-      this.bufSec = null;
       try {
         player.replace({ uri: this.sourceUrl() });
         if (!this.paused) player.play();

--- a/packages/tv/src/features/playback/player/htmlEngine.test.ts
+++ b/packages/tv/src/features/playback/player/htmlEngine.test.ts
@@ -657,6 +657,19 @@ describe('HtmlEngine stall recovery', () => {
     hlsMock.startLoad.mockClear();
   });
 
+  it('nudges the element itself, never through the seek policy', async () => {
+    const fv = fakeVideo();
+    const { engine, hlsMasterUrl } = makeEngine({ fv, direct: false, forceNativeHls: true });
+    await tick();
+    fv.set('currentTime', 42);
+    hlsMasterUrl.mockClear();
+
+    engine.nudge();
+
+    expect(fv.get('currentTime')).toBeCloseTo(42.1, 5);
+    expect(hlsMasterUrl).not.toHaveBeenCalled();
+  });
+
   it('asks Shaka to retry the stream', async () => {
     const fv = fakeVideo();
     const { engine } = makeEngine({ fv, direct: false, masterShaka: true, forceNativeHls: false });

--- a/packages/tv/src/features/playback/player/htmlEngine.test.ts
+++ b/packages/tv/src/features/playback/player/htmlEngine.test.ts
@@ -35,15 +35,23 @@ vi.mock('shaka-player/dist/shaka-player.compiled.js', () => ({
 }));
 const hlsMock = vi.hoisted(() => ({
   supported: false,
+  on: vi.fn(),
+  startLoad: vi.fn(),
+  recoverMediaError: vi.fn(),
   loadSource: vi.fn(),
   attachMedia: vi.fn(),
   destroy: vi.fn(),
 }));
 vi.mock('hls.js', () => ({
   default: class {
+    static Events = { ERROR: 'hlsError' };
+    static ErrorTypes = { NETWORK_ERROR: 'networkError', MEDIA_ERROR: 'mediaError' };
     static isSupported() {
       return hlsMock.supported;
     }
+    on = hlsMock.on;
+    startLoad = hlsMock.startLoad;
+    recoverMediaError = hlsMock.recoverMediaError;
     loadSource = hlsMock.loadSource;
     attachMedia = hlsMock.attachMedia;
     destroy = hlsMock.destroy;

--- a/packages/tv/src/features/playback/player/htmlEngine.test.ts
+++ b/packages/tv/src/features/playback/player/htmlEngine.test.ts
@@ -18,6 +18,7 @@ const shakaMock = vi.hoisted(() => ({
   load: vi.fn(() => Promise.resolve()),
   configure: vi.fn(),
   destroy: vi.fn(() => Promise.resolve()),
+  retryStreaming: vi.fn(() => true),
 }));
 vi.mock('shaka-player/dist/shaka-player.compiled.js', () => ({
   default: {
@@ -30,6 +31,7 @@ vi.mock('shaka-player/dist/shaka-player.compiled.js', () => ({
       load = shakaMock.load;
       configure = shakaMock.configure;
       destroy = shakaMock.destroy;
+      retryStreaming = shakaMock.retryStreaming;
     },
   },
 }));
@@ -642,5 +644,75 @@ describe('HtmlEngine destroy', () => {
     expect(fv.listenerCount('loadedmetadata')).toBe(0);
     fv.fire('loadedmetadata');
     expect(fv.get('currentTime')).toBe(0);
+  });
+});
+
+describe('HtmlEngine stall recovery', () => {
+  beforeEach(() => {
+    shakaMock.supported = true;
+    shakaMock.retryStreaming.mockClear();
+    hlsMock.supported = true;
+    hlsMock.on.mockClear();
+    hlsMock.recoverMediaError.mockClear();
+    hlsMock.startLoad.mockClear();
+  });
+
+  it('asks Shaka to retry the stream', async () => {
+    const fv = fakeVideo();
+    const { engine } = makeEngine({ fv, direct: false, masterShaka: true, forceNativeHls: false });
+    await tick();
+    await tick();
+
+    expect(engine.recoverStall()).toBe(true);
+    expect(shakaMock.retryStreaming).toHaveBeenCalledTimes(1);
+  });
+
+  it('recovers a media error through hls.js', async () => {
+    const fv = fakeVideo();
+    const { engine } = makeEngine({ fv, direct: false, forceNativeHls: false });
+    await tick();
+    await tick();
+
+    expect(engine.recoverStall()).toBe(true);
+    expect(hlsMock.recoverMediaError).toHaveBeenCalledTimes(1);
+  });
+
+  it('declines where neither MSE engine is attached', async () => {
+    const fv = fakeVideo();
+    const { engine } = makeEngine({ fv, direct: false, forceNativeHls: true });
+    await tick();
+    await tick();
+
+    expect(engine.recoverStall()).toBe(false);
+  });
+
+  it('restarts on a fresh master anchored where it is told', async () => {
+    const fv = fakeVideo();
+    const { engine, hlsMasterUrl } = makeEngine({ fv, direct: false, forceNativeHls: true });
+    await tick();
+    hlsMasterUrl.mockClear();
+
+    engine.restart(1800);
+    await tick();
+    await tick();
+
+    expect(hlsMasterUrl).toHaveBeenCalledWith('vid1', false, 1800, 0, { copyCodecs: DECODABLE });
+    expect(engine.position()).toBe(7.5);
+  });
+
+  it('re-anchors where hls.js has given up on a fatal error', async () => {
+    const fv = fakeVideo();
+    const { hlsMasterUrl } = makeEngine({ fv, direct: false, forceNativeHls: false });
+    await tick();
+    await tick();
+    fv.set('currentTime', 42);
+    hlsMasterUrl.mockClear();
+    const onError = hlsMock.on.mock.calls[0]?.[1] as (e: string, d: unknown) => void;
+
+    for (let i = 0; i < 3; i += 1) onError('hlsError', { type: 'mediaError', fatal: true });
+    await tick();
+
+    expect(hlsMock.recoverMediaError).toHaveBeenCalledTimes(2);
+    expect(hlsMasterUrl).toHaveBeenCalledWith('vid1', false, 42, 0, { copyCodecs: DECODABLE });
   });
 });

--- a/packages/tv/src/features/playback/player/htmlEngine.ts
+++ b/packages/tv/src/features/playback/player/htmlEngine.ts
@@ -6,9 +6,11 @@
 
 import {
   attachDirectPlay,
+  attachHlsRecovery,
   type BufferPlan,
   decodableAudioCodecs,
   hlsBufferConfig,
+  isPlayableAt,
   itemBufferPlan,
   type KromaClient,
   type MediaItem,
@@ -31,6 +33,7 @@ interface ShakaPlayerLike {
   load(uri: string, startTime?: number | null): Promise<void>;
   destroy(): Promise<void>;
   configure(config: Record<string, unknown>): boolean;
+  retryStreaming(retryDelaySeconds?: number): boolean;
 }
 interface ShakaStatic {
   Player: { new (): ShakaPlayerLike; isBrowserSupported(): boolean };
@@ -233,6 +236,7 @@ export class HtmlEngine implements TvEngine {
         ...hlsBufferConfig(this.plan),
       });
       this.hls = hls;
+      attachHlsRecovery(Hls, hls, () => this.reanchor(this.position()));
       hls.loadSource(url);
       hls.attachMedia(v);
     });
@@ -287,20 +291,24 @@ export class HtmlEngine implements TvEngine {
     return end > 0 ? this.baseSec + end : 0;
   }
 
+  recoverStall(): boolean {
+    if (this.shaka) return this.shaka.retryStreaming();
+    if (!this.hls) return false;
+    this.hls.recoverMediaError();
+    return true;
+  }
+
+  restart(absSec: number): void {
+    this.reanchor(absSec);
+  }
+
   seekTo(absSec: number): void {
     if (this.opts.direct) {
       this.v.currentTime = absSec; // direct-play timeline is absolute
       return;
     }
     const rel = absSec - this.baseSec;
-    let buffered = false;
-    for (let i = 0; i < this.v.buffered.length; i += 1) {
-      if (rel >= this.v.buffered.start(i) - 0.1 && rel <= this.v.buffered.end(i) - 0.3) {
-        buffered = true;
-        break;
-      }
-    }
-    if (rel >= 0 && buffered) {
+    if (rel >= 0 && isPlayableAt(this.v.buffered, rel)) {
       this.v.currentTime = rel;
       return;
     }

--- a/packages/tv/src/features/playback/player/htmlEngine.ts
+++ b/packages/tv/src/features/playback/player/htmlEngine.ts
@@ -15,6 +15,8 @@ import {
   type KromaClient,
   type MediaItem,
   reachableBufferEnd,
+  recoverMse,
+  STALL_NUDGE_SEC,
   shakaStreamingConfig,
 } from '@kroma/core';
 import {
@@ -291,11 +293,12 @@ export class HtmlEngine implements TvEngine {
     return end > 0 ? this.baseSec + end : 0;
   }
 
+  nudge(): void {
+    this.v.currentTime += STALL_NUDGE_SEC;
+  }
+
   recoverStall(): boolean {
-    if (this.shaka) return this.shaka.retryStreaming();
-    if (!this.hls) return false;
-    this.hls.recoverMediaError();
-    return true;
+    return recoverMse(this.shaka, this.hls);
   }
 
   restart(absSec: number): void {

--- a/packages/tv/src/features/playback/player/useEngineLifecycle.test.ts
+++ b/packages/tv/src/features/playback/player/useEngineLifecycle.test.ts
@@ -1,9 +1,19 @@
 // @vitest-environment jsdom
 import type { KromaClient, MediaItem } from '@kroma/core';
-import { renderHook, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { EngineListeners } from '#tv/features/playback/player/engine';
 
-const H = vi.hoisted(() => ({ stalled: false }));
+const H = vi.hoisted(() => ({
+  stalled: false,
+  listeners: null as EngineListeners | null,
+  engine: {
+    play: vi.fn(),
+    destroy: vi.fn(),
+    setAudioRendition: vi.fn(),
+    audioFilterSupported: () => true,
+  },
+}));
 
 vi.mock('#tv/features/playback/player/useStallGuard', () => ({
   useStallGuard: () => H.stalled,
@@ -17,11 +27,14 @@ vi.mock('#tv/features/playback/player/backend', () => ({
     deviceLabel: 'a television',
     rebuildKey: 'video:true',
   }),
-  createTvEngine: () => null,
+  createTvEngine: (args: { listeners: EngineListeners }) => {
+    H.listeners = args.listeners;
+    return H.engine;
+  },
 }));
 
 vi.mock('#tv/features/playback/player/useResolvedStart', () => ({
-  useResolvedStart: () => ({ startSec: null, setStartSec: vi.fn() }),
+  useResolvedStart: () => ({ startSec: 0, setStartSec: vi.fn() }),
 }));
 
 vi.mock('#tv/features/playback/player/vlcPlane', () => ({ vlcAvailable: () => false }));
@@ -31,21 +44,42 @@ const { useEngineLifecycle } = await import('#tv/features/playback/player/useEng
 const CLIENT = { hasAuth: false } as unknown as KromaClient;
 const ITEM = { id: 'vid1', durationMs: 7_200_000 } as unknown as MediaItem;
 
+function open() {
+  const view = renderHook(() => useEngineLifecycle(CLIENT, ITEM));
+  if (!H.listeners) throw new Error('expected the lifecycle to have built an engine');
+  return { ...view, on: H.listeners };
+}
+
 describe('useEngineLifecycle stall guard', () => {
+  beforeEach(() => {
+    H.stalled = false;
+    H.listeners = null;
+  });
+
   it('shows a stuck playhead as buffering rather than as a healthy bar', async () => {
     H.stalled = true;
+    const { result, on } = open();
 
-    const { result } = renderHook(() => useEngineLifecycle(CLIENT, ITEM));
+    act(() => on.onPlay());
 
     await waitFor(() => expect(result.current.waiting).toBe(true));
   });
 
-  it('leaves the buffering flag to the engine while nothing is stuck', async () => {
-    H.stalled = false;
+  it('leaves the buffering flag alone while nothing is stuck', async () => {
+    const { result, on } = open();
 
-    const { result } = renderHook(() => useEngineLifecycle(CLIENT, ITEM));
+    act(() => on.onPlay());
 
-    await waitFor(() => expect(result.current.ready).toBe(false));
-    expect(result.current.playing).toBe(false);
+    await waitFor(() => expect(result.current.waiting).toBe(false));
+    expect(result.current.playing).toBe(true);
+  });
+
+  it('arms the guard only once the engine is ready and has not failed', async () => {
+    const { result, on } = open();
+
+    act(() => on.onReady());
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.error).toBeNull();
   });
 });

--- a/packages/tv/src/features/playback/player/useEngineLifecycle.test.ts
+++ b/packages/tv/src/features/playback/player/useEngineLifecycle.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import type { KromaClient, MediaItem } from '@kroma/core';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const H = vi.hoisted(() => ({ stalled: false }));
+
+vi.mock('#tv/features/playback/player/useStallGuard', () => ({
+  useStallGuard: () => H.stalled,
+}));
+
+vi.mock('#tv/features/playback/player/backend', () => ({
+  planEngine: () => ({
+    eng: 'video',
+    surface: 'video',
+    playbackMode: 'direct',
+    deviceLabel: 'a television',
+    rebuildKey: 'video:true',
+  }),
+  createTvEngine: () => null,
+}));
+
+vi.mock('#tv/features/playback/player/useResolvedStart', () => ({
+  useResolvedStart: () => ({ startSec: null, setStartSec: vi.fn() }),
+}));
+
+vi.mock('#tv/features/playback/player/vlcPlane', () => ({ vlcAvailable: () => false }));
+
+const { useEngineLifecycle } = await import('#tv/features/playback/player/useEngineLifecycle');
+
+const CLIENT = { hasAuth: false } as unknown as KromaClient;
+const ITEM = { id: 'vid1', durationMs: 7_200_000 } as unknown as MediaItem;
+
+describe('useEngineLifecycle stall guard', () => {
+  it('shows a stuck playhead as buffering rather than as a healthy bar', async () => {
+    H.stalled = true;
+
+    const { result } = renderHook(() => useEngineLifecycle(CLIENT, ITEM));
+
+    await waitFor(() => expect(result.current.waiting).toBe(true));
+  });
+
+  it('leaves the buffering flag to the engine while nothing is stuck', async () => {
+    H.stalled = false;
+
+    const { result } = renderHook(() => useEngineLifecycle(CLIENT, ITEM));
+
+    await waitFor(() => expect(result.current.ready).toBe(false));
+    expect(result.current.playing).toBe(false);
+  });
+});

--- a/packages/tv/src/features/playback/player/useEngineLifecycle.ts
+++ b/packages/tv/src/features/playback/player/useEngineLifecycle.ts
@@ -23,6 +23,7 @@ import {
   type TvEngine,
 } from '#tv/features/playback/player/engine';
 import { useResolvedStart } from '#tv/features/playback/player/useResolvedStart';
+import { useStallGuard } from '#tv/features/playback/player/useStallGuard';
 import { vlcAvailable } from '#tv/features/playback/player/vlcPlane';
 
 export interface EngineLifecycle {
@@ -225,6 +226,8 @@ export function useEngineLifecycle(
     return () => clearTimeout(id);
   }, [surface, ready, error, failKey, loadBeat]);
 
+  const stalled = useStallGuard(engineRef, ready && error === null);
+
   // Re-anchor the resume position so the rebuilt engine resumes here, not at 0.
   const setEngine = useCallback(
     (p: EnginePref) => {
@@ -254,7 +257,7 @@ export function useEngineLifecycle(
     error,
     ready,
     playing,
-    waiting,
+    waiting: waiting || stalled,
     cur,
     setCur,
     dur,

--- a/packages/tv/src/features/playback/player/useStallGuard.test.ts
+++ b/packages/tv/src/features/playback/player/useStallGuard.test.ts
@@ -15,6 +15,7 @@ function fakeEngine(over: Partial<Record<string, unknown>> = {}) {
     position: vi.fn(() => at),
     bufferedEnd: vi.fn((): number | null => at + ahead),
     isPaused: vi.fn(() => false),
+    nudge: vi.fn(),
     seekTo: vi.fn(),
     recoverStall: vi.fn(() => true),
     restart: vi.fn(),
@@ -54,7 +55,7 @@ describe('useStallGuard', () => {
       vi.advanceTimersByTime(RUNG_MS + POLL_MS);
     });
 
-    expect(f.calls.seekTo).toHaveBeenCalledWith(100.1);
+    expect(f.calls.nudge).toHaveBeenCalledTimes(1);
     expect(result.current).toBe(true);
   });
 
@@ -66,7 +67,7 @@ describe('useStallGuard', () => {
       vi.advanceTimersByTime(RUNG_MS * 4 + POLL_MS);
     });
 
-    expect(f.calls.seekTo).toHaveBeenCalledTimes(2);
+    expect(f.calls.nudge).toHaveBeenCalledTimes(2);
     expect(f.calls.recoverStall).toHaveBeenCalledTimes(1);
     expect(f.calls.restart).toHaveBeenCalledWith(100);
   });
@@ -112,17 +113,6 @@ describe('useStallGuard', () => {
     expect(f.calls.restart).toHaveBeenCalledTimes(1);
   });
 
-  it('survives a backend with neither recovery nor restart of its own', () => {
-    const f = fakeEngine({ recoverStall: undefined, restart: undefined });
-
-    renderHook(() => useStallGuard(f.ref, true));
-    act(() => {
-      vi.advanceTimersByTime(RUNG_MS * 4 + POLL_MS);
-    });
-
-    expect(f.calls.seekTo).toHaveBeenCalledTimes(2);
-  });
-
   it('leaves a paused film alone', () => {
     const f = fakeEngine({ isPaused: vi.fn(() => true) });
 
@@ -131,7 +121,7 @@ describe('useStallGuard', () => {
       vi.advanceTimersByTime(RUNG_MS * 4);
     });
 
-    expect(f.calls.seekTo).not.toHaveBeenCalled();
+    expect(f.calls.nudge).not.toHaveBeenCalled();
     expect(result.current).toBe(false);
   });
 
@@ -144,7 +134,7 @@ describe('useStallGuard', () => {
       vi.advanceTimersByTime(RUNG_MS * 4);
     });
 
-    expect(f.calls.seekTo).not.toHaveBeenCalled();
+    expect(f.calls.nudge).not.toHaveBeenCalled();
     expect(result.current).toBe(false);
   });
 
@@ -156,7 +146,7 @@ describe('useStallGuard', () => {
       vi.advanceTimersByTime(RUNG_MS * 4);
     });
 
-    expect(f.calls.seekTo).not.toHaveBeenCalled();
+    expect(f.calls.nudge).not.toHaveBeenCalled();
   });
 
   it('watches nothing while it is not armed, or before an engine exists', () => {
@@ -169,7 +159,7 @@ describe('useStallGuard', () => {
       vi.advanceTimersByTime(RUNG_MS * 4);
     });
 
-    expect(f.calls.seekTo).not.toHaveBeenCalled();
+    expect(f.calls.nudge).not.toHaveBeenCalled();
     expect(idle.result.current).toBe(false);
     expect(engineless.result.current).toBe(false);
   });
@@ -183,6 +173,6 @@ describe('useStallGuard', () => {
       vi.advanceTimersByTime(RUNG_MS * 4);
     });
 
-    expect(f.calls.seekTo).not.toHaveBeenCalled();
+    expect(f.calls.nudge).not.toHaveBeenCalled();
   });
 });

--- a/packages/tv/src/features/playback/player/useStallGuard.test.ts
+++ b/packages/tv/src/features/playback/player/useStallGuard.test.ts
@@ -112,6 +112,17 @@ describe('useStallGuard', () => {
     expect(f.calls.restart).toHaveBeenCalledTimes(1);
   });
 
+  it('survives a backend with neither recovery nor restart of its own', () => {
+    const f = fakeEngine({ recoverStall: undefined, restart: undefined });
+
+    renderHook(() => useStallGuard(f.ref, true));
+    act(() => {
+      vi.advanceTimersByTime(RUNG_MS * 4 + POLL_MS);
+    });
+
+    expect(f.calls.seekTo).toHaveBeenCalledTimes(2);
+  });
+
   it('leaves a paused film alone', () => {
     const f = fakeEngine({ isPaused: vi.fn(() => true) });
 

--- a/packages/tv/src/features/playback/player/useStallGuard.test.ts
+++ b/packages/tv/src/features/playback/player/useStallGuard.test.ts
@@ -1,0 +1,177 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TvEngine } from '#tv/features/playback/player/engine';
+import { useStallGuard } from '#tv/features/playback/player/useStallGuard';
+
+const POLL_MS = 500;
+const RUNG_MS = 2000;
+
+function fakeEngine(over: Partial<Record<string, unknown>> = {}) {
+  let at = 100;
+  let ahead = 60;
+  const engine = {
+    kind: 'video',
+    position: vi.fn(() => at),
+    bufferedEnd: vi.fn((): number | null => at + ahead),
+    isPaused: vi.fn(() => false),
+    seekTo: vi.fn(),
+    recoverStall: vi.fn(() => true),
+    restart: vi.fn(),
+    play: vi.fn(),
+    pause: vi.fn(),
+    duration: vi.fn(() => 7200),
+    setAudioRendition: vi.fn(),
+    destroy: vi.fn(),
+    ...over,
+  };
+  return {
+    engine: engine as unknown as TvEngine,
+    calls: engine,
+    ref: { current: engine as unknown as TvEngine },
+    move: (by: number) => {
+      at += by;
+    },
+    starve: () => {
+      ahead = 0.2;
+    },
+  };
+}
+
+describe('useStallGuard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('nudges a playhead that stopped with buffer still ahead of it', () => {
+    const f = fakeEngine();
+
+    const { result } = renderHook(() => useStallGuard(f.ref, true));
+    act(() => {
+      vi.advanceTimersByTime(RUNG_MS + POLL_MS);
+    });
+
+    expect(f.calls.seekTo).toHaveBeenCalledWith(100.1);
+    expect(result.current).toBe(true);
+  });
+
+  it('climbs to the backend recovery, then to a fresh source', () => {
+    const f = fakeEngine();
+
+    renderHook(() => useStallGuard(f.ref, true));
+    act(() => {
+      vi.advanceTimersByTime(RUNG_MS * 4 + POLL_MS);
+    });
+
+    expect(f.calls.seekTo).toHaveBeenCalledTimes(2);
+    expect(f.calls.recoverStall).toHaveBeenCalledTimes(1);
+    expect(f.calls.restart).toHaveBeenCalledWith(100);
+  });
+
+  it('goes straight on to a fresh source where the backend has no recovery', () => {
+    const f = fakeEngine({ recoverStall: undefined });
+
+    renderHook(() => useStallGuard(f.ref, true));
+    act(() => {
+      vi.advanceTimersByTime(RUNG_MS * 3 + POLL_MS);
+    });
+
+    expect(f.calls.restart).toHaveBeenCalledTimes(1);
+  });
+
+  it('reaches for a fresh source when the backend recovery declines', () => {
+    const f = fakeEngine({ recoverStall: vi.fn(() => false) });
+
+    renderHook(() => useStallGuard(f.ref, true));
+    act(() => {
+      vi.advanceTimersByTime(RUNG_MS * 3 + POLL_MS);
+    });
+
+    expect(f.calls.recoverStall).toHaveBeenCalledTimes(1);
+    expect(f.calls.restart).toHaveBeenCalledTimes(1);
+  });
+
+  it('restarts once inside the cooldown, however often it stalls again', () => {
+    const f = fakeEngine();
+
+    renderHook(() => useStallGuard(f.ref, true));
+    act(() => {
+      vi.advanceTimersByTime(RUNG_MS * 4 + POLL_MS);
+    });
+    act(() => {
+      f.move(5);
+      vi.advanceTimersByTime(POLL_MS);
+      f.move(5);
+      vi.advanceTimersByTime(POLL_MS);
+      vi.advanceTimersByTime(RUNG_MS * 4);
+    });
+
+    expect(f.calls.restart).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves a paused film alone', () => {
+    const f = fakeEngine({ isPaused: vi.fn(() => true) });
+
+    const { result } = renderHook(() => useStallGuard(f.ref, true));
+    act(() => {
+      vi.advanceTimersByTime(RUNG_MS * 4);
+    });
+
+    expect(f.calls.seekTo).not.toHaveBeenCalled();
+    expect(result.current).toBe(false);
+  });
+
+  it('leaves a playhead that has genuinely run out to the backend', () => {
+    const f = fakeEngine();
+    f.starve();
+
+    const { result } = renderHook(() => useStallGuard(f.ref, true));
+    act(() => {
+      vi.advanceTimersByTime(RUNG_MS * 4);
+    });
+
+    expect(f.calls.seekTo).not.toHaveBeenCalled();
+    expect(result.current).toBe(false);
+  });
+
+  it('leaves a backend with no buffered range to report alone', () => {
+    const f = fakeEngine({ bufferedEnd: vi.fn(() => null) });
+
+    renderHook(() => useStallGuard(f.ref, true));
+    act(() => {
+      vi.advanceTimersByTime(RUNG_MS * 4);
+    });
+
+    expect(f.calls.seekTo).not.toHaveBeenCalled();
+  });
+
+  it('watches nothing while it is not armed, or before an engine exists', () => {
+    const f = fakeEngine();
+    const empty: { current: TvEngine | null } = { current: null };
+
+    const idle = renderHook(() => useStallGuard(f.ref, false));
+    const engineless = renderHook(() => useStallGuard(empty, true));
+    act(() => {
+      vi.advanceTimersByTime(RUNG_MS * 4);
+    });
+
+    expect(f.calls.seekTo).not.toHaveBeenCalled();
+    expect(idle.result.current).toBe(false);
+    expect(engineless.result.current).toBe(false);
+  });
+
+  it('stops polling once it is unmounted', () => {
+    const f = fakeEngine();
+
+    const { unmount } = renderHook(() => useStallGuard(f.ref, true));
+    unmount();
+    act(() => {
+      vi.advanceTimersByTime(RUNG_MS * 4);
+    });
+
+    expect(f.calls.seekTo).not.toHaveBeenCalled();
+  });
+});

--- a/packages/tv/src/features/playback/player/useStallGuard.ts
+++ b/packages/tv/src/features/playback/player/useStallGuard.ts
@@ -1,0 +1,65 @@
+import { STALL_NUDGE_SEC, STALL_POLL_MS, type StallStep, stallWatch } from '@kroma/core';
+import { useEffect, useRef, useState } from 'react';
+import type { TvEngine } from '#tv/features/playback/player/engine';
+
+// A restart re-anchors the stream, which costs a fresh remux session: worth it
+// once for a picture that is otherwise frozen, not worth it in a loop.
+const RESTART_COOLDOWN_MS = 30_000;
+
+/**
+ * Watches whichever engine is playing for a playhead that has stopped with
+ * buffer still ahead of it, and works it back up: a nudge, then the backend's
+ * own recovery, then a fresh source at the same position. Returns whether it is
+ * stuck right now, which the chrome shows as buffering rather than as a healthy
+ * full bar.
+ */
+export function useStallGuard(
+  engineRef: React.RefObject<TvEngine | null>,
+  active: boolean,
+): boolean {
+  const [stalled, setStalled] = useState(false);
+  const restartedAt = useRef(0);
+
+  useEffect(() => {
+    if (!active) return;
+    const watch = stallWatch();
+
+    const apply = (step: StallStep, engine: TvEngine) => {
+      const at = engine.position();
+      if (step === 'nudge') {
+        engine.seekTo(at + STALL_NUDGE_SEC);
+        return;
+      }
+      if (step === 'recover' && engine.recoverStall?.() === true) return;
+      const now = Date.now();
+      if (now - restartedAt.current < RESTART_COOLDOWN_MS) return;
+      restartedAt.current = now;
+      engine.restart?.(at);
+    };
+
+    const id = setInterval(() => {
+      const engine = engineRef.current;
+      // A backend with no buffered range to report cannot tell a stall from an
+      // honest rebuffer, so it is left to its own devices.
+      const bufferedEnd = engine?.bufferedEnd();
+      if (!engine || bufferedEnd == null) return;
+      const step = watch.observe(
+        {
+          currentTime: engine.position(),
+          bufferedEnd,
+          paused: engine.isPaused(),
+        },
+        Date.now(),
+      );
+      setStalled(watch.stalled());
+      if (step) apply(step, engine);
+    }, STALL_POLL_MS);
+
+    return () => {
+      clearInterval(id);
+      setStalled(false);
+    };
+  }, [active, engineRef]);
+
+  return stalled;
+}

--- a/packages/tv/src/features/playback/player/useStallGuard.ts
+++ b/packages/tv/src/features/playback/player/useStallGuard.ts
@@ -1,4 +1,4 @@
-import { driveStallRecovery, STALL_NUDGE_SEC } from '@kroma/core';
+import { driveStallRecovery } from '@kroma/core';
 import { useEffect, useState } from 'react';
 import type { TvEngine } from '#tv/features/playback/player/engine';
 
@@ -24,9 +24,9 @@ export function useStallGuard(
           if (bufferedEnd == null) return null;
           return { currentTime: engine.position(), bufferedEnd, paused: engine.isPaused() };
         },
-        nudge: () => engine.seekTo(engine.position() + STALL_NUDGE_SEC),
+        nudge: () => engine.nudge(),
         recover: () => engine.recoverStall?.() === true,
-        restart: () => engine.restart?.(engine.position()),
+        restart: () => engine.restart(engine.position()),
       },
       setStalled,
     );

--- a/packages/tv/src/features/playback/player/useStallGuard.ts
+++ b/packages/tv/src/features/playback/player/useStallGuard.ts
@@ -1,64 +1,45 @@
-import { STALL_NUDGE_SEC, STALL_POLL_MS, type StallStep, stallWatch } from '@kroma/core';
-import { useEffect, useRef, useState } from 'react';
+import { driveStallRecovery, STALL_NUDGE_SEC, type StallSample } from '@kroma/core';
+import { useEffect, useState } from 'react';
 import type { TvEngine } from '#tv/features/playback/player/engine';
 
-// A restart re-anchors the stream, which costs a fresh remux session: worth it
-// once for a picture that is otherwise frozen, not worth it in a loop.
-const RESTART_COOLDOWN_MS = 30_000;
-
 /**
- * Watches whichever engine is playing for a playhead that has stopped with
- * buffer still ahead of it, and works it back up: a nudge, then the backend's
- * own recovery, then a fresh source at the same position. Returns whether it is
- * stuck right now, which the chrome shows as buffering rather than as a healthy
- * full bar.
+ * Works a stuck playhead back up on whichever engine is playing: a nudge, then
+ * the backend's own recovery, then a fresh source at the same position. Returns
+ * whether it is stuck right now, which the chrome shows as buffering rather than
+ * as a healthy full bar.
  */
 export function useStallGuard(
   engineRef: React.RefObject<TvEngine | null>,
   active: boolean,
 ): boolean {
   const [stalled, setStalled] = useState(false);
-  const restartedAt = useRef(0);
 
   useEffect(() => {
     if (!active) return;
-    const watch = stallWatch();
-
-    const apply = (step: StallStep, engine: TvEngine) => {
-      const at = engine.position();
-      if (step === 'nudge') {
-        engine.seekTo(at + STALL_NUDGE_SEC);
-        return;
-      }
-      if (step === 'recover' && engine.recoverStall?.() === true) return;
-      const now = Date.now();
-      if (now - restartedAt.current < RESTART_COOLDOWN_MS) return;
-      restartedAt.current = now;
-      engine.restart?.(at);
-    };
-
-    const id = setInterval(() => {
-      const engine = engineRef.current;
-      // A backend with no buffered range to report cannot tell a stall from an
-      // honest rebuffer, so it is left to its own devices.
-      const bufferedEnd = engine?.bufferedEnd();
-      if (!engine || bufferedEnd == null) return;
-      const step = watch.observe(
-        {
-          currentTime: engine.position(),
-          bufferedEnd,
-          paused: engine.isPaused(),
+    return driveStallRecovery(
+      {
+        sample: (): StallSample | null => {
+          const engine = engineRef.current;
+          const bufferedEnd = engine?.bufferedEnd();
+          if (!engine || bufferedEnd == null) return null;
+          return {
+            currentTime: engine.position(),
+            bufferedEnd,
+            paused: engine.isPaused(),
+          };
         },
-        Date.now(),
-      );
-      setStalled(watch.stalled());
-      if (step) apply(step, engine);
-    }, STALL_POLL_MS);
-
-    return () => {
-      clearInterval(id);
-      setStalled(false);
-    };
+        nudge: () => {
+          const engine = engineRef.current;
+          if (engine) engine.seekTo(engine.position() + STALL_NUDGE_SEC);
+        },
+        recover: () => engineRef.current?.recoverStall?.() === true,
+        restart: () => {
+          const engine = engineRef.current;
+          engine?.restart?.(engine.position());
+        },
+      },
+      setStalled,
+    );
   }, [active, engineRef]);
 
   return stalled;

--- a/packages/tv/src/features/playback/player/useStallGuard.ts
+++ b/packages/tv/src/features/playback/player/useStallGuard.ts
@@ -1,4 +1,4 @@
-import { driveStallRecovery, STALL_NUDGE_SEC, type StallSample } from '@kroma/core';
+import { driveStallRecovery, STALL_NUDGE_SEC } from '@kroma/core';
 import { useEffect, useState } from 'react';
 import type { TvEngine } from '#tv/features/playback/player/engine';
 
@@ -15,28 +15,18 @@ export function useStallGuard(
   const [stalled, setStalled] = useState(false);
 
   useEffect(() => {
-    if (!active) return;
+    const engine = engineRef.current;
+    if (!active || !engine) return;
     return driveStallRecovery(
       {
-        sample: (): StallSample | null => {
-          const engine = engineRef.current;
-          const bufferedEnd = engine?.bufferedEnd();
-          if (!engine || bufferedEnd == null) return null;
-          return {
-            currentTime: engine.position(),
-            bufferedEnd,
-            paused: engine.isPaused(),
-          };
+        sample: () => {
+          const bufferedEnd = engine.bufferedEnd();
+          if (bufferedEnd == null) return null;
+          return { currentTime: engine.position(), bufferedEnd, paused: engine.isPaused() };
         },
-        nudge: () => {
-          const engine = engineRef.current;
-          if (engine) engine.seekTo(engine.position() + STALL_NUDGE_SEC);
-        },
-        recover: () => engineRef.current?.recoverStall?.() === true,
-        restart: () => {
-          const engine = engineRef.current;
-          engine?.restart?.(engine.position());
-        },
+        nudge: () => engine.seekTo(engine.position() + STALL_NUDGE_SEC),
+        recover: () => engine.recoverStall?.() === true,
+        restart: () => engine.restart?.(engine.position()),
       },
       setStalled,
     );


### PR DESCRIPTION
## What

Testers report a picture that freezes while the seek bar shows a full buffer, and one of them paused a film for forty minutes and came back to it playing. The freeze is that nothing recovers a stalled playhead: hls.js nudges one `nudgeMaxRetry` times, raises a fatal `bufferStalledError` reading "Playhead still not moving while enough data buffered", and its own action for that error is `createDoNothingErrorAction`, so recovery belongs to the caller. Neither client registered an `Events.ERROR` listener, and the watchdog in `useEngineLifecycle` returns early once `ready` is true, so nothing covered a mid-playback stall on any surface. What is already appended to the SourceBuffer stays there, which is why `reachableBufferEnd` honestly reports a full bar over a dead picture. `playback-stall.ts` is the missing half of `playback-buffer.ts`: `stallWatch` fires only when the playhead stops with at least half a second still reachable ahead of it, the one case an engine's own rebuffering does not own, and `driveStallRecovery` climbs a ladder two seconds apart from a nudge, to the engine's own recovery, to a fresh source at the same position, holding a restart to one per thirty seconds.

The self-starting film is a second fault, and it ships here because the recovery adds two new ways to reach it. Any re-attach played: `bindMediaEvents` declares `started` per binding, so the first `canplay` called `play()` whatever the viewer had done — and the `<video>` carried a bare `autoPlay` while being keyed `${anchor}:${audioIndex}`, so the browser started a fresh element by itself regardless. Tizen had the same fault as `restore(..., 'PLAYING')` after a visibility change, which is what a screensaver over a paused film does to it; mobile had it as an unconditional `resumeOnLoad = true` in `load()`, so a far scrub or an audio-track change restarted a paused film. AVPlay and mpv already read `!this.paused` at that point, which is what makes the others oversights rather than a decision.

Three buffer readouts were lying in the same direction and are fixed alongside — AVPlay reported the playhead itself as the buffered end while its own `bufferedEnd()` returns null, and both native engines drew a stale depth against a new anchor. The two copies of "is this seek target buffered" that disagreed on the sign are now one `isPlayableAt`.

## Closes

No issue. It came in as tester reports rather than a filed bug, and the investigation is in the commit messages.

## Checks

- [x] `bun run lint` and `bun run test` pass, in a clean worktree off `main` with its own `bun install`: 8531 tests, 0 failures. `bun run typecheck` is clean. `bun run check` also reports a stale `$schema` in `biome.json` (declares 2.5.5, `package.json` pins `^2.5.8`) — that is on `main` already and fails a pristine checkout the same way.
- [ ] `cargo clippy` and `cargo test` — the server did not change.
- [x] Follows `CODE_STYLE.md` — no comments narrating the work, exported API only
- [x] One idea. If it grew a second, it was split.

## Quality gate

100% coverage on new code, 0% duplication, 0 issues, A/A/A. It started at 64.1% coverage; the second commit covered the ladder end to end, the third took the last seven branches — three of them by deleting guards that could not be reached rather than testing the impossible.

`driveStallRecovery` is one driver rather than the two the hooks first copied, and it has tests of its own; both adapters are now ~40 lines of target mapping.

## Risk

The ladder moves the playhead on its own, so its guards are what matter: it stays silent unless the element is unpaused, not seeking, at `readyState >= 3`, and holds half a second of reachable buffer. Get that wrong and it nudges a film that was merely rebuffering. `playback-stall.test.ts` pins each guard and the driver, both adapter suites pin the mapping, and the 30 s cooldown bounds the worst case to one re-anchor. A reviewer would notice as a picture that stutters forward during normal buffering.

Two deliberate behaviour changes worth a look. Web seeks near the buffer edge now re-anchor instead of seeking in place, which costs a remux session where it used to stall — the TV engine has always done this, and adopting the shared rule tightened the web tolerance from `end + 0.5` to `end - 0.3`. And the Tizen seek bar loses its buffered fill entirely, because AVPlay reports no buffered range and `SeekBarProps.bufEnd` documents `null` as "no fill at all"; that changes a pinned assertion in `avplayEngine.test.ts`, so say if the fill was wanted.

The server is unchanged and load-bearing here: a session idle for 180 s is reaped with its segments (`reclaim.rs`), which a forty minute pause guarantees, and this recovery is what carries a client across it.

## Known gaps, deliberately not in this PR

- **Shaka has no fatal-error handler.** `attachHlsRecovery` is hls-shaped, and Shaka is the default MSE engine. A dead Shaka stops the playhead with nothing buffered ahead, which `stallWatch` correctly classifies as idle and ignores. Wants an engine-neutral `onFatal` in core.
- **`HtmlEngine.restart` on a direct-played file commits to the remux**, because `reanchor` calls `attachMaster` unconditionally. Reachable now that the ladder can call `restart`.
- **Play intent is reconstructed from element events** on web and from `!core.started || player.playing` on mobile, rather than recorded where the viewer acts. Correct today by effect ordering and a 0.5 s window.
- **`resumeOnLoad = !this.paused` is spelled in three native engines.** Wants a template method on `BaseTvEngine` so a new backend cannot forget it.
