### PR TITLE
chore(sonar): the eight open issues, and eleven files that had no test

### DIFF
--- a/clients/desktop/src-tauri/src/mpv/launch.rs
+++ b/clients/desktop/src-tauri/src/mpv/launch.rs
@@ -34,7 +34,7 @@ fn ytdlp_shim_dir() -> Option<PathBuf> {
     if !stub.exists() {
         std::fs::write(&stub, "#!/bin/sh\nexit 0\n").ok()?;
     }
-    std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755)).ok()?;
+    std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o700)).ok()?;
     Some(dir)
 }
 

--- a/clients/mobile/src/player/trackOptions.test.ts
+++ b/clients/mobile/src/player/trackOptions.test.ts
@@ -1,0 +1,169 @@
+import type { AudioTrack, MediaItem } from '@kroma/core';
+import type { AudioTrack as LocalAudioTrack } from 'expo-video';
+import { describe, expect, it } from 'vitest';
+import type { useT } from '#mobile/lib/i18n';
+import type { Engine } from './engine';
+import { audioOptions, qualityBadge, subNote, subtitleLabel } from './trackOptions';
+import type { Subtitles } from './useSubtitles';
+
+const NAMES: Record<string, string> = {
+  'lang.fr': 'Français',
+  'lang.fr-FR': 'Français (France)',
+  'lang.en': 'Anglais',
+  'player.subtitlesOff': 'Désactivés',
+  'player.subPreparing': 'Préparation',
+  'error.subtitleUnavailable': 'Indisponible',
+};
+const t = ((key: string) => NAMES[key] ?? key) as ReturnType<typeof useT>;
+
+const track = (fields: Partial<AudioTrack>): AudioTrack => ({
+  index: 0,
+  codec: 'eac3',
+  channels: 6,
+  language: 'fra',
+  title: null,
+  default: false,
+  ...fields,
+});
+
+const item = (tracks: AudioTrack[]): MediaItem =>
+  ({ audioTracks: tracks, audio: tracks[0] ?? null }) as MediaItem;
+
+const engine = (fields: Partial<Engine>): Engine =>
+  ({ offline: false, localAudio: [], ...fields }) as Engine;
+
+const subs = (fields: Partial<Subtitles>): Subtitles =>
+  ({ tracks: [], active: null, loading: false, failed: new Set<number>(), ...fields }) as Subtitles;
+
+describe('the audio picker while streaming from the server', () => {
+  it('keeps the stream index the server knows the track by', () => {
+    const options = audioOptions(engine({}), item([track({ index: 3 })]), t);
+
+    expect(options[0].index).toBe(3);
+  });
+
+  it('refines the language by the variant in the title, so a dub is remembered', () => {
+    const options = audioOptions(engine({}), item([track({ title: 'VFF 5.1' })]), t);
+
+    expect(options[0].prefCode).toBe('fr-FR');
+  });
+
+  it('falls back to a numbered label when the track says nothing at all', () => {
+    const options = audioOptions(
+      engine({}),
+      item([track({ language: null, codec: '', channels: null })]),
+      t,
+    );
+
+    expect(options[0].label).toBe('#1');
+  });
+});
+
+describe('the audio picker over an offline download', () => {
+  it('numbers the tracks the way the local file does, not the way the server did', () => {
+    const local = [{ language: 'fra', label: 'VF' }, { language: 'eng' }] as LocalAudioTrack[];
+
+    const options = audioOptions(
+      engine({ offline: true, localAudio: local }),
+      item([track({ index: 7 }), track({ index: 9, language: 'eng' })]),
+      t,
+    );
+
+    expect(options.map((o) => o.index)).toEqual([0, 1]);
+  });
+
+  it('borrows the server label when the two track lists line up', () => {
+    const local = [{ language: 'fra', label: 'track 1' }] as LocalAudioTrack[];
+
+    const options = audioOptions(
+      engine({ offline: true, localAudio: local }),
+      item([track({ title: 'Français VFF' })]),
+      t,
+    );
+
+    expect(options[0].label).toBe('Français VFF · 5.1 · EAC3');
+  });
+
+  it('reads the local label when the counts disagree, since the pairing is a guess', () => {
+    const local = [{ language: 'fra', label: 'VF' }, { language: 'eng' }] as LocalAudioTrack[];
+
+    const options = audioOptions(
+      engine({ offline: true, localAudio: local }),
+      item([track({ title: 'Français VFF' })]),
+      t,
+    );
+
+    expect(options.map((o) => o.label)).toEqual(['VF', 'Anglais']);
+  });
+
+  it('numbers a local track that carries neither label nor language', () => {
+    const local = [{ language: null, label: '  ' }] as unknown as LocalAudioTrack[];
+
+    const options = audioOptions(engine({ offline: true, localAudio: local }), item([]), t);
+
+    expect(options[0].label).toBe('#1');
+  });
+});
+
+describe('the subtitle button', () => {
+  it('says subtitles are off when none is picked', () => {
+    expect(subtitleLabel(subs({}), t)).toBe('Désactivés');
+  });
+
+  it('names the picked track by its own label', () => {
+    const tracks = [{ index: 2, language: 'fra', url: '', label: 'Forcés' }];
+
+    expect(subtitleLabel(subs({ active: 2, tracks }), t)).toBe('Forcés');
+  });
+
+  it('falls back to the language when the track carries no label', () => {
+    const tracks = [{ index: 2, language: 'fra', url: '' }];
+
+    expect(subtitleLabel(subs({ active: 2, tracks }), t)).toBe('Français');
+  });
+
+  it('numbers a picked track the list no longer holds', () => {
+    expect(subtitleLabel(subs({ active: 4, tracks: [] }), t)).toBe('#5');
+  });
+});
+
+describe('the note under a subtitle row', () => {
+  it('stays absent for a track that is ready', () => {
+    expect(subNote(t, subs({ active: 1 }), 1)).toBeUndefined();
+  });
+
+  it('marks a track whose cues could not be fetched', () => {
+    expect(subNote(t, subs({ failed: new Set([1]) }), 1)).toBe('Indisponible');
+  });
+
+  it('marks only the row being prepared, not its neighbours', () => {
+    const preparing = subs({ active: 1, loading: true });
+
+    expect(subNote(t, preparing, 1)).toBe('Préparation');
+    expect(subNote(t, preparing, 2)).toBeUndefined();
+  });
+});
+
+describe('the quality suffix on the title line', () => {
+  it('says nothing for a title with no video track', () => {
+    expect(qualityBadge({ video: null } as MediaItem)).toBe('');
+  });
+
+  it('reads the height, the codec and HDR, separated from the title', () => {
+    const movie = { video: { height: 2160, codec: 'hevc', hdr: true } } as MediaItem;
+
+    expect(qualityBadge(movie)).toBe(' · 2160p HEVC HDR');
+  });
+
+  it('drops the parts the track does not know', () => {
+    const movie = { video: { height: null, codec: 'h264', hdr: false } } as MediaItem;
+
+    expect(qualityBadge(movie)).toBe(' · H264');
+  });
+
+  it('says nothing when the track knows nothing worth showing', () => {
+    const movie = { video: { height: null, codec: '', hdr: false } } as MediaItem;
+
+    expect(qualityBadge(movie)).toBe('');
+  });
+});

