### PR TITLE
fix(home): one title, one place on the screen, and a seed that means you finished it

### DIFF
--- a/server/crates/kroma-db/src/home.rs
+++ b/server/crates/kroma-db/src/home.rs
@@ -55,14 +55,25 @@ pub fn recently_added_ids(pool: &Pool, n: usize) -> Result<Vec<String>> {
     Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
 }
 
-/// The user's most recently finished item id (for "Because you watched …").
-pub fn last_played(pool: &Pool, user_id: &str) -> Result<Option<String>> {
+/// The user's most recently **finished** title id (for "Because you watched …").
+///
+/// Finished means what it means in "Continue watching": marked watched, or left
+/// past 95% of the runtime. Merely opening a title is not a taste signal. An
+/// episode answers as its parent show, the only seed of the two that carries an
+/// embedding to rank from.
+pub fn last_finished(pool: &Pool, user_id: &str) -> Result<Option<String>> {
+    let percent = crate::playback::FINISHED_PERCENT;
     let conn = pool.get()?;
-    let mut stmt = conn.prepare(
-        "SELECT item_id FROM play_history \
-         WHERE user_id = ?1 AND item_id IS NOT NULL \
-         ORDER BY ended_at DESC LIMIT 1",
-    )?;
+    let mut stmt = conn.prepare(&format!(
+        "SELECT COALESCE(i.show_id, f.item_id) FROM ( \
+             SELECT item_id, watched_at AS at FROM watched WHERE user_id = ?1 \
+             UNION ALL \
+             SELECT item_id, updated_at FROM progress \
+              WHERE user_id = ?1 AND duration_ms IS NOT NULL \
+                AND position_ms >= duration_ms * {percent} / 100 \
+         ) f LEFT JOIN items i ON i.id = f.item_id \
+         ORDER BY f.at DESC LIMIT 1"
+    ))?;
     let mut rows = stmt.query_map(params![user_id], |r| r.get::<_, String>(0))?;
     Ok(rows.next().transpose()?)
 }
@@ -74,7 +85,7 @@ mod tests {
     use std::sync::atomic::Ordering;
 
     #[test]
-    fn recently_added_last_played_and_trending() {
+    fn recently_added_and_trending() {
         let p = seeded();
         {
             let conn = p.get().unwrap();
@@ -94,9 +105,72 @@ mod tests {
                                                       // Newest added_at first: nogen (2022) before c2 (2021) before c1 (2020).
         let idx = |id: &str| recent.iter().position(|x| x == id).unwrap();
         assert!(idx("nogen") < idx("c2") && idx("c2") < idx("c1"));
+    }
 
-        assert!(last_played(&p, "u1").unwrap().is_some());
-        assert!(last_played(&p, "nobody").unwrap().is_none());
+    #[test]
+    fn a_film_sampled_for_a_few_seconds_seeds_nothing() {
+        let p = seeded();
+        let user = seeded_user(&p);
+        let conn = p.get().unwrap();
+        conn.execute(
+            "INSERT INTO play_history (id,user_id,item_id,kind,title,started_at,ended_at) \
+             VALUES ('p1',?1,'c1','movie','T',0,strftime('%s','now'))",
+            params![user],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO progress (user_id,item_id,position_ms,duration_ms,updated_at) \
+             VALUES (?1,'c1',5000,7200000,'2026-01-01T00:00:00Z')",
+            params![user],
+        )
+        .unwrap();
+        drop(conn);
+
+        assert!(last_finished(&p, &user).unwrap().is_none());
+        assert!(last_finished(&p, "nobody").unwrap().is_none());
+    }
+
+    #[test]
+    fn the_newest_finished_title_is_the_seed() {
+        let p = seeded();
+        let user = seeded_user(&p);
+        let conn = p.get().unwrap();
+        conn.execute(
+            "INSERT INTO progress (user_id,item_id,position_ms,duration_ms,updated_at) \
+             VALUES (?1,'c1',6900000,7200000,'2026-01-01T00:00:00Z')",
+            params![user],
+        )
+        .unwrap();
+        drop(conn);
+
+        assert_eq!(last_finished(&p, &user).unwrap().as_deref(), Some("c1"));
+
+        p.get()
+            .unwrap()
+            .execute(
+                "INSERT INTO watched (user_id,item_id,watched_at) \
+                 VALUES (?1,'c2','2026-02-01T00:00:00Z')",
+                params![user],
+            )
+            .unwrap();
+
+        assert_eq!(last_finished(&p, &user).unwrap().as_deref(), Some("c2"));
+    }
+
+    #[test]
+    fn a_finished_episode_seeds_its_show() {
+        let p = seeded();
+        let user = seeded_user(&p);
+        p.get()
+            .unwrap()
+            .execute(
+                "INSERT INTO watched (user_id,item_id,watched_at) \
+                 VALUES (?1,'e1','2026-02-01T00:00:00Z')",
+                params![user],
+            )
+            .unwrap();
+
+        assert_eq!(last_finished(&p, &user).unwrap().as_deref(), Some("sh1"));
     }
 
     #[test]

--- a/server/crates/kroma-db/src/home/test_support.rs
+++ b/server/crates/kroma-db/src/home/test_support.rs
@@ -2,7 +2,9 @@ use std::sync::atomic::AtomicU32;
 
 use rusqlite::params;
 
+use crate::pool::Pool;
 use crate::testing::TempPool;
+use kroma_domain::Permission;
 
 pub(super) static SEQ: AtomicU32 = AtomicU32::new(0);
 
@@ -49,4 +51,10 @@ pub(super) fn seeded() -> TempPool {
     .unwrap();
     drop(conn);
     pool
+}
+
+pub(super) fn seeded_user(pool: &Pool) -> String {
+    crate::create_user(pool, "h@e.com", "h", "hash", &[Permission::Playback])
+        .unwrap()
+        .id
 }

--- a/server/crates/kroma-db/src/playback.rs
+++ b/server/crates/kroma-db/src/playback.rs
@@ -22,6 +22,16 @@ pub use show_progress::*;
 pub use up_next::*;
 pub use watch_state::*;
 
+pub(crate) const RESUME_FLOOR_MS: i64 = 15_000;
+pub(crate) const FINISHED_PERCENT: i64 = 95;
+
+pub(crate) fn resumable_sql() -> String {
+    format!(
+        "p.position_ms > {RESUME_FLOOR_MS} \
+         AND (p.duration_ms IS NULL OR p.position_ms < p.duration_ms * {FINISHED_PERCENT} / 100)"
+    )
+}
+
 /// Upsert one item's playback position for a user.
 pub fn upsert_progress(
     pool: &Pool,

--- a/server/crates/kroma-db/src/playback/continue_watching.rs
+++ b/server/crates/kroma-db/src/playback/continue_watching.rs
@@ -17,13 +17,13 @@ const LIMIT: usize = 30;
 pub fn continue_watching(pool: &Pool, user_id: &str) -> Result<Vec<ContinueItem>> {
     let conn = pool.get()?;
     // The JOIN drops any orphan progress row whose item no longer exists.
-    let mut stmt = conn.prepare(
+    let mut stmt = conn.prepare(&format!(
         "SELECT p.item_id,p.position_ms,p.duration_ms,p.updated_at \
          FROM progress p JOIN items i ON i.id = p.item_id \
-         WHERE p.user_id = ?1 AND p.position_ms > 15000 \
-           AND (p.duration_ms IS NULL OR p.position_ms < p.duration_ms * 95 / 100) \
+         WHERE p.user_id = ?1 AND {} \
          ORDER BY p.updated_at DESC LIMIT ?2",
-    )?;
+        super::resumable_sql()
+    ))?;
     let mut rows: Vec<(String, i64, Option<i64>, String)> = stmt
         .query_map(params![user_id, LIMIT as i64], |r| {
             Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?))
@@ -101,6 +101,31 @@ pub fn continue_watching(pool: &Pool, user_id: &str) -> Result<Vec<ContinueItem>
     Ok(out)
 }
 
+/// The ids "Continue watching" occupies, plus the parent show of any episode
+/// among them: what the home generator must not offer again in a row below it.
+pub fn continue_watching_ids(pool: &Pool, user_id: &str) -> Result<Vec<String>> {
+    let conn = pool.get()?;
+    let mut stmt = conn.prepare(&format!(
+        "SELECT p.item_id FROM progress p JOIN items i ON i.id = p.item_id \
+         WHERE p.user_id = ?1 AND {} \
+         ORDER BY p.updated_at DESC LIMIT ?2",
+        super::resumable_sql()
+    ))?;
+    let mut ids: Vec<String> = stmt
+        .query_map(params![user_id, LIMIT as i64], |r| r.get::<_, String>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    drop(stmt);
+    ids.extend(
+        on_deck(&conn, user_id, LIMIT)?
+            .into_iter()
+            .map(|(id, _)| id),
+    );
+    let refs: Vec<&str> = ids.iter().map(String::as_str).collect();
+    let shows = crate::show_ids_for(pool, &refs)?;
+    ids.extend(shows);
+    Ok(ids)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -143,6 +168,32 @@ mod tests {
         assert_eq!(cw[0].duration_ms, Some(100_000));
         assert_eq!(cw[1].position_ms, 30_000);
         assert_eq!(cw[1].duration_ms, None);
+    }
+
+    #[test]
+    fn the_ids_already_on_the_continue_rail_include_the_parent_show() {
+        let (pool, uid) = pool_with_user();
+        seed_show(&pool, "s1", "e", 3);
+        {
+            let conn = pool.get().unwrap();
+            conn.execute(
+                "INSERT INTO progress (user_id,item_id,position_ms,duration_ms,updated_at) \
+                 VALUES (?1,'e1',20000,100000,'2021-01-01T00:00:00Z')",
+                params![uid],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO progress (user_id,item_id,position_ms,duration_ms,updated_at) \
+                 VALUES (?1,'m1',5000,100000,'2021-01-02T00:00:00Z')",
+                params![uid],
+            )
+            .unwrap();
+        }
+
+        let mut ids = continue_watching_ids(&pool, &uid).unwrap();
+        ids.sort();
+
+        assert_eq!(ids, vec!["e1".to_string(), "s1".to_string()]);
     }
 
     #[test]

--- a/server/crates/kroma-db/src/playback/on_deck.rs
+++ b/server/crates/kroma-db/src/playback/on_deck.rs
@@ -6,13 +6,14 @@ use rusqlite::{params, Connection};
 // The episode after the last watched one, for every show the user has watched and
 // left with no episode in progress, newest show first: `(item_id, watched_at)`.
 // A show that is caught up yields no row (the JOIN finds nothing to play).
-const SQL: &str = "\
+fn sql() -> String {
+    let resumable = crate::playback::resumable_sql();
+    format!(
+        "\
 WITH busy AS ( \
     SELECT DISTINCT pi.show_id AS show_id \
       FROM progress p JOIN items pi ON pi.id = p.item_id \
-     WHERE p.user_id = ?1 AND pi.show_id IS NOT NULL \
-       AND p.position_ms > 15000 \
-       AND (p.duration_ms IS NULL OR p.position_ms < p.duration_ms * 95 / 100) \
+     WHERE p.user_id = ?1 AND pi.show_id IS NOT NULL AND {resumable} \
 ), seen AS ( \
     SELECT i.show_id AS show_id, \
            MAX(w.watched_at) AS watched_at, \
@@ -33,14 +34,16 @@ SELECT next.id, seen.watched_at \
           AND NOT EXISTS (SELECT 1 FROM progress p2 \
                            WHERE p2.user_id = ?1 AND p2.item_id = e.id) \
         ORDER BY e.season, e.episode LIMIT 1) \
- ORDER BY seen.watched_at DESC LIMIT ?2";
+ ORDER BY seen.watched_at DESC LIMIT ?2"
+    )
+}
 
 pub(super) fn on_deck(
     conn: &Connection,
     user_id: &str,
     limit: usize,
 ) -> Result<Vec<(String, String)>> {
-    let mut stmt = conn.prepare(SQL)?;
+    let mut stmt = conn.prepare(&sql())?;
     let rows = stmt
         .query_map(params![user_id, limit as i64], |r| {
             Ok((r.get(0)?, r.get(1)?))

--- a/server/crates/kroma-engine/src/services/sections/context.rs
+++ b/server/crates/kroma-engine/src/services/sections/context.rs
@@ -17,9 +17,11 @@ pub struct Context {
     pub month: u8,
     pub weekday: Weekday,
     pub part_of_day: PartOfDay,
-    pub last_played: Option<String>,
+    pub last_finished: Option<String>,
     // Recent distinct watched ids: the taste window for the "For You" centroid.
     pub watched: Vec<String>,
+    // What "Continue watching" already occupies on the same screen.
+    pub in_progress: Vec<String>,
 }
 
 impl Context {
@@ -35,8 +37,9 @@ impl Context {
             month: u8::from(now.month()),
             weekday: now.weekday(),
             part_of_day,
-            last_played: db::last_played(pool, user_id).ok().flatten(),
+            last_finished: db::last_finished(pool, user_id).ok().flatten(),
             watched: db::recent_watched_ids(pool, user_id).unwrap_or_default(),
+            in_progress: db::continue_watching_ids(pool, user_id).unwrap_or_default(),
         }
     }
 
@@ -58,8 +61,9 @@ mod tests {
             month: 1,
             weekday,
             part_of_day: part,
-            last_played: None,
+            last_finished: None,
             watched: Vec::new(),
+            in_progress: Vec::new(),
         }
     }
 

--- a/server/crates/kroma-engine/src/services/sections/curate.rs
+++ b/server/crates/kroma-engine/src/services/sections/curate.rs
@@ -81,10 +81,12 @@ pub fn build_catalog(items: &[MediaItem], shows: &[Show]) -> Vec<CatalogEntry> {
 fn meta_bits(meta: Option<&crate::model::Metadata>) -> (f32, Vec<String>, Vec<String>) {
     match meta {
         Some(m) => {
+            let mut seen = HashSet::new();
             let directors = m
                 .crew
                 .iter()
                 .filter(|c| DIRECTING_JOBS.contains(&c.job.as_str()))
+                .filter(|c| seen.insert(c.name.as_str()))
                 .map(|c| c.name.clone())
                 .collect();
             (m.rating.unwrap_or(0.0), m.genres.clone(), directors)
@@ -620,6 +622,27 @@ mod tests {
         let v1 = cat.iter().find(|e| e.id == "v1").unwrap();
         assert_eq!(v1.rating, 0.0);
         assert!(v1.genres.is_empty());
+    }
+
+    #[test]
+    fn a_person_credited_twice_joins_their_collection_once() {
+        let items: Vec<MediaItem> = (0..MIN_ITEMS)
+            .map(|i| {
+                item(
+                    &format!("m{i}"),
+                    &format!("Film {i}"),
+                    Kind::Movie,
+                    Some(meta(8.0, &["Drama"], &["Villeneuve", "Villeneuve"])),
+                )
+            })
+            .collect();
+
+        let cat = build_catalog(&items, &[]);
+        let rows = director_collections(&cat);
+
+        assert_eq!(cat[0].directors, vec!["Villeneuve"]);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].item_ids.len(), MIN_ITEMS);
     }
 
     #[test]

--- a/server/crates/kroma-engine/src/services/sections/mod.rs
+++ b/server/crates/kroma-engine/src/services/sections/mod.rs
@@ -47,7 +47,7 @@ pub fn build_home(state: &SharedState, pool: &Pool, locale: &str, user_id: &str)
     let mut out = Builder {
         pool,
         sections: Vec::new(),
-        seen: HashSet::new(),
+        seen: ctx.in_progress.iter().cloned().collect(),
     };
 
     // Reserve the tail slots for the baseline browse rows (Trending, plus
@@ -114,7 +114,7 @@ pub fn build_home(state: &SharedState, pool: &Pool, locale: &str, user_id: &str)
 // horror film) and this row claims a specific resemblance to one seed. No-op when
 // the seed has no genres, or with a discriminative backend.
 fn push_because(out: &mut Builder, state: &SharedState, pool: &Pool, ctx: &Context, locale: &str) {
-    if let Some(last) = &ctx.last_played {
+    if let Some(last) = &ctx.last_finished {
         if let Some(title) = last_title(pool, last) {
             let heading = i18n::t(locale, "content.becauseYouWatched", &[("title", &title)]);
             let ranked = db::genre_guard(pool, last, state.vectors.similar(last, FETCH));
@@ -268,11 +268,12 @@ impl Builder<'_> {
         if self.sections.len() >= MAX_SECTIONS {
             return false;
         }
+        let mut taken: HashSet<&str> = HashSet::new();
         let fresh: Vec<&str> = ranked
             .iter()
             .filter(|(_, score)| *score >= floor)
             .map(|(id, _)| id.as_str())
-            .filter(|i| !self.seen.contains(*i))
+            .filter(|i| !self.seen.contains(*i) && taken.insert(*i))
             .take(SECTION_CAP)
             .collect();
         if fresh.len() < MIN_ITEMS {
@@ -297,11 +298,7 @@ impl Builder<'_> {
 }
 
 fn last_title(pool: &Pool, id: &str) -> Option<String> {
-    db::items_by_ids(pool, &[id])
-        .ok()?
-        .into_iter()
-        .next()
-        .map(|i| i.title)
+    db::get_title(pool, id).ok()?.map(|t| t.title)
 }
 
 #[cfg(test)]
@@ -448,6 +445,28 @@ mod tests {
     }
 
     #[test]
+    fn a_ranked_list_that_repeats_a_title_spends_one_slot_on_it() {
+        let pool = test_pool();
+        let ids: Vec<String> = (0..SECTION_CAP).map(|i| format!("m{i}")).collect();
+        let refs: Vec<&str> = ids.iter().map(String::as_str).collect();
+        seed_movies(&pool, &refs);
+        let mut b = Builder {
+            pool: &pool,
+            sections: Vec::new(),
+            seen: HashSet::new(),
+        };
+        let ranked: Vec<(String, f32)> = ids
+            .iter()
+            .flat_map(|id| [(id.clone(), 1.0), (id.clone(), 1.0)])
+            .collect();
+
+        assert!(b.push("row1", "Row".into(), None, ranked, NO_FLOOR));
+
+        let shown: Vec<&str> = b.sections[0].items.iter().map(|i| i.id()).collect();
+        assert_eq!(shown, refs);
+    }
+
+    #[test]
     fn builder_push_rejects_once_at_max_sections() {
         let pool = test_pool();
         seed_movies(&pool, &["a", "b", "c", "d", "e"]);
@@ -582,6 +601,26 @@ mod tests {
         assert_eq!(recent.items.len(), 6);
         // The quality gate means every emitted row clears MIN_ITEMS (nothing thin).
         assert!(sections.iter().all(|s| s.items.len() >= MIN_ITEMS));
+    }
+
+    #[test]
+    fn a_film_left_half_watched_is_not_offered_again_under_the_continue_rail() {
+        let state = test_support::test_state();
+        let ids: Vec<String> = (0..8).map(|i| format!("m{i}")).collect();
+        let refs: Vec<&str> = ids.iter().map(String::as_str).collect();
+        seed_movies(&state.db, &refs);
+        let user = crate::db::create_user(&state.db, "cw@t.dev", "Cw", "h", &[])
+            .unwrap()
+            .id;
+        crate::db::upsert_progress(&state.db, &user, "m0", 60_000, Some(600_000)).unwrap();
+
+        let sections = build_home(&state, &state.db, "en", &user);
+
+        assert!(sections.iter().any(|s| s.id == "recent"));
+        assert!(sections
+            .iter()
+            .flat_map(|s| &s.items)
+            .all(|i| i.id() != "m0"));
     }
 
     #[test]

--- a/server/crates/kroma-engine/src/services/sections/phrases.rs
+++ b/server/crates/kroma-engine/src/services/sections/phrases.rs
@@ -157,8 +157,9 @@ mod tests {
             month,
             weekday,
             part_of_day: part,
-            last_played: None,
+            last_finished: None,
             watched: Vec::new(),
+            in_progress: Vec::new(),
         }
     }
 


### PR DESCRIPTION
## What

Two things, both on `/api/home`.

**No title twice on the screen.** The generator already de-dupes its rows against
each other, but "Continue watching" is a separate endpoint the shells draw above
them, so a film left half-watched came back a second time in a row underneath it.
`build_home` seeds its `seen` set with the ids that rail already holds, parent
shows included. A row that comes up short because of it comes up short: nine
titles rather than ten beats the same one twice.

Inside a row, a repeated id used to spend one of the twenty slots and then vanish
at hydration, where the id-keyed `HashMap` collapses it. Ranked vector rows cannot
repeat themselves, but a curated row's members are stored JSON, so a row written
before the resolver de-duped shortened the shelf instead of filling it. `push`
counts distinct ids now. Upstream of that, TMDB credits a person once per job, so
whoever both directed and created a title appeared twice in its crew and put the
title into their director collection twice.

**"Parce que vous avez regardé" means you finished it.** The seed was the newest
`play_history` row, which five seconds of a film is enough to write. It is the
newest *finished* title instead, where finished means what it already means in
"Continue watching": marked watched, or left past 95% of the runtime. That
threshold was written out three times and is one `FINISHED_PERCENT` now. An
episode answers as its parent show, which is also the only one of the two carrying
an embedding, so the row finally has something to rank from when the last thing
you finished was a series.

Deliberately left alone: the "For You" centroid and the featured hero still read
`recent_watched_ids`, every play regardless of length. Same signal, wider blast
radius, worth its own change if you want it.

## Closes

No issue. Reported in conversation: rails repeating a title, and a five-second
sample naming the "because you watched" row.

## Checks

- [x] `cargo clippy --workspace --all-targets` clean on the touched files (the
      pre-existing warnings elsewhere are unchanged)
- [x] `cargo test --workspace` green
- [x] Both fixes verified by reverting them: the two new tests fail without the
      change and pass with it
- [x] No new comments; the two new doc comments are on exported functions

## Risk

Rows can get shorter. Priming `seen` from "Continue watching" removes candidates
before the `MIN_ITEMS` gate, so on a small library a row that used to squeak past
five items can now vanish. Over-fetch is `SECTION_CAP + 16`, so a normal library
absorbs it. A reviewer would notice as a missing rail on the home of an account
with a long Continue list and few titles.

"Because you watched" can also disappear where it used to always appear: an
account that has started things but finished nothing gets no seed, which is the
intended reading of the bug.
