### PR TITLE
fix(ci): a broken vendor repo on the runner image stops breaking apt

### DIFF
--- a/packages/ci-tools/src/tools.ts
+++ b/packages/ci-tools/src/tools.ts
@@ -14,19 +14,14 @@ async function present(binary: string): Promise<boolean> {
   return (await $`command -v ${binary}`.quiet().nothrow()).exitCode === 0;
 }
 
-const IMAGE_EXTRA_SOURCES = [
-  '/etc/apt/sources.list.d/google-chrome.list',
-  '/etc/apt/sources.list.d/microsoft-prod.list',
-];
-
 async function apt(packages: readonly string[], attempts = 3): Promise<void> {
-  await $`sudo rm -f ${IMAGE_EXTRA_SOURCES}`.quiet().nothrow();
   for (let attempt = 1; attempt <= attempts; attempt++) {
     const update = await $`timeout 120 sudo apt-get update`.nothrow();
+    if (update.exitCode !== 0) {
+      warning(`apt-get update failed a source on attempt ${attempt}; installing from what it fetched`);
+    }
     const install =
-      update.exitCode === 0
-        ? await $`timeout 180 sudo apt-get install -y --no-install-recommends ${packages}`.nothrow()
-        : update;
+      await $`timeout 180 sudo apt-get install -y --no-install-recommends ${packages}`.nothrow();
     if (install.exitCode === 0) return;
     warning(`apt attempt ${attempt} for ${packages.join(' ')} stalled or failed`);
     await Bun.sleep(10_000);

--- a/packages/ci-tools/src/tools.ts
+++ b/packages/ci-tools/src/tools.ts
@@ -14,7 +14,13 @@ async function present(binary: string): Promise<boolean> {
   return (await $`command -v ${binary}`.quiet().nothrow()).exitCode === 0;
 }
 
+const IMAGE_EXTRA_SOURCES = [
+  '/etc/apt/sources.list.d/google-chrome.list',
+  '/etc/apt/sources.list.d/microsoft-prod.list',
+];
+
 async function apt(packages: readonly string[], attempts = 3): Promise<void> {
+  await $`sudo rm -f ${IMAGE_EXTRA_SOURCES}`.quiet().nothrow();
   for (let attempt = 1; attempt <= attempts; attempt++) {
     const update = await $`timeout 120 sudo apt-get update`.nothrow();
     const install =

--- a/packages/ci-tools/src/tools.ts
+++ b/packages/ci-tools/src/tools.ts
@@ -18,7 +18,9 @@ async function apt(packages: readonly string[], attempts = 3): Promise<void> {
   for (let attempt = 1; attempt <= attempts; attempt++) {
     const update = await $`timeout 120 sudo apt-get update`.nothrow();
     if (update.exitCode !== 0) {
-      warning(`apt-get update failed a source on attempt ${attempt}; installing from what it fetched`);
+      warning(
+        `apt-get update failed a source on attempt ${attempt}; installing from what it fetched`,
+      );
     }
     const install =
       await $`timeout 180 sudo apt-get install -y --no-install-recommends ${packages}`.nothrow();


### PR DESCRIPTION
## What

The Rust job failed on main with nothing Rust about it:

```
E: Failed to fetch https://dl.google.com/linux/chrome-stable/deb/dists/stable/main/binary-amd64/Packages.gz
   Hash Sum mismatch
##[warning]apt attempt 3 for ffmpeg stalled or failed
##[error]could not install ffmpeg after 3 attempts
```

Google's apt repository, which the runner image ships and which we never use, served an index whose hash did not match its own Release file. `apt-get update` exits non-zero when any source fails, and `apt()` only ran the install after a clean update, so ffmpeg never installed. The retries could not help: the cause was the same on every attempt.

The first version of this PR removed `google-chrome.list` and `microsoft-prod.list` before updating. Its own run failed on the same line anyway, so the image keeps that source under another name (runner-images now deletes `google-chrome*` itself, which covers both the `.list` and the deb822 `.sources` layout). Chasing file names is the wrong layer. `apt()` now runs the install even when the update reports a failed source, and says so in a warning. apt already describes that outcome in the same log: "Some index files failed to download. They have been ignored, or old ones used instead." Everything this helper installs, ffmpeg and the Tauri deps, comes from the Ubuntu archive, whose indexes that update did fetch.

## Closes

No issue. Found as a red Rust job on main.

## Checks

- [x] `bun run lint` and `bun run test` pass, or I said below which failed and why
- [ ] `cargo clippy` and `cargo test` pass, if the server changed
- [x] Follows `CODE_STYLE.md`, no comments narrating the work, exported API only
- [x] One idea. If it grew a second, it was split.

Biome, the `@kromatv/ci-tools` typecheck and its tests pass. No server change. No test for `apt()` itself: it is a sequence of shell calls, and mocking `$` would pin the command spelling rather than the behaviour. The evidence is the log above, and it cannot be reproduced on demand any more: Google's index has recovered, so the Rust and Desktop jobs passed on #242 and #243 without this change. A green run here shows the helper still installs, not that it survives a broken vendor source.

## Risk

If the Ubuntu archive itself fails to update, the install now runs once against the lists already on the image before the retry, where it used to skip straight to the retry. At worst that is one failed `apt-get install` per attempt, and the retry loop is unchanged.
