### PR TITLE
chore: the repository answers to kromatv, and every URL follows

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security vulnerability
-    url: https://github.com/maxscharwath/kroma/security/advisories/new
+    url: https://github.com/kromatv/kroma/security/advisories/new
     about: Do not open a public issue. Report privately through a security advisory — see SECURITY.md.

--- a/BETA.md
+++ b/BETA.md
@@ -73,7 +73,7 @@ Nvidia Shield boxes.
 You need your Android phone and the beamer on the same Wi-Fi network.
 
 1. On the **phone**, download the `.apk` file: open
-   https://github.com/maxscharwath/kroma/releases/latest and tap the file whose
+   https://github.com/kromatv/kroma/releases/latest and tap the file whose
    name starts with `KROMA-androidtv`.
 2. Install the free **Send Files to TV** app on both the phone **and** the
    beamer (it exists in both app stores).
@@ -88,7 +88,7 @@ You need your Android phone and the beamer on the same Wi-Fi network.
 2. Open Downloader and type this address into the URL field:
 
    ```
-   https://github.com/maxscharwath/kroma/releases/latest
+   https://github.com/kromatv/kroma/releases/latest
    ```
 
 3. On the page that opens, scroll down to the list of files and select the one
@@ -157,7 +157,7 @@ the main row automatically.
   taken from inside the app.
 - Android: from the App Tester app.
 - By email: beta@kroma.tv
-- Or open an issue at https://github.com/maxscharwath/kroma/issues.
+- Or open an issue at https://github.com/kromatv/kroma/issues.
 
 Please mention the device, the KROMA version and what you were doing when the
 problem happened. Screenshots help a lot.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ own README for details.
 ## Getting started
 
 ```bash
-git clone https://github.com/maxscharwath/kroma.git
+git clone https://github.com/kromatv/kroma.git
 cd kroma
 bun install
 bun run dev      # media server (:4040) + web client (:3000) together

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ One Rust binary scans your files and streams them to the web, your phone, your T
 Everything past playback and catalog is a module you install from inside the app.
 </p>
 
-[![CI](https://github.com/maxscharwath/kroma/actions/workflows/ci.yml/badge.svg)](https://github.com/maxscharwath/kroma/actions/workflows/ci.yml) [![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=maxscharwath_kroma&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=maxscharwath_kroma) [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=maxscharwath_kroma&metric=coverage)](https://sonarcloud.io/component_measures?id=maxscharwath_kroma&metric=coverage) [![Release](https://img.shields.io/github/v/release/maxscharwath/kroma?style=flat-square&color=F4B642&labelColor=0A0A0C)](https://github.com/maxscharwath/kroma/releases)<br/>
+[![CI](https://github.com/kromatv/kroma/actions/workflows/ci.yml/badge.svg)](https://github.com/kromatv/kroma/actions/workflows/ci.yml) [![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=maxscharwath_kroma&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=maxscharwath_kroma) [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=maxscharwath_kroma&metric=coverage)](https://sonarcloud.io/component_measures?id=maxscharwath_kroma&metric=coverage) [![Release](https://img.shields.io/github/v/release/kromatv/kroma?style=flat-square&color=F4B642&labelColor=0A0A0C)](https://github.com/kromatv/kroma/releases)<br/>
 [![Rust](https://img.shields.io/badge/Rust-1.88-0A0A0C.svg?style=flat-square&logo=rust&logoColor=F4B642)](rust-toolchain.toml) [![TypeScript](https://img.shields.io/badge/TypeScript-strict-0A0A0C.svg?style=flat-square&logo=typescript&logoColor=3178C6)](tsconfig.base.json) [![Bun](https://img.shields.io/badge/Bun-1.4-0A0A0C.svg?style=flat-square&logo=bun&logoColor=F4B642)](https://bun.sh) [![License: GPL-2.0](https://img.shields.io/badge/License-GPL--2.0-F4B642.svg?style=flat-square)](LICENSE)
 
 <p>
@@ -66,7 +66,7 @@ Everything past playback and catalog is a module you install from inside the app
 | --- | --- |
 | **Any Linux host** | the container image below, amd64 and arm64 (a Raspberry Pi 4 or 5 works) |
 | **Synology** | the `.spk` from the package source, see [INSTALL.md](INSTALL.md) |
-| **TVs, phones, desktops** | the installers on [kroma.tv/download](https://kroma.tv/download) or [GitHub Releases](https://github.com/maxscharwath/kroma/releases) |
+| **TVs, phones, desktops** | the installers on [kroma.tv/download](https://kroma.tv/download) or [GitHub Releases](https://github.com/kromatv/kroma/releases) |
 | **Testers** | [BETA.md](BETA.md), written for non-technical users |
 
 ```bash
@@ -74,7 +74,7 @@ docker run -d -p 4040:4040 \
   -e KROMA_MEDIA_DIRS=/media \
   -v /volume1/video:/media \
   -v kroma-data:/data \
-  ghcr.io/maxscharwath/kroma:latest
+  ghcr.io/kromatv/kroma:latest
 ```
 
 Open `http://<host>:4040`. With no media configured the server seeds demo

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@
 ## Reporting a vulnerability
 
 Report privately through GitHub: **Security → Advisories → Report a vulnerability**
