### PR TITLE
fix(ui): a click never draws the focus ring, not even for one frame

### DIFF
--- a/packages/ui/src/components/atoms/focusable/focusable.link.test.tsx
+++ b/packages/ui/src/components/atoms/focusable/focusable.link.test.tsx
@@ -135,6 +135,7 @@ describe('a Focusable that delegates its host to a router link', () => {
       </Focusable>,
     );
 
+    fireEvent.keyDown(window, { key: 'Tab' });
     fireEvent.focus(host('Genres'));
 
     expect(host('Genres').style.outlineWidth).toBe(

--- a/packages/ui/src/lib/focus-visible.test.tsx
+++ b/packages/ui/src/lib/focus-visible.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { useFocusVisible } from '#ui/lib/focus-visible';
+
+afterEach(() => {
+  cleanup();
+  fireEvent.keyDown(window, { key: 'Escape' });
+});
+
+function probe() {
+  const seen: boolean[] = [];
+  function Probe({ focus }: Readonly<{ focus: unknown }>) {
+    seen.push(useFocusVisible(focus));
+    return null;
+  }
+  return { Probe, seen };
+}
+
+describe('useFocusVisible', () => {
+  it('shows the ring for a focus the keys asked for', () => {
+    const { Probe, seen } = probe();
+    const view = render(<Probe focus={false} />);
+
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+    view.rerender(<Probe focus />);
+
+    expect(seen.at(-1)).toBe(true);
+  });
+
+  it('never shows the ring for a focus the pointer took, not even for one render', () => {
+    const { Probe, seen } = probe();
+    const view = render(<Probe focus={false} />);
+
+    fireEvent.mouseMove(window);
+    view.rerender(<Probe focus />);
+
+    expect(seen).not.toContain(true);
+  });
+
+  it('counts a click as the pointer even when the cursor did not move since the last key', () => {
+    const { Probe, seen } = probe();
+    const view = render(<Probe focus={false} />);
+
+    fireEvent.keyDown(window, { key: 'Enter' });
+    fireEvent.pointerDown(window);
+    view.rerender(<Probe focus />);
+
+    expect(seen.at(-1)).toBe(false);
+  });
+
+  it('re-reads the modality when the focus moves to another owner', () => {
+    const { Probe, seen } = probe();
+    const view = render(<Probe focus={false} />);
+
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+    view.rerender(<Probe focus="un" />);
+    fireEvent.mouseMove(window);
+    view.rerender(<Probe focus="deux" />);
+
+    expect(seen.at(-1)).toBe(false);
+  });
+});

--- a/packages/ui/src/lib/focus-visible.ts
+++ b/packages/ui/src/lib/focus-visible.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { pointerDriving } from '#ui/lib/input-source';
 
 /**
@@ -22,9 +22,12 @@ import { pointerDriving } from '#ui/lib/input-source';
  * would mean two different things depending on how it was reached.
  */
 export function useFocusVisible(focus: unknown): boolean {
-  const [visible, setVisible] = useState(() => !pointerDriving());
-  useEffect(() => {
-    if (focus !== false && focus != null) setVisible(!pointerDriving());
-  }, [focus]);
-  return focus !== false && focus != null && visible;
+  const held = focus !== false && focus != null;
+  const [seen, setSeen] = useState(() => ({ focus, visible: !pointerDriving() }));
+  let { visible } = seen;
+  if (seen.focus !== focus) {
+    if (held) visible = !pointerDriving();
+    setSeen({ focus, visible });
+  }
+  return held && visible;
 }

--- a/packages/ui/src/lib/input-source.ts
+++ b/packages/ui/src/lib/input-source.ts
@@ -22,6 +22,7 @@ if (win) {
   };
   win.addEventListener('mousemove', pointer, { capture: true, passive: true });
   win.addEventListener('wheel', pointer, { capture: true, passive: true });
+  win.addEventListener('pointerdown', pointer, { capture: true, passive: true });
   win.addEventListener(
     'keydown',
     () => {
@@ -31,8 +32,8 @@ if (win) {
   );
 }
 
-/** True when the last input was the pointer (mouse move or wheel), false the
- * moment a key is pressed. Always false off the web. */
+/** True when the last input was the pointer (mouse move, wheel or press), false
+ * the moment a key is pressed. Always false off the web. */
 export function pointerDriving(): boolean {
   return pointerDrove;
 }


### PR DESCRIPTION
## What

`useFocusVisible` decided whether to draw the ring from a state value that a passive effect refreshed after the focus changed. The frame that gained focus therefore painted with the answer for the previous owner: a control last focused by the keys, or one that mounted before the mouse ever moved, flashed the ring for a frame on every click until the effect corrected it. The hook now derives visibility during render, keeping the last focus owner beside the modality read for it and re-reading synchronously when the owner changes, so the frame that gains focus already knows the pointer took it. A pointer press also counts as the pointer in `input-source`, alongside mouse move and wheel: without it, typing then clicking with a stationary cursor drew a persistent ring, and a tap on a touch browser did the same.

The link test titled "when the keyboard puts focus on it" never pressed a key and relied on pointer presses not counting. It now presses Tab first.

## Closes

No issue. Reproduced from a report in conversation and fixed in one sitting; the regression test is the record.

## Checks

- [x] `bun run lint` and `bun run test` pass, or I said below which failed and why
- [ ] `cargo clippy` and `cargo test` pass, if the server changed (server untouched)
- [x] Follows `CODE_STYLE.md` — no comments narrating the work, exported API only
- [x] One idea. If it grew a second, it was split.

## Risk

Every ring in the kit goes through this hook, so a mistake would show as a ring missing after a keyboard move or parked after a pointer sweep. `focus-visible.test.tsx` records the hook's value on every render and pins both, and the focusable suite still covers the sweep and the key-restores-ring cases. Counting a press as the pointer also silences the reveal scroll on click, which is the same rule hover already follows: a control under the cursor is already in view.
