### PR TITLE
fix(cli): a carried catalog entry follows the repository it is published from

### DIFF
--- a/packages/cli/src/commands/release.test.ts
+++ b/packages/cli/src/commands/release.test.ts
@@ -43,6 +43,12 @@ function bundle(id: string, version: string, target: string, contentHash: string
 
 const catalog = (...modules: Entry[]): Catalog => ({ schema: 2, modules });
 
+const cutUnder = (e: Entry, owner: string): Entry => ({
+  ...e,
+  url: e.url.replace(REPO, owner),
+  artifacts: e.artifacts.map((a) => ({ ...a, url: a.url.replace(REPO, owner) })),
+});
+
 describe('tagFor', () => {
   it('cuts a module its own tag, id and version joined', () => {
     expect(tagFor('tv.kroma.indexer', '0.1.3')).toBe('tv.kroma.indexer@0.1.3');
@@ -256,5 +262,42 @@ describe('decide', () => {
     const one = decide(bundles, catalog(), REPO, NOW);
     const two = decide([...bundles].reverse(), catalog(), REPO, NOW);
     expect(JSON.stringify(one.catalog)).toBe(JSON.stringify(two.catalog));
+  });
+
+  it('moves a carried entry onto the repository the catalog is published from', () => {
+    const live = cutUnder(entry('tv.kroma.whisper', '0.2.0', { mac: 'w' }), 'someone/kroma');
+
+    const { plan, catalog: out } = decide([], catalog(live), REPO, NOW);
+
+    expect(plan.carried).toEqual(['tv.kroma.whisper']);
+    expect(out.modules[0]?.url).toContain(`github.com/${REPO}/releases/download/`);
+    expect(JSON.stringify(out.modules)).not.toContain('someone/kroma');
+  });
+
+  it('moves an unchanged module’s published entry onto the current repository', () => {
+    const live = cutUnder(entry('tv.kroma.indexer', '0.1.0', { mac: 'a' }), 'someone/kroma');
+
+    const { plan, catalog: out } = decide(
+      [bundle('tv.kroma.indexer', '0.1.0', 'mac', 'a')],
+      catalog(live),
+      REPO,
+      NOW,
+    );
+
+    expect(plan.unchanged).toEqual(['tv.kroma.indexer']);
+    expect(out.modules[0]?.artifacts[0]?.url).toContain(`github.com/${REPO}/releases/download/`);
+  });
+
+  it('leaves a download URL that is not a GitHub release alone', () => {
+    const live = entry('tv.kroma.whisper', '0.2.0', { mac: 'w' });
+    live.url = 'https://cdn.example.com/whisper-mac.kmod';
+    live.artifacts = live.artifacts.map((a) => ({
+      ...a,
+      url: 'https://cdn.example.com/whisper-mac.kmod',
+    }));
+
+    const { catalog: out } = decide([], catalog(live), REPO, NOW);
+
+    expect(out.modules[0]?.url).toBe('https://cdn.example.com/whisper-mac.kmod');
   });
 });

--- a/packages/cli/src/commands/release.ts
+++ b/packages/cli/src/commands/release.ts
@@ -14,6 +14,18 @@ export function tagFor(id: string, version: string): string {
   return `${id}@${version}`;
 }
 
+const RELEASE_DOWNLOAD = /^(https:\/\/github\.com\/)[^/]+\/[^/]+(\/releases\/download\/)/;
+
+function underRepo(entry: Entry, repo: string): Entry {
+  const move = (url: string): string =>
+    url.replace(RELEASE_DOWNLOAD, (_, host: string, tail: string) => `${host}${repo}${tail}`);
+  return {
+    ...entry,
+    url: move(entry.url),
+    artifacts: entry.artifacts.map((a) => ({ ...a, url: move(a.url) })),
+  };
+}
+
 export type Verdict =
   | { kind: 'new' }
   | { kind: 'publish'; from: string }
@@ -127,7 +139,7 @@ export function decide(
         break;
       case 'unchanged':
         plan.unchanged.push(entry.id);
-        entries.push(live.get(entry.id) as Entry);
+        entries.push(underRepo(live.get(entry.id) as Entry, repo));
         break;
       case 'stale':
         stale.push(
@@ -138,13 +150,13 @@ export function decide(
             `    Bump the module's version past ${verdict.published} and re-push.`,
           ].join('\n'),
         );
-        entries.push(live.get(entry.id) as Entry);
+        entries.push(underRepo(live.get(entry.id) as Entry, repo));
         break;
       case 'backwards':
         errors.push(
           `${entry.id}: version ${entry.version} is OLDER than the published ${verdict.published}; a release cannot go backwards`,
         );
-        entries.push(live.get(entry.id) as Entry);
+        entries.push(underRepo(live.get(entry.id) as Entry, repo));
         break;
     }
   }
@@ -153,7 +165,7 @@ export function decide(
   for (const [id, entry] of live) {
     if (!packed.has(id)) {
       plan.carried.push(id);
-      entries.push(entry);
+      entries.push(underRepo(entry, repo));
     }
   }
 


### PR DESCRIPTION
`modules.json` still hands out `github.com/maxscharwath/kroma/releases/download/...` for all twelve modules, a day after the repository moved to `kromatv`. The catalog regenerated at 17:14, after the transfer, and came back with the same URLs, so this is not a cache: it is what the generator writes.

`decide()` builds a download URL from `GITHUB_REPOSITORY` only for the modules it is about to publish. A module whose version did not move keeps its live entry verbatim, URL included, and so does one that is carried because this run did not pack it. Nothing in the catalog is ever rewritten, so an entry keeps whatever owner it was first cut under until its version is bumped.

The old URLs work today, because GitHub redirects release downloads after a transfer. But every module install then leans on that redirect, and the redirect dies the day anything is created at the old path. The assets themselves already moved: the API reports `browser_download_url` under `kromatv/kroma`.

So a live entry is now rewritten onto the repository the catalog is being published from, in all four places one is kept: unchanged, stale, backwards, and carried. Only the owner and name of a `github.com/.../releases/download/` URL move; anything else is left exactly as it was, which the third test pins.

Verified: both behavioural tests fail against the current generator and pass with it. `bun run test packages/cli` is 710 tests green, `bun run check` clean, `@kromatv/cli` typechecks.

The catalog corrects itself on the next Modules run after this lands.