--- a/clients/web/src/features/admin/ai-provider-spec.test.ts
+++ b/clients/web/src/features/admin/ai-provider-spec.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { BASE_HINT_KEY, hostOf, PROVIDER_BASE, SPEC, SPEC_OPENAI } from './ai-provider-spec';
+
+describe('the host shown beside an AI provider', () => {
+  it('names Anthropic reaching its own API with no base URL typed', () => {
+    expect(hostOf('', true)).toBe('api.anthropic.com');
+  });
+
+  it('shows nothing for any other provider with no base URL typed', () => {
+    expect(hostOf('', false)).toBe('');
+  });
+
+  it('keeps only the host of a URL, dropping scheme and path', () => {
+    expect(hostOf('https://openrouter.ai/api/v1', false)).toBe('openrouter.ai');
+  });
+
+  it('keeps the port, since that is what a self-hosted runtime is reached on', () => {
+    expect(hostOf('http://localhost:11434/v1', false)).toBe('localhost:11434');
+  });
+
+  it('echoes what was typed back when it does not parse as a URL', () => {
+    expect(hostOf('not a url', true)).toBe('not a url');
+  });
+});
+
+describe('what each provider asks the form for', () => {
+  it('prefills only OpenRouter, whose endpoint is fixed', () => {
+    expect(PROVIDER_BASE.openrouter).toBe('https://openrouter.ai/api/v1');
+    expect(PROVIDER_BASE.openai).toBe('');
+    expect(PROVIDER_BASE.anthropic).toBe('');
+  });
+
+  it('demands a base URL only where the operator picks the endpoint', () => {
+    expect(SPEC.openai?.baseUrl).toBe('required');
+    expect(SPEC.openrouter?.baseUrl).toBe('advanced');
+    expect(SPEC.anthropic?.baseUrl).toBe('advanced');
+  });
+
+  it('offers temperature everywhere but Anthropic, and reasoning only there', () => {
+    expect(SPEC.anthropic).toMatchObject({ temperature: false, reasoning: true });
+    expect(SPEC.openai).toMatchObject({ temperature: true, reasoning: false });
+    expect(SPEC.openrouter).toMatchObject({ temperature: true, reasoning: false });
+  });
+
+  it('lays an unknown provider out the way OpenAI is laid out', () => {
+    expect(SPEC.ollama).toBeUndefined();
+    expect(SPEC_OPENAI).toMatchObject({ baseUrl: 'required', apiKey: 'optional' });
+  });
+
+  it('hints at a base URL only where one is hidden behind the advanced fold', () => {
+    expect(Object.keys(BASE_HINT_KEY).sort()).toEqual(['anthropic', 'openrouter']);
+  });
+});

--- a/clients/web/src/features/catalog/media-labels.test.ts
+++ b/clients/web/src/features/catalog/media-labels.test.ts
@@ -1,0 +1,116 @@
+import type { AudioTrack, MediaItem, Translate, VideoTrack } from '@kroma/core';
+import { describe, expect, it } from 'vitest';
+import { audioFlagLabel, audioString, qualityBadges, subString } from './media-labels';
+
+const NAMES: Record<string, string> = {
+  'lang.fr': 'Français',
+  'lang.en': 'Anglais',
+  'content.audioHighDynamics': 'Écarts marqués',
+  'content.audioQuietDialog': 'Dialogues bas',
+  'subtitle.none': 'Aucun',
+};
+const t = ((key: string) => NAMES[key] ?? key) as Translate;
+
+const video = (fields: Partial<VideoTrack>): VideoTrack => ({
+  codec: 'h264',
+  width: 1920,
+  height: 1080,
+  hdr: false,
+  bitDepth: 8,
+  ...fields,
+});
+
+const audio = (fields: Partial<AudioTrack>): AudioTrack => ({
+  index: 0,
+  codec: 'aac',
+  channels: 2,
+  language: 'fra',
+  title: null,
+  default: true,
+  ...fields,
+});
+
+describe('the quality pills beside the meta line', () => {
+  it('shows nothing for a title with no video track', () => {
+    expect(qualityBadges(null)).toEqual([]);
+  });
+
+  it('leaves a 1080p SDR H.264 title unmarked', () => {
+    expect(qualityBadges(video({}))).toEqual([]);
+  });
+
+  it('reads width rather than height, so a scope 4K master still counts', () => {
+    expect(qualityBadges(video({ width: 3840, height: 1608 }))).toEqual(['4K']);
+  });
+
+  it('stacks every pill a 4K HDR H.265 master earns, widest first', () => {
+    expect(qualityBadges(video({ width: 3840, hdr: true, codec: 'hevc' }))).toEqual([
+      '4K',
+      'HDR',
+      'H.265',
+    ]);
+  });
+});
+
+describe('the audio line', () => {
+  it('reads a dash when the title has no audio track', () => {
+    expect(audioString(t, { audio: null })).toBe('-');
+  });
+
+  it('names the language first, then the codec and the layout', () => {
+    expect(audioString(t, { audio: audio({ codec: 'eac3', channels: 6 }) })).toBe(
+      'Français · EAC3 5.1',
+    );
+  });
+
+  it('drops the separator when the language is the only thing known', () => {
+    expect(audioString(t, { audio: audio({ codec: '', channels: null }) })).toBe('Français');
+  });
+
+  it('falls back to the technical half when the track names no language', () => {
+    expect(audioString(t, { audio: audio({ language: null }) })).toBe('AAC 2.0');
+  });
+});
+
+describe('the loudness warning pill', () => {
+  it('stays silent for a mix nothing is wrong with', () => {
+    expect(audioFlagLabel(t, { audioAnalysis: null })).toBeNull();
+  });
+
+  it('stays silent for a title the pipeline has not measured', () => {
+    expect(audioFlagLabel(t, undefined)).toBeNull();
+  });
+
+  it('names the verdict when the dialog sits too low', () => {
+    const analysis = { lufsI: -27, lra: 14, truePeak: -1, verdict: 'quietDialog' } as const;
+
+    expect(audioFlagLabel(t, { audioAnalysis: analysis })).toBe('Dialogues bas');
+  });
+
+  it('names the verdict when the range is too wide', () => {
+    const analysis = { lufsI: -24, lra: 22, truePeak: -1, verdict: 'highDynamics' } as const;
+
+    expect(audioFlagLabel(t, { audioAnalysis: analysis })).toBe('Écarts marqués');
+  });
+});
+
+describe('the subtitle line', () => {
+  const sub = (language: string | null): MediaItem['subtitles'][number] => ({
+    language,
+    codec: 'subrip',
+  });
+
+  it('says so when the title carries no subtitles', () => {
+    expect(subString(t, { subtitles: [] })).toBe('Aucun');
+  });
+
+  it('names each language once, however many tracks spell it', () => {
+    expect(subString(t, { subtitles: [sub('fra'), sub('fre'), sub('eng')] })).toBe(
+      'Français, Anglais',
+    );
+  });
+
+  it('drops a track with no language rather than showing a gap', () => {
+    expect(subString(t, { subtitles: [sub(null), sub('fra')] })).toBe('Français');
+  });
+});

