### PR TITLE
fix(ci): a site config node can load, a publish that skips without a token, and a path checked before it is read

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,6 +285,7 @@ jobs:
     timeout-minutes: 25
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      HAS_NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -309,9 +310,11 @@ jobs:
           path: dist/sdk/*.tgz
           if-no-files-found: error
       # Skipped, not failed, while the NPM_TOKEN secret is absent: the tarball
-      # is still on the run for a hand publish.
+      # is still on the run for a hand publish. The guard reads its own flag and
+      # never NODE_AUTH_TOKEN, which setup-node fills with a placeholder so npm
+      # has something to expand: it is never empty.
       - name: Publish
-        if: needs.version.outputs.channel != 'none' && env.NODE_AUTH_TOKEN != ''
+        if: needs.version.outputs.channel != 'none' && env.HAS_NPM_TOKEN == 'true'
         run: >-
           bun run ci sdk publish --provenance
           --tag "${{ needs.version.outputs.channel == 'candidate' && 'canary' || 'latest' }}"

--- a/clients/web/src/features/notifications/notification-row.tsx
+++ b/clients/web/src/features/notifications/notification-row.tsx
@@ -37,7 +37,7 @@ function foldLabels(
 ): { span: string | null; repeat: string | null } {
   const { head, items } = run;
   if (items.length <= 1) return { span: null, repeat: null };
-  const oldest = relative(items[items.length - 1]?.createdAt ?? head.createdAt);
+  const oldest = relative(items.at(-1)?.createdAt ?? head.createdAt);
   return {
     span: oldest === latest ? null : t('notifications.repeatSpan', { first: oldest, last: latest }),
     repeat: t('notifications.repeatCount', { count: items.length }),

--- a/packages/bundler/src/message-subset.ts
+++ b/packages/bundler/src/message-subset.ts
@@ -1,6 +1,7 @@
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { LABEL_NAMESPACE, namespaceOf } from '@kroma/i18n';
+import { namespaceOf } from '@kroma/i18n/layout';
+import { LABEL_NAMESPACE } from '@kroma/i18n/locales';
 import type { Plugin } from 'vite';
 
 const KIT_SRC = fileURLToPath(new URL('../../ui/src', import.meta.url));

--- a/packages/bundler/src/site.test.ts
+++ b/packages/bundler/src/site.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -146,5 +147,18 @@ describe('kromaSite', () => {
     config(siteRoot(), { prerender: true });
 
     expect(startOptions).toEqual([{}, { prerender: { enabled: true, crawlLinks: true } }]);
+  });
+
+  it('loads under node alone, the way vite reads a site config', () => {
+    const entry = fileURLToPath(new URL('./site.ts', import.meta.url));
+
+    const node = spawnSync(
+      process.execPath,
+      ['--input-type=module', '-e', `await import(${JSON.stringify(entry)})`],
+      { encoding: 'utf8' },
+    );
+
+    expect(node.stderr).toBe('');
+    expect(node.status).toBe(0);
   });
 });

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -15,6 +15,8 @@
   "main": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
+    "./layout": "./src/layout.ts",
+    "./locales": "./src/locales.ts",
     "./react": "./src/react/index.ts",
     "./schema": "./schema/catalog.schema.json",
     "./vite": "./vite/index.ts"

--- a/packages/sonar-tools/src/config-lint.ts
+++ b/packages/sonar-tools/src/config-lint.ts
@@ -6,10 +6,21 @@
 // Both have happened in this repo, which is why the properties file says so
 // twice. Run: `bun run sonar:lint`.
 
-import { readdirSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { readdirSync, readFileSync, realpathSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
 
-const CONFIG = process.argv[2] ?? 'sonar-project.properties';
+function underCwd(path: string): string {
+  const full = realpathSync(path);
+  const root = realpathSync(process.cwd());
+  if (full !== root && !full.startsWith(root + sep)) {
+    console.error(`${path} is outside ${root}.`);
+    process.exit(1);
+  }
+  return full;
+}
+
+const CONFIG = underCwd(process.argv[2] ?? 'sonar-project.properties');
+const NAME = relative(process.cwd(), CONFIG);
 
 // Patterns that are meant to match nothing today. Each guards against a tree
 // the scanner walks but git does not track (build output, caches, vendored
@@ -153,9 +164,9 @@ for (const id of ids) {
 }
 
 if (problems.length > 0) {
-  console.log(`${CONFIG}\n`);
+  console.log(`${NAME}\n`);
   for (const p of problems) console.log(`  ${p}`);
   console.log(`\n${problems.length} problem(s).`);
   process.exit(1);
 }
-console.log(`${CONFIG}: every exclusion and suppression still matches something.`);
+console.log(`${NAME}: every exclusion and suppression still matches something.`);


### PR DESCRIPTION
Three checks were red on `main` after #196.

## Package-source worker / deploy

`apps/modules` and `apps/packages` both build through `kromaSite`, and Vite
hands that config graph to Node, which strips types and resolves the rest
itself. `message-subset` reached `@kroma/i18n` by its package root, which
re-exports the whole runtime tree, whose relative imports carry no extension.
Node stopped at `./define` and the config never loaded, so neither site built.

It now takes `namespaceOf` and `LABEL_NAMESPACE` from the two modules that own
them. Both are pure and import only types, so Node erases their one relative
import and resolves nothing. They get a subpath each.

`site.test.ts` now spawns Node against `site.ts`, so the next import that only
a bundler can resolve fails a test instead of a deploy. Reverting the
`message-subset` line alone turns that test red.

## Build &amp; Release / Module SDK

The Publish step meant to skip itself when `NPM_TOKEN` is absent, and the
secret is absent, and it ran anyway: `setup-node` writes
`NODE_AUTH_TOKEN=XXXXX-XXXXX-XXXXX-XXXXX` whenever the variable is empty, so
npm has something to expand in the `.npmrc`, and the guard's `!= ''` was never
false. npm answered the tokenless `PUT` with a 404. The guard now reads a flag
of its own, computed from the secret.

The four `@kromatv/sdk` versions on npm were all published by hand. Adding an
`NPM_TOKEN` with publish rights on the scope is what makes the run publish
them instead; without it the job goes green and leaves the tarball on the run.

## SonarCloud

`new_security_rating` was C on one MAJOR finding, `tssecurity:S8707` in
`config-lint.ts`: a CLI reading a path built from `argv` with nothing checked.
It now resolves the argument and refuses one that leaves the working
directory, before it reads a byte. The `.at(-1)` finding in
`notification-row.tsx` came along with it.

## Left alone

`bun run sonar:lint` reports one dead entry of its own:
`sonar.coverage.exclusions` still names `packages/ui/src/services/themeAudio.web.ts`,
which no longer exists. Deleting it and repointing it at `themeAudio.native.ts`
move the coverage denominator in opposite directions, so that is a call to make
deliberately. Nothing runs `sonar:lint` in CI today.