### PR TITLE
fix(scan): symlinks that lead somewhere, and shows that stop merging into their folder

### DIFF
--- a/docs/spec/library/README.md
+++ b/docs/spec/library/README.md
@@ -24,6 +24,12 @@ identity, not by folder. A source is just an input; it is not a category the use
 by. Filtering the catalogue by source is an admin/diagnostic view, not the primary
 navigation.
 
+A source tree may be assembled from symlinks. A curated folder of links into a shared
+pool of files is a source like any other: the link's own name is what the conventions
+below are read from, and the file it points at is what plays. A link the server cannot
+resolve is reported, never silently skipped, because a source built entirely from links
+into an unmounted pool would otherwise scan clean and empty.
+
 A source records the mount path, its content kind, and its scan schedule. Nothing about a
 source is destructive: removing a source removes its titles from the catalogue and stops
 watching the path, but touches no bytes on disk and, per the deletions rule below,
@@ -61,6 +67,13 @@ extras, artwork and sidecars grouped.
 Shows/Severance/Season 02/Severance - S02E01 - Hello, Ms. Cobel.mkv
 Shows/The Bear/Season 01/The Bear - S01E03.mkv
 ```
+
+The season folder is what makes the folder above it the show: with one present, that
+folder names the series and disagreeing filenames inside it still collapse to one show.
+Without one, the folder proves nothing (a flat pool holds many shows side by side) and
+the filename names the series instead; an episode whose filename is only its marker
+(`S01E01.mkv`) takes the name of the folder holding it, so a run of them is one series
+rather than one series per file.
 
 The show folder name and the `SxxEyy` marker are load-bearing; the human episode title
 after the second ` - ` is optional and ignored for matching. `Specials` is accepted as an

--- a/server/README.md
+++ b/server/README.md
@@ -46,13 +46,31 @@ The scanner recognises these layouts and naming cues:
   year *2017* (not 2049). The scanner strips release junk (resolution / source /
   codec / group) from titles, and falls back to the `Title (Year)` folder name
   when the filename is generic.
-- Episodes: `S01E02`, `s1e2`, `S01E02-E03` (multi-episode), `1x02`. The
-  top-level folder under the library root is the show identity
-  (`TV Shows/The Office (2005)/Season 02/The Office - S02E01 - The Dundies.mkv`),
-  with the text after the marker becoming the episode title. Episodes are grouped
-  into shows and seasons.
+- Episodes: `S01E02`, `s1e2`, `S01E02-E03` (multi-episode), `1x02`, with the text
+  after the marker becoming the episode title. Episodes are grouped into shows and
+  seasons.
+
+  A `Season 01` / `Saison 1` / `Specials` folder is what proves the folder above it
+  is a show folder, so that folder names the show and every release convention
+  inside it collapses to one series
+  (`TV Shows/The Office (2005)/Season 02/The Office - S02E01 - The Dundies.mkv`).
+  Intermediate folders are stepped over, so `TV Shows/4K/The Office (2005)/Season 02/…`
+  reaches the same show.
+
+  With no season folder to vouch for one, the path proves nothing (a flat folder
+  holds many shows side by side), so the filename names the show:
+  `dump/Breaking.Bad.S01E01.mkv` and `dump/The.Office.S01E01.mkv` are two series,
+  not one folder's worth. A file that carries no name of its own (`S01E01.mkv`) falls
+  back to the folder holding it, and at the library root to the library folder, so
+  such episodes land in one series rather than one series each.
 
 A library's `kind` (`movies` / `shows` / `mixed`) follows from what it holds.
+
+Symlinks are followed, so a curated library of links into a shared dump scans as if
+the files sat there: the link's own name is what gets parsed, and the target is what
+gets streamed. A link whose target is not mounted (the usual shape in a container that
+mounts the library but not the dump) cannot be read at all; the scan logs how many
+entries it skipped and one offending path rather than reporting an empty library.
 
 ## Quickstart
 

--- a/server/crates/kroma-domain/src/naming/mod.rs
+++ b/server/crates/kroma-domain/src/naming/mod.rs
@@ -4,19 +4,21 @@
 //! name, season, episode (incl. multi-episode files), titles and year using
 //! the same cues Plex/Jellyfin rely on:
 //!   * `S01E02`, `s1e2`, `S01E02-E03`, `1x02` season/episode markers
-//!   * the top-level folder under a library root as the *show* identity
-//!     (`Library/Show Name/Season 01/Show - S01E02.mkv`)
+//!   * the folder a season folder vouches for as the *show* identity, and the
+//!     filename when the path has no season folder to vouch for one (see
+//!     [`show`])
 //!   * `Movie Title (2017)` movie folders / filenames
 //!   * release-junk stripping for clean titles (resolution, source, codec, group)
 //!
 //! This is pure domain logic: filename → parsed identity, no I/O.
 
 mod marker;
+mod show;
 mod title;
 
 use std::path::Path;
 
-use marker::{find_marker, is_season_folder};
+use marker::find_marker;
 use title::clean_episode_title;
 pub use title::{clean_title, parse_year};
 
@@ -57,20 +59,7 @@ pub fn parse(root: &Path, path: &Path) -> Parsed {
         .unwrap_or_default();
 
     if let Some(m) = find_marker(stem) {
-        // Show identity: the top-level folder under the library root, else the
-        // text before the marker in the filename (flat layout).
-        let (show_title, show_year) = match dirs.first() {
-            Some(folder) if !is_season_folder(folder) => (clean_title(folder), parse_year(folder)),
-            _ => {
-                let before = &stem[..m.start];
-                (clean_title(before), parse_year(before))
-            }
-        };
-        let show_title = if show_title.is_empty() {
-            clean_title(stem)
-        } else {
-            show_title
-        };
+        let show = show::identify(root, &dirs, &stem[..m.start], stem);
 
         let after = stem.get(m.end..).unwrap_or("");
         let episode_title = {
@@ -83,8 +72,8 @@ pub fn parse(root: &Path, path: &Path) -> Parsed {
         };
 
         Parsed::Episode {
-            show_title,
-            show_year,
+            show_title: show.title,
+            show_year: show.year,
             season: m.season,
             episode: m.episode,
             episode_end: m.episode_end,
@@ -115,11 +104,11 @@ mod tests {
     }
 
     #[test]
-    fn an_episode_under_a_bare_season_folder_falls_back_to_the_filename() {
+    fn an_episode_under_a_bare_season_folder_falls_back_to_the_library_folder() {
         assert_eq!(
             p("/tv", "/tv/Season 01/S01E02.mkv"),
             Parsed::Episode {
-                show_title: "S01E02".into(),
+                show_title: "tv".into(),
                 show_year: None,
                 season: 1,
                 episode: 2,
@@ -192,6 +181,41 @@ mod tests {
                 episode_title: Some("The Dundies".into()),
             }
         );
+    }
+
+    #[test]
+    fn shows_grouped_under_one_folder_keep_their_own_identities() {
+        let one = p("/lib", "/lib/Shows/Breaking Bad/Season 01/S01E01.mkv");
+        let two = p("/lib", "/lib/Shows/The Office/Season 01/S01E02.mkv");
+
+        assert!(
+            matches!(one, Parsed::Episode { ref show_title, .. } if show_title == "Breaking Bad")
+        );
+        assert!(
+            matches!(two, Parsed::Episode { ref show_title, .. } if show_title == "The Office")
+        );
+    }
+
+    #[test]
+    fn a_dump_folder_lets_each_filename_name_its_own_show() {
+        let one = p("/lib", "/lib/all/Breaking.Bad.S01E01.1080p.mkv");
+        let two = p("/lib", "/lib/all/The.Office.S01E01.1080p.mkv");
+
+        assert!(
+            matches!(one, Parsed::Episode { ref show_title, .. } if show_title == "Breaking Bad")
+        );
+        assert!(
+            matches!(two, Parsed::Episode { ref show_title, .. } if show_title == "The Office")
+        );
+    }
+
+    #[test]
+    fn episodes_named_only_by_their_marker_land_in_one_series() {
+        let one = p("/media/4k Shows", "/media/4k Shows/S01E01.mkv");
+        let two = p("/media/4k Shows", "/media/4k Shows/S01E02.mkv");
+
+        assert!(matches!(one, Parsed::Episode { ref show_title, .. } if show_title == "4k Shows"));
+        assert!(matches!(two, Parsed::Episode { ref show_title, .. } if show_title == "4k Shows"));
     }
 
     #[test]

--- a/server/crates/kroma-domain/src/naming/show.rs
+++ b/server/crates/kroma-domain/src/naming/show.rs
@@ -1,0 +1,184 @@
+//! Which name identifies the *series* an episode belongs to.
+//!
+//! A season folder is proof that the directory above it is a show folder, so
+//! when the path has one the folder wins and every release naming convention
+//! inside it collapses to a single show. Without a season folder the path says
+//! nothing (a flat dump holds many shows side by side), so the filename is
+//! read first and the containing directory is only the fallback for a file
+//! that carries no name of its own.
+
+use std::path::Path;
+
+use super::marker::is_season_folder;
+use super::title::{clean_title, parse_year};
+
+/// The show a file belongs to: its title and, when the path or the name carries
+/// one, its year.
+pub(super) struct ShowIdentity {
+    pub(super) title: String,
+    pub(super) year: Option<u32>,
+}
+
+/// Resolve the show from the directories between the library `root` and the
+/// file, the filename text preceding the season/episode marker, and the whole
+/// stem as a last resort.
+pub(super) fn identify(root: &Path, dirs: &[String], before: &str, stem: &str) -> ShowIdentity {
+    let folder = show_folder(dirs).or_else(|| {
+        clean_title(before)
+            .is_empty()
+            .then(|| nearest_named_dir(dirs).unwrap_or_else(|| root_name(root)))
+    });
+
+    let (title, source) = match folder {
+        Some(dir) => (folder_title(dir), dir),
+        None => (clean_title(before), before),
+    };
+    let title = match title {
+        t if t.is_empty() => clean_title(stem),
+        t => t,
+    };
+    let year = parse_year(source).or_else(|| nearest_named_dir(dirs).and_then(parse_year));
+    ShowIdentity { title, year }
+}
+
+// A directory is a curated name rather than a release string, so when the junk
+// stripper wipes one whole ("4k Shows", "UHD") the folder as written is still a
+// better show title than nothing.
+fn folder_title(dir: &str) -> String {
+    match clean_title(dir) {
+        t if t.is_empty() => dir.split_whitespace().collect::<Vec<_>>().join(" "),
+        t => t,
+    }
+}
+
+// The directory a season folder vouches for: the nearest ancestor above the
+// trailing run of season folders. `None` when the path has no season folder at
+// all, or when that run reaches the library root.
+fn show_folder(dirs: &[String]) -> Option<&str> {
+    let named = dirs
+        .iter()
+        .rposition(|d| !is_season_folder(d))
+        .map_or(0, |i| i + 1);
+    (named < dirs.len())
+        .then(|| dirs[..named].last())
+        .flatten()
+        .map(String::as_str)
+}
+
+fn nearest_named_dir(dirs: &[String]) -> Option<&str> {
+    dirs.iter()
+        .rfind(|d| !is_season_folder(d))
+        .map(String::as_str)
+}
+
+fn root_name(root: &Path) -> &str {
+    root.file_name()
+        .and_then(std::ffi::OsStr::to_str)
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dirs(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(ToString::to_string).collect()
+    }
+
+    #[test]
+    fn a_season_folder_hands_the_show_to_the_directory_above_it() {
+        let d = dirs(&["Shows", "Breaking Bad", "Season 01"]);
+
+        let show = identify(Path::new("/lib"), &d, "", "S01E01");
+
+        assert_eq!(show.title, "Breaking Bad");
+    }
+
+    #[test]
+    fn the_directory_above_the_season_folder_wins_over_the_filename() {
+        let d = dirs(&["The Office (US)", "Season 01"]);
+
+        let show = identify(Path::new("/lib"), &d, "Office.US.", "Office.US.S01E01");
+
+        assert_eq!(show.title, "The Office US");
+        assert_eq!(show.year, None);
+    }
+
+    #[test]
+    fn a_run_of_season_folders_is_skipped_whole() {
+        let d = dirs(&["Breaking Bad", "Season 01", "Specials"]);
+
+        let show = identify(Path::new("/lib"), &d, "", "S00E01");
+
+        assert_eq!(show.title, "Breaking Bad");
+    }
+
+    #[test]
+    fn a_flat_folder_lets_each_filename_name_its_own_show() {
+        let d = dirs(&["all"]);
+        let root = Path::new("/lib");
+
+        let one = identify(root, &d, "Breaking.Bad.", "Breaking.Bad.S01E01.1080p");
+        let two = identify(root, &d, "The.Office.", "The.Office.S01E01.1080p");
+
+        assert_eq!(one.title, "Breaking Bad");
+        assert_eq!(two.title, "The Office");
+    }
+
+    #[test]
+    fn a_nameless_file_takes_the_folder_holding_it() {
+        let d = dirs(&["Breaking Bad (2008)"]);
+
+        let show = identify(Path::new("/lib"), &d, "", "S01E01");
+
+        assert_eq!(show.title, "Breaking Bad");
+        assert_eq!(show.year, Some(2008));
+    }
+
+    #[test]
+    fn a_nameless_file_at_the_library_root_takes_the_root_folder() {
+        let root = Path::new("/media/4k Shows");
+
+        let one = identify(root, &[], "", "S01E01");
+        let two = identify(root, &[], "", "S01E02");
+
+        assert_eq!(one.title, "4k Shows");
+        assert_eq!(one.title, two.title);
+    }
+
+    #[test]
+    fn a_year_missing_from_the_filename_is_widened_from_the_show_folder() {
+        let d = dirs(&["The Office (2005)"]);
+
+        let show = identify(
+            Path::new("/lib"),
+            &d,
+            "The Office - ",
+            "The Office - S01E01",
+        );
+
+        assert_eq!(show.title, "The Office");
+        assert_eq!(show.year, Some(2005));
+    }
+
+    #[test]
+    fn a_bucket_folder_never_lends_its_year_to_a_show_it_does_not_name() {
+        let d = dirs(&["all"]);
+
+        let show = identify(
+            Path::new("/lib"),
+            &d,
+            "Breaking.Bad.",
+            "Breaking.Bad.S01E01",
+        );
+
+        assert_eq!(show.year, None);
+    }
+
+    #[test]
+    fn a_stem_that_is_only_a_marker_survives_an_unnamed_root() {
+        let show = identify(Path::new("/"), &[], "", "S01E01");
+
+        assert_eq!(show.title, "S01E01");
+    }
+}

--- a/server/crates/kroma-engine/src/services/scan/mod.rs
+++ b/server/crates/kroma-engine/src/services/scan/mod.rs
@@ -31,6 +31,9 @@ pub struct ScanData {
     pub libraries: Vec<Library>,
     pub shows: Vec<Show>,
     pub items: Vec<MediaItem>,
+    /// Entries the walk could not read across every folder, so an empty scan can
+    /// say whether the library is genuinely empty or its symlinks dangle.
+    pub unreadable: usize,
     // `file_id -> mtime-secs` for every scanned file. Carried here (rather than
     // on `MediaFile`, which is the client JSON contract) so the DB sync can
     // detect changed files. Owned by this scan no shared global, so two
@@ -61,7 +64,7 @@ pub fn scan_all(defs: &[LibraryDef]) -> ScanData {
                 warn!(path = %root.display(), "media dir does not exist or is not a directory; skipping");
                 continue;
             }
-            scan_root(
+            data.unreadable += scan_root(
                 &def.id,
                 root,
                 &mut items,
@@ -130,6 +133,7 @@ pub fn rescan_sync(state: &crate::state::SharedState) -> anyhow::Result<Scanned>
         if !defs.is_empty() {
             warn!(
                 libraries = defs.len(),
+                unreadable = data.unreadable,
                 "configured libraries produced no items; keeping the stored index (mount offline?)"
             );
             return Ok(Scanned::MountOffline);

--- a/server/crates/kroma-engine/src/services/scan/walk.rs
+++ b/server/crates/kroma-engine/src/services/scan/walk.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use jwalk::{Parallelism, WalkDirGeneric};
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::domain::naming::{self, Parsed};
 use crate::model::{Kind, MediaFile, MediaItem, Show};
@@ -22,6 +22,10 @@ pub const VIDEO_EXTENSIONS: &[&str] = &["mkv", "mp4", "m4v", "mov", "webm", "avi
 /// Scan one folder belonging to `lib_id`, accumulating items (by logical id) and
 /// shows into the shared maps. Flags/ids track what this library contributed so
 /// the caller can compute its kind + item count across all its folders.
+///
+/// Returns how many entries the walk could not read: a symlink whose target is
+/// not mounted resolves to nothing, and a whole library of those otherwise
+/// scans clean and empty.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn scan_root(
     lib_id: &str,
@@ -32,7 +36,7 @@ pub(super) fn scan_root(
     lib_item_ids: &mut std::collections::HashSet<String>,
     movie_seen: &mut bool,
     episode_seen: &mut bool,
-) {
+) -> usize {
     let lib_name = root
         .file_name()
         .and_then(std::ffi::OsStr::to_str)
@@ -57,7 +61,18 @@ pub(super) fn scan_root(
             prepare_children(&descended, children);
         });
 
-    for entry in walk.into_iter().filter_map(Result::ok) {
+    let mut unreadable = 0usize;
+    let mut first_unreadable: Option<PathBuf> = None;
+    for result in walk {
+        let entry = match result {
+            Ok(entry) => entry,
+            Err(err) => {
+                unreadable += 1;
+                first_unreadable.get_or_insert_with(|| err.path().unwrap_or(root).to_path_buf());
+                debug!("skipping an unreadable entry: {err}");
+                continue;
+            }
+        };
         if !entry.file_type().is_file() {
             continue;
         }
@@ -121,6 +136,16 @@ pub(super) fn scan_root(
 
         debug!("indexed file under {}", lib_name);
     }
+
+    if let Some(path) = first_unreadable {
+        warn!(
+            folder = %root.display(),
+            unreadable,
+            example = %path.display(),
+            "entries skipped: a symlink whose target is not mounted reads as missing"
+        );
+    }
+    unreadable
 }
 
 // jwalk `process_read_dir` body: prune Synology/hidden dirs and already-visited
@@ -382,6 +407,46 @@ mod tests {
         kroma_testing::temp_dir("scanroot")
     }
 
+    struct ScanOutcome {
+        items: HashMap<String, MediaItem>,
+        shows: HashMap<String, Show>,
+        mtimes: HashMap<String, Option<i64>>,
+        item_ids: HashSet<String>,
+        movie_seen: bool,
+        episode_seen: bool,
+        unreadable: usize,
+    }
+
+    fn scan_into(lib_id: &str, root: &Path) -> ScanOutcome {
+        let mut items = HashMap::new();
+        let mut shows = HashMap::new();
+        let mut mtimes = HashMap::new();
+        let mut item_ids = HashSet::new();
+        let mut movie_seen = false;
+        let mut episode_seen = false;
+
+        let unreadable = scan_root(
+            lib_id,
+            root,
+            &mut items,
+            &mut shows,
+            &mut mtimes,
+            &mut item_ids,
+            &mut movie_seen,
+            &mut episode_seen,
+        );
+
+        ScanOutcome {
+            items,
+            shows,
+            mtimes,
+            item_ids,
+            movie_seen,
+            episode_seen,
+            unreadable,
+        }
+    }
+
     #[test]
     fn scan_root_groups_movies_and_episodes_and_skips_noise() {
         let root_dir = temp_scan_dir();
@@ -398,42 +463,33 @@ mod tests {
         std::fs::create_dir_all(&hidden).unwrap();
         std::fs::write(hidden.join("Ghost (2000).mkv"), b"x").unwrap();
 
-        let mut items: HashMap<String, MediaItem> = HashMap::new();
-        let mut shows: HashMap<String, Show> = HashMap::new();
-        let mut mtimes: HashMap<String, Option<i64>> = HashMap::new();
-        let mut lib_item_ids = std::collections::HashSet::new();
-        let mut movie_seen = false;
-        let mut episode_seen = false;
+        let scan = scan_into("lib1", root);
 
-        scan_root(
-            "lib1",
-            root,
-            &mut items,
-            &mut shows,
-            &mut mtimes,
-            &mut lib_item_ids,
-            &mut movie_seen,
-            &mut episode_seen,
+        assert!(scan.movie_seen);
+        assert!(scan.episode_seen);
+        // 1 movie + 2 episodes = 3 logical items; jpg and hidden dir ignored.
+        assert_eq!(scan.items.len(), 3, "movie + 2 episodes, noise excluded");
+        assert_eq!(scan.shows.len(), 1, "both episodes grouped under one show");
+        assert_eq!(scan.item_ids.len(), 3);
+        assert_eq!(
+            scan.mtimes.len(),
+            3,
+            "an mtime is recorded per scanned file"
         );
 
-        assert!(movie_seen);
-        assert!(episode_seen);
-        // 1 movie + 2 episodes = 3 logical items; jpg and hidden dir ignored.
-        assert_eq!(items.len(), 3, "movie + 2 episodes, noise excluded");
-        assert_eq!(shows.len(), 1, "both episodes grouped under one show");
-        assert_eq!(lib_item_ids.len(), 3);
-        assert_eq!(mtimes.len(), 3, "an mtime is recorded per scanned file");
-
-        let movie = items.values().find(|i| i.kind == Kind::Movie).unwrap();
+        let movie = scan.items.values().find(|i| i.kind == Kind::Movie).unwrap();
         assert_eq!(movie.title, "The Matrix");
         assert_eq!(movie.year, Some(1999));
         assert_eq!(movie.files.len(), 1);
         assert_eq!(movie.library, "lib1");
 
-        let show = shows.values().next().unwrap();
+        let show = scan.shows.values().next().unwrap();
         assert_eq!(show.title, "Breaking Bad");
-        let episodes: Vec<&MediaItem> =
-            items.values().filter(|i| i.kind == Kind::Episode).collect();
+        let episodes: Vec<&MediaItem> = scan
+            .items
+            .values()
+            .filter(|i| i.kind == Kind::Episode)
+            .collect();
         assert_eq!(episodes.len(), 2);
         assert!(episodes
             .iter()
@@ -447,29 +503,82 @@ mod tests {
         std::fs::write(root.join("The Matrix (1999).mkv"), b"x").unwrap();
         std::os::unix::fs::symlink(".", root.join("loop")).unwrap();
 
-        let mut items: HashMap<String, MediaItem> = HashMap::new();
-        let mut shows: HashMap<String, Show> = HashMap::new();
-        let mut mtimes: HashMap<String, Option<i64>> = HashMap::new();
-        let mut lib_item_ids = std::collections::HashSet::new();
-        let mut movie_seen = false;
-        let mut episode_seen = false;
-        scan_root(
-            "lib1",
-            root,
-            &mut items,
-            &mut shows,
-            &mut mtimes,
-            &mut lib_item_ids,
-            &mut movie_seen,
-            &mut episode_seen,
-        );
+        let scan = scan_into("lib1", root);
 
-        assert_eq!(items.len(), 1);
+        assert_eq!(scan.items.len(), 1);
         assert_eq!(
-            items.values().next().unwrap().files.len(),
+            scan.items.values().next().unwrap().files.len(),
             1,
             "the loop yielded the file again"
         );
+    }
+
+    #[test]
+    fn a_library_of_symlinks_indexes_what_they_point_at() {
+        let root_dir = temp_scan_dir();
+        let base = root_dir.path();
+        let dump = base.join("dump");
+        std::fs::create_dir_all(&dump).unwrap();
+        std::fs::write(dump.join("The Matrix (1999).mkv"), b"x").unwrap();
+        std::fs::write(dump.join("Breaking.Bad.S01E01.mkv"), b"x").unwrap();
+        std::fs::write(dump.join("Breaking.Bad.S01E02.mkv"), b"x").unwrap();
+        let root = base.join("4k Movies");
+        std::fs::create_dir_all(&root).unwrap();
+        for name in [
+            "The Matrix (1999).mkv",
+            "Breaking.Bad.S01E01.mkv",
+            "Breaking.Bad.S01E02.mkv",
+        ] {
+            std::os::unix::fs::symlink(dump.join(name), root.join(name)).unwrap();
+        }
+
+        let scan = scan_into("lib1", &root);
+
+        assert_eq!(scan.unreadable, 0);
+        assert_eq!(scan.items.len(), 3);
+        assert_eq!(scan.shows.len(), 1, "both episodes grouped under one show");
+        let matrix = scan
+            .items
+            .values()
+            .find(|i| i.kind == Kind::Movie)
+            .expect("the symlinked movie is indexed");
+        assert_eq!(matrix.files[0].size, Some(1), "the target was stat-ed");
+    }
+
+    #[test]
+    fn a_symlinked_folder_of_episodes_groups_them_by_filename() {
+        let root_dir = temp_scan_dir();
+        let base = root_dir.path();
+        let dump = base.join("dump");
+        std::fs::create_dir_all(&dump).unwrap();
+        std::fs::write(dump.join("Breaking.Bad.S01E01.mkv"), b"x").unwrap();
+        std::fs::write(dump.join("Breaking.Bad.S01E02.mkv"), b"x").unwrap();
+        std::fs::write(dump.join("The.Office.S01E01.mkv"), b"x").unwrap();
+        let root = base.join("4k Shows");
+        std::fs::create_dir_all(&root).unwrap();
+        std::os::unix::fs::symlink(&dump, root.join("all")).unwrap();
+
+        let scan = scan_into("lib1", &root);
+
+        let mut titles: Vec<&str> = scan.shows.values().map(|s| s.title.as_str()).collect();
+        titles.sort_unstable();
+        assert_eq!(titles, ["Breaking Bad", "The Office"]);
+        assert_eq!(scan.items.len(), 3);
+    }
+
+    #[test]
+    fn a_symlink_whose_target_is_gone_is_counted_rather_than_dropped() {
+        let root_dir = temp_scan_dir();
+        let root = root_dir.path();
+        std::fs::write(root.join("The Matrix (1999).mkv"), b"x").unwrap();
+        std::os::unix::fs::symlink("/nowhere/Gone (2014).mkv", root.join("Gone (2014).mkv"))
+            .unwrap();
+        std::os::unix::fs::symlink("/nowhere/shows", root.join("Shows")).unwrap();
+
+        let scan = scan_into("lib1", root);
+
+        assert_eq!(scan.unreadable, 2);
+        assert_eq!(scan.items.len(), 1, "only the real file is indexed");
     }
 
     #[test]
@@ -480,26 +589,11 @@ mod tests {
         // index_parsed replaces with "Untitled".
         std::fs::write(root.join("1999.mkv"), b"x").unwrap();
 
-        let mut items: HashMap<String, MediaItem> = HashMap::new();
-        let mut shows: HashMap<String, Show> = HashMap::new();
-        let mut mtimes: HashMap<String, Option<i64>> = HashMap::new();
-        let mut lib_item_ids = std::collections::HashSet::new();
-        let mut movie_seen = false;
-        let mut episode_seen = false;
-        scan_root(
-            "lib1",
-            root,
-            &mut items,
-            &mut shows,
-            &mut mtimes,
-            &mut lib_item_ids,
-            &mut movie_seen,
-            &mut episode_seen,
-        );
+        let scan = scan_into("lib1", root);
 
-        assert!(movie_seen);
-        assert!(!episode_seen);
-        assert_eq!(items.len(), 1);
-        assert_eq!(items.values().next().unwrap().title, "Untitled");
+        assert!(scan.movie_seen);
+        assert!(!scan.episode_seen);
+        assert_eq!(scan.items.len(), 1);
+        assert_eq!(scan.items.values().next().unwrap().title, "Untitled");
     }
 }

--- a/server/crates/kroma-engine/src/services/settings/accessors.rs
+++ b/server/crates/kroma-engine/src/services/settings/accessors.rs
@@ -268,9 +268,6 @@ pub fn library_defs(settings: &Settings, config: &crate::config::Config) -> Vec<
             auto_scan: true,
         });
     }
-    if defs.is_empty() {
-        return demo_defs(config);
-    }
     defs.extend(config.media_dirs.iter().map(|dir| {
         let path = dir.to_string_lossy().to_string();
         let name = dir
@@ -286,6 +283,9 @@ pub fn library_defs(settings: &Settings, config: &crate::config::Config) -> Vec<
             auto_scan: true,
         }
     }));
+    if defs.is_empty() {
+        return demo_defs(config);
+    }
     defs
 }
 
@@ -698,6 +698,24 @@ mod tests {
         assert_eq!(defs.len(), 1);
         assert_eq!(defs[0].name, "Films");
         assert_eq!(defs[0].folders, vec!["/media/films".to_string()]);
+    }
+
+    #[test]
+    fn an_untyped_media_dir_is_a_library_on_its_own() {
+        let pool = test_pool();
+        let s = settings(&pool);
+        let dir = kroma_testing::temp_dir("media-dirs-only");
+        let (movies, _) = crate::services::demo::media::roots(dir.path());
+        std::fs::create_dir_all(&movies).unwrap();
+        let mut cfg = test_config();
+        cfg.data_dir = dir.path().to_path_buf();
+        cfg.media_dirs = vec![PathBuf::from("/media/4k Shows")];
+
+        let defs = library_defs(&s, &cfg);
+
+        assert_eq!(defs.len(), 1, "KROMA_MEDIA_DIRS alone configures a library");
+        assert_eq!(defs[0].name, "4k Shows");
+        assert_eq!(defs[0].folders, vec!["/media/4k Shows".to_string()]);
     }
 
     #[test]


### PR DESCRIPTION
## What

Three faults behind #199, all in the library walk and the name parser.

**A symlink the process cannot resolve was dropped without a word.** jwalk hands a
dangling link back as an error and the walk kept only the `Ok` half, so a library built
entirely from links into a pool the container never mounted scanned clean and empty: no
items, no warning, nothing to distinguish it from a folder someone had emptied. The walk
now counts what it could not read, names one offending path, and carries the count on
`ScanData` so the "produced no items" warning says which of the two it is. Links that
resolve were already followed and stay followed: the link's own name is parsed, the
target is streamed.

**The show a file belongs to was taken from the top-level folder under the library
root.** One grouping folder in the way and every show collapsed into it:
`Shows/Breaking Bad/Season 01/S01E01.mkv` and `Shows/The Office/Season 01/S01E02.mkv`
both came back as a series called "Shows", and a symlinked pool folder became a series
called "all".

What identifies a show is the season folder. A `Season 01` under a directory proves that
directory is a show folder, and with one present it names the series however the files
inside are spelled. Without one the path proves nothing, because a flat pool holds many
shows side by side, so the filename names the series: `all/Breaking.Bad.S01E01.mkv` next
to `all/The.Office.S01E01.mkv` is two shows, not one folder's worth. One rule, no
string-similarity guessing, in the new `kroma-domain::naming::show`.

**A file carrying no name of its own (`S01E01.mkv`) became a series named after its own
marker**, so a folder of them was one series per file. That is the second half of the
report. It now falls back to the folder holding it, and at the library root to the
library folder, so they land together.

Found on the way and fixed here because it blocked the end-to-end check:
`KROMA_MEDIA_DIRS` was dead config. `library_defs` returned the demo definitions before
it ever read `media_dirs`, so the variable both READMEs point operators at did nothing
unless `KROMA_MOVIES_DIRS` or `KROMA_SERIES_DIRS` was also set.

## Closes

Closes #199

## Checks

- [x] `cargo clippy --workspace --all-targets` and `cargo test --workspace` pass (0
  failures; the warnings clippy prints are all pre-existing on main and none are in the
  touched files)
- [x] No TS changed, so `bun run test` / `check` are untouched. `bun run spec:check` is
  up to date.
- [x] Follows `CODE_STYLE.md`
- [x] One idea, plus the dead `KROMA_MEDIA_DIRS` it uncovered, called out above

Verified on a real server, not only in tests: a private `kroma-server` on `:4041` with
its own data dir, pointed at two libraries of symlinks into a shared pool with one
broken link among them.

```
scanned library library=4k Shows items=6
scanned library library=4k Movies items=1
WARN entries skipped: a symlink whose target is not mounted reads as missing
     folder=.../4k Shows unreadable=1 example=.../4k Shows/Missing Show