--- a/modules/tv.kroma.remote/module.json
+++ b/modules/tv.kroma.remote/module.json
@@ -3,7 +3,7 @@
   "schemaVersion": 2,
   "id": "tv.kroma.remote",
   "name": "Remote access",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Public HTTPS access: the share / Quick Connect URL plus an optional managed Cloudflare Tunnel connector. Disable it to hide the page + routes.",
   "engines": {
     "server": ">=0.1.39"

--- a/modules/tv.kroma.remote/server/src/provision.rs
+++ b/modules/tv.kroma.remote/server/src/provision.rs
@@ -101,7 +101,7 @@ pub async fn download(data_dir: &Path) -> Result<PathBuf, String> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o755));
+        let _ = std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o700));
     }
 
     // Validate: it must actually run, else discard the (partial/corrupt) file.

--- a/modules/tv.kroma.vpn/module.json
+++ b/modules/tv.kroma.vpn/module.json
@@ -3,7 +3,7 @@
   "schemaVersion": 2,
   "id": "tv.kroma.vpn",
   "name": "VPN",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Managed WireGuard bridge (any provider) that torrent traffic routes through, with a live seal test. Disable it to stop the bridge and hide its page + routes.",
   "engines": {
     "server": ">=0.1.39"

--- a/modules/tv.kroma.vpn/server/src/provision.rs
+++ b/modules/tv.kroma.vpn/server/src/provision.rs
@@ -95,7 +95,7 @@ async fn download(data_dir: &Path) -> Result<PathBuf, String> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o755));
+        let _ = std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o700));
     }
 
     let runs = Command::new(&dest)

--- a/packages/react-audit/src/analyse.test.ts
+++ b/packages/react-audit/src/analyse.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { type Commit, churn, components, hosts, rerenders, type Work } from './analyse';
+
+const work = (mounted: number, updated: number): Work => ({ mounted, updated });
+
+const commit = (fields: Partial<Commit>): Commit => ({
+  touched: 0,
+  work: {},
+  census: {},
+  hosts: {},
+  deleted: {},
+  ms: 0,
+  ...fields,
+});
+
+describe('the components that did work', () => {
+  it('reads nothing out of no commits', () => {
+    expect(components([])).toEqual([]);
+  });
+
+  it('sums a component across every commit it appears in', () => {
+    const commits = [commit({ work: { Row: work(3, 0) } }), commit({ work: { Row: work(0, 4) } })];
+
+    expect(components(commits)).toEqual([['Row', { mounted: 3, updated: 4 }]]);
+  });
+
+  it('ranks one remount above nine re-renders, because it costs more', () => {
+    const commits = [commit({ work: { Rail: work(0, 9), Tile: work(1, 0) } })];
+
+    expect(components(commits).map(([name]) => name)).toEqual(['Tile', 'Rail']);
+  });
+});
+
+describe('the components destroyed while the screen still needed them', () => {
+  it('reads nothing out of a mount with nothing after it', () => {
+    expect(churn([commit({ census: { Tile: 4 } })])).toEqual([]);
+  });
+
+  it('reads nothing out of no commits at all', () => {
+    expect(churn([])).toEqual([]);
+  });
+
+  it('names a component deleted and still on screen afterwards', () => {
+    const commits = [
+      commit({ census: { Tile: 4 } }),
+      commit({ deleted: { Tile: 4 }, census: { Tile: 4 } }),
+    ];
+
+    expect(churn(commits)).toEqual([['Tile', 4]]);
+  });
+
+  it('leaves a menu that was closed alone, since nothing rebuilt it', () => {
+    const commits = [
+      commit({ census: { Menu: 1, Tile: 4 } }),
+      commit({ deleted: { Menu: 1 }, census: { Tile: 4 } }),
+    ];
+
+    expect(churn(commits)).toEqual([]);
+  });
+
+  it('adds up deletions across every commit after the mount, worst first', () => {
+    const commits = [
+      commit({ census: { Tile: 1, Row: 1 } }),
+      commit({ deleted: { Tile: 1, Row: 3 }, census: { Tile: 1, Row: 1 } }),
+      commit({ deleted: { Tile: 5 }, census: { Tile: 1, Row: 1 } }),
+    ];
+
+    expect(churn(commits)).toEqual([
+      ['Tile', 6],
+      ['Row', 3],
+    ]);
+  });
+});
+
+describe('the fibers that ran again', () => {
+  it('does not count the mount, which is the first commit', () => {
+    expect(rerenders([commit({ work: { Row: work(0, 7) } })])).toBe(0);
+  });
+
+  it('counts updates and ignores mounts, across every later commit', () => {
+    const commits = [
+      commit({}),
+      commit({ work: { Row: work(2, 3), Tile: work(0, 4) } }),
+      commit({ work: { Row: work(0, 1) } }),
+    ];
+
+    expect(rerenders(commits)).toBe(8);
+  });
+});
+
+describe('the host elements on screen once everything settled', () => {
+  it('reads nothing out of no commits', () => {
+    expect(hosts([])).toEqual([]);
+  });
+
+  it('reads the last commit, not the sum, and orders by count', () => {
+    const commits = [
+      commit({ hosts: { div: 90, span: 1 } }),
+      commit({ hosts: { div: 3, span: 7 } }),
+    ];
+
+    expect(hosts(commits)).toEqual([
+      ['span', 7],
+      ['div', 3],
+    ]);
+  });
+});

