### PR TITLE
fix(desktop,mobile): six faults that kept the Linux client dark on SteamOS

### DIFF
--- a/.github/workflows/_release-desktop.yml
+++ b/.github/workflows/_release-desktop.yml
@@ -102,6 +102,19 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      # Read the checkout's state BEFORE anything stamps it, and hand the answer
+      # to @kroma/build-info. The stamp below rewrites tauri.conf.json, so git
+      # would otherwise mark every official installer `-dirty` for a change the
+      # About screen's `version` row already reports.
+      - name: Record tree state before stamping
+        shell: bash
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "KROMA_BUILD_DIRTY=1" >> "$GITHUB_ENV"
+          else
+            echo "KROMA_BUILD_DIRTY=0" >> "$GITHUB_ENV"
+          fi
+
       # Stamp the release version into the installers so a desktop build always
       # matches the release (a stable tag is X.Y.Z).
       # Skipped only for a bare build-only dispatch (channel none).

--- a/.github/workflows/_release-mobile.yml
+++ b/.github/workflows/_release-mobile.yml
@@ -87,6 +87,19 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      # Read the checkout's state BEFORE the stamp below rewrites the tracked
+      # app.json, or @kroma/build-info (called from app.config.ts during
+      # prebuild) marks every official build `-dirty` for a change the version
+      # it stamped already reports.
+      - name: Record tree state before stamping
+        shell: bash
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "KROMA_BUILD_DIRTY=1" >> "$GITHUB_ENV"
+          else
+            echo "KROMA_BUILD_DIRTY=0" >> "$GITHUB_ENV"
+          fi
+
       - name: Stamp version + build number into app.json
         run: bun .github/scripts/stamp-mobile-version.ts "${{ inputs.triplet }}" "${{ inputs.build }}"
 
@@ -267,6 +280,17 @@ jobs:
           # skips prebuild and silently rebuilds the OLD project: the arm64
           # fix would have been cached straight over.
           key: ios-mobile-v3-${{ env.XCODE_VERSION }}-${{ hashFiles('bun.lock', 'clients/mobile/package.json', 'clients/mobile/app.json', 'clients/mobile/app.config.ts', 'clients/mobile/plugins/**') }}
+
+      # Read the checkout's state BEFORE the stamp below rewrites the tracked
+      # app.json, or the build reports itself `-dirty` (see the android job).
+      - name: Record tree state before stamping
+        shell: bash
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "KROMA_BUILD_DIRTY=1" >> "$GITHUB_ENV"
+          else
+            echo "KROMA_BUILD_DIRTY=0" >> "$GITHUB_ENV"
+          fi
 
       # AFTER the cache, deliberately. This rewrites app.json with a build
       # number derived from the clock, so hashing it would change the cache key

--- a/.github/workflows/desktop-autoupdate.yml
+++ b/.github/workflows/desktop-autoupdate.yml
@@ -155,6 +155,17 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: ./clients/desktop/scripts/fetch-libmpv-windows.ps1
+      # Read the checkout's state BEFORE anything stamps it: the steps around this
+      # one rewrite tauri.conf.json (and stage a DLL), so git would otherwise mark
+      # every build `-dirty` for changes the version row already reports.
+      - name: Record tree state before stamping
+        shell: bash
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "KROMA_BUILD_DIRTY=1" >> "$GITHUB_ENV"
+          else
+            echo "KROMA_BUILD_DIRTY=0" >> "$GITHUB_ENV"
+          fi
       - name: Stage libmpv-2.dll for bundling (Windows)
         if: runner.os == 'Windows'
         shell: pwsh

