### PR TITLE
fix(ci): the iOS pods stop asking Sonatype for a Hermes that is gone

### DIFF
--- a/.github/workflows/_release-appletv.yml
+++ b/.github/workflows/_release-appletv.yml
@@ -183,6 +183,10 @@ jobs:
         if: steps.signing.outputs.ready == 'true' && steps.ios-cache.outputs.cache-hit != 'true'
         env:
           KROMA_VERSION: ${{ inputs.triplet }}
+          # The nightly Hermes this react-native-tvos pins was purged from
+          # Sonatype, and the podspec parses the 404 page as XML. Building from
+          # the tag in sdks/.hermesversion asks Sonatype nothing.
+          RCT_BUILD_HERMES_FROM_SOURCE: 'true'
         run: |
           set -euo pipefail
           export KROMA_VERSION_CODE=${{ inputs.build }}

--- a/.github/workflows/_release-mobile.yml
+++ b/.github/workflows/_release-mobile.yml
@@ -302,6 +302,11 @@ jobs:
       - name: Prebuild the iOS project
         if: steps.signing.outputs.ready == 'true' && steps.ios-cache.outputs.cache-hit != 'true'
         working-directory: clients/mobile
+        env:
+          # The nightly Hermes this react-native-tvos pins was purged from
+          # Sonatype, and the podspec parses the 404 page as XML. Building from
+          # the tag in sdks/.hermesversion asks Sonatype nothing.
+          RCT_BUILD_HERMES_FROM_SOURCE: 'true'
         run: |
           npx expo prebuild --platform ios --no-install
           cd ios && pod install

--- a/clients/tv-native/package.json
+++ b/clients/tv-native/package.json
@@ -16,7 +16,7 @@
     "ios": "EXPO_TV=1 REACT_NATIVE_NODE_MODULES_DIR=\"$PWD/node_modules\" expo run:ios",
     "android": "EXPO_TV=1 expo run:android",
     "prebuild": "EXPO_TV=1 expo prebuild --clean",
-    "pod": "cd ios && REACT_NATIVE_NODE_MODULES_DIR=\"$PWD/../node_modules\" pod install",
+    "pod": "cd ios && RCT_BUILD_HERMES_FROM_SOURCE=true REACT_NATIVE_NODE_MODULES_DIR=\"$PWD/../node_modules\" pod install",
     "bundle:check": "bun ../expo-build/bundle-check.ts . EXPO_TV=1 --max 10",
     "typecheck": "tsc --noEmit",
     "focus:probe": "bun ./scripts/focus-probe.ts",


### PR DESCRIPTION
Both TestFlight jobs started failing at 16:47 today, a minute into `pod install`, on every run since. The tvOS job was still green at 08:30, so nothing in the repository moved under them.

`react-native-tvos@0.86.0-2` pins the Hermes iOS nightly `250829098.0.14-SNAPSHOT`. That snapshot is no longer served:

```
$ curl .../hermes-ios/250829098.0.14-SNAPSHOT/maven-metadata.xml
http=404  type=text/html  size=1662
```

CocoaPods downloads the Nexus 404 page, parses it as the snapshot metadata, and dies on the first HTML tag: `Invalid hermes-engine.podspec file: Missing end tag for 'link' (got 'head')`. The 1662 bytes in the runner log are that error page.

`hermes_source_type` in `sdks/hermes-engine/hermes-utils.rb` tests `RCT_BUILD_HERMES_FROM_SOURCE` **before** it looks up either the release or the nightly artifact, and `sdks/.hermesversion` is present and reads `hermes-v0.17.0`. Setting the variable therefore never reaches Sonatype at all: Hermes is built from that GitHub tag, which is a fixed input rather than a snapshot someone else can delete.

The same variable goes into the package's own `pod` script, because a local build hits the identical 404 today.

The cost is compiling Hermes on the runner when the iOS project cache misses. The alternative was bumping `react-native-tvos`, which moves the whole native stack for an outage in someone else's repository.