--- a/packages/react-audit/src/report.test.ts
+++ b/packages/react-audit/src/report.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import type { Commit } from './analyse';
+import type { Result } from './record';
+import { formatResult } from './report';
+
+const result = (fields: Partial<Result>): Result => ({
+  commits: [] as readonly Commit[],
+  churn: [],
+  rerenders: 0,
+  components: [],
+  elements: [],
+  elementCount: 0,
+  ...fields,
+});
+
+describe('a result as a person reads it', () => {
+  it('opens with the four totals, whatever else it has to say', () => {
+    const clean = result({ commits: [{}, {}] as unknown as readonly Commit[], elementCount: 42 });
+
+    expect(formatResult(clean)).toBe('2 commits  42 elements  0 churned  0 re-rendered');
+  });
+
+  it('adds the churned fibers up rather than counting the components they came from', () => {
+    const churned = result({
+      churn: [
+        ['Tile', 6],
+        ['Row', 3],
+      ],
+    });
+
+    expect(formatResult(churned).split('\n')[0]).toContain('9 churned');
+  });
+
+  it('lists what was destroyed and rebuilt, count first and right-aligned', () => {
+    const churned = result({ churn: [['Tile', 6]] });
+
+    expect(formatResult(churned)).toBe(
+      [
+        '0 commits  0 elements  6 churned  0 re-rendered',
+        '',
+        'destroyed and rebuilt:',
+        '      6  Tile',
+      ].join('\n'),
+    );
+  });
+
+  it('leaves out a component that only mounted, since nothing re-rendered', () => {
+    const mounted = result({ components: [['Tile', { mounted: 4, updated: 0 }]] });
+
+    expect(formatResult(mounted)).not.toContain('re-rendered:');
+  });
+
+  it('lists only the components that re-rendered', () => {
+    const mixed = result({
+      components: [
+        ['Rail', { mounted: 0, updated: 9 }],
+        ['Tile', { mounted: 4, updated: 0 }],
+      ],
+    });
+
+    expect(formatResult(mixed)).toContain('      9  Rail');
+    expect(formatResult(mixed)).not.toContain('Tile');
+  });
+
+  it('stops at the limit rather than printing every offender', () => {
+    const many = result({
+      churn: Array.from({ length: 20 }, (_, i) => [`C${i}`, 20 - i] as const),
+    });
+
+    expect(formatResult(many, 3).split('\n')).toHaveLength(6);
+  });
+});

--- a/packages/registry/src/sort.test.ts
+++ b/packages/registry/src/sort.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { byCodeUnit } from './sort';
+
+describe('the machine-independent string ordering', () => {
+  it('orders a pair the way their code units run', () => {
+    expect(byCodeUnit('a', 'b')).toBe(-1);
+    expect(byCodeUnit('b', 'a')).toBe(1);
+  });
+
+  it('reads two equal strings as equal', () => {
+    expect(byCodeUnit('tv.kroma.vpn', 'tv.kroma.vpn')).toBe(0);
+  });
+
+  it('keeps every capital before every lowercase, as a locale sort would not', () => {
+    expect(['b', 'A', 'a', 'B'].sort(byCodeUnit)).toEqual(['A', 'B', 'a', 'b']);
+  });
+
+  it('orders accents by code point rather than beside their base letter', () => {
+    expect(byCodeUnit('zoo', 'école')).toBe(-1);
+  });
+});

--- a/packages/tv/src/features/catalog/home/sectionEntry.test.ts
+++ b/packages/tv/src/features/catalog/home/sectionEntry.test.ts
@@ -1,0 +1,29 @@
+import type { MediaItem, SectionItem, Show } from '@kroma/core';
+import { describe, expect, it } from 'vitest';
+import { entryId, entryMetadata } from './sectionEntry';
+
+const METADATA = { tmdbId: 1, overview: 'a' } as unknown as MediaItem['metadata'];
+
+const movie: SectionItem = {
+  type: 'movie',
+  item: { id: 'it_1', metadata: METADATA } as MediaItem,
+};
+const show: SectionItem = {
+  type: 'show',
+  show: { id: 'sh_1', metadata: METADATA } as Show,
+};
+
+describe('a recommendation row entry, which is a movie or a show', () => {
+  it('reads the id off the item when the row mixed in a film', () => {
+    expect(entryId(movie)).toBe('it_1');
+  });
+
+  it('reads the id off the show when the row mixed in a series', () => {
+    expect(entryId(show)).toBe('sh_1');
+  });
+
+  it('reaches the artwork through whichever half the entry carries', () => {
+    expect(entryMetadata(movie)).toBe(METADATA);
+    expect(entryMetadata(show)).toBe(METADATA);
+  });
+});

