### PR TITLE
feat(player): the pointer that leaves with the chrome

### DIFF
--- a/packages/ui/src/components/organisms/player/hooks/use-idle-cursor.test.ts
+++ b/packages/ui/src/components/organisms/player/hooks/use-idle-cursor.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useIdleCursor } from './use-idle-cursor';
+
+const rule = () => document.getElementById('kroma-player-idle-cursor')?.textContent ?? null;
+
+describe('useIdleCursor', () => {
+  it('takes the pointer away while the chrome is away and gives it back with it', () => {
+    const view = renderHook(({ hidden }) => useIdleCursor(hidden), {
+      initialProps: { hidden: false },
+    });
+
+    expect(rule()).toBeNull();
+
+    view.rerender({ hidden: true });
+    expect(rule()).toContain('cursor: none !important');
+
+    view.rerender({ hidden: false });
+    expect(rule()).toBeNull();
+  });
+
+  it('claims the player root and everything under it, so a control keeps no hand', () => {
+    renderHook(() => useIdleCursor(true));
+
+    expect(rule()).toContain('#kroma-player, #kroma-player *');
+  });
+
+  it('leaves no rule behind when the player unmounts hidden', () => {
+    const view = renderHook(() => useIdleCursor(true));
+
+    view.unmount();
+
+    expect(rule()).toBeNull();
+  });
+});

--- a/packages/ui/src/components/organisms/player/hooks/use-idle-cursor.ts
+++ b/packages/ui/src/components/organisms/player/hooks/use-idle-cursor.ts
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+import { webDocument } from '#ui/lib/dom';
+
+/** The player root's element id, which the idle-cursor rule hooks onto. */
+export const PLAYER_ROOT_ID = 'kroma-player';
+
+const IDLE_STYLE_ID = 'kroma-player-idle-cursor';
+
+// Every element under the root, with `!important`, rather than one `cursor` on
+// the root: the cursor is read off whatever the pointer is over, and the stage
+// is a button, so the kit reset's hand beats anything merely inherited down.
+const IDLE_RULE = `#${PLAYER_ROOT_ID}, #${PLAYER_ROOT_ID} * { cursor: none !important; }`;
+
+/**
+ * Takes the pointer away while the chrome is away, and gives it back with it -
+ * what YouTube's `ytp-autohide` does. A no-op on a target with no document.
+ */
+export function useIdleCursor(hidden: boolean): void {
+  useEffect(() => {
+    const doc = webDocument();
+    if (!hidden || !doc?.head) return;
+    const el = doc.createElement('style');
+    el.id = IDLE_STYLE_ID;
+    el.textContent = IDLE_RULE;
+    doc.head.append(el);
+    return () => el.remove();
+  }, [hidden]);
+}

--- a/packages/ui/src/components/organisms/player/player.tsx
+++ b/packages/ui/src/components/organisms/player/player.tsx
@@ -6,6 +6,7 @@ import { Box } from '#ui/components/atoms/box';
 import { Ground } from '#ui/components/atoms/ground';
 import { styles } from '#ui/core';
 import type { StoryboardTile } from '#ui/services/storyboard';
+import { PLAYER_ROOT_ID, useIdleCursor } from './hooks/use-idle-cursor';
 import { usePlayerCredits } from './hooks/use-player-credits';
 import { usePlayerKeys } from './hooks/use-player-keys';
 import { usePlayerNav } from './hooks/use-player-nav';
@@ -168,6 +169,8 @@ function Root({
     metrics.controls,
   );
 
+  useIdleCursor(flags.pointer && !nav.revealed);
+
   const creditsKey = (key: RemoteKey): boolean =>
     handleCreditsKey(key, creditsFocus, setCreditsFocus, () => onPlayNext?.(), credits.cancel);
 
@@ -216,6 +219,7 @@ function Root({
     <PlayerSlotContext.Provider value={true}>
       <Box
         ref={ref}
+        nativeID={PLAYER_ROOT_ID}
         fill
         z={60}
         // Transparent ONLY over a hardware plane, which is behind the page and


### PR DESCRIPTION
## What

The controls fade after 3.5 s of a still pointer and the arrow stayed behind, sitting over the film for the rest of the reel. YouTube answers this with one rule hung off the same class its controls fade under, `.ytp-autohide{cursor:none}`: the cursor is part of the chrome, so it leaves when the chrome leaves and returns on the first pointer move. Same seam here. `useIdleCursor` follows `nav.revealed`, which `usePlayerNav` already sets false only while a film runs with no panel open, so nothing new decides when the pointer should be away.

It is an injected rule over the root's whole subtree rather than a `cursor` on the root, because the cursor is read off whatever the pointer is standing over and the stage is a `role="button"`: the reset in `styles/reset.ts` gives it a hand that beats anything merely inherited down. That is the same reason `holdCursor` takes the page with `!important` for the length of a resize drag.

Televisions keep their pointer. A magic remote draws a real cursor and never emits the move that would bring it back, so the hiding is gated on `flags.pointer`, off on every TV shell.

## Closes

No issue. A one-behaviour gap in the player chrome, raised directly.

## Checks

- [x] `bun run check` and `bun run test` pass, with two exceptions that are not this change: `packages/tv/src/app/providers/auth.test.tsx` fails all 7 identically at the base commit (3126716f), and `apps/kit/src/kit.test.tsx` times out under full-suite load but passes 33/33 on its own, before and after.
- [ ] `cargo clippy` and `cargo test` pass, if the server changed — no Rust in this change.
- [x] Follows `CODE_STYLE.md` — no comments narrating the work, exported API only
- [x] One idea. If it grew a second, it was split.

Also verified in Chromium against the workbench player story rather than only in jsdom: playing plus 4 s still gives `cursor: none` under the pointer and on the stage while everything outside `#kroma-player` keeps its own; one mouse move restores it; paused never hides; under TV flags the chrome still fades and the cursor stays.

## Risk

Contained to the browser targets. If the rule were wrong the worst case is a pointer that stays hidden, and it would show up the moment you move the mouse over a playing film in any web or desktop shell. `flags.pointer` keeps it away from the televisions entirely.

One YouTube behaviour deliberately not copied, because it changes the chrome rather than the cursor: YouTube blocks the hide timer while the pointer rests over the control bar. Here, parking on the seek bar still fades the controls at 3.5 s and now takes the cursor with them. Worth a follow-up.