-([direct link](https://github.com/maxscharwath/kroma/security/advisories/new)). Private
+([direct link](https://github.com/kromatv/kroma/security/advisories/new)). Private
 reporting is enabled here, so the report stays between you and the maintainer until a
 fix ships.
 

--- a/apps/kit/package.json
+++ b/apps/kit/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "apps/kit"
   },
   "main": "index.ts",

--- a/apps/kit/src/buildInfo.native.test.ts
+++ b/apps/kit/src/buildInfo.native.test.ts
@@ -32,7 +32,7 @@ const STAMPED: BuildInfo = {
   branch: 'main',
   dirty: false,
   buildDate: '2026-07-01T10:00:00Z',
-  repository: 'https://github.com/maxscharwath/kroma',
+  repository: 'https://github.com/kromatv/kroma',
 };
 
 const EMPTY: BuildInfo = {

--- a/apps/modules/package.json
+++ b/apps/modules/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "apps/modules"
   },
   "imports": {

--- a/apps/modules/src/lib/source.ts
+++ b/apps/modules/src/lib/source.ts
@@ -3,7 +3,7 @@ export type Env = {
   GITHUB_TOKEN?: string;
 };
 
-export const DEFAULT_REPO = 'maxscharwath/kroma';
+export const DEFAULT_REPO = 'kromatv/kroma';
 
 const CACHE_FRESH = 'https://kroma-modules.cache/catalog-fresh';
 const CACHE_STALE = 'https://kroma-modules.cache/catalog-stale';

--- a/apps/modules/wrangler.jsonc
+++ b/apps/modules/wrangler.jsonc
@@ -7,7 +7,7 @@
   "observability": { "enabled": true },
   "workers_dev": true,
   "vars": {
-    "GITHUB_REPO": "maxscharwath/kroma"
+    "GITHUB_REPO": "kromatv/kroma"
   },
   "assets": {
     "directory": "./dist/client",

--- a/apps/packages/package.json
+++ b/apps/packages/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "apps/packages"
   },
   "imports": {

--- a/apps/packages/src/lib/api.test.ts
+++ b/apps/packages/src/lib/api.test.ts
@@ -3,7 +3,7 @@ import { type ExecCtx, machineResponse } from './api';
 import type { Env } from './catalog';
 
 const ICON_SRC =
-  'https://raw.githubusercontent.com/maxscharwath/kroma/main/clients/synology/spk/PACKAGE_ICON_256.PNG';
+  'https://raw.githubusercontent.com/kromatv/kroma/main/clients/synology/spk/PACKAGE_ICON_256.PNG';
 
 const ctx = () => ({ waitUntil: vi.fn() });
 
@@ -177,7 +177,7 @@ describe('machineResponse', () => {
       repo: string;
       packages: { channel: string; version: string; link: string; release: string }[];
     };
-    expect(body.repo).toBe('maxscharwath/kroma');
+    expect(body.repo).toBe('kromatv/kroma');
     expect(body.fetchedAt).toBeTruthy();
     expect(body.packages.map((p) => p.channel)).toEqual(['canary', 'stable']);
     expect(body.packages[1]).toMatchObject({

--- a/apps/packages/src/lib/catalog.test.ts
+++ b/apps/packages/src/lib/catalog.test.ts
@@ -18,7 +18,7 @@ function entry(over: Partial<Entry> = {}): Entry {
     channel: 'stable',
     tag: 'v0.1.25',
     releaseName: 'KROMA 0.1.25',
-    releaseUrl: 'https://github.com/maxscharwath/kroma/releases/tag/v0.1.25',
+    releaseUrl: 'https://github.com/kromatv/kroma/releases/tag/v0.1.25',
     publishedAt: '2026-07-01T00:00:00Z',
     spkName: 'kroma-0.1.25-3439372-x86_64.spk',
     spkUrl: 'https://example/kroma.spk',
@@ -143,7 +143,7 @@ describe('dsmVersion', () => {
 
 describe('toDsmPackage', () => {
   it('fills defaults when there is no sidecar info', () => {
-    const pkg = toDsmPackage(entry(), 'https://pkg.kroma.tv', 'maxscharwath/kroma');
+    const pkg = toDsmPackage(entry(), 'https://pkg.kroma.tv', 'kromatv/kroma');
     expect(pkg.package).toBe('kroma');
     expect(pkg.version).toBe('0.1.25-3439372');
     expect(pkg.dname).toBe('KROMA');
@@ -154,7 +154,7 @@ describe('toDsmPackage', () => {
     // No `beta` field at all - DSM hides `beta:true` from a dynamic source.
     expect('beta' in pkg).toBe(false);
     expect(pkg.thumbnail).toEqual(['https://pkg.kroma.tv/icon.png']);
-    expect(pkg.maintainer_url).toBe('https://github.com/maxscharwath/kroma');
+    expect(pkg.maintainer_url).toBe('https://github.com/kromatv/kroma');
     expect(pkg.changelog).toBe(entry().releaseUrl);
   });
 
@@ -162,7 +162,7 @@ describe('toDsmPackage', () => {
     const pkg = toDsmPackage(
       entry({ info, channel: 'canary' }),
       'https://pkg.kroma.tv',
-      'maxscharwath/kroma',
+      'kromatv/kroma',
     );
     expect(pkg.version).toBe('0.1.25-3439372');
     expect(pkg.size).toBe(2097152); // sidecar size wins
@@ -174,7 +174,7 @@ describe('toDsmPackage', () => {
 
 describe('DEFAULT_REPO', () => {
   it('points at the kroma repo', () => {
-    expect(DEFAULT_REPO).toBe('maxscharwath/kroma');
+    expect(DEFAULT_REPO).toBe('kromatv/kroma');
   });
 });
 

--- a/apps/packages/src/lib/catalog.ts
+++ b/apps/packages/src/lib/catalog.ts
@@ -55,7 +55,7 @@ type GhRelease = {
   assets: GhAsset[];
 };
 
-export const DEFAULT_REPO = 'maxscharwath/kroma';
+export const DEFAULT_REPO = 'kromatv/kroma';
 const CACHE_FRESH = 'https://kroma-packages.cache/catalog-fresh';
 const CACHE_STALE = 'https://kroma-packages.cache/catalog-stale';
 const MAX_SIDECARS = 60;

--- a/apps/packages/src/lib/release.test.ts
+++ b/apps/packages/src/lib/release.test.ts
@@ -6,7 +6,7 @@ const entry = (over: Partial<Entry> = {}): Entry => ({
   channel: 'stable',
   tag: 'v0.1.25',
   releaseName: 'KROMA 0.1.25',
-  releaseUrl: 'https://github.com/maxscharwath/kroma/releases/tag/v0.1.25',
+  releaseUrl: 'https://github.com/kromatv/kroma/releases/tag/v0.1.25',
   publishedAt: '2026-03-04T09:12:33Z',
   spkName: 'kroma-0.1.25-3439372-x86_64.spk',
   spkUrl: 'https://dl.test/kroma-0.1.25-3439372-x86_64.spk',
@@ -45,7 +45,7 @@ describe('toRelease', () => {
       day: '2026-03-04',
       size: '50.0 MB',
       spk: 'https://dl.test/kroma-0.1.25-3439372-x86_64.spk',
-      release: 'https://github.com/maxscharwath/kroma/releases/tag/v0.1.25',
+      release: 'https://github.com/kromatv/kroma/releases/tag/v0.1.25',
       notes: 'Fixes the thing.',
       md5: null,
     });

--- a/apps/packages/wrangler.jsonc
+++ b/apps/packages/wrangler.jsonc
@@ -6,7 +6,7 @@
   "compatibility_flags": ["nodejs_compat"],
   "observability": { "enabled": true },
   "vars": {
-    "GITHUB_REPO": "maxscharwath/kroma"
+    "GITHUB_REPO": "kromatv/kroma"
   },
   "assets": {
     "directory": "./dist/client",

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "apps/www"
   },
   "imports": {

--- a/apps/www/src/components/download/image-channels.tsx
+++ b/apps/www/src/components/download/image-channels.tsx
@@ -3,7 +3,7 @@ import { IconGitBranch, IconTag } from '@tabler/icons-react';
 import type { IconComponent } from '#site/components/download/icon';
 import { m } from '#site/paraglide/messages';
 
-export const IMAGE = 'ghcr.io/maxscharwath/kroma';
+export const IMAGE = 'ghcr.io/kromatv/kroma';
 
 export function ImageChannels() {
   return (

--- a/apps/www/src/components/home/self-host-band.tsx
+++ b/apps/www/src/components/home/self-host-band.tsx
@@ -97,7 +97,7 @@ export function SelfHostBand() {
                   <span className="text-accent-text">$</span> docker run -d -p 4040:4040 \{'\n'}
                   {'    '}-v /volume1/video:/media \{'\n'}
                   {'    '}-v kroma-data:/data \{'\n'}
-                  {'    '}ghcr.io/maxscharwath/kroma
+                  {'    '}ghcr.io/kromatv/kroma
                 </code>
               </pre>
             </div>

--- a/apps/www/src/lib/channels.test.ts
+++ b/apps/www/src/lib/channels.test.ts
@@ -5,7 +5,7 @@ import { Release } from './release-feed.ts';
 const asset = (name: string, createdAt: string, size = 1024) => ({
   name,
   size,
-  browser_download_url: `https://github.com/maxscharwath/kroma/releases/download/canary/${name}`,
+  browser_download_url: `https://github.com/kromatv/kroma/releases/download/canary/${name}`,
   digest: null,
   created_at: createdAt,
 });
@@ -15,7 +15,7 @@ const rolling = (tag: string, assets: ReturnType<typeof asset>[]) =>
     tag_name: tag,
     prerelease: true,
     published_at: '2026-07-10T19:42:27Z',
-    html_url: `https://github.com/maxscharwath/kroma/releases/tag/${tag}`,
+    html_url: `https://github.com/kromatv/kroma/releases/tag/${tag}`,
     assets,
   });
 

--- a/apps/www/src/lib/releases.test.ts
+++ b/apps/www/src/lib/releases.test.ts
@@ -13,7 +13,7 @@ const HEX = 'bbc124ee97eedce6f94b6e9baaacb56301f2e968466ca5c3ec74b78a376e9b35';
 const asset = (name: string, size = 1024, extra: Record<string, unknown> = {}) => ({
   name,
   size,
-  browser_download_url: `https://github.com/maxscharwath/kroma/releases/download/v0.1.38/${name}`,
+  browser_download_url: `https://github.com/kromatv/kroma/releases/download/v0.1.38/${name}`,
   digest: `sha256:${HEX}`,
   created_at: '2026-08-14T00:17:26Z',
   ...extra,
@@ -22,7 +22,7 @@ const asset = (name: string, size = 1024, extra: Record<string, unknown> = {}) =
 const bare = (tag: string) => ({
   tag_name: tag,
   published_at: '2026-08-14T00:17:31Z',
-  html_url: `https://github.com/maxscharwath/kroma/releases/tag/${tag}`,
+  html_url: `https://github.com/kromatv/kroma/releases/tag/${tag}`,
   assets: [],
 });
 
@@ -30,7 +30,7 @@ const raw = (fields: Record<string, unknown>) =>
   Release.parse({
     tag_name: 'v0.1.38',
     published_at: '2026-08-14T00:17:31Z',
-    html_url: 'https://github.com/maxscharwath/kroma/releases/tag/v0.1.38',
+    html_url: 'https://github.com/kromatv/kroma/releases/tag/v0.1.38',
     assets: [],
     ...fields,
   });
@@ -43,12 +43,12 @@ describe('toSiteRelease', () => {
       version: '0.1.38',
       tag: 'v0.1.38',
       publishedAt: '2026-08-14T00:17:31Z',
-      notesUrl: 'https://github.com/maxscharwath/kroma/releases/tag/v0.1.38',
+      notesUrl: 'https://github.com/kromatv/kroma/releases/tag/v0.1.38',
       downloads: [
         {
           target: 'macos',
           name: 'KROMA_0.1.38_aarch64.dmg',
-          url: 'https://github.com/maxscharwath/kroma/releases/download/v0.1.38/KROMA_0.1.38_aarch64.dmg',
+          url: 'https://github.com/kromatv/kroma/releases/download/v0.1.38/KROMA_0.1.38_aarch64.dmg',
           bytes: 52807435,
           sha256: HEX,
           builtAt: '2026-08-14T00:17:26Z',

--- a/apps/www/src/server/canary/canary.test.ts
+++ b/apps/www/src/server/canary/canary.test.ts
@@ -5,7 +5,7 @@ import type { Artifact, Run } from './github';
 const run = (over: Partial<Run> = {}): Run => ({
   id: 3490258,
   head_sha: 'a'.repeat(40),
-  html_url: 'https://github.com/maxscharwath/kroma/actions/runs/3490258',
+  html_url: 'https://github.com/kromatv/kroma/actions/runs/3490258',
   updated_at: '2026-08-20T19:14:00Z',
   display_title: 'feat: the thing',
   ...over,

--- a/apps/www/src/server/canary/github.ts
+++ b/apps/www/src/server/canary/github.ts
@@ -7,7 +7,7 @@ export type Env = {
   GITHUB_TOKEN?: string;
 };
 
-export const DEFAULT_REPO = 'maxscharwath/kroma';
+export const DEFAULT_REPO = 'kromatv/kroma';
 
 export const repoOf = (env: Env) => env.GITHUB_REPO || DEFAULT_REPO;
 

--- a/clients/bench/package.json
+++ b/clients/bench/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "clients/bench"
   },
   "scripts": {

--- a/clients/build-info/package.json
+++ b/clients/build-info/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "clients/build-info"
   },
   "//type": "ESM, even though an Expo app.config.ts reaches this through a CommonJS `require`. Node's type stripping does not rewrite modules, so an ESM `import` inside a \"commonjs\" package fails with \"Cannot use import statement outside a module\"; declaring it a module instead lets require(esm) - supported since Node 22.12 - do the interop.",

--- a/clients/desktop/package.json
+++ b/clients/desktop/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "clients/desktop"
   },
   "scripts": {

--- a/clients/desktop/scripts/fetch-libmpv-windows.ps1
+++ b/clients/desktop/scripts/fetch-libmpv-windows.ps1
@@ -52,7 +52,7 @@ function Get-Sha256($path) {
 }
 
 if (-not (Test-Path $archive) -or (Get-Sha256 $archive) -ne $Sha256) {
-  $url = "https://github.com/maxscharwath/kroma/releases/download/$VendorTag/$Asset"
+  $url = "https://github.com/kromatv/kroma/releases/download/$VendorTag/$Asset"
   Write-Host "fetch-libmpv-windows: downloading $Asset"
   Invoke-WebRequest -Uri $url -OutFile $archive
   # A mismatch is usually not a tampered archive, it is not an archive at all:

--- a/clients/desktop/src-tauri/tauri.conf.json
+++ b/clients/desktop/src-tauri/tauri.conf.json
@@ -52,7 +52,7 @@
   "plugins": {
     "updater": {
       "endpoints": [
-        "https://github.com/maxscharwath/kroma/releases/download/desktop-latest/latest.json"
+        "https://github.com/kromatv/kroma/releases/download/desktop-latest/latest.json"
       ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDM2MUJFMkE3QjU2NkNFRUQKUldUdHptYTFwK0liTmxNaUhIM2hwNmhyWXZrT3ExZFBEdmYyK2J0VTVURlp4YVQzRDNzTUdrbkUK"
     }

--- a/clients/mobile/package.json
+++ b/clients/mobile/package.json
@@ -7,7 +7,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "clients/mobile"
   },
   "main": "expo-router/entry",

--- a/clients/mobile/src/lib/buildInfo.test.ts
+++ b/clients/mobile/src/lib/buildInfo.test.ts
@@ -31,7 +31,7 @@ const FULL = {
       branch: 'main',
       dirty: false,
       buildDate: '2026-07-01T10:00:00Z',
-      repository: 'https://github.com/maxscharwath/kroma',
+      repository: 'https://github.com/kromatv/kroma',
     },
   },
 };

--- a/clients/tizen/SETUP.md
+++ b/clients/tizen/SETUP.md
@@ -131,7 +131,7 @@ the TV's network (`bun run server` on the host, or the Docker image on your NAS)
 KROMA targets **Tizen 3.0 (2017 models) and newer**. `config.xml` sets
 `required_version="3.0"`, and a retail set refuses a widget that demands a
 platform newer than its own with an opaque `install failed[118]`, which was the
-whole of [#86](https://github.com/maxscharwath/kroma/issues/86).
+whole of [#86](https://github.com/kromatv/kroma/issues/86).
 
 Reaching that far down is what the **deep tier** is for. Chromium is frozen per
 Tizen major (3.0 = M47, 4.0 = M56, 5.0 = M63, 5.5 = M69, 6.0 = M76, 6.5 = M85,

--- a/clients/tizen/package.json
+++ b/clients/tizen/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "clients/tizen"
   },
   "scripts": {

--- a/clients/tv-native/package.json
+++ b/clients/tv-native/package.json
@@ -7,7 +7,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "clients/tv-native"
   },
   "main": "index.ts",

--- a/clients/tv-web/package.json
+++ b/clients/tv-web/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "clients/tv-web"
   },
   "scripts": {

--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "clients/web"
   },
   "scripts": {

--- a/clients/webos/package.json
+++ b/clients/webos/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "clients/webos"
   },
   "scripts": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@
 # bind-mount below. See server/README.md for the full option reference.
 services:
   kroma:
-    image: ghcr.io/maxscharwath/kroma:latest
+    image: ghcr.io/kromatv/kroma:latest
     container_name: kroma
     restart: unless-stopped
     ports:

--- a/docs/TICKETS.md
+++ b/docs/TICKETS.md
@@ -75,7 +75,7 @@ is how boards die.
 
 ## The board
 
-Project: **KROMA** (Projects v2, `maxscharwath/kroma`). Every issue and PR is added
+Project: **KROMA** (Projects v2, `kromatv/kroma`). Every issue and PR is added
 automatically; nothing is tracked in someone's head.
 
 | Column | Means | Leaves when |

--- a/modules/tv.kroma.acquisition/package.json
+++ b/modules/tv.kroma.acquisition/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "modules/tv.kroma.acquisition"
   },
   "exports": {

--- a/modules/tv.kroma.indexer/package.json
+++ b/modules/tv.kroma.indexer/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "modules/tv.kroma.indexer"
   },
   "exports": {

--- a/modules/tv.kroma.remote/package.json
+++ b/modules/tv.kroma.remote/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "modules/tv.kroma.remote"
   },
   "exports": {

--- a/modules/tv.kroma.torrents/package.json
+++ b/modules/tv.kroma.torrents/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "modules/tv.kroma.torrents"
   },
   "exports": {

--- a/modules/tv.kroma.vpn/package.json
+++ b/modules/tv.kroma.vpn/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "modules/tv.kroma.vpn"
   },
   "exports": {

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "description": "KROMA self-hosted, multi-platform video streaming (Rust server + web / Tizen / webOS clients). Direct-play HEVC everywhere.",
   "author": "Maxime Scharwath <maxscharwath@gmail.com>",
   "license": "GPL-2.0-or-later",
-  "repository": "https://github.com/maxscharwath/kroma",
+  "repository": "https://github.com/kromatv/kroma",
   "homepage": "https://kroma.tv",
-  "bugs": "https://github.com/maxscharwath/kroma/issues",
+  "bugs": "https://github.com/kromatv/kroma/issues",
   "workspaces": [
     "packages/*",
     "clients/*",

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "packages/bundler"
   },
   "exports": {

--- a/packages/ci-tools/package.json
+++ b/packages/ci-tools/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "packages/ci-tools"
   },
   "exports": {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -76,5 +76,5 @@ them; a deep kit import (`@kromatv/ui/kit/atoms/button`) is folded onto
 `@kromatv/ui/kit`, and any other `@kromatv/*` import fails the build. Anything
 else (`zod`, an icon set, your own code) is bundled.
 
-See [`modules/README.md`](https://github.com/maxscharwath/kroma/blob/main/modules/README.md)
+See [`modules/README.md`](https://github.com/kromatv/kroma/blob/main/modules/README.md)
 for the module model: points, storage, events, the runtime contract.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://kroma.tv",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "packages/cli"
   },
   "keywords": [

--- a/packages/cli/src/commands/release-command.test.ts
+++ b/packages/cli/src/commands/release-command.test.ts
@@ -7,7 +7,7 @@ import { packBundle } from '../bundle/pack';
 import type { Plan } from './release';
 import { releaseCommand } from './release';
 
-const REPO = 'maxscharwath/kroma';
+const REPO = 'kromatv/kroma';
 
 let dir: string;
 

--- a/packages/cli/src/commands/release.test.ts
+++ b/packages/cli/src/commands/release.test.ts
@@ -3,7 +3,7 @@ import type { Catalog, Entry } from '../bundle/catalog';
 import type { Bundle } from '../bundle/read';
 import { decide, tagFor, verdictFor } from './release';
 
-const REPO = 'maxscharwath/kroma';
+const REPO = 'kromatv/kroma';
 const NOW = '2026-08-14T00:00:00.000Z';
 
 function entry(id: string, version: string, hashes: Record<string, string>): Entry {

--- a/packages/cli/templates/base/README.md
+++ b/packages/cli/templates/base/README.md
@@ -11,4 +11,4 @@ bunx kroma build                    # dist/modules/__ID__.kmod
 
 Layout: `module.json` is the manifest, `ui/` the page a KROMA client renders,
 `server/` the sidecar the server spawns, `locales/` the strings. See
-https://github.com/maxscharwath/kroma/blob/main/modules/README.md.
+https://github.com/kromatv/kroma/blob/main/modules/README.md.

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "packages/client"
   },
   "sideEffects": false,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "packages/core"
   },
   "sideEffects": false,

--- a/packages/i18n-devtools/package.json
+++ b/packages/i18n-devtools/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "packages/i18n-devtools"
   },
   "exports": {

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "packages/i18n"
   },
   "sideEffects": false,

--- a/packages/lan-beacon/package.json
+++ b/packages/lan-beacon/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "packages/lan-beacon"
   },
   "main": "index.ts",

--- a/packages/mdns-beacon/package.json
+++ b/packages/mdns-beacon/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "packages/mdns-beacon"
   },
   "main": "./src/index.ts",

--- a/packages/media3-ffmpeg/package.json
+++ b/packages/media3-ffmpeg/package.json
@@ -7,7 +7,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "packages/media3-ffmpeg"
   },
   "main": "app.plugin.js",

--- a/packages/module-sdk/package.json
+++ b/packages/module-sdk/package.json
@@ -9,7 +9,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "packages/module-sdk"
   },
   "exports": {

--- a/packages/push-relay/package.json
+++ b/packages/push-relay/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "packages/push-relay"
   },
   "scripts": {

--- a/packages/react-audit/package.json
+++ b/packages/react-audit/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "packages/react-audit"
   },
   "sideEffects": false,

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "packages/registry"
   },
   "main": "src/index.ts",

--- a/packages/shots/package.json
+++ b/packages/shots/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "packages/shots"
   },
   "scripts": {

--- a/packages/shots/src/cli.ts
+++ b/packages/shots/src/cli.ts
@@ -19,7 +19,7 @@ import { assertPng, assetName, outDirFor, type Screen, type Shot } from './shot'
 import { DEFAULT_TARGETS, type Target, targetsFrom } from './targets';
 
 const REPO_DIR = new URL('../../..', import.meta.url).pathname;
-const DEFAULT_REPO = 'maxscharwath/kroma';
+const DEFAULT_REPO = 'kromatv/kroma';
 const DEFAULT_SETTLE_MS = 600;
 
 const USAGE = `usage: bun run shots:pr <slug> [options]

--- a/packages/site-kit/package.json
+++ b/packages/site-kit/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "packages/site-kit"
   },
   "sideEffects": false,

--- a/packages/site-meta/package.json
+++ b/packages/site-meta/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "packages/site-meta"
   },
   "sideEffects": false,

--- a/packages/site-meta/src/index.ts
+++ b/packages/site-meta/src/index.ts
@@ -1,5 +1,5 @@
 const url = 'https://kroma.tv';
-const repo = 'https://github.com/maxscharwath/kroma';
+const repo = 'https://github.com/kromatv/kroma';
 
 /**
  * The facts every KROMA web property repeats. Language-invariant only:

--- a/packages/sonar-tools/package.json
+++ b/packages/sonar-tools/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "packages/sonar-tools"
   },
   "scripts": {

--- a/packages/spatial-nav/package.json
+++ b/packages/spatial-nav/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "packages/spatial-nav"
   },
   "sideEffects": false,

--- a/packages/stats-relay/package.json
+++ b/packages/stats-relay/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "packages/stats-relay"
   },
   "scripts": {

--- a/packages/synology-repo/.env.example
+++ b/packages/synology-repo/.env.example
@@ -3,10 +3,10 @@
 # Copy to `.env` and adjust. Only CATALOG_DOWNLOAD_URL + CATALOG_PAGES_URL are required.
 
 # Public URL DSM downloads the .spk from (e.g. a GitHub Release asset). REQUIRED.
-CATALOG_DOWNLOAD_URL=https://github.com/maxscharwath/kroma/releases/download/v0.1.4/kroma-0.1.4-x86_64.spk
+CATALOG_DOWNLOAD_URL=https://github.com/kromatv/kroma/releases/download/v0.1.4/kroma-0.1.4-x86_64.spk
 
 # Base URL the generated repo dir is served at (used for the store icon). REQUIRED.
-CATALOG_PAGES_URL=https://maxscharwath.github.io/kroma
+CATALOG_PAGES_URL=https://kromatv.github.io/kroma
 
 # Path to the .spk. Optional - defaults to the newest *.spk under
 # ./, ./dist, or ./clients/synology/dist (relative to the working directory).
@@ -23,10 +23,10 @@ CATALOG_PAGES_URL=https://maxscharwath.github.io/kroma
 
 # Store-card metadata. Optional.
 # CATALOG_MAINTAINER=Maxime Scharwath
-# CATALOG_MAINTAINER_URL=https://github.com/maxscharwath/kroma
+# CATALOG_MAINTAINER_URL=https://github.com/kromatv/kroma
 # CATALOG_DISTRIBUTOR=KROMA
-# CATALOG_DISTRIBUTOR_URL=https://github.com/maxscharwath/kroma
-# CATALOG_CHANGELOG_URL=https://github.com/maxscharwath/kroma/releases
+# CATALOG_DISTRIBUTOR_URL=https://github.com/kromatv/kroma
+# CATALOG_CHANGELOG_URL=https://github.com/kromatv/kroma/releases
 
 # Path to a store icon PNG override. Optional - by default the icon is read
 # straight out of the .spk (PACKAGE_ICON_256.PNG).

--- a/packages/synology-repo/package.json
+++ b/packages/synology-repo/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "packages/synology-repo"
   },
   "bin": {

--- a/packages/synology-repo/src/backfill-info.ts
+++ b/packages/synology-repo/src/backfill-info.ts
@@ -14,7 +14,7 @@ const flag = (name: string) => {
   return i >= 0 ? args[i + 1] : undefined;
 };
 const limit = Number.parseInt(flag('--limit') ?? '1000', 10);
-const repo = flag('--repo') ?? 'maxscharwath/kroma';
+const repo = flag('--repo') ?? 'kromatv/kroma';
 
 const gh = (ghArgs: string[]) =>
   execFileSync('gh', [...ghArgs, '--repo', repo], {

--- a/packages/synology-repo/src/gen-catalog.ts
+++ b/packages/synology-repo/src/gen-catalog.ts
@@ -44,10 +44,10 @@ const catalogName = env('CATALOG_NAME', 'catalog.json'); // e.g. nightly.json fo
 const beta = env('CATALOG_BETA', 'false') === 'true';
 const meta = {
   maintainer: env('CATALOG_MAINTAINER', 'KROMA'),
-  maintainerUrl: env('CATALOG_MAINTAINER_URL', 'https://github.com/maxscharwath/kroma'),
+  maintainerUrl: env('CATALOG_MAINTAINER_URL', 'https://github.com/kromatv/kroma'),
   distributor: env('CATALOG_DISTRIBUTOR', env('CATALOG_MAINTAINER', 'KROMA')),
-  distributorUrl: env('CATALOG_DISTRIBUTOR_URL', 'https://github.com/maxscharwath/kroma'),
-  changelogUrl: env('CATALOG_CHANGELOG_URL', 'https://github.com/maxscharwath/kroma/releases'),
+  distributorUrl: env('CATALOG_DISTRIBUTOR_URL', 'https://github.com/kromatv/kroma'),
+  changelogUrl: env('CATALOG_CHANGELOG_URL', 'https://github.com/kromatv/kroma/releases'),
 };
 
 const {

--- a/packages/synology-repo/src/preview.ts
+++ b/packages/synology-repo/src/preview.ts
@@ -27,8 +27,8 @@ const sampleSubs: Subs = {
   VERSION: '0.1.4.3431188-3431188',
   ARCH: 'x86_64',
   DSM_FLOOR: '7.0',
-  CATALOG_URL: `https://maxscharwath.github.io/kroma/${beta ? 'nightly.json' : 'catalog.json'}`,
-  DOWNLOAD_URL: 'https://github.com/maxscharwath/kroma/releases/latest',
+  CATALOG_URL: `https://kromatv.github.io/kroma/${beta ? 'nightly.json' : 'catalog.json'}`,
+  DOWNLOAD_URL: 'https://github.com/kromatv/kroma/releases/latest',
   ...channelSubs(beta, 'KROMA'),
 };
 

--- a/packages/tv-installer/package.json
+++ b/packages/tv-installer/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "packages/tv-installer"
   },
   "exports": {

--- a/packages/tv-probe/package.json
+++ b/packages/tv-probe/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "packages/tv-probe"
   },
   "scripts": {

--- a/packages/tv/package.json
+++ b/packages/tv/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "packages/tv"
   },
   "exports": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "packages/ui"
   },
   "sideEffects": false,

--- a/packages/workbench/package.json
+++ b/packages/workbench/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "packages/workbench"
   },
   "exports": {

--- a/packages/workbench/src/history-menu.test.tsx
+++ b/packages/workbench/src/history-menu.test.tsx
@@ -32,7 +32,7 @@ const STORIES: readonly Story[] = [
 ];
 
 const SOURCE: StorySource = {
-  repository: 'https://github.com/maxscharwath/kroma',
+  repository: 'https://github.com/kromatv/kroma',
   commit: 'c51eb485a1b2c3d4e5f60718293a4b5c6d7e8f90',
   dirty: false,
   root: ROOT,

--- a/packages/workbench/src/history.test.ts
+++ b/packages/workbench/src/history.test.ts
@@ -13,7 +13,7 @@ import {
 } from './history';
 
 const SHA = 'c51eb485a1b2c3d4e5f60718293a4b5c6d7e8f90';
-const REPO = 'https://github.com/maxscharwath/kroma';
+const REPO = 'https://github.com/kromatv/kroma';
 const ROOT = 'packages/ui/src';
 
 const BUTTON = `${ROOT}/components/atoms/button/button.stories.tsx`;

--- a/packages/workbench/src/link.test.ts
+++ b/packages/workbench/src/link.test.ts
@@ -6,7 +6,7 @@ import { openWebLink, permalink, WEB_LINK } from './link';
 
 afterEach(() => vi.restoreAllMocks());
 
-const REPO = 'https://github.com/maxscharwath/kroma';
+const REPO = 'https://github.com/kromatv/kroma';
 const SHA = '9db893fe1a4e0b1c2d3f4a5b6c7d8e9f0a1b2c3d';
 
 describe('permalink', () => {
@@ -44,7 +44,7 @@ describe('permalink', () => {
   it('refuses a remote that is not a web address', () => {
     // The link is handed to `openWebLink`, which opens http(s) alone; a `file:`
     // or an ssh remote would be a button that does nothing.
-    expect(permalink('git@github.com:maxscharwath/kroma', 'commit', SHA)).toBeNull();
+    expect(permalink('git@github.com:kromatv/kroma', 'commit', SHA)).toBeNull();
     expect(permalink('file:///Users/someone/kroma', 'commit', SHA)).toBeNull();
   });
 
@@ -58,8 +58,8 @@ describe('openWebLink', () => {
 
   it('hands an http(s) address to the platform', () => {
     const openURL = opener();
-    openWebLink('https://github.com/maxscharwath/kroma');
-    expect(openURL).toHaveBeenCalledWith('https://github.com/maxscharwath/kroma');
+    openWebLink('https://github.com/kromatv/kroma');
+    expect(openURL).toHaveBeenCalledWith('https://github.com/kromatv/kroma');
   });
 
   it('opens nothing at all for any other scheme', () => {

--- a/packages/workbench/src/page-history.test.tsx
+++ b/packages/workbench/src/page-history.test.tsx
@@ -30,7 +30,7 @@ const HISTORY: KitHistory = {
 };
 
 const SOURCE: StorySource = {
-  repository: 'https://github.com/maxscharwath/kroma',
+  repository: 'https://github.com/kromatv/kroma',
   commit: 'c51eb485a1b2c3d4e5f60718293a4b5c6d7e8f90',
   dirty: true,
   root: ROOT,

--- a/packages/workbench/src/recent-changes.test.tsx
+++ b/packages/workbench/src/recent-changes.test.tsx
@@ -41,7 +41,7 @@ const STORIES: readonly Story[] = [
 ];
 
 const SOURCE: StorySource = {
-  repository: 'https://github.com/maxscharwath/kroma',
+  repository: 'https://github.com/kromatv/kroma',
   commit: 'c51eb485a1b2c3d4e5f60718293a4b5c6d7e8f90',
   dirty: false,
   root: ROOT,

--- a/packages/workbench/src/source.test.ts
+++ b/packages/workbench/src/source.test.ts
@@ -4,7 +4,7 @@ import { type StorySource, sourceUrl } from './source';
 const SHA = 'c51eb485a1b2c3d4e5f60718293a4b5c6d7e8f90';
 
 const KROMA: StorySource = {
-  repository: 'https://github.com/maxscharwath/kroma',
+  repository: 'https://github.com/kromatv/kroma',
   commit: SHA,
   dirty: false,
   root: 'packages/ui/src',
@@ -15,7 +15,7 @@ const KROMA: StorySource = {
 // the context was opened on.
 const VITE = '../../packages/ui/src/components/atoms/button/button.stories.tsx';
 const METRO = './components/atoms/button/button.stories.tsx';
-const FOLDER = `https://github.com/maxscharwath/kroma/tree/${SHA}/packages/ui/src/components/atoms/button`;
+const FOLDER = `https://github.com/kromatv/kroma/tree/${SHA}/packages/ui/src/components/atoms/button`;
 
 describe('sourceUrl', () => {
   it('pins the folder the story was found in to the commit that was built', () => {
@@ -29,7 +29,7 @@ describe('sourceUrl', () => {
   it('takes an absolute path from the root onwards', () => {
     const absolute = '/Users/someone/kroma/packages/ui/src/foundations/colors.stories.tsx';
     expect(sourceUrl(KROMA, absolute)).toBe(
-      `https://github.com/maxscharwath/kroma/tree/${SHA}/packages/ui/src/foundations`,
+      `https://github.com/kromatv/kroma/tree/${SHA}/packages/ui/src/foundations`,
     );
   });
 
@@ -51,7 +51,7 @@ describe('sourceUrl', () => {
 
   it('accepts the short revision git also answers with', () => {
     expect(sourceUrl({ ...KROMA, commit: 'c51eb485' }, VITE)).toBe(
-      'https://github.com/maxscharwath/kroma/tree/c51eb485/packages/ui/src/components/atoms/button',
+      'https://github.com/kromatv/kroma/tree/c51eb485/packages/ui/src/components/atoms/button',
     );
   });
 
@@ -66,14 +66,12 @@ describe('sourceUrl', () => {
 
   it('refuses a remote the platform must not be handed', () => {
     expect(sourceUrl({ ...KROMA, repository: 'file:///Users/someone/kroma' }, VITE)).toBeNull();
-    expect(
-      sourceUrl({ ...KROMA, repository: 'git@github.com:maxscharwath/kroma' }, VITE),
-    ).toBeNull();
+    expect(sourceUrl({ ...KROMA, repository: 'git@github.com:kromatv/kroma' }, VITE)).toBeNull();
   });
 
   it('does not double the slash a remote may end on', () => {
-    expect(
-      sourceUrl({ ...KROMA, repository: 'https://github.com/maxscharwath/kroma/' }, VITE),
-    ).toBe(FOLDER);
+    expect(sourceUrl({ ...KROMA, repository: 'https://github.com/kromatv/kroma/' }, VITE)).toBe(
+      FOLDER,
+    );
   });
 });

--- a/packages/workspace-tools/package.json
+++ b/packages/workspace-tools/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maxscharwath/kroma.git",
+    "url": "git+https://github.com/kromatv/kroma.git",
     "directory": "packages/workspace-tools"
   },
   "main": "src/index.ts",

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -11,14 +11,14 @@
 # Mount media READ-WRITE if you use the built-in requests/downloads (the import
 # step writes into the library); :ro is fine for a purely pre-existing library:
 #     docker run -p 4040:4040 -v kroma-data:/data -v /media:/media \
-#       -e KROMA_MEDIA_DIRS=/media ghcr.io/maxscharwath/kroma:latest
+#       -e KROMA_MEDIA_DIRS=/media ghcr.io/kromatv/kroma:latest
 #
 # Optional HTTPS (auto self-signed cert, off by default): publish 4443, set
 # KROMA_HTTPS=1, and on the bridge network pass the host's real IP/DNS via
 # KROMA_TLS_SANS (the container can't detect it). The cert persists in /data/tls.
 #     docker run -p 4040:4040 -p 4443:4443 -v kroma-data:/data -v /media:/media \
 #       -e KROMA_MEDIA_DIRS=/media -e KROMA_HTTPS=1 \
-#       -e KROMA_TLS_SANS=192.168.1.50 ghcr.io/maxscharwath/kroma:latest
+#       -e KROMA_TLS_SANS=192.168.1.50 ghcr.io/kromatv/kroma:latest
 
 # ---- 1) Web SPA (node + bun) -----------------------------------------------
 # Node base (not the bun-only image): the TanStack Start prerender spawns a `node`

--- a/server/Dockerfile.runtime
+++ b/server/Dockerfile.runtime
@@ -23,7 +23,7 @@
 # Mount media READ-WRITE if you use the built-in requests/downloads (the import
 # step writes into the library); :ro is fine for a purely pre-existing library:
 #     docker run -p 4040:4040 -v kroma-data:/data -v /media:/media \
-#       -e KROMA_MEDIA_DIRS=/media ghcr.io/maxscharwath/kroma:latest
+#       -e KROMA_MEDIA_DIRS=/media ghcr.io/kromatv/kroma:latest
 #
 # Hardware transcoding: pass the render node in, or every re-encode lands on the
 # CPU. The device alone is not enough - the container user has to be able to open
@@ -36,7 +36,7 @@
 # KROMA_TLS_SANS (the container can't detect it). The cert persists in /data/tls.
 #     docker run -p 4040:4040 -p 4443:4443 -v kroma-data:/data -v /media:/media \
 #       -e KROMA_MEDIA_DIRS=/media -e KROMA_HTTPS=1 \
-#       -e KROMA_TLS_SANS=192.168.1.50 ghcr.io/maxscharwath/kroma:latest
+#       -e KROMA_TLS_SANS=192.168.1.50 ghcr.io/kromatv/kroma:latest
 
 FROM debian:bookworm-slim
 # Which payload to COPY below; set automatically by BuildKit per platform.

--- a/server/README.md
+++ b/server/README.md
@@ -435,7 +435,7 @@ docker run -d --name kroma \
   -v kroma-data:/data \
   -v /path/on/host/media:/media \
   -e KROMA_MEDIA_DIRS=/media \
-  ghcr.io/maxscharwath/kroma:latest
+  ghcr.io/kromatv/kroma:latest
 ```
 
 Or as compose. A ready-to-run [`docker-compose.yml`](../docker-compose.yml) sits
@@ -444,7 +444,7 @@ at the repo root, so `docker compose up -d` works from there:
 ```yaml
 services:
   kroma:
-    image: ghcr.io/maxscharwath/kroma:latest
+    image: ghcr.io/kromatv/kroma:latest
     ports: ["4040:4040"]
     environment:
       KROMA_MEDIA_DIRS: /media
@@ -471,7 +471,7 @@ docker run -d --name kroma \
   -v kroma-data:/data \
   -v /path/on/host/media:/media \
   -e KROMA_MEDIA_DIRS=/media \
-  ghcr.io/maxscharwath/kroma:latest
+  ghcr.io/kromatv/kroma:latest
 ```
 
 Or as compose:
@@ -479,7 +479,7 @@ Or as compose:
 ```yaml
 services:
   kroma:
-    image: ghcr.io/maxscharwath/kroma:latest
+    image: ghcr.io/kromatv/kroma:latest
     ports:
       - "4040:4040"
       - "4443:4443"


### PR DESCRIPTION
Every reference to `maxscharwath/kroma` becomes `kromatv/kroma`, ahead of transferring the repository to the organisation.

**Do not merge before the transfer.** The new URLs resolve only once the repository lives at `kromatv/kroma`. After the transfer GitHub redirects the old paths, so merging late is harmless while merging early is not.

## What moves

- `DEFAULT_REPO` in `apps/modules` and `apps/packages`, plus `GITHUB_REPO` in both `wrangler.jsonc`: the official `.kmod` catalogue and the DSM package listing.
- The desktop updater endpoint in `tauri.conf.json`. Installed clients keep polling the old URL and reach the new one through GitHub's redirect.
- `ghcr.io/maxscharwath/kroma` becomes `ghcr.io/kromatv/kroma` in the Dockerfiles, `docker-compose.yml` and the docs. The package itself still has to be republished or moved under the organisation.
- The repository template in `packages/module-tools/src/gen.ts`, so regenerated modules carry the new URL.
- `repository.url` in every workspace `package.json`, the security advisory link, the Synology catalogue URLs, the workbench source links, the release feeds and the badges.

## What deliberately stays

- `sonar-project.properties` and `packages/sonar-tools/src/accept.ts` keep `maxscharwath_kroma`. The key depends on how the SonarCloud project is rebound to the organisation, and guessing it wrong breaks the quality gate. Separate change, once the Sonar side is settled.
- The author email in the manifests, `@maxscharwath` in `CODEOWNERS`, and the credit line in the README. Those name a person, not the repository.

## Checks

`bun run test` over the six affected workspaces: 107 files, 1670 tests. `bun run check` clean.