--- a/packages/ui/src/components/organisms/player/player-input.test.ts
+++ b/packages/ui/src/components/organisms/player/player-input.test.ts
@@ -1,0 +1,194 @@
+import type { RemoteKey } from '@kroma/core';
+import type { Dispatch, SetStateAction } from 'react';
+import { describe, expect, it, type Mock, vi } from 'vitest';
+import type { usePlayerNav } from './hooks/use-player-nav';
+import { handleCreditsKey, handlePostPlayKey, playerInputHandlers } from './player-input';
+import { type PlayerController, type PlayerFlags, WEB_FLAGS } from './types';
+
+function applied<T extends string>(
+  setFocus: Mock<Dispatch<SetStateAction<T>>>,
+  from: NoInfer<T>,
+): T[] {
+  return setFocus.mock.calls.map(([next]) => (typeof next === 'function' ? next(from) : next));
+}
+
+function credits(focus: 'play' | 'cancel') {
+  const setFocus = vi.fn<Dispatch<SetStateAction<'play' | 'cancel'>>>();
+  const onPlay = vi.fn();
+  const onCancel = vi.fn();
+  const press = (key: RemoteKey) => handleCreditsKey(key, focus, setFocus, onPlay, onCancel);
+  return { setFocus, onPlay, onCancel, press };
+}
+
+function postPlay(focus: 'play' | 'home') {
+  const setFocus = vi.fn<Dispatch<SetStateAction<'play' | 'home'>>>();
+  const onPlay = vi.fn();
+  const onHome = vi.fn();
+  const press = (key: RemoteKey) => handlePostPlayKey(key, focus, setFocus, onPlay, onHome);
+  return { setFocus, onPlay, onHome, press };
+}
+
+describe('the remote over the up-next card in the credits', () => {
+  it('swaps the two buttons on either horizontal key', () => {
+    const { setFocus, press } = credits('play');
+
+    press('Left');
+    press('Right');
+
+    expect(applied(setFocus, 'play')).toEqual(['cancel', 'cancel']);
+    expect(applied(setFocus, 'cancel')).toEqual(['play', 'play']);
+  });
+
+  it('takes the button that is focused when Enter arrives', () => {
+    const focused = credits('play');
+    const other = credits('cancel');
+
+    focused.press('Enter');
+    other.press('Enter');
+
+    expect(focused.onPlay).toHaveBeenCalledOnce();
+    expect(other.onCancel).toHaveBeenCalledOnce();
+  });
+
+  it('dismisses the card on Back wherever the focus sits', () => {
+    const { onCancel, onPlay, press } = credits('play');
+
+    press('Back');
+
+    expect(onCancel).toHaveBeenCalledOnce();
+    expect(onPlay).not.toHaveBeenCalled();
+  });
+
+  it('claims the keys it acts on and leaves the rest to the player', () => {
+    const { press } = credits('play');
+
+    expect(['Left', 'Right', 'Enter', 'Back'].map((k) => press(k as RemoteKey))).toEqual([
+      true,
+      true,
+      true,
+      true,
+    ]);
+    expect(['Up', 'Down', 'Play', 'Stop'].map((k) => press(k as RemoteKey))).toEqual([
+      false,
+      false,
+      false,
+      false,
+    ]);
+  });
+});
+
+describe('the remote over the end screen', () => {
+  it('swaps play and home on either horizontal key', () => {
+    const { setFocus, press } = postPlay('play');
+
+    press('Right');
+
+    expect(applied(setFocus, 'play')).toEqual(['home']);
+    expect(applied(setFocus, 'home')).toEqual(['play']);
+  });
+
+  it('takes the focused button on Enter and on either transport key', () => {
+    const { onPlay, press } = postPlay('play');
+
+    for (const key of ['Enter', 'Play', 'PlayPause'] as const) press(key);
+
+    expect(onPlay).toHaveBeenCalledTimes(3);
+  });
+
+  it('leaves for home when the focus is on home', () => {
+    const { onHome, onPlay, press } = postPlay('home');
+
+    press('Enter');
+
+    expect(onHome).toHaveBeenCalledOnce();
+    expect(onPlay).not.toHaveBeenCalled();
+  });
+
+  it('leaves for home on Back, since there is no player left to return to', () => {
+    const { onHome, press } = postPlay('play');
+
+    press('Back');
+
+    expect(onHome).toHaveBeenCalledOnce();
+  });
+
+  it('ignores a key neither button answers', () => {
+    const { setFocus, onHome, onPlay, press } = postPlay('play');
+
+    press('Up');
+
+    expect(setFocus).not.toHaveBeenCalled();
+    expect(onHome).not.toHaveBeenCalled();
+    expect(onPlay).not.toHaveBeenCalled();
+  });
+});
+
+describe('the pointer and press handlers over the video', () => {
+  const build = (flags: Partial<PlayerFlags>, locked = false) => {
+    const nav = { poke: vi.fn() } as unknown as ReturnType<typeof usePlayerNav>;
+    const controller = {
+      togglePlay: vi.fn(),
+      toggleFullscreen: vi.fn(),
+    } as unknown as PlayerController;
+    const handlers = playerInputHandlers(nav, controller, { ...WEB_FLAGS, ...flags }, locked);
+    return { nav, controller, handlers };
+  };
+
+  it('wakes the chrome when a real mouse moves', () => {
+    const { nav, handlers } = build({});
+
+    handlers.onPointerMove({ nativeEvent: { pointerType: 'mouse' } });
+
+    expect(nav.poke).toHaveBeenCalledOnce();
+  });
+
+  it('ignores a touch, which already reaches the chrome as a press', () => {
+    const { nav, handlers } = build({});
+
+    handlers.onPointerMove({ nativeEvent: { pointerType: 'touch' } });
+
+    expect(nav.poke).not.toHaveBeenCalled();
+  });
+
+  it('ignores the phantom moves a magic remote emits on a television', () => {
+    const { nav, handlers } = build({ pointer: false });
+
+    handlers.onPointerMove({ nativeEvent: { pointerType: 'mouse' } });
+
+    expect(nav.poke).not.toHaveBeenCalled();
+  });
+
+  it('wakes the chrome and toggles playback on a press of the video', () => {
+    const { nav, controller, handlers } = build({});
+
+    handlers.onStagePress();
+
+    expect(nav.poke).toHaveBeenCalledOnce();
+    expect(controller.togglePlay).toHaveBeenCalledOnce();
+  });
+
+  it('takes nothing from a press while the controls are locked', () => {
+    const { nav, controller, handlers } = build({}, true);
+
+    handlers.onStagePress();
+
+    expect(nav.poke).not.toHaveBeenCalled();
+    expect(controller.togglePlay).not.toHaveBeenCalled();
+  });
+
+  it('reads a long press as the request for fullscreen', () => {
+    const { controller, handlers } = build({});
+
+    handlers.onStageLongPress();
+
+    expect(controller.toggleFullscreen).toHaveBeenCalledOnce();
+  });
+
+  it('leaves a long press alone where the platform has no fullscreen', () => {
+    const { controller, handlers } = build({ fullscreen: false });
+
+    handlers.onStageLongPress();
+
+    expect(controller.toggleFullscreen).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/organisms/resizable/resizable-cursor.native.test.ts
+++ b/packages/ui/src/components/organisms/resizable/resizable-cursor.native.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { holdCursor } from './resizable-cursor';
+
+describe('holdCursor on a platform with no cursor to hold', () => {
+  it('takes nothing, and gives back a release that does nothing', () => {
+    const release = holdCursor('vertical');
+
+    expect(release).toBeTypeOf('function');
+    expect(() => release()).not.toThrow();
+  });
+
+  it('answers either orientation with the same do-nothing release', () => {
+    expect(holdCursor('horizontal')).toBe(holdCursor('vertical'));
+  });
+});

--- a/packages/ui/src/lib/ring-room.test.ts
+++ b/packages/ui/src/lib/ring-room.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { RING_ROOM } from '#ui/core/tokens';
+import { ringRoomBlock, ringRoomInline } from './ring-room';
+
+describe('the room a focus ring needs inside a scroller', () => {
+  it('reaches out by the ring and pads back in by the same amount', () => {
+    expect(ringRoomBlock()).toEqual({
+      marginBlock: -RING_ROOM,
+      paddingBlock: RING_ROOM,
+      scrollPadding: RING_ROOM,
+    });
+  });
+
+  it('measures the reach from the padding the edge already carried', () => {
+    expect(ringRoomBlock(RING_ROOM)).toMatchObject({ marginBlock: 0, paddingBlock: RING_ROOM });
+  });
+
+  it('says the same thing on the inline axis', () => {
+    expect(ringRoomInline(4)).toEqual({
+      marginInline: 4 - RING_ROOM,
+      paddingInline: RING_ROOM,
+      scrollPadding: RING_ROOM,
+    });
+  });
+
+  it('brings the control into view with the room still around it', () => {
+    expect(ringRoomInline().scrollPadding).toBe(RING_ROOM);
+  });
+});

--- a/packages/workspace-tools/src/io/git.test.ts
+++ b/packages/workspace-tools/src/io/git.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { changedFiles, type Exec } from './git';
+
+describe('the files a range changed', () => {
+  it('asks git for names only, over the range it was handed', () => {
+    const seen: Array<[string, string[]]> = [];
+    const exec: Exec = (cmd, args) => {
+      seen.push([cmd, args]);
+      return '';
+    };
+
+    changedFiles('v0.1.38..HEAD', exec);
+
+    expect(seen).toEqual([['git', ['diff', '--name-only', 'v0.1.38..HEAD']]]);
+  });
+
+  it('reads one repo-relative path per line', () => {
+    const exec: Exec = () => 'server/src/main.rs\npackages/ui/src/index.ts\n';
+
+    expect(changedFiles('HEAD~1..HEAD', exec)).toEqual([
+      'server/src/main.rs',
+      'packages/ui/src/index.ts',
+    ]);
+  });
+
+  it('drops the blank line git leaves at the end rather than reporting it', () => {
+    const exec: Exec = () => '\nserver/Cargo.toml\n  \n';
+
+    expect(changedFiles('HEAD~1..HEAD', exec)).toEqual(['server/Cargo.toml']);
+  });
+
+  it('reads a range that changed nothing as no files', () => {
+    const exec: Exec = () => '';
+
+    expect(changedFiles('HEAD..HEAD', exec)).toEqual([]);
+  });
+});

--- a/packages/workspace-tools/src/io/load.test.ts
+++ b/packages/workspace-tools/src/io/load.test.ts
@@ -1,0 +1,99 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+import { loadGraph } from './load';
+
+const ROOT = mkdtempSync(join(tmpdir(), 'kroma-graph-'));
+
+function write(rel: string, body: string | object): void {
+  const path = join(ROOT, rel);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, typeof body === 'string' ? body : JSON.stringify(body));
+}
+
+write('server/Cargo.toml', '[package]\nname = "kroma-server"\nversion = "0.1.38"\n');
+write('packages/ui/package.json', { name: '@kroma/ui', version: '1.2.0' });
+write('packages/core/package.json', {
+  name: '@kroma/core',
+  version: '1.0.0',
+  dependencies: { '@kroma/ui': 'workspace:*', zod: '^4' },
+  devDependencies: { vitest: '^4' },
+});
+write('packages/broken/package.json', '{ not json');
+write('packages/unnamed/package.json', { version: '1.0.0' });
+write('modules/tv.kroma.vpn/module.json', {
+  id: 'tv.kroma.vpn',
+  version: '0.4.1',
+  dependencies: { 'tv.kroma.torrents': '^0.1.0' },
+  engines: { server: '>=0.1.4' },
+});
+write('modules/tv.kroma.remote/module.json', { id: 'tv.kroma.remote', engines: [] });
+write('modules/not-a-module/module.json', { version: '9.9.9' });
+
+const graph = loadGraph({ root: ROOT });
+
+afterAll(() => rmSync(ROOT, { recursive: true, force: true }));
+
+describe('reading a repo into a graph', () => {
+  it('reads the server version out of its Cargo manifest', () => {
+    expect(graph.server).toMatchObject({ name: 'server', dir: 'server', version: '0.1.38' });
+  });
+
+  it('leaves the server out when the tree has no Rust manifest', () => {
+    expect(loadGraph({ root: ROOT, serverManifest: 'nope/Cargo.toml' }).server).toBeUndefined();
+  });
+
+  it('falls back to 0.0.0 for a Cargo manifest that states no version', () => {
+    write('other/Cargo.toml', '[package]\nname = "x"\n');
+
+    expect(loadGraph({ root: ROOT, serverManifest: 'other/Cargo.toml' }).server?.version).toBe(
+      '0.0.0',
+    );
+  });
+});
+
+describe('the JS workspace projects', () => {
+  const named = (name: string) => graph.projects.find((p) => p.name === name);
+
+  it('keeps only the dependencies that name another project in this graph', () => {
+    expect(named('@kroma/core')?.deps).toEqual(['@kroma/ui']);
+  });
+
+  it('skips a package.json that does not parse rather than failing the load', () => {
+    expect(graph.projects.map((p) => p.dir)).not.toContain('packages/broken');
+  });
+
+  it('skips a package.json with no name, which nothing could depend on', () => {
+    expect(graph.projects.map((p) => p.dir)).not.toContain('packages/unnamed');
+  });
+
+  it('reads nothing from a workspace root that is not there', () => {
+    expect(loadGraph({ root: ROOT, workspaceRoots: ['nowhere'] }).projects).toHaveLength(3);
+  });
+});
+
+describe('the module projects', () => {
+  const named = (name: string) => graph.projects.find((p) => p.name === name);
+
+  it('keeps the declared ranges beside the resolved dependency names', () => {
+    expect(named('tv.kroma.vpn')).toMatchObject({
+      version: '0.4.1',
+      deps: ['tv.kroma.torrents'],
+      ranges: { 'tv.kroma.torrents': '^0.1.0' },
+      serverRange: '>=0.1.4',
+    });
+  });
+
+  it('falls back to 0.0.0 and no dependencies for a bare manifest', () => {
+    expect(named('tv.kroma.remote')).toMatchObject({ version: '0.0.0', deps: [] });
+  });
+
+  it('ignores an engines block that is not a table of ranges', () => {
+    expect(named('tv.kroma.remote')?.serverRange).toBeUndefined();
+  });
+
+  it('skips a module.json with no id', () => {
+    expect(graph.projects.map((p) => p.dir)).not.toContain('modules/not-a-module');
+  });
+});

--- a/server/crates/kroma-engine/src/infra/hls/hwaccel/mod.rs
+++ b/server/crates/kroma-engine/src/infra/hls/hwaccel/mod.rs
@@ -62,7 +62,7 @@ pub enum HwAccel {
 const DEFAULT_RENDER_NODE: &str = "/dev/dri/renderD128";
 
 pub(super) fn render_node() -> &'static str {
-    static NODE: OnceLock<&'static str> = OnceLock::new();
+    static NODE: OnceLock<&str> = OnceLock::new();
     NODE.get_or_init(|| match std::env::var("KROMA_RENDER_NODE") {
         Ok(v) if !v.trim().is_empty() => Box::leak(v.trim().to_owned().into_boxed_str()),
         _ => DEFAULT_RENDER_NODE,

--- a/server/crates/kroma-module-supervisor/src/install.rs
+++ b/server/crates/kroma-module-supervisor/src/install.rs
@@ -105,7 +105,7 @@ impl Supervisor {
                 use std::os::unix::fs::PermissionsExt;
                 let bin = dest.join(MODULE_BIN);
                 if bin.exists() {
-                    std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755))?;
+                    std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o700))?;
                 }
             }
             self.write_origin(&id, origin.0, origin.1);

--- a/server/crates/kroma-module-supervisor/tests/install.rs
+++ b/server/crates/kroma-module-supervisor/tests/install.rs
@@ -20,7 +20,7 @@ fn tar_with_manifest(manifest: &str) -> Vec<u8> {
     let bytes = manifest.as_bytes();
     let mut header = tar::Header::new_gnu();
     header.set_size(bytes.len() as u64);
-    header.set_mode(0o644);
+    header.set_mode(0o600);
     header.set_cksum();
     builder
         .append_data(&mut header, "module.json", bytes)

--- a/server/crates/kroma-module-supervisor/tests/stop.rs
+++ b/server/crates/kroma-module-supervisor/tests/stop.rs
@@ -50,7 +50,7 @@ fn install_module(dir: &Path, id: &str, marker: &Path) {
     )
     .unwrap();
     use std::os::unix::fs::PermissionsExt;
-    std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+    std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o700)).unwrap();
 }
 
 fn ready_flag(dir: &Path, id: &str) -> PathBuf {
@@ -147,7 +147,7 @@ fn stop_kills_a_module_that_ignores_the_signal() {
     )
     .unwrap();
     use std::os::unix::fs::PermissionsExt;
-    std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+    std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o700)).unwrap();
 
     let sup = supervisor(dir);
     sup.spawn("com.example.deaf").expect("spawn");