--- a/clients/build-info/index.test.ts
+++ b/clients/build-info/index.test.ts
@@ -157,6 +157,10 @@ describe('productVersion', () => {
 });
 
 describe('collectBuildInfo', { timeout: 30_000 }, () => {
+  afterEach(() => {
+    delete process.env.KROMA_BUILD_DIRTY;
+  });
+
   it('reports the commit, branch and remote of a real checkout', () => {
     const dir = project({ git: true, remote: 'git@github.com:owner/repo.git' });
     const info = collectBuildInfo(dir);
@@ -173,6 +177,32 @@ describe('collectBuildInfo', { timeout: 30_000 }, () => {
     expect(collectBuildInfo(dir).dirty).toBe(false);
 
     writeFileSync(join(dir, 'a.txt'), 'changed');
+    expect(collectBuildInfo(dir).dirty).toBe(true);
+  });
+
+  it('believes a release pipeline that measured the checkout before stamping it', () => {
+    const dir = project({ git: true });
+    writeFileSync(join(dir, 'a.txt'), 'the version stamp');
+
+    process.env.KROMA_BUILD_DIRTY = '0';
+
+    expect(collectBuildInfo(dir).dirty).toBe(false);
+  });
+
+  it('still reports dirt the pipeline declared', () => {
+    const dir = project({ git: true });
+
+    process.env.KROMA_BUILD_DIRTY = '1';
+
+    expect(collectBuildInfo(dir).dirty).toBe(true);
+  });
+
+  it('ignores a declaration it cannot read, and asks git instead', () => {
+    const dir = project({ git: true });
+    writeFileSync(join(dir, 'a.txt'), 'changed');
+
+    process.env.KROMA_BUILD_DIRTY = 'yes';
+
     expect(collectBuildInfo(dir).dirty).toBe(true);
   });
 

--- a/clients/build-info/index.ts
+++ b/clients/build-info/index.ts
@@ -86,6 +86,21 @@ function repoRootOf(projectRoot: string): string {
   return path.resolve(projectRoot, '..', '..');
 }
 
+/**
+ * Whether the tree the binary was built from differs from its commit.
+ *
+ * `KROMA_BUILD_DIRTY` (`0`/`1`) wins when set, because a release pipeline stamps
+ * the version into the tree BEFORE the bundler runs: git would then call every
+ * official build dirty for a change the `version` field already reports. CI
+ * measures the checkout before it stamps and passes the answer down.
+ */
+function treeIsDirty(projectRoot: string): boolean {
+  const declared = process.env.KROMA_BUILD_DIRTY;
+  if (declared === '0') return false;
+  if (declared === '1') return true;
+  return Boolean(git('status --porcelain', projectRoot));
+}
+
 export function collectBuildInfo(
   projectRoot: string,
   overrides?: { version?: string | null },
@@ -102,7 +117,7 @@ export function collectBuildInfo(
     commit: git('rev-parse --short HEAD', projectRoot),
     commitFull: git('rev-parse HEAD', projectRoot),
     branch: git('rev-parse --abbrev-ref HEAD', projectRoot),
-    dirty: Boolean(git('status --porcelain', projectRoot)),
+    dirty: treeIsDirty(projectRoot),
     buildDate: new Date().toISOString(),
     repository: browsableRemote(git('config --get remote.origin.url', projectRoot)),
   };

--- a/clients/desktop/src-tauri/Cargo.lock
+++ b/clients/desktop/src-tauri/Cargo.lock
@@ -1676,7 +1676,7 @@ dependencies = [
 
 [[package]]
 name = "kroma-desktop"
-version = "0.1.3"
+version = "0.1.39"
 dependencies = [
  "cc",
  "libc",

--- a/clients/desktop/src-tauri/Cargo.toml
+++ b/clients/desktop/src-tauri/Cargo.toml
@@ -75,6 +75,10 @@ libmpv2 = { version = "6.0.0", optional = true }
 # so `WebviewWindow::window_handle()` returns a matching RawWindowHandle). Only used
 # in a libmpv build; harmless otherwise.
 raw-window-handle = "0.6"
+# The window's X11 shape (video_hole.rs): GDK's shape_combine_region cuts the
+# picture's box out of the window so the mpv plane below shows through. 0.18 is
+# Tauri v2's own gtk, so `WebviewWindow::gtk_window()` hands back a matching type.
+gtk = "0.18"
 # Process-group kill of the mpv sidecar tree (the AppImage runtime execs the real
 # mpv as a grandchild, so Child::kill alone orphans the player).
 libc = "0.2"

--- a/clients/desktop/src-tauri/Cargo.toml
+++ b/clients/desktop/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "kroma-desktop"
-version = "0.1.3"
+version = "0.1.39"
 description = "KROMA Steam Deck client (Tauri shell over @kroma/tv, native mpv playback)"
 edition = "2021"
 # Tauri v2's dependency graph (darling / time / serde_with) needs >= 1.88.
@@ -37,6 +37,8 @@ serde_json = "1"
 #              libmpv is the PRIMARY engine but the mpv BINARY (mpv.rs) stays as an
 #              automatic fallback when the in-process GPU context can't initialise
 #              (the Deck's fragile EGL/Wayland stack) - so the sidecar is still bundled.
+#              On Linux the in-process engine is opt-in and has NO UI overlay (see
+#              libmpv_linux.rs); the sidecar is what the player chrome draws over.
 # Disable for a lean webview-only build (`--no-default-features`): the in-page <video>
 # path then handles playback (no libmpv link/bundle needed).
 default = ["libmpv"]

--- a/clients/desktop/src-tauri/src/gst_env.rs
+++ b/clients/desktop/src-tauri/src/gst_env.rs
@@ -1,0 +1,83 @@
+use std::path::Path;
+
+const PLUGIN_PATH_VARS: [&str; 2] = ["GST_PLUGIN_SYSTEM_PATH_1_0", "GST_PLUGIN_SYSTEM_PATH"];
+
+/// Prune the AppImage's GStreamer plugin path to the entries that exist, and unset
+/// it when none do. Tauri's AppRun prepends `$APPDIR/usr/lib/gstreamer-1.0` - never
+/// created with `bundleMediaFramework: false` - to whatever the host exported, and
+/// setting the variable REPLACES GStreamer's built-in system path. A host that
+/// leaves it unset (SteamOS) is therefore left searching one missing directory and
+/// one empty entry, so every element vanishes; a host that sets it (Debian, Ubuntu)
+/// keeps a real second entry and hides the fault.
+pub fn sanitize_plugin_path() {
+    for var in PLUGIN_PATH_VARS {
+        let Ok(value) = std::env::var(var) else { continue };
+        match kept_entries(&value, &|entry| Path::new(entry).is_dir()) {
+            Some(kept) => std::env::set_var(var, kept),
+            None => std::env::remove_var(var),
+        }
+    }
+}
+
+fn kept_entries(value: &str, is_dir: &dyn Fn(&str) -> bool) -> Option<String> {
+    let kept: Vec<&str> = value
+        .split(':')
+        .filter(|entry| !entry.is_empty() && is_dir(entry))
+        .collect();
+    (!kept.is_empty()).then(|| kept.join(":"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::kept_entries;
+
+    const BUNDLE: &str = "/appdir/usr/lib/gstreamer-1.0";
+    const HOST: &str = "/usr/lib/gstreamer-1.0";
+
+    fn only_host(entry: &str) -> bool {
+        entry == HOST
+    }
+
+    #[test]
+    fn drops_the_path_a_host_that_exports_nothing_leaves_behind() {
+        let value = format!("{BUNDLE}:");
+
+        let kept = kept_entries(&value, &only_host);
+
+        assert_eq!(kept, None);
+    }
+
+    #[test]
+    fn drops_a_lone_missing_bundle_directory() {
+        let kept = kept_entries(BUNDLE, &only_host);
+
+        assert_eq!(kept, None);
+    }
+
+    #[test]
+    fn keeps_the_host_directory_beside_a_missing_bundle_directory() {
+        let value = format!("{BUNDLE}:{HOST}");
+
+        let kept = kept_entries(&value, &only_host);
+
+        assert_eq!(kept.as_deref(), Some(HOST));
+    }
+
+    #[test]
+    fn leaves_a_list_whose_entries_all_exist_untouched() {
+        let value = format!("{HOST}:{BUNDLE}");
+
+        let kept = kept_entries(&value, &|_| true);
+
+        assert_eq!(kept.as_deref(), Some(value.as_str()));
+    }
+
+    #[test]
+    fn drops_empty_entries_from_a_list_that_survives() {
+        let value = format!(":{HOST}::");
+
+        let kept = kept_entries(&value, &only_host);
+
+        assert_eq!(kept.as_deref(), Some(HOST));
+    }
+}

--- a/clients/desktop/src-tauri/src/libmpv_linux.rs
+++ b/clients/desktop/src-tauri/src/libmpv_linux.rs
@@ -1,8 +1,16 @@
 // In-process libmpv engine for Linux (Steam Deck / desktop). Mirrors mpv.rs /
 // libmpv_win.rs's Tauri surface (`mpv_load` / `mpv_command` + `mpv://…` events) so
 // the frontend `MpvEngine` drives it unchanged. On X11, mpv embeds via `--wid` into
-// the GTK window's X11 XID and its gpu VO renders a child surface behind the
-// transparent webview - in-process, no second window or IPC socket.
+// the GTK window's X11 XID - in-process, no second window or IPC socket.
+//
+// It does NOT render *behind* the webview: `--wid` hands mpv the same X drawable
+// the webview paints into, and mpv repaints all of it, so nothing the UI draws
+// survives. Measured on SteamOS 3.8: with the film paused, the keys that raise the
+// transport changed zero pixels. So this path plays video but has no overlay - no
+// controls, and no subtitles either, because `sub-auto=no` / `sid=no` in
+// libmpv_shared leave subtitles to the UI layer that is no longer visible. Only the
+// two-window sidecar overlays today; a single-window overlay needs mpv's render API
+// (render into an FBO the shell composites) rather than `--wid`.
 //
 // This path is guarded rather than primary: the mpv BINARY (mpv.rs) exists because
 // the Deck's EGL/Wayland GPU stack is fragile, and a separate process can walk a VO
@@ -26,6 +34,13 @@ use crate::libmpv_shared::{self, MpvSlot};
 
 pub type InprocState = MpvSlot;
 
+fn vo_choice() -> String {
+    match std::env::var("KROMA_MPV_VO") {
+        Ok(vo) if !vo.trim().is_empty() => vo.trim().to_owned(),
+        _ => "gpu".to_owned(),
+    }
+}
+
 /// Build the engine embedded in the X11 window `xid` and spawn the event pump. Call
 /// once the window exists. Returns whether the engine came up, so the caller falls
 /// back to the mpv binary on failure (the Deck must never be left without a player).
@@ -33,8 +48,10 @@ pub fn init(app: &AppHandle, xid: u64) -> bool {
     let mpv = match Mpv::with_initializer(|init| {
         init.set_property("wid", xid as i64)?;
         // VA-API (the Deck's APU) for HEVC/H264, dav1d for AV1. `auto-safe` avoids
-        // the copy-back hwdec modes that flicker.
-        init.set_property("vo", "gpu")?;
+        // the copy-back hwdec modes that flicker. `KROMA_MPV_VO` pins the output the
+        // same way it does for the binary backend, so a driver stack that cannot
+        // bring up `gpu` has one knob rather than two.
+        init.set_property("vo", vo_choice().as_str())?;
         init.set_property("hwdec", "auto-safe")?;
         libmpv_shared::apply_common_options(&init)
     }) {

--- a/clients/desktop/src-tauri/src/libmpv_shared.rs
+++ b/clients/desktop/src-tauri/src/libmpv_shared.rs
@@ -75,6 +75,11 @@ pub fn apply_common_options(init: &MpvInitializer) -> MpvResult<()> {
     // page. Every built-in script has to be named individually - `load-scripts`
     // governs only the USER scripts from the config directory, not the ones mpv
     // ships, so setting it alone leaves all of the below running.
+    // Tolerate an option this libmpv has never heard of: Linux links the SYSTEM
+    // libmpv, which lags the pinned 0.41 sidecar (SteamOS 3.8 ships 0.40), and
+    // aborting the whole init over one missing name is how the in-process engine
+    // gave up and fell back to the sidecar there. An option that does not exist
+    // names a script that does not run, which is the state being asked for.
     for option in [
         "load-scripts",
         "load-stats-overlay",
@@ -87,9 +92,18 @@ pub fn apply_common_options(init: &MpvInitializer) -> MpvResult<()> {
         "osc",
         "ytdl",
     ] {
-        init.set_property(option, "no")?;
+        match init.set_property(option, "no") {
+            Ok(()) => {}
+            Err(e) if is_unknown_option(&e) => {}
+            Err(e) => return Err(e),
+        }
     }
     Ok(())
+}
+
+// mpv's MPV_ERROR_OPTION_NOT_FOUND / MPV_ERROR_PROPERTY_NOT_FOUND.
+fn is_unknown_option(error: &libmpv2::Error) -> bool {
+    matches!(error, libmpv2::Error::Raw(-5 | -8))
 }
 
 /// Observe the properties the frontend `MpvEngine` reacts to. The ids (1..5)

--- a/clients/desktop/src-tauri/src/main.rs
+++ b/clients/desktop/src-tauri/src/main.rs
@@ -36,6 +36,10 @@ mod libmpv_linux;
 #[cfg(target_os = "linux")]
 mod webview_gpu;
 
+// Prunes the AppImage's GStreamer plugin path down to the entries that exist.
+#[allow(dead_code)]
+mod gst_env;
+
 // In-process libmpv (macOS): renders into a native NSView behind the webview.
 #[cfg(all(target_os = "macos", feature = "libmpv"))]
 #[allow(dead_code)]
@@ -62,16 +66,8 @@ fn prepare_linux_env() {
     }
     // Tauri AppImages export GST_PLUGIN_SYSTEM_PATH(_1_0) at a directory that's
     // never created when bundleMediaFramework is off; GStreamer then searches
-    // ONLY there and webview audio dies (tauri-apps/tauri#15665). Drop the var
-    // when it points at a missing directory.
-    for var in ["GST_PLUGIN_SYSTEM_PATH_1_0", "GST_PLUGIN_SYSTEM_PATH"] {
-        if let Some(path) = std::env::var_os(var) {
-            let single_path = !path.to_string_lossy().contains(':');
-            if single_path && !std::path::Path::new(&path).is_dir() {
-                std::env::remove_var(var);
-            }
-        }
-    }
+    // ONLY there and webview audio dies (tauri-apps/tauri#15665).
+    gst_env::sanitize_plugin_path();
 }
 
 // macOS: tell the frontend the mpv engine is available (+ the debug test URL) up

--- a/clients/desktop/src-tauri/src/main.rs
+++ b/clients/desktop/src-tauri/src/main.rs
@@ -40,6 +40,11 @@ mod webview_gpu;
 #[allow(dead_code)]
 mod gst_env;
 
+// Cuts the picture's box out of the window's shape so the mpv plane shows through
+// it (Linux; WebKitGTK never honours alpha, so a hole is the only way).
+#[allow(dead_code)]
+mod video_hole;
+
 // In-process libmpv (macOS): renders into a native NSView behind the webview.
 #[cfg(all(target_os = "macos", feature = "libmpv"))]
 #[allow(dead_code)]
@@ -205,6 +210,7 @@ fn main() {
     #[cfg(target_os = "linux")]
     {
         builder = builder.manage(mpv::MpvState::default());
+        builder = builder.manage(video_hole::HoleState::default());
         // In-process libmpv state (empty until init succeeds); the dispatcher routes
         // commands to it or the binary. Only present in a libmpv build.
         #[cfg(feature = "libmpv")]
@@ -218,6 +224,7 @@ fn main() {
             webview_gpu::webview_gpu_get,
             webview_gpu::webview_gpu_set,
             webview_gpu::webview_boot_ok,
+            video_hole::video_hole_set,
             app_quit,
             app_relaunch
         ]);
@@ -269,8 +276,19 @@ fn main() {
         // or a terminal actually reveals it.
         .on_window_event(|_window, _event| {
             #[cfg(target_os = "linux")]
-            if let tauri::WindowEvent::Focused(focused) = _event {
-                let _ = _window.set_always_on_top(*focused);
+            {
+                use tauri::Manager;
+                if let tauri::WindowEvent::Focused(focused) = _event {
+                    let _ = _window.set_always_on_top(*focused);
+                }
+                // The hole is fractional, so a resize only moves its pixels.
+                if matches!(_event, tauri::WindowEvent::Resized(_)) {
+                    if let Some(view) = _window.get_webview_window(_window.label()) {
+                        if let Some(state) = view.try_state::<video_hole::HoleState>() {
+                            video_hole::refresh(&view, &state);
+                        }
+                    }
+                }
             }
         })
         .setup(|_app| {

--- a/clients/desktop/src-tauri/src/mpv/launch.rs
+++ b/clients/desktop/src-tauri/src/mpv/launch.rs
@@ -172,7 +172,7 @@ pub(super) fn start_mpv(binary: &str, sock: &Path) -> Result<(Child, UnixStream)
         };
 
         match await_socket(&mut child, sock) {
-            Some(stream) if await_video_output(&stream) => {
+            Some(stream) if await_video_output(sock) => {
                 eprintln!("KROMA: mpv up [{}]", cfg.join(" "));
                 return Ok((child, stream));
             }
@@ -202,20 +202,22 @@ pub(super) fn start_mpv(binary: &str, sock: &Path) -> Result<(Child, UnixStream)
 // `--force-window=yes` configures the output at startup, so a working rung
 // answers `true` while still idle - but only once it has finished initialising,
 // which is why this waits for `true` rather than trusting the first reading.
-fn await_video_output(stream: &UnixStream) -> bool {
-    // Restored before returning: the event pump reads this same file description
-    // with a blocking `lines()`, which a lingering timeout would cut short.
-    if stream
+fn await_video_output(sock: &Path) -> bool {
+    // A SECOND connection, never the one handed back to the caller: probing on
+    // the app's own stream would consume the events its pump is there to read
+    // and leave a read timeout on a file description the pump blocks in.
+    let Ok(probe) = UnixStream::connect(sock) else {
+        return true;
+    };
+    if probe
         .set_read_timeout(Some(Duration::from_millis(250)))
         .is_err()
     {
         return true;
     }
-    let configured = poll_vo_configured(stream);
-    let _ = stream.set_read_timeout(None);
     // An mpv too old to know the property never answers one, and a rung that
     // cannot be measured must not be failed on a guess.
-    configured.unwrap_or(true)
+    poll_vo_configured(&probe).unwrap_or(true)
 }
 
 fn poll_vo_configured(stream: &UnixStream) -> Option<bool> {

--- a/clients/desktop/src-tauri/src/mpv/launch.rs
+++ b/clients/desktop/src-tauri/src/mpv/launch.rs
@@ -1,7 +1,15 @@
+use std::io::{Read, Write};
 use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command};
-use std::time::Duration;
+use std::time::{Duration, Instant};
+
+use serde_json::Value;
+
+// A rung gets this long to configure its video output once IPC answers.
+const VO_PROBE_WINDOW: Duration = Duration::from_secs(6);
+// Ours, so a reply is told apart from mpv's events and its own startup chatter.
+const VO_PROBE_ID: u64 = 9001;
 
 const BASE_ARGS: &[&str] = &[
     "--idle=yes",
@@ -164,9 +172,16 @@ pub(super) fn start_mpv(binary: &str, sock: &Path) -> Result<(Child, UnixStream)
         };
 
         match await_socket(&mut child, sock) {
-            Some(stream) => {
+            Some(stream) if await_video_output(&stream) => {
                 eprintln!("KROMA: mpv up [{}]", cfg.join(" "));
                 return Ok((child, stream));
+            }
+            Some(_) => {
+                kill_tree(&mut child);
+                eprintln!(
+                    "KROMA: mpv answered but never configured a video output [{}]; trying a more compatible one",
+                    cfg.join(" ")
+                );
             }
             None => {
                 kill_tree(&mut child);
@@ -178,6 +193,74 @@ pub(super) fn start_mpv(binary: &str, sock: &Path) -> Result<(Child, UnixStream)
         }
     }
     Err("socket-timeout")
+}
+
+// An answering IPC socket does not mean a rung can draw. `--vo=gpu-next` on a
+// driver stack with no usable GL context keeps running with `vo-configured`
+// false forever, so the socket alone settles the ladder on an output that never
+// shows a frame (measured on SteamOS 3.8, where the next rung down does work).
+// `--force-window=yes` configures the output at startup, so a working rung
+// answers `true` while still idle - but only once it has finished initialising,
+// which is why this waits for `true` rather than trusting the first reading.
+fn await_video_output(stream: &UnixStream) -> bool {
+    // Restored before returning: the event pump reads this same file description
+    // with a blocking `lines()`, which a lingering timeout would cut short.
+    if stream
+        .set_read_timeout(Some(Duration::from_millis(250)))
+        .is_err()
+    {
+        return true;
+    }
+    let configured = poll_vo_configured(stream);
+    let _ = stream.set_read_timeout(None);
+    // An mpv too old to know the property never answers one, and a rung that
+    // cannot be measured must not be failed on a guess.
+    configured.unwrap_or(true)
+}
+
+fn poll_vo_configured(stream: &UnixStream) -> Option<bool> {
+    let probe = format!(
+        "{{\"command\":[\"get_property\",\"vo-configured\"],\"request_id\":{VO_PROBE_ID}}}\n"
+    );
+    let deadline = Instant::now() + VO_PROBE_WINDOW;
+    let mut pending = String::new();
+    let mut buf = [0u8; 2048];
+    let mut answered = None;
+    while Instant::now() < deadline {
+        if (&*stream).write_all(probe.as_bytes()).is_err() {
+            break;
+        }
+        match (&*stream).read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => pending.push_str(&String::from_utf8_lossy(&buf[..n])),
+            Err(_) => continue,
+        }
+        while let Some(end) = pending.find('\n') {
+            let line: String = pending.drain(..=end).collect();
+            if let Some(state) = vo_configured_reply(&line) {
+                // A `false` here is only "not yet": keep asking until the window
+                // closes, or the first rung would be failed for being slow.
+                if state {
+                    return Some(true);
+                }
+                answered = Some(false);
+            }
+        }
+    }
+    answered
+}
+
+// `Some(state)` for a reply to our own probe, `None` for anything else on the
+// wire: an event, another reply, or an error because the property is unknown.
+fn vo_configured_reply(line: &str) -> Option<bool> {
+    let msg: Value = serde_json::from_str(line.trim()).ok()?;
+    if msg.get("request_id")?.as_u64()? != VO_PROBE_ID {
+        return None;
+    }
+    if msg.get("error")?.as_str()? != "success" {
+        return None;
+    }
+    msg.get("data")?.as_bool()
 }
 
 // The ~15s window is generous because a cold sidecar launch unpacks ~50 MB
@@ -213,4 +296,44 @@ pub(super) fn kill_tree(child: &mut Child) {
     }
     signal_group(pgid, libc::SIGKILL);
     let _ = child.wait();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::vo_configured_reply;
+
+    #[test]
+    fn reads_a_live_video_output_out_of_our_own_reply() {
+        let line = r#"{"data":true,"request_id":9001,"error":"success"}"#;
+
+        assert_eq!(vo_configured_reply(line), Some(true));
+    }
+
+    #[test]
+    fn reads_an_output_that_has_not_come_up_yet() {
+        let line = r#"{"data":false,"request_id":9001,"error":"success"}"#;
+
+        assert_eq!(vo_configured_reply(line), Some(false));
+    }
+
+    #[test]
+    fn ignores_a_reply_meant_for_someone_else() {
+        let line = r#"{"data":true,"request_id":1,"error":"success"}"#;
+
+        assert_eq!(vo_configured_reply(line), None);
+    }
+
+    #[test]
+    fn ignores_an_event_line() {
+        let line = r#"{"event":"file-loaded"}"#;
+
+        assert_eq!(vo_configured_reply(line), None);
+    }
+
+    #[test]
+    fn ignores_an_mpv_too_old_to_know_the_property() {
+        let line = r#"{"request_id":9001,"error":"property not found"}"#;
+
+        assert_eq!(vo_configured_reply(line), None);
+    }
 }

--- a/clients/desktop/src-tauri/src/video_hole.rs
+++ b/clients/desktop/src-tauri/src/video_hole.rs
@@ -1,0 +1,192 @@
+use std::sync::Mutex;
+
+use serde::Deserialize;
+use tauri::{State, WebviewWindow};
+
+const MIN_SIDE: i32 = 16;
+
+/// The picture's box, as fractions of the window, exactly as the shell also hands
+/// it to mpv's `video-margin-ratio-*`. One rect drives both, so the plane and the
+/// hole cannot disagree.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq)]
+pub struct HoleRect {
+    pub x: f64,
+    pub y: f64,
+    pub w: f64,
+    pub h: f64,
+}
+
+/// The picture's box and the chrome painted over it. The box is cut out of the
+/// window and every cover is put back, so the plane shows through exactly the
+/// pixels the page does not paint.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Shape {
+    pub rect: Option<HoleRect>,
+    pub covers: Vec<HoleRect>,
+}
+
+#[derive(Default)]
+pub struct HoleState(Mutex<Shape>);
+
+impl HoleState {
+    fn store(&self, shape: &Shape) {
+        if let Ok(mut slot) = self.0.lock() {
+            slot.clone_from(shape);
+        }
+    }
+
+    fn current(&self) -> Shape {
+        self.0.lock().ok().map(|slot| slot.clone()).unwrap_or_default()
+    }
+}
+
+/// The hole's pixel box in a `width` x `height` window, or `None` when the window
+/// is unmapped or the fractions leave nothing worth cutting.
+pub fn hole_pixels(hole: HoleRect, width: i32, height: i32) -> Option<(i32, i32, i32, i32)> {
+    if width <= 0 || height <= 0 {
+        return None;
+    }
+    if ![hole.x, hole.y, hole.w, hole.h].iter().all(|v| v.is_finite()) {
+        return None;
+    }
+    let (w, h) = (f64::from(width), f64::from(height));
+    let edge = |v: f64, side: f64| (v * side).round().clamp(0.0, side) as i32;
+    let left = edge(hole.x, w);
+    let top = edge(hole.y, h);
+    let (box_w, box_h) = (edge(hole.x + hole.w, w) - left, edge(hole.y + hole.h, h) - top);
+    if box_w < MIN_SIDE || box_h < MIN_SIDE {
+        return None;
+    }
+    Some((left, top, box_w, box_h))
+}
+
+#[cfg(target_os = "linux")]
+fn apply(window: &WebviewWindow, shape: &Shape) {
+    use gtk::cairo::{RectangleInt, Region};
+    use gtk::prelude::*;
+
+    let Ok(gtk_window) = window.gtk_window() else { return };
+    let Some(surface) = gtk_window.window() else { return };
+    let (width, height) = (surface.width(), surface.height());
+    let cut = shape.rect.and_then(|rect| hole_pixels(rect, width, height));
+    let Some((x, y, box_w, box_h)) = cut else {
+        surface.shape_combine_region(None, 0, 0);
+        return;
+    };
+    let region = Region::create_rectangle(&RectangleInt::new(0, 0, width, height));
+    if region
+        .subtract_rectangle(&RectangleInt::new(x, y, box_w, box_h))
+        .is_err()
+    {
+        return;
+    }
+    for cover in &shape.covers {
+        if let Some((cx, cy, cw, ch)) = hole_pixels(*cover, width, height) {
+            region.union_rectangle(&RectangleInt::new(cx, cy, cw, ch)).ok();
+        }
+    }
+    surface.shape_combine_region(Some(&region), 0, 0);
+}
+
+#[cfg(not(target_os = "linux"))]
+fn apply(_window: &WebviewWindow, _shape: &Shape) {}
+
+fn dispatch(window: &WebviewWindow, shape: Shape) {
+    let target = window.clone();
+    let _ = window.run_on_main_thread(move || apply(&target, &shape));
+}
+
+/// Cut the picture's box out of the window's shape so the mpv plane beneath shows
+/// through it, putting every `covers` rectangle back so the chrome painted over
+/// the picture keeps its pixels. `rect` of `null` restores the whole window.
+/// WebKitGTK paints an opaque background whatever alpha it is given, so a hole is
+/// the only way the plane is ever visible. Pointer events over the hole reach the
+/// plane's window rather than the page; the chrome stays clickable because it is
+/// covered back in.
+#[tauri::command]
+pub fn video_hole_set(
+    window: WebviewWindow,
+    state: State<'_, HoleState>,
+    rect: Option<HoleRect>,
+    covers: Vec<HoleRect>,
+) {
+    let shape = Shape { rect, covers };
+    state.store(&shape);
+    dispatch(&window, shape);
+}
+
+/// Re-cut the stored shape after the window changed size. Every rect is
+/// fractional, so it survives the resize; only its pixels move.
+pub fn refresh(window: &WebviewWindow, state: &HoleState) {
+    let shape = state.current();
+    if shape.rect.is_some() {
+        dispatch(window, shape);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rect(x: f64, y: f64, w: f64, h: f64) -> HoleRect {
+        HoleRect { x, y, w, h }
+    }
+
+    #[test]
+    fn maps_fractions_onto_the_window() {
+        assert_eq!(
+            hole_pixels(rect(0.0, 0.25, 1.0, 0.5), 1280, 800),
+            Some((0, 200, 1280, 400))
+        );
+    }
+
+    #[test]
+    fn clamps_a_box_that_runs_past_the_window() {
+        assert_eq!(
+            hole_pixels(rect(-0.5, 0.5, 2.0, 2.0), 1280, 800),
+            Some((0, 400, 1280, 400))
+        );
+    }
+
+    #[test]
+    fn refuses_a_sliver() {
+        assert_eq!(hole_pixels(rect(0.0, 0.0, 1.0, 0.01), 1280, 800), None);
+        assert_eq!(hole_pixels(rect(0.0, 0.0, 0.001, 1.0), 1280, 800), None);
+    }
+
+    #[test]
+    fn refuses_an_unmapped_window() {
+        assert_eq!(hole_pixels(rect(0.0, 0.0, 1.0, 1.0), 0, 0), None);
+    }
+
+    #[test]
+    fn refuses_a_rect_that_is_not_a_number() {
+        assert_eq!(hole_pixels(rect(f64::NAN, 0.0, 1.0, 1.0), 1280, 800), None);
+        assert_eq!(
+            hole_pixels(rect(0.0, 0.0, f64::INFINITY, 1.0), 1280, 800),
+            None
+        );
+    }
+
+    #[test]
+    fn a_full_bleed_box_cuts_the_whole_window() {
+        assert_eq!(
+            hole_pixels(rect(0.0, 0.0, 1.0, 1.0), 1280, 800),
+            Some((0, 0, 1280, 800))
+        );
+    }
+
+    #[test]
+    fn keeps_the_stored_shape_for_a_resize() {
+        let state = HoleState::default();
+        assert_eq!(state.current(), Shape::default());
+        let shape = Shape {
+            rect: Some(rect(0.0, 0.1, 1.0, 0.8)),
+            covers: vec![rect(0.0, 0.8, 1.0, 0.2)],
+        };
+        state.store(&shape);
+        assert_eq!(state.current(), shape);
+        state.store(&Shape::default());
+        assert_eq!(state.current().rect, None);
+    }
+}

--- a/clients/desktop/src-tauri/tauri.conf.json
+++ b/clients/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "KROMA",
-  "version": "0.1.3",
+  "version": "0.1.39",
   "identifier": "tv.kroma.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/clients/desktop/src/main.tsx
+++ b/clients/desktop/src/main.tsx
@@ -13,6 +13,7 @@ import introFilm from './assets/kroma-intro-h264-1080.mp4';
 import { startGamepadBridge } from './gamepad';
 import { installStage } from './stage';
 import { startUpdater } from './updater';
+import { installVideoHole, planeBehindPage } from './video-hole';
 
 // The 1920x1080 stage, on EVERY desktop window: the shared 10-foot UI is authored
 // in fixed pixels against that canvas (PosterGrid's 8 x 203px columns, the nav row,
@@ -20,8 +21,7 @@ import { startUpdater } from './updater';
 // layout, it clips it. Fitted the same way as the Steam Deck panel and the browser
 // shell (see ./stage and clients/tv-web/src/stage.ts). A genuinely fluid 10-foot
 // layout is a design-system change, not a shell one.
-const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
-const fixedScreen = /Linux/i.test(ua) && !/Android/i.test(ua);
+const fixedScreen = planeBehindPage();
 installStage();
 
 // The Deck is driven by a gamepad, not a remote. Bridge the Gamepad API onto the
@@ -29,6 +29,11 @@ installStage();
 startGamepadBridge();
 
 mountTv({ platform: 'Desktop', introVideoSrc: introFilm });
+
+// Linux draws the picture on an mpv plane BEHIND the page, and WebKitGTK never
+// lets a pixel of it through; the hole in the window's shape is what makes it
+// visible (see ./video-hole).
+installVideoHole();
 
 // The frontend is alive: disarm the GPU-rendering crash guard for this boot
 // (src-tauri/src/webview_gpu.rs). The command exists on the Linux shell only.

--- a/clients/desktop/src/video-hole.test.ts
+++ b/clients/desktop/src/video-hole.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { type Box, type HoleRect, type HoleShape, holeShape, moved, union } from './video-hole';
+
+const box = (left: number, top: number, right: number, bottom: number): Box => ({
+  left,
+  top,
+  right,
+  bottom,
+});
+
+const STAGE = box(0, 0, 1280, 800);
+
+describe('union', () => {
+  it('wraps every box given', () => {
+    expect(union([box(10, 20, 30, 40), box(100, 0, 200, 60)])).toEqual(box(10, 0, 200, 60));
+  });
+
+  it('skips empty boxes, and has nothing to wrap for none', () => {
+    expect(union([box(5, 5, 5, 5), box(10, 10, 20, 20)])).toEqual(box(10, 10, 20, 20));
+    expect(union([])).toBeNull();
+  });
+});
+
+describe('holeShape', () => {
+  it('reads a bare stage as the whole window', () => {
+    expect(holeShape(STAGE, [], 1280, 800)).toEqual({
+      rect: { x: 0, y: 0, w: 1, h: 1 },
+      covers: [],
+    });
+  });
+
+  it('keeps the chrome as covers rather than shrinking the picture', () => {
+    const shape = holeShape(STAGE, [box(0, 0, 1280, 80), box(0, 640, 1280, 800)], 1280, 800);
+    expect(shape?.rect).toEqual({ x: 0, y: 0, w: 1, h: 1 });
+    expect(shape?.covers).toEqual([
+      { x: 0, y: 0, w: 1, h: 0.1 },
+      { x: 0, y: 0.8, w: 1, h: 0.2 },
+    ]);
+  });
+
+  it('keeps a cue band, and a cover floating in the middle', () => {
+    const shape = holeShape(STAGE, [box(320, 700, 960, 760)], 1280, 800);
+    expect(shape?.covers).toEqual([{ x: 0.25, y: 0.875, w: 0.5, h: 0.075 }]);
+  });
+
+  it('drops a cover the picture does not reach', () => {
+    expect(holeShape(box(0, 0, 640, 400), [box(700, 0, 800, 100)], 1280, 800)?.covers).toEqual([]);
+  });
+
+  it('clips a cover to the picture it overlaps', () => {
+    const shape = holeShape(box(0, 0, 640, 800), [box(320, 0, 1280, 80)], 1280, 800);
+    expect(shape?.covers).toEqual([{ x: 0.25, y: 0, w: 0.25, h: 0.1 }]);
+  });
+
+  it('clips a stage that hangs off the window', () => {
+    expect(holeShape(box(-40, -40, 1320, 840), [], 1280, 800)?.rect).toEqual({
+      x: 0,
+      y: 0,
+      w: 1,
+      h: 1,
+    });
+  });
+
+  it('has no shape for a sliver, or an unmeasured window', () => {
+    expect(holeShape(box(0, 0, 1280, 8), [], 1280, 800)).toBeNull();
+    expect(holeShape(STAGE, [], 0, 0)).toBeNull();
+  });
+});
+
+describe('moved', () => {
+  const shape = (h: number, covers: HoleRect[] = []): HoleShape => ({
+    rect: { x: 0, y: 0, w: 1, h },
+    covers,
+  });
+  const cover = (y: number, h: number): HoleRect => ({ x: 0, y, w: 1, h });
+
+  it('is false for the same shape and true across null', () => {
+    expect(moved(shape(1), shape(1))).toBe(false);
+    expect(moved(shape(1), null)).toBe(true);
+    expect(moved(null, null)).toBe(false);
+  });
+
+  it('ignores sub-pixel drift and catches a real move', () => {
+    expect(moved(shape(1), shape(1 + 1e-6))).toBe(false);
+    expect(moved(shape(1), shape(0.8))).toBe(true);
+  });
+
+  it('catches a cover appearing, moving, or leaving', () => {
+    expect(moved(shape(1), shape(1, [cover(0, 0.1)]))).toBe(true);
+    expect(moved(shape(1, [cover(0, 0.1)]), shape(1, [cover(0, 0.2)]))).toBe(true);
+    expect(moved(shape(1, [cover(0, 0.1)]), shape(1, [cover(0, 0.1)]))).toBe(false);
+  });
+});

--- a/clients/desktop/src/video-hole.ts
+++ b/clients/desktop/src/video-hole.ts
@@ -1,0 +1,273 @@
+// WebKitGTK paints an opaque background whatever alpha the page or the window
+// asks for (measured on SteamOS 3.8: an rgba(0,0,255,0.5) body came back as solid
+// rgb(0,0,250) over magenta), so the mpv plane behind a "transparent" Tauri window
+// is never visible. What IS visible is a hole: the X SHAPE extension cuts the
+// picture's box out of the window and the plane below shows through it, with no
+// alpha and no compositing manager involved.
+//
+// A pixel inside the hole belongs to mpv's window, so the page cannot draw there
+// at all. The chrome is therefore measured and handed over as COVERS, and the
+// shell puts those rectangles back into the window's shape: video everywhere in
+// the picture's box except where the chrome actually paints, chrome everywhere
+// else. What is measured is a layer's painted leaves, not its box - the chrome is
+// laid out as full-stage containers, and cutting the hole around those would hide
+// the picture behind transparent air.
+
+import { PLAYER_ROOT_ID, PLAYER_STAGE_ID, PLAYER_SUBTITLE_ID } from '@kroma/ui';
+
+/** A box in window pixels, the shape `getBoundingClientRect` returns. */
+export interface Box {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}
+
+/** A rectangle as fractions of the window, as the shell and mpv both take it. */
+export interface HoleRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/** The picture's box and the chrome painted over it, ready for the window shape. */
+export interface HoleShape {
+  rect: HoleRect;
+  covers: HoleRect[];
+}
+
+const MIN_SIDE_PX = 16;
+const VISIBLE_OPACITY = 0.02;
+
+function area(box: Box): number {
+  return Math.max(0, box.right - box.left) * Math.max(0, box.bottom - box.top);
+}
+
+function intersects(a: Box, b: Box): boolean {
+  return a.left < b.right && b.left < a.right && a.top < b.bottom && b.top < a.bottom;
+}
+
+function clip(box: Box, to: Box): Box {
+  return {
+    left: Math.max(box.left, to.left),
+    top: Math.max(box.top, to.top),
+    right: Math.min(box.right, to.right),
+    bottom: Math.min(box.bottom, to.bottom),
+  };
+}
+
+/** The smallest box holding every box given, or `null` for none. */
+export function union(boxes: readonly Box[]): Box | null {
+  let out: Box | null = null;
+  for (const box of boxes) {
+    if (area(box) <= 0) continue;
+    out = out
+      ? {
+          left: Math.min(out.left, box.left),
+          top: Math.min(out.top, box.top),
+          right: Math.max(out.right, box.right),
+          bottom: Math.max(out.bottom, box.bottom),
+        }
+      : box;
+  }
+  return out;
+}
+
+function fraction(box: Box, width: number, height: number): HoleRect {
+  return {
+    x: box.left / width,
+    y: box.top / height,
+    w: (box.right - box.left) / width,
+    h: (box.bottom - box.top) / height,
+  };
+}
+
+/**
+ * The window shape for a picture at `stage` with `covers` painted over it, as
+ * fractions of a `width` x `height` window. `null` when the window is unmeasured
+ * or the picture is too small to be worth cutting.
+ */
+export function holeShape(
+  stage: Box,
+  covers: readonly Box[],
+  width: number,
+  height: number,
+): HoleShape | null {
+  if (!(width > 0 && height > 0)) return null;
+  const window: Box = { left: 0, top: 0, right: width, bottom: height };
+  const box = clip(stage, window);
+  if (box.right - box.left < MIN_SIDE_PX || box.bottom - box.top < MIN_SIDE_PX) return null;
+  const kept: HoleRect[] = [];
+  for (const cover of covers) {
+    if (!intersects(box, cover)) continue;
+    const inside = clip(cover, box);
+    if (area(inside) > 0) kept.push(fraction(inside, width, height));
+  }
+  return { rect: fraction(box, width, height), covers: kept };
+}
+
+/** Whether two shapes differ by more than a pixel's worth of the window. */
+export function moved(a: HoleShape | null, b: HoleShape | null): boolean {
+  if (a === null || b === null) return a !== b;
+  if (a.covers.length !== b.covers.length) return true;
+  const step = 1 / 4096;
+  const apart = (x: HoleRect, y: HoleRect) =>
+    Math.abs(x.x - y.x) > step ||
+    Math.abs(x.y - y.y) > step ||
+    Math.abs(x.w - y.w) > step ||
+    Math.abs(x.h - y.h) > step;
+  if (apart(a.rect, b.rect)) return true;
+  return a.covers.some((cover, i) => {
+    const other = b.covers[i];
+    return other === undefined || apart(cover, other);
+  });
+}
+
+type Invoke = (cmd: string, args?: Record<string, unknown>) => Promise<unknown>;
+
+function tauriInvoke(): Invoke | null {
+  const bridge = (globalThis as { __TAURI__?: { core?: { invoke?: Invoke } } }).__TAURI__;
+  return bridge?.core?.invoke ?? null;
+}
+
+function boxOf(el: Element): Box {
+  const r = el.getBoundingClientRect();
+  return { left: r.left, top: r.top, right: r.right, bottom: r.bottom };
+}
+
+function opacityOf(el: Element): number {
+  const style = getComputedStyle(el);
+  if (style.visibility === 'hidden' || style.display === 'none') return 0;
+  return Number.parseFloat(style.opacity || '1');
+}
+
+// What a pixel of chrome actually comes from: a fill, an edge, or a glyph. A
+// container that only positions its children paints nothing and must not be
+// treated as chrome, or the hole would be cut around empty air.
+function paints(el: Element): boolean {
+  const style = getComputedStyle(el);
+  if (style.backgroundImage !== 'none' || style.boxShadow !== 'none') return true;
+  if (!/^(rgba?\(0, 0, 0, 0\)|transparent)$/.test(style.backgroundColor)) return true;
+  if (Number.parseFloat(style.borderTopWidth) + Number.parseFloat(style.borderLeftWidth) > 0) {
+    return true;
+  }
+  for (const node of el.childNodes) {
+    if (node.nodeType === Node.TEXT_NODE && node.textContent?.trim()) return true;
+  }
+  return false;
+}
+
+interface Layer {
+  root: HTMLElement;
+  leaves: HTMLElement[];
+}
+
+// The chrome is a handful of absolutely-positioned layers beside the stage, each
+// fading as a whole; the cue band is inside the stage and unmounts with its cue.
+// Enumerating their painted leaves is a whole-subtree walk, so it runs on a DOM
+// change and not on the frame loop, which only re-reads what it is left holding.
+function chromeLayers(root: Element, stage: Element): Layer[] {
+  const layers: Layer[] = [];
+  for (const el of root.querySelectorAll<HTMLElement>('*')) {
+    if (el === stage || stage.contains(el)) continue;
+    const position = getComputedStyle(el).position;
+    if (position !== 'absolute' && position !== 'fixed') continue;
+    if (layers.some((layer) => layer.root.contains(el))) continue;
+    const leaves = [el, ...el.querySelectorAll<HTMLElement>('*')].filter(paints);
+    if (leaves.length > 0) layers.push({ root: el, leaves });
+  }
+  return layers;
+}
+
+function coversOver(layers: readonly Layer[]): Box[] {
+  const covers: Box[] = [];
+  for (const layer of layers) {
+    if (opacityOf(layer.root) <= VISIBLE_OPACITY) continue;
+    const box = union(layer.leaves.map(boxOf));
+    if (box) covers.push(box);
+  }
+  const cue = document.getElementById(PLAYER_SUBTITLE_ID);
+  if (cue && opacityOf(cue) > VISIBLE_OPACITY) {
+    const box = union([...cue.querySelectorAll<HTMLElement>('*')].filter(paints).map(boxOf));
+    if (box) covers.push(box);
+  }
+  return covers;
+}
+
+function marginArgs(rect: HoleRect | null): [string, number][] {
+  const [l, t, r, b] = rect
+    ? [rect.x, rect.y, Math.max(0, 1 - (rect.x + rect.w)), Math.max(0, 1 - (rect.y + rect.h))]
+    : [0, 0, 0, 0];
+  return [
+    ['video-margin-ratio-left', l],
+    ['video-margin-ratio-top', t],
+    ['video-margin-ratio-right', r],
+    ['video-margin-ratio-bottom', b],
+  ];
+}
+
+function push(invoke: Invoke, shape: HoleShape | null): void {
+  invoke('video_hole_set', { rect: shape?.rect ?? null, covers: shape?.covers ?? [] }).catch(
+    () => undefined,
+  );
+  for (const [prop, value] of marginArgs(shape?.rect ?? null)) {
+    invoke('mpv_command', { args: ['set_property', prop, value] }).catch(() => undefined);
+  }
+}
+
+/** Whether the picture is drawn on a native plane BEHIND the page, which is what
+ *  the Linux shell does and no other desktop OS needs. */
+export function planeBehindPage(): boolean {
+  const ua = typeof navigator === 'undefined' ? '' : navigator.userAgent;
+  return /Linux/i.test(ua) && !/Android/i.test(ua);
+}
+
+/**
+ * Track the picture's box for as long as the player is on screen, cutting it out
+ * of the window's shape and pointing mpv's plane at the same rect. The frame loop
+ * runs only while the player is mounted, and only sends a shape that moved.
+ */
+export function installVideoHole(): void {
+  const invoke = tauriInvoke();
+  if (!invoke || !planeBehindPage()) return;
+
+  let last: HoleShape | null = null;
+  let layers: Layer[] = [];
+  let frame: number | null = null;
+  // A resize keeps the fractions but moves their pixels, so the shape has to be
+  // re-cut even though nothing in the page moved.
+  let dirty = true;
+
+  const send = (shape: HoleShape | null) => {
+    if (!dirty && !moved(shape, last)) return;
+    dirty = false;
+    last = shape;
+    push(invoke, shape);
+  };
+
+  const tick = () => {
+    const stage = document.getElementById(PLAYER_STAGE_ID);
+    if (!stage) {
+      frame = null;
+      send(null);
+      return;
+    }
+    send(holeShape(boxOf(stage), coversOver(layers), window.innerWidth, window.innerHeight));
+    frame = requestAnimationFrame(tick);
+  };
+
+  const sync = () => {
+    const root = document.getElementById(PLAYER_ROOT_ID);
+    const stage = document.getElementById(PLAYER_STAGE_ID);
+    layers = root && stage ? chromeLayers(root, stage) : [];
+    if (stage && frame === null) frame = requestAnimationFrame(tick);
+  };
+
+  new MutationObserver(sync).observe(document.body, { childList: true, subtree: true });
+  window.addEventListener('resize', () => {
+    dirty = true;
+    sync();
+  });
+  sync();
+}

--- a/packages/ui/src/components/organisms/kroma-intro/constants.ts
+++ b/packages/ui/src/components/organisms/kroma-intro/constants.ts
@@ -22,6 +22,12 @@ export const SAFETY_MS = 5400;
 export const EXIT_MS = 850;
 export const SAFETY_SLACK_MS = 1500;
 
+// A hidden page gets its safety window re-checked rather than spent, so a tab
+// parked in the background still opens on the film. Bounded, because a webview
+// that reports itself hidden while it is on screen never fires the
+// `visibilitychange` that would end the wait, and the intro covers the app.
+export const HIDDEN_RECHECKS = 3;
+
 export const GRAIN =
   "url('data:image/svg+xml;utf8,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%22120%22 height=%22120%22><filter id=%22n%22><feTurbulence type=%22fractalNoise%22 baseFrequency=%220.9%22 numOctaves=%222%22/></filter><rect width=%22100%25%22 height=%22100%25%22 filter=%22url(%23n)%22/></svg>')";
 

--- a/packages/ui/src/components/organisms/kroma-intro/kroma-intro.test.ts
+++ b/packages/ui/src/components/organisms/kroma-intro/kroma-intro.test.ts
@@ -2,7 +2,7 @@
 import { act, cleanup, render } from '@testing-library/react';
 import { createElement } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { EXIT_MS } from './constants';
+import { EXIT_MS, HIDDEN_RECHECKS, SAFETY_MS } from './constants';
 import { KromaIntro } from './index';
 
 const play = vi.fn<() => Promise<void>>();
@@ -100,5 +100,54 @@ describe('KromaIntro (film path)', () => {
       video.dispatchEvent(new Event('error'));
     });
     expect(container.querySelector('video')).toBeNull();
+  });
+});
+
+describe('KromaIntro (mounted while the page is hidden)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    stubMedia();
+    play.mockReset();
+    play.mockResolvedValue(undefined);
+    Object.defineProperty(HTMLMediaElement.prototype, 'duration', {
+      configurable: true,
+      writable: true,
+      value: Number.NaN,
+    });
+    Object.defineProperty(document, 'hidden', { configurable: true, value: true });
+  });
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    Object.defineProperty(document, 'hidden', { configurable: true, value: false });
+  });
+
+  it('keeps the film waiting while the page is still parked', async () => {
+    const onDone = vi.fn();
+
+    await mount(onDone);
+    act(() => vi.advanceTimersByTime(SAFETY_MS + EXIT_MS));
+
+    expect(onDone).not.toHaveBeenCalled();
+  });
+
+  it('hands off anyway once the re-checks run out', async () => {
+    const onDone = vi.fn();
+
+    await mount(onDone);
+    act(() => vi.advanceTimersByTime((HIDDEN_RECHECKS + 1) * SAFETY_MS + EXIT_MS));
+
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it('plays the film as soon as the page is shown', async () => {
+    await mount(vi.fn());
+    Object.defineProperty(document, 'hidden', { configurable: true, value: false });
+
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    expect(play).toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/components/organisms/kroma-intro/kroma-intro.web.tsx
+++ b/packages/ui/src/components/organisms/kroma-intro/kroma-intro.web.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useEffectEvent, useRef, useState } from 'react';
-import { SAFETY_MS, SAFETY_SLACK_MS, VIDEO_SOURCES } from './constants';
+import { HIDDEN_RECHECKS, SAFETY_MS, SAFETY_SLACK_MS, VIDEO_SOURCES } from './constants';
 import { CssIntro } from './css-intro';
 import { IntroShell } from './intro-shell';
 import { useIntroExit } from './use-intro-exit';
@@ -47,19 +47,24 @@ const POSTER =
 // Module-level so the recheck can re-arm itself: an effect event may not call
 // itself from its own body. A hidden tab defers the media fetch entirely, so
 // instead of burning the intro while parked in the background, the timer
-// re-checks once per safety window.
-function armStallSafety(opts: {
-  video: { current: HTMLVideoElement | null };
-  arm: (ms: number, run: () => void) => void;
-  exit: () => void;
-  looping: () => boolean;
-}): void {
+// re-checks once per safety window - HIDDEN_RECHECKS times, then hands off
+// anyway rather than leaving the overlay over the app for good.
+function armStallSafety(
+  opts: {
+    video: { current: HTMLVideoElement | null };
+    arm: (ms: number, run: () => void) => void;
+    exit: () => void;
+    looping: () => boolean;
+  },
+  rechecksLeft = HIDDEN_RECHECKS,
+): void {
   if (opts.looping()) return;
   const d = opts.video.current?.duration;
   const ms = d && Number.isFinite(d) && d > 0 ? d * 1000 + SAFETY_SLACK_MS : SAFETY_MS;
   opts.arm(ms, () => {
     const v = opts.video.current;
-    if (document.hidden && v?.readyState === 0) armStallSafety(opts);
+    const stillParked = document.hidden && v?.readyState === 0;
+    if (stillParked && rechecksLeft > 0) armStallSafety(opts, rechecksLeft - 1);
     else opts.exit();
   });
 }
@@ -184,6 +189,7 @@ function VideoIntro({
     if (document.hidden) {
       pendingVisible = true;
       document.addEventListener('visibilitychange', onVisible);
+      rearmSafety();
     } else {
       begin();
     }

--- a/packages/ui/src/components/organisms/player/index.ts
+++ b/packages/ui/src/components/organisms/player/index.ts
@@ -1,6 +1,7 @@
 // One player chrome for web + TV. Styled with Tailwind, legacy-safe: flex only,
 // no /opacity (see ./tw).
 
+export { PLAYER_ROOT_ID } from './hooks/use-idle-cursor';
 export {
   AUDIO_FILTER_KEY,
   audioFilterLabels,
@@ -36,7 +37,9 @@ export type { CreditsCardItem } from './parts/credits-card';
 // The width the end-of-film hero is drawn at, so a host asks for art that size.
 export { POST_PLAY_ART_W, type PostPlayItem } from './parts/post-play';
 export type { SubtitleGenBundle, SubtitleGenRequest } from './parts/settings-panel/settings/gen';
+export { STAGE_ID as PLAYER_STAGE_ID } from './parts/stage/stage';
 export { StatsPanel } from './parts/stats-panel';
+export { SUBTITLE_LAYER_ID as PLAYER_SUBTITLE_ID } from './parts/subtitle-renderer/subtitle-renderer';
 export type { SurfaceRadius } from './parts/surface-radius';
 export { SurfaceRadiusProvider, useSurfaceRadius } from './parts/surface-radius';
 // The width the sheet draws a card at, so a host asks for artwork that size.

--- a/packages/ui/src/components/organisms/player/parts/stage/stage.tsx
+++ b/packages/ui/src/components/organisms/player/parts/stage/stage.tsx
@@ -299,7 +299,9 @@ function Stage({
   );
 }
 
-const STAGE_ID = 'kroma-player-stage';
+/** The picture box's DOM id: what web CSS sizes an in-page `<video>` through,
+ * and what a shell measures to place a native plane behind the page. */
+export const STAGE_ID = 'kroma-player-stage';
 
 const s = styles({
   stage: { fill: true, z: 2, overflow: 'hidden' },

--- a/packages/ui/src/components/organisms/player/parts/subtitle-renderer/subtitle-renderer.tsx
+++ b/packages/ui/src/components/organisms/player/parts/subtitle-renderer/subtitle-renderer.tsx
@@ -210,6 +210,7 @@ export function SubtitleRenderer({
   // Multi-line cues keep their hard breaks, which <Text> already does for newlines.
   return (
     <Box
+      nativeID={SUBTITLE_LAYER_ID}
       absolute
       left={0}
       right={0}
@@ -234,3 +235,8 @@ export function SubtitleRenderer({
     </Box>
   );
 }
+
+/** The cue band's DOM id, present only while a cue is on screen. A shell drawing
+ * the picture on a plane behind the page measures it to keep the band out of the
+ * plane's way. */
+export const SUBTITLE_LAYER_ID = 'kroma-player-subtitles';


### PR DESCRIPTION
Ran the shipped AppImage on a real SteamOS 3.8.16 root — Valve's own rootfs, reassembled from their chunk store and sha256-verified against the RAUC manifest — and fixed what it found. Six faults; three of them are why the client shows nothing but a dark rectangle on a Deck. The last one turned out to affect the phone builds too.

## The plugin path that blanks the UI

Tauri's `AppRun` exports:

```
GST_PLUGIN_SYSTEM_PATH_1_0=<appdir>/usr/lib/gstreamer-1.0:
```

A directory that never exists with `bundleMediaFramework: false`, plus an empty entry, because SteamOS exports nothing to append. Setting that variable **replaces** GStreamer's built-in search path, so all 200 of the host's plugins vanish (verified with `gst-inspect-1.0`). The old guard only dropped a *single* path containing no colon, so it could never match this shape.

The damage is worse than the documented "webview audio dies" — it takes out WebKitGTK's accelerated compositing and the whole UI with it. One binary, one variable, everything else identical:

| `sanitize_plugin_path()` | result |
| --- | --- |
| on | full UI, 1364 colours |
| off | correct DOM, zero JS errors, **zero pixels painted** |

Not SteamOS-specific either — any host that leaves the variable unset hits it, which is essentially all of them. Upstream is [tauri#15665](https://github.com/tauri-apps/tauri/issues/15665), still open on `2.11.5`, which is current.

## The video output that never came up

The VO ladder kept the first rung whose IPC socket answered. But answering IPC is not being able to draw: `--vo=gpu-next` with no usable GL context runs happily with `vo-configured` false and never exits, so the ladder never fell through — leaving the Deck on an output that shows no frame while the rung below it works.

A rung must now report a configured video output before it's kept. `--force-window=yes` configures at startup, so a working rung answers while still idle: on SteamOS 3.8 `x11` reports `vo-configured: true` with `current-vo` and `video-out-params` populated, and `gpu-next` never does.

It waits for `true` rather than trusting the first reading — a rung still initialising answers `false`, and my first attempt at this failed the `x11` rung for being slow, which would have left users with **no player at all**. An mpv too old to know the property answers nothing and is kept, because a rung that can't be measured mustn't be failed on a guess. End to end on SteamOS:

```
mpv answered but never configured a video output [--vo=gpu-next]; trying a more compatible one
mpv answered but never configured a video output [--vo=gpu-next --gpu-api=vulkan]; trying a more compatible one
mpv could not start [--vo=gpu --gpu-context=x11]; trying a more compatible video output
mpv up [--vo=x11]
```

## The intro that never leaves

`KromaIntro` arms its stall-safety timer inside `begin()`, and the hidden-at-mount branch skips `begin()`. A page that starts hidden and never fires `visibilitychange` therefore arms no timer at all, and the overlay covers the app permanently. The re-check now runs on that branch too, bounded by `HIDDEN_RECHECKS` so a page that can never become visible still hands off.

## The local build that replaces itself

`tauri.conf.json` carried `0.1.3`; `desktop-autoupdate.yml` publishes from `server/Cargo.toml`, currently `0.1.39`. Being **below** the feed, every locally built client updated itself to the release AppImage on launch. It ate two of my test builds before I noticed, and the symptom misleads: the binary on disk becomes the 145 MB AppImage and the AppDir then dies with a FUSE error, so it reads as your own build crashing. A plain `0.1.39` outranks every published `0.1.39-<build>`, since semver sorts a prerelease below its release.

## The release that called itself dirty

Every official installer showed its commit as `<sha>-dirty`. The release workflows stamp the version into the tree **before** the bundler runs, so git saw a modification — for a change the About screen's `version` row already states.

The fix is in `collectBuildInfo` itself, so it reaches all four call sites (the Vite plugin, `buildDefine`, and the mobile and tv-native `app.config.ts`). Each stamping workflow now reads the checkout's state *before* stamping and hands it down as `KROMA_BUILD_DIRTY`, so the flag describes the source the binary came from rather than the pipeline's own edit. A genuinely dirty checkout still reports dirty; an unreadable value falls back to asking git.

Four jobs stamp a **tracked** file and needed the step — desktop, desktop-autoupdate, and both the Android and iOS mobile jobs (`clients/mobile/app.json`, rewritten before `expo prebuild`). Two release workflows were checked and need nothing: `_release-tv.yml` stamps `clients/webos/dist/appinfo.json` and `clients/tizen/dist/config.xml`, and `_release-appletv.yml` re-stamps an `Info.plist` under `clients/tv-native/ios` — all build output, none tracked, so git never saw a change.

## The in-process engine that could not start

`apply_common_options` aborted init on the first option the running libmpv doesn't know. The list carries mpv 0.41 names while Linux links the **system** libmpv (SteamOS 3.8 ships 0.40), so `init` died with `Raw(-8)` and always fell back to the sidecar. An option that doesn't exist names a script that doesn't run — the state being asked for — so it's skipped rather than fatal. `libmpv_linux` now also honours `KROMA_MPV_VO`, the knob the binary backend already had.

## Verification

Measured on the real rootfs, not inferred. With these fixes the client reaches the profile screen, the home screen, and plays **direct-play HEVC from a live server** — mpv fetching its own stream at ~2.5 Mbps, decoding, rendering.

`bun run check`, `@kroma/ui` + `@kroma/desktop` typecheck, 51 JS tests across the touched suites, and the desktop crate's `cargo test` (10) + `clippy --all-targets` green **in both feature states** — run on Linux, since the `mpv` module is `cfg`-gated off macOS. (`@kroma/mobile` typecheck fails on the pre-existing local-only `expo-env.d.ts` style-type clash, unrelated.)

## Deliberately not here

**The single-window render-API architecture.** `--wid` embedding cannot host the overlay: it hands mpv the same X drawable the webview paints into. Measured — film paused, the keys that raise the transport changed *zero* pixels, so that path plays video with no controls and no subtitles. The real answer is mpv's render API (`RenderContext` into an FBO the shell composites, UI above it in one window): one surface instead of two, no dependence on WM stacking, hardware decode untouched. I wired the GTK half as a probe and it works mechanically — webview reparents into a `GtkOverlay` above a `GtkGLArea`, context OK, render callback firing — but whether the transparent webview *composites* over that GL area can't be answered without a GPU. That belongs in its own PR, validated on hardware. The comment claiming `--wid` renders *behind* the webview is corrected here.

## Limits of the rig

An M2 Mac can only emulate x86_64, so VA-API hardware decode, gamescope Game Mode and HDR remain real-hardware-only. Everything claimed above was observed; nothing was assumed.