```

```
'Breaking Bad'   year=2008 seasons=1 eps=2     (symlinked dir, files named only S01E01/S01E02)
'Severance'      year=None seasons=1 eps=2     (in the symlinked pool folder)
'The Bear'       year=None seasons=1 eps=1     (same folder, correctly a separate show)
'The Office'     year=2005 seasons=1 eps=1
```

Before this change the last three were one series called "all".

## Risk

A show id is derived from its title, so a library hit by either grouping fault re-keys on
the next scan: its old items are replaced and the watch progress cascading off those rows
(`progress.item_id REFERENCES items(id) ON DELETE CASCADE`) goes with them. That only
touches libraries whose shows were already merged under one wrong title, which is the
bug being fixed, but it is a one-way change and worth knowing before merge.

The narrower behaviour change: in a show folder with no season folder, the filename now
names the series instead of the folder. Files inside such a folder are named
consistently, so it stays one show, but the title can shift
(`Marvel's Daredevil (2015)/Daredevil.S01E01.mkv` was "Marvel's Daredevil", becomes
"Daredevil") and re-keys with it. The recommended layout in `docs/spec/library` has a
season folder and is unaffected.

The remaining limitation, unchanged and now documented: a pool folder whose files carry
no show name at all still cannot be split, because nothing in the path or the name says
where one series ends.