--- a/server/src/api/it_admin2.rs
+++ b/server/src/api/it_admin2.rs
@@ -914,3 +914,26 @@ async fn an_official_catalog_that_reports_its_own_outage_is_a_failure_not_an_emp
     assert_eq!(status, StatusCode::BAD_REQUEST);
     assert!(message.contains("is unreachable"), "{message}");
 }
+
+#[tokio::test]
+async fn transcodes_names_the_silicon_even_when_nothing_is_re_encoding() {
+    let t = test_app();
+    let (status, body) = get(&t.app, "/api/admin/transcodes", Some(&t.token)).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["sessions"].as_array().map(Vec::len), Some(0));
+    assert_eq!(body["encoding"], json!(0));
+    assert_eq!(body["cacheBytes"], json!(0));
+
+    let hardware = &body["hardware"];
+    assert!(hardware["accel"].as_str().is_some_and(|a| !a.is_empty()));
+    assert!(hardware["reason"].as_str().is_some_and(|r| !r.is_empty()));
+    assert!(hardware["accelerated"].is_boolean());
+}
+
+#[tokio::test]
+async fn transcodes_is_admin_only() {
+    let t = test_app();
+    let m = member(&t, "transcodes-member");
+    let (status, _) = get(&t.app, "/api/admin/transcodes", Some(&m)).await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -229,12 +229,14 @@ sonar.coverage.exclusions=\
   server/crates/kroma-module-host/src/testing/*.rs,\
   server/crates/kroma-module-host/src/test_serve.rs,\
   server/src/api/stream.rs,\
+  server/src/api/stream/download.rs,\
   server/src/api/ws.rs,\
   server/src/api/card.rs,\
   server/src/api/poster.rs,\
   server/src/api/images.rs,\
   server/src/api/passkeys.rs,\
   server/src/api/online_subs.rs,\
+  server/src/api/online_subs/generate.rs,\
   server/src/api/suggest.rs,\
   server/src/api/requests.rs,\
   server/src/api/discover.rs,\
@@ -348,6 +350,16 @@ sonar.coverage.exclusions=\
 # that matches nothing fails SILENTLY - the files simply reappeared in the
 # denominator, and new-code coverage read 51% for work that had not changed its
 # testability at all. When a file listed here moves, this list moves with it.
+#
+# A SPLIT is the same failure with a quieter face, and the two entries above
+# (`stream/download.rs`, `online_subs/generate.rs`) are it. Neither file moved:
+# each was carved out of the handler already listed here when that handler grew
+# past the 300-LOC rule, and the new sibling landed outside a pattern that names
+# one file. The parents are excluded for what the code DOES - an ffmpeg byte
+# stream, a transcriber sidecar - and the halves that carry exactly that are the
+# halves that left. `stream/download/audio_args.rs` is the other half of the same
+# split and is deliberately NOT here: which tracks a download copies is a
+# decision, it is unit-tested, and it answers to the gate.
 #
 # The native module sources (Swift / Kotlin / Java under clients/tv-native) carry
 # no coverage because this repo has no Swift or Kotlin test runner at all - there

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -163,16 +163,20 @@ sonar.coverage.exclusions=\
   apps/kit/index.ts,\
   apps/kit/src/stories.ts,\
   server/preflight.ts,\
+  server/dev.ts,\
   packages/module-tools/**,\
   packages/sonar-tools/**,\
   packages/ci-tools/**,\
+  packages/workspace-tools/src/cli.ts,\
   packages/ui/scripts/**,\
   packages/ui/audit/**,\
+  packages/react-audit/**,\
   clients/web/scripts/**,\
   clients/webos/scripts/**,\
   clients/tizen/scripts/**,\
   docs/spec/scripts/**,\
   packages/push-relay/scripts/**,\
+  packages/tv-installer/scripts/**,\
   packages/synology-repo/src/gen-catalog.ts,\
   packages/synology-repo/src/gen-spk-info.ts,\
   packages/synology-repo/src/backfill-info.ts,\
@@ -197,6 +201,7 @@ sonar.coverage.exclusions=\
   apps/www/vite/og-cards.ts,\
   apps/www/vite/mdx.ts,\
   apps/www/vite/modules.ts,\
+  apps/www/vite/releases.ts,\
   apps/www/src/lib/beams.ts,\
   apps/www/src/lib/i18n.ts,\
   apps/www/src/lib/seo.ts,\
@@ -370,7 +375,31 @@ sonar.coverage.exclusions=\
 # `server/preflight.ts` is one of those and lives outside scripts/ only because
 # `bun run dev` invokes it by path: it is top-level statements, not exports -
 # it shells out to lsof/ps and SIGTERMs what it finds - so there is nothing a
-# test could import without killing the developer's own server.
+# test could import without killing the developer's own server. `server/dev.ts`
+# is its twin and is here for the same sentence: importing it probes PATH for
+# the Dioxus CLI and then spawns `dx serve` or `cargo watch -x run`.
+#
+# `packages/workspace-tools/src/cli.ts` says what it is in its own first line -
+# "the analysis lives in the tested core; this only loads the repo and prints" -
+# which is the ci-tools/module-tools argument in one sentence. Its two IO
+# collaborators are NOT excluded and are unit-tested, `io/git.ts` against the
+# injectable exec it was written to take.
+#
+# `apps/www/vite/releases.ts` is the fourth build plugin beside the three above,
+# and the same call for the same reason: a fetch against the GitHub releases API
+# and a virtual module built from the answer. Its pure half already lives out in
+# `src/lib/{channels,releases,release-targets}.ts`, each with its own test, which
+# is the pattern `vite/modules.ts` set. The two plugins in that directory with
+# logic a test can reach, `fetch-body.ts` and `reading-time.ts`, stay in scope.
+#
+# `packages/react-audit/**` joins `packages/ui/audit/**` for a reason that is
+# about the RUNNER, not the code. Its tests are real and CI runs them, but they
+# run in the `audit` vitest project, and packages/ci-tools/src/test.ts measures
+# coverage over `web` and `native` only: the audit project compiles with the
+# React Compiler, so merging its report would count the compiler's memo-cache
+# guards as uncovered conditions on lines that hold none. A library whose only
+# tests can live in the unmeasured project cannot report anything but zero here,
+# and that zero measures where a test runs rather than whether one exists.
 #
 # The native
 # player-engine adapters (baseEngine transport / mpv IPC / Tizen AVPlay /


### PR DESCRIPTION
## What

Main's Sonar board had eight open issues and a coverage gate resting on files
nothing imported. This clears the board and puts tests under the worst of what it
was measuring.

Seven of the eight were `rust:S2612`: a file written `0o755` or `0o644`, which
grants "others" read and execute. None of these files has a reader outside the
process that wrote it. The supervisor spawns the module binary it unpacks;
wireproxy and cloudflared are run by the module that downloaded them; the mpv
`yt-dlp` shim is executed by mpv, a child of the desktop app, and it sits in a
shared temp dir, which is the one place the old mode actually mattered. They are
`0o700` now, and the tar entry in the supervisor's install test is `0o600`,
matching what `tls.rs` and the VPN module already write for a key. The rule's own
compliant example is `0o750`; owner-only is the stricter answer and the one this
codebase already reaches for. The eighth was `rust:S8863`: inside a `static` item
the type's elided lifetimes are already `'static`, so `OnceLock<&'static str>`
said it twice.

Coverage is eleven new test files, 105 tests, every one against a file Sonar read
at 0% or 36% with nothing importing it: the catalog's media labels, the AI
provider spec, ring-room, the registry sort, the recommendation-row accessors,
the mobile track picker, the player's remote and pointer handlers,
workspace-tools' two IO files, and react-audit's ranking and churn reads.
`resizable-cursor` had a test that only ever ran the web half, so the native
no-op has its own now. On the Rust side `/api/admin/transcodes` shipped last week
at 6% and answers two integration tests.

Seven coverage exclusions were added rather than tested, each with its reason
written in beside it, because the honest split matters more than the number. Two
lapsed by a SPLIT rather than a move, which is the quieter version of the failure
`sonar-project.properties` already warns about: `stream/download.rs` and
`online_subs/generate.rs` were carved out of handlers already excluded there when
those grew past 300 lines, and each carries exactly the thing its parent was
excluded for. The other half of that same split, `stream/download/audio_args.rs`,
deliberately stays in scope and is unit-tested. Four more are script-class files
beside siblings already excluded. The last, `packages/react-audit/**`, is about
the runner rather than the code: `ci-tools/src/test.ts` measures coverage over the
web and native projects only, on purpose, so a library whose tests can only live
in the audit project reads as zero however well tested it is.

Both provisioning changes are module code, so `tv.kroma.vpn` goes to 0.4.1 and
`tv.kroma.remote` to 0.3.2.

## Closes

No issue. This is the standing quality gate rather than a reported defect.

## Checks

- [x] `bun run lint` passes. `bun run test` has 7 failures, all of them in
      `packages/tv/src/app/providers/auth.test.tsx` and all of them present on
      `main` before this branch: `localStorage` is `undefined` under
      `@vitest-environment jsdom`. It reproduces on a two-line probe test under
      both Node and Bun, with `location.href` correctly `http://localhost/` and
      jsdom 29.1.1 handing back a real `localStorage` when called directly. CI's
      four unit-test shards passed on 9a52ed74, so something differs between a
      local checkout and CI that I did not find. Worth a look on its own; it is
      not this branch.
- [x] `cargo clippy --workspace --all-targets` and `cargo test --workspace` pass,
      plus clippy and tests in both touched module workspaces.
- [x] Follows `CODE_STYLE.md`.
- [ ] One idea, loosely: the board and the coverage under it. Splitting them would
      have put the permission changes in a PR whose gate the other half fixes.

Also run: `bun run typecheck` (only `@kroma/mobile` fails, with the 16 known
`expo-env.d.ts` errors in files this branch does not touch),
`bun run modules:check`, `bun run modules:validate`, `bun run sonar:lint`.

## Risk

The permission changes are the part worth a second reading. If a deployment ever
executes one of these files as a different uid than the one that wrote it, `0o700`
refuses where `0o755` allowed. I could not find such a path: each file is spawned
by the process that installed it, and the only uid handling in the repo is the
Synology `postinst`, which `chown -R`s the data dir to the service user. A
reviewer would notice as a module that installs and then will not start, or a
desktop build where mpv cannot run its shim.

The exclusions are the other risk, since an exclusion is how you hide work rather
than do it. Each is stated in the file with the argument for it; the ones to push
back on are `react-audit` and the two split handlers.
