### PR TITLE
docs(spec): every requirement carries a stable id, and every section a status

### DIFF
--- a/docs/spec/INDEX.md
+++ b/docs/spec/INDEX.md
@@ -3,7 +3,43 @@
 
 # Requirement index
 
-226 requirements across the spec. The machine-readable source is [`requirements.json`](requirements.json).
+311 requirements across the spec. The machine-readable source is [`requirements.json`](requirements.json).
+
+## ACCT - [accounts](accounts/)
+
+- **ACCT-1** (SHIPPED) - An **account** is a person. It has credentials, its own watch state,
+- **ACCT-2** (SHIPPED) - The first account created at first-run is the **owner**, an account
+- **ACCT-3** (SHIPPED) - Every subsequent account is an ordinary **user**, created by invitation
+- **ACCT-4** (SHIPPED) - There are no profiles under an account, and there will not be. A person
+- **ACCT-5** (SHIPPED) - A person proves who they are with a **username and password**. That is
+- **ACCT-6** (SHIPPED) - A successful authentication mints a **session**: a long-lived,
+- **ACCT-7** (SHIPPED) - **Sessions do not expire on a clock.** A session lives until it is
+- **ACCT-8** (SHIPPED) - A session is per device, not per account, so one can be revoked without
+- **ACCT-9** (SHIPPED) - A **device** is where a session lives. Signing in on a phone, a browser
+- **ACCT-10** (AGREED) - Every session appears in the account's **device list** with enough to
+- **ACCT-11** (SHIPPED) - A television binds to an account through the pairing handshake rather
+- **ACCT-12** (AGREED) - A paired television is not a special class of trust. It lands in the
+- **ACCT-13** (SHIPPED) - **Unbinding is revocation.** Revoking a device's session ends its
+- **ACCT-14** (SHIPPED) - A revoked device that returns must pair or sign in afresh.
+- **ACCT-15** (SHIPPED) - A television session is long-lived and revocable, and is **never
+- **ACCT-16** (AGREED) - The device list is the control that replaces expiry: security comes
+- **ACCT-17** (SHIPPED) - An **owner or admin** runs the server: users, settings, jobs and
+- **ACCT-18** (AGREED) - The owner is the founding admin, the owner may grant admin to another
+- **ACCT-19** (SHIPPED) - A **user** uses the server: browses and plays what they are permitted
+- **ACCT-20** (AGREED) - **Library visibility is per user.** An admin decides which libraries a
+- **ACCT-21** (AGREED) - Visibility gates browsing, search and playback alike. A title a user
+- **ACCT-22** (SHIPPED) - Installing a module is an **admin** right, because it runs new
+- **ACCT-23** (AGREED) - The matrix below is the whole of what each role may do. A user's power
+- **ACCT-24** (SHIPPED) - **Per-user**: watch state, meaning resume points, watched flags and
+- **ACCT-25** (SHIPPED) - **Per-server**: the libraries and their contents, metadata and
+- **ACCT-26** (SHIPPED) - Watch state is per user and never per device: resume a film on the
+- **ACCT-27** (SHIPPED) - Deletion destroys the account's credentials, all of its sessions and
+- **ACCT-28** (SHIPPED) - Everything per-server survives. Libraries, media, metadata and
+- **ACCT-29** (AGREED) - The owner account cannot be deleted while it is the only admin.
+- **ACCT-30** (AGREED) - A user may request deletion of their own account, which revokes their
+- **ACCT-31** (SHIPPED) - Revocation stops a session doing anything new. It cannot fetch, refresh
+- **ACCT-32** (AGREED) - Bytes already downloaded for offline viewing sit in local storage the
+- **ACCT-33** (AGREED) - The guarantee is that a revoked device gains nothing new and loses its
 
 ## ADMIN - [admin](admin/)
 
@@ -196,6 +232,61 @@
 - **MEDIA-44** (AGREED) - An undescribed stream is *not direct-playable*, because KROMA will
 - **MEDIA-45** (AGREED) - A file that will not open at all, a truncated or corrupt container,
 - **MEDIA-46** (AGREED) - Undescribed and unreadable are distinct states. The first is "we
+
+## PLAY - [playback](playback/)
+
+- **PLAY-1** (SHIPPED) - Direct play means the client fetches the original file, byte for byte,
+- **PLAY-2** (AGREED) - The client declares it can demux the **container**
+- **PLAY-3** (AGREED) - The client can decode the **video stream**, meaning codec, profile,
+- **PLAY-4** (AGREED) - Every **audio stream the person might select** is decodable by the
+- **PLAY-5** (AGREED) - The chosen **subtitle**, if any, is either a format the client renders
+- **PLAY-6** (AGREED) - The **link** sustains the file's peak bitrate. On a local network this
+- **PLAY-7** (AGREED) - When a title cannot direct-play, KROMA walks a fixed ladder and stops at
+- **PLAY-8** (AGREED) - Change the least: the video stream is never touched while a cheaper
+- **PLAY-9** (SHIPPED) - Rung 1, **direct play**. The original file, untouched. No compromise.
+- **PLAY-10** (SHIPPED) - Rung 2, **remux**, also called direct stream. The video and audio
+- **PLAY-11** (SHIPPED) - Rung 3, **audio-only fallback**. The video is still copied and one
+- **PLAY-12** (AGREED) - Video is never touched to solve an audio problem.
+- **PLAY-13** (AGREED) - Rung 4, **subtitle burn-in**. Only when a selected subtitle can
+- **PLAY-14** (SHIPPED) - Rung 5, **video transcode**, the last resort. The video stream is
+- **PLAY-15** (AGREED) - KROMA takes the highest rung that satisfies the client and does not
+- **PLAY-16** (AGREED) - Transcode is a tolerated last resort, not a headline feature. KROMA is
+- **PLAY-17** (AGREED) - Transcode is always the lowest rung and is never the default for a
+- **PLAY-18** (AGREED) - An admin may **cap or disable** video transcode per server and per
+- **PLAY-19** (AGREED) - KROMA ships no adaptive multi-bitrate ladder, no quality knobs and no
+- **PLAY-20** (AGREED) - Any rung below direct play is a compromise, and the client always shows
+- **PLAY-21** (AGREED) - **Video transcode** and **subtitle burn-in** are shown as *reduced
+- **PLAY-22** (AGREED) - **Audio downmix** and **audio transcode** are shown as *audio
+- **PLAY-23** (AGREED) - **Remux** is shown as *repackaged*. Quality is untouched, so this is
+- **PLAY-24** (AGREED) - Direct play shows nothing. The absence of a badge *is* the signal
+- **PLAY-25** (AGREED) - KROMA never re-encodes video to save bandwidth unless the device
+- **PLAY-26** (AGREED) - KROMA never tone-maps HDR without saying so.
+- **PLAY-27** (AGREED) - KROMA never burns in subtitles the person did not ask to see.
+- **PLAY-28** (AGREED) - When the only playable path is one a person or an admin has disabled,
+- **PLAY-29** (SHIPPED) - Under **direct play and remux**, seeking is instant and exact. The
+- **PLAY-30** (AGREED) - Under **transcode**, the stream is produced live from a play position,
+- **PLAY-31** (AGREED) - KROMA anchors at the requested position rather than pre-producing the
+- **PLAY-32** (AGREED) - Seeking accuracy is never silently coarsened. A transcoded seek lands
+- **PLAY-33** (SHIPPED) - Progress is **per person, per media version**, stored on the server. It
+- **PLAY-34** (SHIPPED) - The playing client reports position on a steady heartbeat while
+- **PLAY-35** (AGREED) - The write is idempotent on the person, the version, the position and
+- **PLAY-36** (SHIPPED) - Reopening a title in progress offers *Resume* from the stored position
+- **PLAY-37** (AGREED) - A title is **watched** at **90% of runtime or more**, or at reaching a
+- **PLAY-38** (SHIPPED) - At the watched threshold, continue-watching drops the title and, for
+- **PLAY-39** (AGREED) - Below the threshold, progress is retained and the title stays in
+- **PLAY-40** (AGREED) - Starting a watched title again resets it to unwatched and clears the
+- **PLAY-41** (SHIPPED) - A device watching offline queues its unsent progress reports and, on
+- **PLAY-42** (AGREED) - When queued reports from two offline sessions land for the same person
+- **PLAY-43** (AGREED) - An explicit **reset to start**, from finishing a title or choosing
+- **PLAY-44** (AGREED) - If either device crossed the watched threshold, the title is watched.
+- **PLAY-45** (AGREED) - One account may play on several clients at once. KROMA enforces no
+- **PLAY-46** (AGREED) - Each playing client is an independent session with its own fallback
+- **PLAY-47** (AGREED) - Sessions interleave into one continue-watching state under the
+- **PLAY-48** (AGREED) - KROMA does not hand off an active session between devices as a
+- **PLAY-49** (AGREED) - When a stream dies mid-playback, whether the network drops, a transcode
+- **PLAY-50** (AGREED) - A **transient** failure, a network drop or a brief server hiccup, is
+- **PLAY-51** (AGREED) - A **fatal** failure, a source gone, a transcode that cannot start, or
+- **PLAY-52** (AGREED) - When a television's older decoder cannot play a file a modern phone
 
 ## SURF - [surfaces](surfaces/)
 

--- a/docs/spec/INDEX.md
+++ b/docs/spec/INDEX.md
@@ -3,7 +3,7 @@
 
 # Requirement index
 
-88 requirements across the spec. The machine-readable source is [`requirements.json`](requirements.json).
+131 requirements across the spec. The machine-readable source is [`requirements.json`](requirements.json).
 
 ## ADMIN - [admin](admin/)
 
@@ -95,3 +95,49 @@
 - **ADMIN-86** (AGREED) - The owner sends a verification from the member editor, with the <sub>[README.md](admin/README.md)</sub>
 - **ADMIN-87** (AGREED) - Changing the address clears the verified state: the proof belongs <sub>[README.md](admin/README.md)</sub>
 - **ADMIN-88** (AGREED) - A user who cannot sign in can ask for a reset from the sign-in <sub>[README.md](admin/README.md)</sub>
+
+## SURF - [surfaces](surfaces/)
+
+- **SURF-1** (SHIPPED) - Every client KROMA ships is one of the surfaces named here, and each
+- **SURF-2** (AGREED) - A build that cannot do all six rungs below is a preview, not a
+- **SURF-3** (SHIPPED) - **Sign in or pair.** A surface reaches a server and becomes an
+- **SURF-4** (SHIPPED) - **Browse the library.** A surface moves through the titles the
+- **SURF-5** (SHIPPED) - **View a title.** A surface shows a title's artwork, its metadata,
+- **SURF-6** (SHIPPED) - **Start playback.** A surface plays the title, taking whatever rung
+- **SURF-7** (SHIPPED) - **Resume.** A surface reopens an in-progress title at the
+- **SURF-8** (SHIPPED) - **Sign out.** A surface ends the session and drops the server from
+- **SURF-9** (AGREED) - Everything past the six rungs is a *may*, not a *must*. A surface that
+- **SURF-10** (SHIPPED) - Web is the reference implementation. Where two surfaces disagree on
+- **SURF-11** (AGREED) - A feature is not shipped until web has it.
+- **SURF-12** (SHIPPED) - **First-class.** Web, mobile, desktop and the native television
+- **SURF-13** (AGREED) - A baseline regression on a first-class surface blocks the release.
+- **SURF-14** (AGREED) - A first-class surface may diverge from web where its input model
+- **SURF-15** (SHIPPED) - **Best-effort.** The sandboxed television shells, Samsung and LG,
+- **SURF-16** (AGREED) - A capability a best-effort surface's platform cannot express, such
+- **SURF-17** (SHIPPED) - **The NAS package is not a surface.** It puts the *server* on a
+- **SURF-18** (AGREED) - The matrix below is the record of what each surface must, may and may
+- **SURF-19** (SHIPPED) - **Browser-backed surfaces**, web and the sandboxed television
+- **SURF-20** (SHIPPED) - **Native surfaces**, mobile, desktop and the native television
+- **SURF-21** (AGREED) - When a television's older decoder cannot play a file a modern phone
+- **SURF-22** (AGREED) - KROMA never papers over a generation gap by silently transcoding for
+- **SURF-23** (SHIPPED) - **Pointer**, on web and desktop, is the reference model: dense
+- **SURF-24** (SHIPPED) - **Touch**, on mobile, means targets sized for a thumb, gestures for
+- **SURF-25** (SHIPPED) - **Remote, 10-foot**, on every television, is a directional focus
+- **SURF-26** (SHIPPED) - A television signs in through the pairing handshake precisely
+- **SURF-27** (AGREED) - A television build that ships a pointer-shaped screen has not met
+- **SURF-28** (AGREED) - A surface serving more than one model, such as a tablet with a
+- **SURF-29** (SHIPPED) - **Only mobile is offline.** Web, desktop and every television hold no
+- **SURF-30** (SHIPPED) - A download is a progressive file, the raw original when the device
+- **SURF-31** (SHIPPED) - Downloads survive backgrounding and app kills, and are re-adopted
+- **SURF-32** (SHIPPED) - Progress reports that could not be sent queue on the device and
+- **SURF-33** (DESIGN, NOT IMPLEMENTED) - Per-title rows in the OS storage manager, deletable
+- **SURF-34** (AGREED) - A surface stays current without asking a person to babysit it.
+- **SURF-35** (SHIPPED) - **Web.** The server serves the web surface itself. There is no
+- **SURF-36** (SHIPPED) - **Desktop.** The app checks for, fetches and applies updates in the
+- **SURF-37** (AGREED) - **Mobile.** The app updates on the store's cadence, so a server
+- **SURF-38** (AGREED) - **Televisions.** Each television updates through its own platform's
+- **SURF-39** (SHIPPED) - **NAS.** The Synology package installs and updates through Package
+- **SURF-40** (AGREED) - A surface is dropped when its host platform can no longer meet the
+- **SURF-41** (AGREED) - **Notice first.** A surface entering deprecation tells its users *in
+- **SURF-42** (AGREED) - **Sessions survive the app.** A deprecated surface's sessions are
+- **SURF-43** (AGREED) - **The library outlives any surface.** Nothing about a person's

--- a/docs/spec/INDEX.md
+++ b/docs/spec/INDEX.md
@@ -3,7 +3,7 @@
 
 # Requirement index
 
-131 requirements across the spec. The machine-readable source is [`requirements.json`](requirements.json).
+226 requirements across the spec. The machine-readable source is [`requirements.json`](requirements.json).
 
 ## ADMIN - [admin](admin/)
 
@@ -95,6 +95,107 @@
 - **ADMIN-86** (AGREED) - The owner sends a verification from the member editor, with the <sub>[README.md](admin/README.md)</sub>
 - **ADMIN-87** (AGREED) - Changing the address clears the verified state: the proof belongs <sub>[README.md](admin/README.md)</sub>
 - **ADMIN-88** (AGREED) - A user who cannot sign in can ask for a reset from the sign-in <sub>[README.md](admin/README.md)</sub>
+
+## LIB - [library](library/)
+
+- **LIB-1** (AGREED) - A **source** is a directory tree the server is told to watch, tagged
+- **LIB-2** (AGREED) - A movie source never produces episodes and a show source never produces
+- **LIB-3** (AGREED) - A server has zero or more sources, any number of them may point at the
+- **LIB-4** (AGREED) - A source is an input, not a category a person browses by. Filtering the
+- **LIB-5** (SHIPPED) - A source tree may be assembled from symlinks. A curated folder of links
+- **LIB-6** (SHIPPED) - A link the server cannot resolve is reported, never silently skipped,
+- **LIB-7** (AGREED) - A source records its mount path, its content kind and its scan schedule.
+- **LIB-8** (AGREED) - Nothing about a source is destructive. Removing one drops its titles
+- **LIB-9** (AGREED) - Matching is convention-first: a correctly named file matches offline,
+- **LIB-10** (SHIPPED) - The `Title (Year)` stem is what is matched. The year is not
+- **LIB-11** (SHIPPED) - A trailing tag after ` - `, a resolution, an edition or a source, is
+- **LIB-12** (SHIPPED) - A loose file directly under the source root, with no folder, is
+- **LIB-13** (SHIPPED) - A season folder is what makes the folder above it the show. With one
+- **LIB-14** (SHIPPED) - Without a season folder the folder proves nothing, because a flat pool
+- **LIB-15** (SHIPPED) - An episode whose filename is only its marker (`S01E01.mkv`) takes the
+- **LIB-16** (SHIPPED) - The show folder name and the `SxxEyy` marker are load-bearing; the
+- **LIB-17** (SHIPPED) - `Specials` is accepted as an alias for `Season 00`.
+- **LIB-18** (SHIPPED) - A multi-episode file is named with a range (`S01E01-E02`) and matched
+- **LIB-19** (AGREED) - A show folder MAY carry a `(Year)` for disambiguation
+- **LIB-20** (SHIPPED) - Case is ignored, and separators may be spaces, dots or underscores.
+- **LIB-21** (SHIPPED) - Only recognised video containers are considered files to match.
+- **LIB-22** (AGREED) - The scheme is a convention rather than configuration, so a library is
+- **LIB-23** (SHIPPED) - An **initial scan** runs when a source is added: the whole tree is
+- **LIB-24** (AGREED) - An **incremental rescan** keeps the catalogue true to disk afterwards.
+- **LIB-25** (AGREED) - An incremental rescan only reconsiders what changed, meaning new paths,
+- **LIB-26** (AGREED) - Scanning is safe to run at any time, including while files are being
+- **LIB-27** (AGREED) - A file is matched only once it looks **settled**, its size and
+- **LIB-28** (SHIPPED) - Scanning **reads only**. It never writes, moves, renames or deletes
+- **LIB-29** (AGREED) - KROMA never demands exclusive access to a library and never blocks the
+- **LIB-30** (AGREED) - Matching resolves a settled file to an identity: a convention parse
+- **LIB-31** (AGREED) - A file that parses to no confident identity, whether from an
+- **LIB-32** (AGREED) - Unmatched items appear in a browsable **Unmatched** view in the library
+- **LIB-33** (AGREED) - **Manual match.** A person searches the provider, picks the correct
+- **LIB-34** (AGREED) - **Rename on disk.** A name fixed to the convention above matches
+- **LIB-35** (AGREED) - A file that could be more than one identity, a title shared by a remake
+- **LIB-36** (AGREED) - One unplaceable file never stalls a source. The catalogue is always the
+- **LIB-37** (AGREED) - Every field and image a provider returns is written to the server's own
+- **LIB-38** (AGREED) - With no internet, everything already matched browses and plays exactly
+- **LIB-39** (AGREED) - Offline, a brand-new file that needs a first provider lookup stays
+- **LIB-40** (AGREED) - Offline, a forced refresh queues rather than fails.
+- **LIB-41** (DRAFT) - A newly matched item fetches its metadata once.
+- **LIB-42** (DRAFT) - Running series are re-checked on a slow cadence, so a new episode's air
+- **LIB-43** (DRAFT) - A "Refresh metadata" action on any title, season or whole source
+- **LIB-44** (DRAFT) - A forced refresh **never** discards a manual match or user-chosen
+- **LIB-45** (AGREED) - When a file disappears from a source, its title is **marked absent**:
+- **LIB-46** (AGREED) - Content that reappears, because a NAS remounts or a file is moved back
+- **LIB-47** (AGREED) - A **move** is therefore not a special case. It is an absent path plus a
+- **LIB-48** (AGREED) - A rescan **only ever marks absent**. It never deletes user data.
+- **LIB-49** (AGREED) - Permanently deleting a title's history is an explicit, person-initiated
+
+## MEDIA - [media](media/)
+
+- **MEDIA-1** (AGREED) - **Title.** The work a person searches for: a film, or one episode
+- **MEDIA-2** (AGREED) - **Edition.** A named cut of a title: theatrical, director's,
+- **MEDIA-3** (AGREED) - **Media file.** One physical file on disk that realises an edition
+- **MEDIA-4** (AGREED) - **Stream.** One track inside a media file, exactly one of video,
+- **MEDIA-5** (AGREED) - **Stream properties.** The describable facts about a stream: codec,
+- **MEDIA-6** (AGREED) - The nesting is strict and total: every stream belongs to exactly one
+- **MEDIA-7** (AGREED) - A 1080p file and a 4K file of the same cut are **two media files of
+- **MEDIA-8** (AGREED) - KROMA ranks a title's media files and keeps a **preferred** one.
+- **MEDIA-9** (AGREED) - The preference is a *default*, not a lock. The model enumerates a
+- **MEDIA-10** (AGREED) - Editions are surfaced to the person, because they are different
+- **MEDIA-11** (AGREED) - First-class means KROMA fully describes the format, preserves it end
+- **MEDIA-12** (AGREED) - The first-class containers are **MP4**, **MKV** and **WebM**.
+- **MEDIA-13** (AGREED) - **HEVC / H.265** is the priority codec. 8-bit and 10-bit, SDR and
+- **MEDIA-14** (AGREED) - **H.264 / AVC** is the universal floor, assumed playable
+- **MEDIA-15** (AGREED) - **AV1** is first-class media truth whatever the client generation,
+- **MEDIA-16** (AGREED) - **VP9** is first-class within WebM, chiefly for the browser
+- **MEDIA-17** (AGREED) - A codec being first-class states how *KROMA* handles it, never that a
+- **MEDIA-18** (AGREED) - HDR is preserved end to end or it is not offered. KROMA never
+- **MEDIA-19** (AGREED) - **Bit depth.** 8-bit and 10-bit are first-class, and 10-bit is
+- **MEDIA-20** (AGREED) - KROMA distinguishes **HDR10**, **HDR10+**, **Dolby Vision** and
+- **MEDIA-21** (AGREED) - Colour primaries, transfer characteristics and matrix coefficients
+- **MEDIA-22** (AGREED) - Where dynamic metadata, HDR10+ or Dolby Vision, cannot be carried
+- **MEDIA-23** (AGREED) - The first-class audio codecs are **AAC**, **AC-3** and **E-AC-3**
+- **MEDIA-24** (AGREED) - An audio stream's **channel layout**, stereo, 5.1, 7.1 or Atmos
+- **MEDIA-25** (AGREED) - **Passthrough** is the default for multichannel and lossless audio:
+- **MEDIA-26** (AGREED) - **Downmixing** to stereo happens only when the target cannot render
+- **MEDIA-27** (AGREED) - Multiple audio streams, languages and commentary alike, are all
+- **MEDIA-28** (AGREED) - A subtitle stream is either **embedded**, a track inside the media
+- **MEDIA-29** (AGREED) - The first-class subtitle formats are **SRT**, **WebVTT** and
+- **MEDIA-30** (AGREED) - The **forced** disposition, only the foreign-language lines a
+- **MEDIA-31** (AGREED) - **Burning in**, rendering a subtitle permanently into the video, is
+- **MEDIA-32** (AGREED) - Every title carries a **poster**, a **backdrop**, a **logo** and, per
+- **MEDIA-33** (AGREED) - Image sources rank by trust: embedded in the media file, then a
+- **MEDIA-34** (AGREED) - KROMA derives a fixed set of sizes per image, a small grid
+- **MEDIA-35** (AGREED) - Derived sizes are cached and served without re-deriving, and a
+- **MEDIA-36** (AGREED) - Artwork is never a reason a title fails to appear. A title with no
+- **MEDIA-37** (AGREED) - KROMA learns a file's streams by **probing** it once, when the
+- **MEDIA-38** (AGREED) - A probe is the authoritative stream truth until the file's bytes
+- **MEDIA-39** (AGREED) - When a direct play fails in a way that implicates the stream
+- **MEDIA-40** (AGREED) - Trust is per-file and durable: a corrected probe is written back,
+- **MEDIA-41** (AGREED) - A file whose container opens and whose streams enumerate, but which
+- **MEDIA-42** (AGREED) - The title **appears** in the library with whatever *is* known. A
+- **MEDIA-43** (AGREED) - The unknown stream is marked **undescribed** and carries its raw
+- **MEDIA-44** (AGREED) - An undescribed stream is *not direct-playable*, because KROMA will
+- **MEDIA-45** (AGREED) - A file that will not open at all, a truncated or corrupt container,
+- **MEDIA-46** (AGREED) - Undescribed and unreadable are distinct states. The first is "we
 
 ## SURF - [surfaces](surfaces/)
 

--- a/docs/spec/INDEX.md
+++ b/docs/spec/INDEX.md
@@ -3,7 +3,7 @@
 
 # Requirement index
 
-311 requirements across the spec. The machine-readable source is [`requirements.json`](requirements.json).
+349 requirements across the spec. The machine-readable source is [`requirements.json`](requirements.json).
 
 ## ACCT - [accounts](accounts/)
 
@@ -131,6 +131,42 @@
 - **ADMIN-86** (AGREED) - The owner sends a verification from the member editor, with the <sub>[README.md](admin/README.md)</sub>
 - **ADMIN-87** (AGREED) - Changing the address clears the verified state: the proof belongs <sub>[README.md](admin/README.md)</sub>
 - **ADMIN-88** (AGREED) - A user who cannot sign in can ask for a reset from the sign-in <sub>[README.md](admin/README.md)</sub>
+
+## DISC - [discovery](discovery/)
+
+- **DISC-1** (SHIPPED) - A client on the same network as a server is never told the server's
+- **DISC-2** (SHIPPED) - On a private network the server sits inside, "the same network" means
+- **DISC-3** (SHIPPED) - When the server is reached from outside, it means the *exact* same
+- **DISC-4** (SHIPPED) - Over IPv6, it means the same delegated prefix: one home's allocation.
+- **DISC-5** (SHIPPED) - A home this cannot place, split across subnets, dual-stack with the two
+- **DISC-6** (SHIPPED) - Native mobile shells, iOS and Android, can *browse*: they find nearby
+- **DISC-7** (SHIPPED) - Native TV shells, Apple TV and Android TV, and webOS can *announce*:
+- **DISC-8** (SHIPPED) - Web, desktop and TV-web shells can do neither from the browser
+- **DISC-9** (SHIPPED) - Tizen cannot announce at all, because its TV profile ships no way to.
+- **DISC-10** (SHIPPED) - Browsing and announcing settle *reach*, whether two devices are near
+- **DISC-11** (SHIPPED) - Every shell offers a manual path: a person can always type an address,
+- **DISC-12** (SHIPPED) - Manual connection is the only supported path from *outside* the local
+- **DISC-13** (SHIPPED) - Once an address is reachable, every sign-in road below works over it,
+- **DISC-14** (SHIPPED) - All three roads end in the same place. The server holds a pending
+- **DISC-15** (SHIPPED) - **Quick Connect is the floor.** The television prints a short code; the
+- **DISC-16** (SHIPPED) - **Nearby handoff** is the shortcut for televisions the platform lets us
+- **DISC-17** (SHIPPED) - **Confirmed handoff** covers the listed television a server cannot
+- **DISC-18** (SHIPPED) - Discovery finding nothing is a normal state, not an error, and every
+- **DISC-19** (SHIPPED) - A TV shell that can announce but not browse is *already* showing its
+- **DISC-20** (SHIPPED) - A TV shell that cannot announce shows Quick Connect and, when it is
+- **DISC-21** (SHIPPED) - A mobile shell that browses and sees an empty list offers, in that
+- **DISC-22** (SHIPPED) - Web and desktop, which never browse, present the manual address field
+- **DISC-23** (SHIPPED) - No shell ever traps a person on a road that failed. There is always a
+- **DISC-24** (SHIPPED) - A Quick Connect or handoff code is valid for **five minutes**, because
+- **DISC-25** (SHIPPED) - A code that expires mid-flow is replaced on the television by a clear
+- **DISC-26** (SHIPPED) - A code already consumed by a successful sign-in vanishes rather than
+- **DISC-27** (SHIPPED) - An expired code is visibly dead and one tap from being alive again,
+- **DISC-28** (SHIPPED) - Approval is one-time. The moment an account approves a pairing, the
+- **DISC-29** (SHIPPED) - A paired television is a *device*, not a second key to the account. It
+- **DISC-30** (SHIPPED) - Revocation is symmetrical with every other device. The account sees the
+- **DISC-31** (DESIGN, NOT IMPLEMENTED) - Samsung and LG televisions do not reach the deeper
+- **DISC-32** (SHIPPED) - Native TV shells also *browse* for a server, so a television that was
+- **DISC-33** (SHIPPED) - A client with a camera may read the code from the television's QR
 
 ## LIB - [library](library/)
 
@@ -290,24 +326,24 @@
 
 ## SURF - [surfaces](surfaces/)
 
-- **SURF-1** (SHIPPED) - Every client KROMA ships is one of the surfaces named here, and each
-- **SURF-2** (AGREED) - A build that cannot do all six rungs below is a preview, not a
+- **SURF-1** (SHIPPED) - Every client KROMA ships is one of the surfaces named here. A client
+- **SURF-2** (AGREED) - A build that cannot do all six rungs below is a **preview**, not a
 - **SURF-3** (SHIPPED) - **Sign in or pair.** A surface reaches a server and becomes an
 - **SURF-4** (SHIPPED) - **Browse the library.** A surface moves through the titles the
-- **SURF-5** (SHIPPED) - **View a title.** A surface shows a title's artwork, its metadata,
+- **SURF-5** (SHIPPED) - **View a title.** A surface shows a title's artwork, its metadata
 - **SURF-6** (SHIPPED) - **Start playback.** A surface plays the title, taking whatever rung
 - **SURF-7** (SHIPPED) - **Resume.** A surface reopens an in-progress title at the
 - **SURF-8** (SHIPPED) - **Sign out.** A surface ends the session and drops the server from
-- **SURF-9** (AGREED) - Everything past the six rungs is a *may*, not a *must*. A surface that
-- **SURF-10** (SHIPPED) - Web is the reference implementation. Where two surfaces disagree on
-- **SURF-11** (AGREED) - A feature is not shipped until web has it.
+- **SURF-9** (AGREED) - Every capability past the six rungs is a *may*, not a *must*, and a
+- **SURF-10** (AGREED) - Web is the reference implementation. Where two surfaces disagree on a
+- **SURF-11** (AGREED) - A feature that belongs on more than one surface is not shipped until
 - **SURF-12** (SHIPPED) - **First-class.** Web, mobile, desktop and the native television
 - **SURF-13** (AGREED) - A baseline regression on a first-class surface blocks the release.
 - **SURF-14** (AGREED) - A first-class surface may diverge from web where its input model
 - **SURF-15** (SHIPPED) - **Best-effort.** The sandboxed television shells, Samsung and LG,
 - **SURF-16** (AGREED) - A capability a best-effort surface's platform cannot express, such
 - **SURF-17** (SHIPPED) - **The NAS package is not a surface.** It puts the *server* on a
-- **SURF-18** (AGREED) - The matrix below is the record of what each surface must, may and may
+- **SURF-18** (SHIPPED) - The matrix below is the record of what each surface must, may and may
 - **SURF-19** (SHIPPED) - **Browser-backed surfaces**, web and the sandboxed television
 - **SURF-20** (SHIPPED) - **Native surfaces**, mobile, desktop and the native television
 - **SURF-21** (AGREED) - When a television's older decoder cannot play a file a modern phone
@@ -319,7 +355,7 @@
 - **SURF-27** (AGREED) - A television build that ships a pointer-shaped screen has not met
 - **SURF-28** (AGREED) - A surface serving more than one model, such as a tablet with a
 - **SURF-29** (SHIPPED) - **Only mobile is offline.** Web, desktop and every television hold no
-- **SURF-30** (SHIPPED) - A download is a progressive file, the raw original when the device
+- **SURF-30** (SHIPPED) - A downloaded title plays with no server connection.
 - **SURF-31** (SHIPPED) - Downloads survive backgrounding and app kills, and are re-adopted
 - **SURF-32** (SHIPPED) - Progress reports that could not be sent queue on the device and
 - **SURF-33** (DESIGN, NOT IMPLEMENTED) - Per-title rows in the OS storage manager, deletable
@@ -328,8 +364,13 @@
 - **SURF-36** (SHIPPED) - **Desktop.** The app checks for, fetches and applies updates in the
 - **SURF-37** (AGREED) - **Mobile.** The app updates on the store's cadence, so a server
 - **SURF-38** (AGREED) - **Televisions.** Each television updates through its own platform's
-- **SURF-39** (SHIPPED) - **NAS.** The Synology package installs and updates through Package
+- **SURF-39** (AGREED) - **NAS.** The Synology package installs and updates through Package
 - **SURF-40** (AGREED) - A surface is dropped when its host platform can no longer meet the
 - **SURF-41** (AGREED) - **Notice first.** A surface entering deprecation tells its users *in
 - **SURF-42** (AGREED) - **Sessions survive the app.** A deprecated surface's sessions are
 - **SURF-43** (AGREED) - **The library outlives any surface.** Nothing about a person's
+- **SURF-44** (AGREED) - Web is where the baseline is defined, so web is first-class by
+- **SURF-45** (AGREED) - A best-effort surface ships when its platform allows and may lag the
+- **SURF-46** (AGREED) - KROMA never claims a panel decodes a codec its generation predates.
+- **SURF-47** (SHIPPED) - The input model is the one thing a surface may *not* copy from web,
+- **SURF-48** (SHIPPED) - A download is a single progressive file: the raw original when the

--- a/docs/spec/INDEX.md
+++ b/docs/spec/INDEX.md
@@ -3,7 +3,7 @@
 
 # Requirement index
 
-349 requirements across the spec. The machine-readable source is [`requirements.json`](requirements.json).
+396 requirements across the spec. The machine-readable source is [`requirements.json`](requirements.json).
 
 ## ACCT - [accounts](accounts/)
 
@@ -268,6 +268,56 @@
 - **MEDIA-44** (AGREED) - An undescribed stream is *not direct-playable*, because KROMA will
 - **MEDIA-45** (AGREED) - A file that will not open at all, a truncated or corrupt container,
 - **MEDIA-46** (AGREED) - Undescribed and unreadable are distinct states. The first is "we
+
+## MOD - [modules](modules/)
+
+- **MOD-1** (SHIPPED) - The base build ships **zero modules**. Everything past playback and
+- **MOD-2** (SHIPPED) - A module is a self-contained capability with a reverse-DNS id
+- **MOD-3** (SHIPPED) - Within its own process a module has wide latitude: it registers
+- **MOD-4** (SHIPPED) - A database is a **declared capability**, not something every module
+- **MOD-5** (SHIPPED) - It may not reach into the server's process or another module's
+- **MOD-6** (SHIPPED) - It may not replace core. Playback, catalogue, accounts and the
+- **MOD-7** (SHIPPED) - It may not claim a first-party module id it does not own.
+- **MOD-8** (SHIPPED) - It may not assume it is present. Because any module is uninstallable,
+- **MOD-9** (SHIPPED) - A module *may* depend on another module, hard or optional, and that
+- **MOD-10** (SHIPPED) - A module ships as a single `.kmod` file: a manifest, the native
+- **MOD-11** (SHIPPED) - **Identity and version.** The reverse-DNS id and a hand-set version.
+- **MOD-12** (SHIPPED) - The release process refuses to publish changed bytes under an
+- **MOD-13** (SHIPPED) - **`minServer`, the compatibility floor.** The minimum server version
+- **MOD-14** (SHIPPED) - **Dependencies.** Hard ones that must be installed alongside it, and
+- **MOD-15** (SHIPPED) - **Target.** Which platform the backend was built for. A library-only
+- **MOD-16** (SHIPPED) - The server checks the bytes it downloads against a published SHA-256
+- **MOD-17** (SHIPPED) - Integrity is not safety: a matching checksum proves the bytes are the
+- **MOD-18** (SHIPPED) - **From the Store**, by id. The server resolves hard dependencies
+- **MOD-19** (SHIPPED) - **By upload**, handing the server a `.kmod` by hand: same unpack,
+- **MOD-20** (SHIPPED) - Both are admin actions on the [`admin/`](../admin/) surface.
+- **MOD-21** (SHIPPED) - The Store (Admin → Modules) is the in-app browser over the configured
+- **MOD-22** (SHIPPED) - The official registry is pinned first and cannot be removed; operators
+- **MOD-23** (SHIPPED) - For each module the Store shows **this server's verdict**, not just the
+- **MOD-24** (DRAFT) - **First-party is trusted by default.** The official registry is
+- **MOD-25** (DRAFT) - **A third-party registry is an explicit operator opt-in.** Adding one
+- **MOD-26** (DRAFT) - The operator is told, in plain terms, that a module is a native binary
+- **MOD-27** (DRAFT) - **Checksums guarantee integrity, never safety**, and the server says so
+- **MOD-28** (SHIPPED) - **Enable.** The server spawns the sidecar and the module's routes,
+- **MOD-29** (SHIPPED) - **Disable.** The sidecar is stopped, the module stops running, and
+- **MOD-30** (SHIPPED) - **Update.** A newer version replaces the bundle and the sidecar is
+- **MOD-31** (SHIPPED) - `minServer` is re-checked on update, so an update that outgrows the
+- **MOD-32** (SHIPPED) - **Uninstall.** The module is removed entirely. It is the one
+- **MOD-33** (SHIPPED) - The server refuses to uninstall a module another enabled module still
+- **MOD-34** (SHIPPED) - Uninstalling a module never touches media on disk. A downloads module
+- **MOD-35** (SHIPPED) - **A crashed module cannot take down the server.** The sidecar is a
+- **MOD-36** (SHIPPED) - **An incompatible module never runs by accident.** `minServer` is
+- **MOD-37** (SHIPPED) - **Failure is visible, not silent.** A module that will not start or
+- **MOD-38** (SHIPPED) - The server is forward-compatible with older modules. A module declares
+- **MOD-39** (SHIPPED) - A module installed today keeps working as the server is updated,
+- **MOD-40** (SHIPPED) - A *newer* module may raise its `minServer`, and the Store says so
+- **MOD-41** (SHIPPED) - A module **may** ship UI, and the position is deliberate: a module's
+- **MOD-42** (AGREED) - A module renders **its own admin surface**: configuration, status and
+- **MOD-43** (SHIPPED) - A module's UI is served through the same reverse proxy as its backend
+- **MOD-44** (DRAFT) - **The compatibility gate is the early warning.** As the server moves
+- **MOD-45** (DRAFT) - **Data is retained.** An incompatible or abandoned module is not
+- **MOD-46** (DRAFT) - **The signal is honest.** The person is told the module has not kept
+- **MOD-47** (SHIPPED) - Every capability below could have been core and is a module instead,
 
 ## PLAY - [playback](playback/)
 

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -66,11 +66,10 @@ copying it.
 
 Example:
 
-> **LIB-4** (AGREED) - A rescan never deletes user data. A file that disappears is
-> marked absent; its watch history survives.
+> **LIB-48** (AGREED) - A rescan **only ever marks absent**. It never deletes user data.
 
 The ID is the join key between the spec and the board: an epic or story writes
-`Implements: LIB-4, LIB-7` rather than restating the rule. This keeps the earlier
+`Implements: LIB-45, LIB-48` rather than restating the rule. This keeps the earlier
 promise, *never copy spec text into an issue*, while still letting work trace
 back to exactly what it satisfies.
 

--- a/docs/spec/accounts/README.md
+++ b/docs/spec/accounts/README.md
@@ -1,5 +1,8 @@
 # Accounts
 
+Status: **AGREED**. Sections carry their own status below, and requirements carry
+theirs, because much of this model already ships while library visibility does not.
+
 Who is using the server, what they may see, and how a device proves it is them.
 
 One server, one household. The account model is sized for that: a person who owns
@@ -10,114 +13,122 @@ grander is a cost this product declines to pay.
 
 Status: **AGREED**
 
-An **account** is a person. It has credentials, its own watch state, its own
-settings, and a set of signed-in devices. Nothing else hangs off it.
+**ACCT-1** (SHIPPED) - An **account** is a person. It has credentials, its own watch state,
+its own settings, and a set of signed-in devices. Nothing else hangs off it.
 
-The first account created at first-run is the **owner**. The owner is an account
-like any other that also holds the server itself. See the roles below.
-Every subsequent account is an ordinary **user**, created by invitation from
-[`admin.md`](../admin/README.md); a KROMA server is never self-signup.
+**ACCT-2** (SHIPPED) - The first account created at first-run is the **owner**, an account
+like any other that also holds the server itself.
 
-**There are no profiles under an account, and there will not be.** A "profile"
-in other media servers is a login you do not have to type a password for: a way
-to split one household login into several viewing identities. KROMA already gives
-every person their own account, so a profile would be a second, weaker identity
-mechanism sitting beside the real one: two ways to be "someone", one of which
-carries no authentication. For a single-NAS household where making an account is
-one invitation, that buys nothing and costs the confusion of two overlapping
-concepts. A person who wants their own Continue Watching gets an account. A shared
-screen in the kitchen signs into one account and stays there. Profiles and users
-are the same thing named twice, so we keep the name that already carries a password.
+**ACCT-3** (SHIPPED) - Every subsequent account is an ordinary **user**, created by invitation
+from [`admin/`](../admin/). A KROMA server is never self-signup.
 
-The honest cost: a genuinely shared device (one television, several viewers) mixes
-everyone's watch state under whichever account it holds. We accept that. The fix
-is switching accounts on the device, not inventing passwordless sub-identities to
-avoid it.
+**ACCT-4** (SHIPPED) - There are no profiles under an account, and there will not be. A person
+who wants their own Continue Watching gets an account; a shared screen in the kitchen signs
+into one account and stays there.
+
+A "profile" in other media servers is a login you do not have to type a password for: a way to
+split one household login into several viewing identities. KROMA already gives every person
+their own account, so a profile would be a second, weaker identity mechanism sitting beside the
+real one, one of which carries no authentication. For a single-NAS household where making an
+account is one invitation, that buys nothing and costs the confusion of two overlapping
+concepts.
+
+The honest cost: a genuinely shared device, one television with several viewers, mixes
+everyone's watch state under whichever account it holds. We accept that. The fix is switching
+accounts on the device, not inventing passwordless sub-identities to avoid it.
 
 ## Authentication
 
 Status: **AGREED**
 
-A person proves who they are with a **username and password**. That is the only
-credential the server stores, and it stores only a verifier for it, never the
-password. Password strength, reset, and lockout policy are the server operator's
-concern and live in [`admin.md`](../admin/README.md).
+**ACCT-5** (SHIPPED) - A person proves who they are with a **username and password**. That is
+the only credential the server stores, and it stores only a verifier for it, never the
+password. Strength, reset and lockout policy are the operator's concern
+([`admin/`](../admin/)).
 
-A successful authentication mints a **session**: a long-lived, server-issued token
-bound to one device. Every request carries the session; the password is typed once
-per device and, in the ordinary case, never again.
+**ACCT-6** (SHIPPED) - A successful authentication mints a **session**: a long-lived,
+server-issued token bound to one device. Every request carries the session, so the password is
+typed once per device and, in the ordinary case, never again.
 
-**Sessions do not expire on a clock.** A session lives until it is revoked, by the
-account that owns it, by an admin, or by the person signing out. There is no forced
-periodic re-authentication. A session can be individually revoked without disturbing
-any other session the same account holds, because a session is per-device, not
-per-account.
+**ACCT-7** (SHIPPED) - **Sessions do not expire on a clock.** A session lives until it is
+revoked, by the account that owns it, by an admin, or by the person signing out. There is no
+forced periodic re-authentication.
 
-Rationale: see the television rule below, which is the hard case this policy is
-built around.
+**ACCT-8** (SHIPPED) - A session is per device, not per account, so one can be revoked without
+disturbing any other session the same account holds.
+
+The television rule below is the hard case this policy is built around.
 
 ## Devices and pairing
 
 Status: **AGREED**
 
-A **device** is where a session lives. Signing in on a phone, a browser, or a
-television each produces one session, and each shows up in the account's **device
-list** with enough to recognise it (shell, rough location, last-seen) and one
-action: revoke.
+**ACCT-9** (SHIPPED) - A **device** is where a session lives. Signing in on a phone, a browser
+or a television each produces one session.
 
-A television binds to an account through the pairing handshake, not a typed
-password. The mechanics of that handshake are [`discovery.md`](../discovery/README.md), and
-its raw material [`tv-pairing.md`](../../tv-pairing.md). The product rule that matters
-here: **pairing ends in an ordinary session.** A paired television is not a special
-class of trust; it lands in the same device list as everything else and revokes the
-same way. There is nothing you can do to a paired television that you cannot do to a
-phone, and nothing you must do differently to unbind it.
+**ACCT-10** (AGREED) - Every session appears in the account's **device list** with enough to
+recognise it, meaning shell, rough location and last-seen, and one action: revoke.
 
-**Unbinding is revocation.** Revoke a device's session and its access ends at the
-next request it makes. The device is not consulted, wiped, or asked to cooperate;
-the server simply stops honouring its token. A revoked device that returns must
-pair or sign in afresh.
+**ACCT-11** (SHIPPED) - A television binds to an account through the pairing handshake rather
+than a typed password ([`discovery/`](../discovery/),
+[`tv-pairing.md`](../../tv-pairing.md)), and **pairing ends in an ordinary session**.
+
+**ACCT-12** (AGREED) - A paired television is not a special class of trust. It lands in the
+same device list as everything else and revokes the same way. There is nothing you can do to a
+paired television that you cannot do to a phone.
+
+**ACCT-13** (SHIPPED) - **Unbinding is revocation.** Revoking a device's session ends its
+access at the next request it makes. The device is not consulted, wiped or asked to cooperate;
+the server simply stops honouring its token.
+
+**ACCT-14** (SHIPPED) - A revoked device that returns must pair or sign in afresh.
 
 ### Session lifetime on a television
 
 Status: **AGREED**
 
-A television session is long-lived and revocable, and **is never forced to
-re-authenticate on a schedule.** A television has no keyboard worth using and often
-no practical way to re-run the pairing dance unattended; an expiring session would
-mean a screen that silently signs itself out and a person hunting for a phone to fix
-it. So the television keeps its session until a human revokes it. The revocation
-path, the device list, is the control that replaces expiry: security comes from
-being able to cut a specific screen off instantly from any other device, not from
-making every screen prove itself again on a timer. This is the same rule as every
-other device; the television is only the case that makes forced expiry obviously
-wrong.
+**ACCT-15** (SHIPPED) - A television session is long-lived and revocable, and is **never
+forced to re-authenticate on a schedule**. It keeps its session until a human revokes it.
+
+**ACCT-16** (AGREED) - The device list is the control that replaces expiry: security comes
+from cutting a specific screen off instantly from any other device, not from making every
+screen prove itself again on a timer.
+
+A television has no keyboard worth using and often no practical way to re-run the pairing dance
+unattended. An expiring session would mean a screen that silently signs itself out and a person
+hunting for a phone to fix it. This is the same rule as every other device; the television is
+only the case that makes forced expiry obviously wrong.
 
 ## Authorisation
 
 Status: **AGREED**
 
-Two roles, and a per-user visibility rule layered on top.
+**ACCT-17** (SHIPPED) - An **owner or admin** runs the server: users, settings, jobs and
+modules. Admin rights are server-wide, never per-library.
 
-- **Owner / admin.** Runs the server. Manages users, settings, jobs, and modules.
-  The owner is the founding admin; the owner may grant admin to another account, and
-  there is always at least one admin. Admin rights are server-wide, not per-library.
-- **User.** Uses the server. Browses and plays what they are permitted to see,
-  owns their own watch state and preferences, and manages their own devices.
+**ACCT-18** (AGREED) - The owner is the founding admin, the owner may grant admin to another
+account, and there is always at least one admin.
 
-**Library visibility is per-user.** An admin decides which libraries a given user
-may see; a user sees exactly those and cannot discover the rest. Visibility gates
-browsing, search, and playback alike. A title a user cannot see is a title they
-cannot play, resume, or find.
+**ACCT-19** (SHIPPED) - A **user** uses the server: browses and plays what they are permitted
+to see, owns their own watch state and preferences, and manages their own devices.
 
-Module installation is an **admin** right, because installing a module runs new
-out-of-process code on the server. See [`modules.md`](../modules/README.md). A plain user
-may use whatever modules an admin has installed and enabled, within their own
-library visibility; they may not install, update, or remove them.
+**ACCT-20** (AGREED) - **Library visibility is per user.** An admin decides which libraries a
+given user may see; that user sees exactly those and cannot discover the rest.
+
+**ACCT-21** (AGREED) - Visibility gates browsing, search and playback alike. A title a user
+cannot see is a title they cannot play, resume or find.
+
+**ACCT-22** (SHIPPED) - Installing a module is an **admin** right, because it runs new
+out-of-process code on the server ([`modules/`](../modules/)). A plain user may use whatever
+modules an admin has installed and enabled, within their own library visibility, and may not
+install, update or remove them.
 
 ### Permission matrix
 
 Status: **AGREED**
+
+**ACCT-23** (AGREED) - The matrix below is the whole of what each role may do. A user's power
+over their own account is total; their power over anyone else's, or over the server, is none.
 
 | Capability | Owner / admin | User |
 |---|---|---|
@@ -135,9 +146,7 @@ Status: **AGREED**
 | Install / update / remove modules | ✓ | no |
 | Change server settings, run and cancel jobs | ✓ | no |
 
-A user's power over their own account is total; their power over anyone else's, or
-over the server, is none. Everything in the admin column is [`admin.md`](../admin/README.md)'s
-subject in depth.
+Everything in the admin column is [`admin/`](../admin/)'s subject in depth.
 
 ## Per-user versus per-server
 
@@ -145,19 +154,18 @@ Status: **AGREED**
 
 The dividing line is ownership of the experience versus ownership of the machine.
 
-**Per-user.** Watch state (resume points, watched flags, Continue Watching),
-personal preferences (playback defaults, language, subtitle choices, interface
-settings), the device list, and library visibility as it applies to them. Two
-people on one server share nothing here.
+**ACCT-24** (SHIPPED) - **Per-user**: watch state, meaning resume points, watched flags and
+Continue Watching; personal preferences, meaning playback defaults, language, subtitle choices
+and interface settings; and the device list. Two people on one server share nothing here, and
+library visibility (ACCT-20) applies per person on top.
 
-**Per-server.** The libraries and their contents, metadata and artwork, the set of
-installed modules, transcode and job policy, and every setting under
-[`admin.md`](../admin/README.md). One person's Continue Watching is theirs; the library that
-row points into is everyone's.
+**ACCT-25** (SHIPPED) - **Per-server**: the libraries and their contents, metadata and
+artwork, the set of installed modules, transcode and job policy, and every setting under
+[`admin/`](../admin/).
 
-Watch state is deliberately per-user and never per-device: resume a film on the
-television, finish it on the phone. The device is where a session lives, not where
-progress is kept.
+**ACCT-26** (SHIPPED) - Watch state is per user and never per device: resume a film on the
+television, finish it on the phone. The device is where a session lives, not where progress is
+kept.
 
 ## Account deletion
 
@@ -165,32 +173,38 @@ Status: **AGREED**
 
 Deleting an account destroys the person, not the media.
 
-**Destroyed.** The account's credentials, all of its sessions and paired devices
-(every one is revoked in the act of deletion), its watch state, and its personal
-preferences. After deletion the person cannot sign in, and none of their screens can
-refresh access.
+**ACCT-27** (SHIPPED) - Deletion destroys the account's credentials, all of its sessions and
+paired devices, its watch state and its personal preferences. Afterwards the person cannot sign
+in, and none of their screens can refresh access.
 
-**Survives.** Everything per-server. Libraries, media, metadata, and installed
-modules are untouched, because they were never the deleted account's to take.
-Another user's watch state is untouched even where it points at the same titles.
+**ACCT-28** (SHIPPED) - Everything per-server survives. Libraries, media, metadata and
+installed modules are untouched, because they were never the deleted account's to take, and
+another user's watch state is untouched even where it points at the same titles.
 
-The owner account cannot be deleted while it is the only admin; ownership must first
-pass to another account, so a server is never left with no one able to run it.
-An admin deleting another user is an [`admin.md`](../admin/README.md) action; a user may
-request deletion of their own account, which revokes their access on the spot.
+**ACCT-29** (AGREED) - The owner account cannot be deleted while it is the only admin.
+Ownership must first pass to another account, so a server is never left with no one able to run
+it.
+
+**ACCT-30** (AGREED) - A user may request deletion of their own account, which revokes their
+access on the spot. An admin deleting another user is an [`admin/`](../admin/) action.
 
 ### Does a revoked or deleted device lose downloaded content?
 
 Status: **AGREED**
 
-Honestly: not immediately, and the server cannot make it. Revocation stops a
-session from doing anything new. It cannot fetch, refresh, or stream another byte.
-But bytes already downloaded for offline viewing sit in local storage on the device,
-and the server has no reach into that storage. What enforces removal is the **app**:
-on discovering its session is dead, the client is required to purge downloaded media
-before it will run again. So the guarantee is "a revoked device gains nothing new and
-loses its downloads the next time the app runs", not "the download evaporates the
-instant you tap revoke". We state it plainly rather than pretend to a control we do
-not hold; the offline-download reality is [`modules.md`](../modules/README.md)'s and the mobile
-client's to enforce, and the account model's job is only to kill the session that
-would let those downloads be refreshed.
+Honestly: not immediately, and the server cannot make it.
+
+**ACCT-31** (SHIPPED) - Revocation stops a session doing anything new. It cannot fetch, refresh
+or stream another byte.
+
+**ACCT-32** (AGREED) - Bytes already downloaded for offline viewing sit in local storage the
+server cannot reach, so on discovering its session is dead the client is required to purge
+downloaded media before it will run again.
+
+**ACCT-33** (AGREED) - The guarantee is that a revoked device gains nothing new and loses its
+downloads the next time the app runs, not that the download evaporates the instant revoke is
+tapped.
+
+We state it plainly rather than pretend to a control we do not hold. Enforcing the purge is the
+mobile client's job; the account model's is only to kill the session that would let those
+downloads be refreshed.

--- a/docs/spec/accounts/README.md
+++ b/docs/spec/accounts/README.md
@@ -11,7 +11,7 @@ grander is a cost this product declines to pay.
 
 ## The account model
 
-Status: **AGREED**
+Status: **SHIPPED**
 
 **ACCT-1** (SHIPPED) - An **account** is a person. It has credentials, its own watch state,
 its own settings, and a set of signed-in devices. Nothing else hangs off it.
@@ -39,7 +39,7 @@ accounts on the device, not inventing passwordless sub-identities to avoid it.
 
 ## Authentication
 
-Status: **AGREED**
+Status: **SHIPPED**
 
 **ACCT-5** (SHIPPED) - A person proves who they are with a **username and password**. That is
 the only credential the server stores, and it stores only a verifier for it, never the
@@ -61,7 +61,7 @@ The television rule below is the hard case this policy is built around.
 
 ## Devices and pairing
 
-Status: **AGREED**
+Status: **SHIPPED**, with the device list itself **AGREED**.
 
 **ACCT-9** (SHIPPED) - A **device** is where a session lives. Signing in on a phone, a browser
 or a television each produces one session.
@@ -85,7 +85,7 @@ the server simply stops honouring its token.
 
 ### Session lifetime on a television
 
-Status: **AGREED**
+Status: **SHIPPED**
 
 **ACCT-15** (SHIPPED) - A television session is long-lived and revocable, and is **never
 forced to re-authenticate on a schedule**. It keeps its session until a human revokes it.
@@ -101,7 +101,7 @@ only the case that makes forced expiry obviously wrong.
 
 ## Authorisation
 
-Status: **AGREED**
+Status: **SHIPPED** for the two roles, **AGREED** for library visibility.
 
 **ACCT-17** (SHIPPED) - An **owner or admin** runs the server: users, settings, jobs and
 modules. Admin rights are server-wide, never per-library.
@@ -150,7 +150,7 @@ Everything in the admin column is [`admin/`](../admin/)'s subject in depth.
 
 ## Per-user versus per-server
 
-Status: **AGREED**
+Status: **SHIPPED**
 
 The dividing line is ownership of the experience versus ownership of the machine.
 
@@ -169,7 +169,7 @@ kept.
 
 ## Account deletion
 
-Status: **AGREED**
+Status: **SHIPPED**
 
 Deleting an account destroys the person, not the media.
 

--- a/docs/spec/admin/README.md
+++ b/docs/spec/admin/README.md
@@ -11,6 +11,8 @@ should ask nothing of them the rest of the time.
 
 ## Chapters
 
+Status: **SHIPPED**
+
 The dashboard and the record it reads have their own chapters. Each states what one screen
 must do; this file stays the landing page for running a server at all.
 
@@ -34,10 +36,10 @@ server the owner can explore at leisure. The minimum path, in exact order:
    exists yet, so the server presents the owner-creation step and nothing else.
 2. **Create the owner.** One account: a name and a credential. This account is the owner
    from the moment it exists. There is no separate "make me admin" step, and roles are
-   [`accounts.md`](../accounts/README.md), not asked here.
+   [`accounts/`](../accounts/), not asked here.
 3. **Add one source.** Point the server at one directory of movies or shows and tag its
    content kind. The initial scan starts immediately as a background job with visible
-   progress, [`library.md`](../library/README.md); the catalogue fills as it goes.
+   progress, [`library/`](../library/); the catalogue fills as it goes.
 4. **Play.** As soon as the first title matches, it is playable. First-run is over. The
    owner did not wait for the whole scan to finish.
 
@@ -57,9 +59,9 @@ person to break their own server at 1am, so the default posture is *no setting*.
 earns its place only when a real hobbyist has a real reason to turn it and no default can
 serve both sides of that reason.
 
-What is exposed: **sources** and their scan schedules ([`library.md`](../library/README.md));
+What is exposed: **sources** and their scan schedules ([`library/`](../library/));
 **users** and invitations (below); **metadata provider** credentials where a provider needs
-a key; **modules** and their configuration ([`modules.md`](../modules/README.md)); **server identity**
+a key; **modules** and their configuration ([`modules/`](../modules/)); **server identity**
 (a display name for the server on the network); and the **backup** controls (below).
 
 What is deliberately not exposed: transcoding ladders, cache sizes and eviction policy,
@@ -81,7 +83,7 @@ owner reconstructing a config file by hand.
 Deploy-time is reserved for the few things that genuinely cannot change safely while the
 server runs: where the server's own data lives, what address and port it binds, and the
 identity of the persistent store itself. These are the parameters a restart is *for*. They
-are set once by whatever packaged KROMA for the host, [`surfaces.md`](../surfaces/README.md), and
+are set once by whatever packaged KROMA for the host, [`surfaces/`](../surfaces/), and
 are not surfaced as settings, because changing them is a redeploy, not a preference.
 
 ## Users
@@ -92,16 +94,16 @@ The owner manages who else may use the server. Three actions, kept deliberately 
 
 - **Invite.** The owner creates an invitation the new user redeems to set their own
   credential; the owner never sets or sees another user's password. Whether an invite is a
-  link or a code is [`surfaces.md`](../surfaces/README.md); that a user sets their own secret is the
+  link or a code is [`surfaces/`](../surfaces/); that a user sets their own secret is the
   product rule.
 - **Remove.** The owner removes a user. This revokes that user's sessions and devices and
-  destroys their account per [`accounts.md`](../accounts/README.md), but touches no media and does not
+  destroys their account per [`accounts/`](../accounts/), but touches no media and does not
   affect anyone else's watch state.
 - **Reset.** The owner triggers a credential reset for a user who is locked out; the user
   re-establishes their own secret. The owner resets access, never impersonates.
 
 Roles, per-user library visibility, session lifetime and what survives an account deletion
-are all [`accounts.md`](../accounts/README.md). This section is only the admin verbs.
+are all [`accounts/`](../accounts/). This section is only the admin verbs.
 
 ### Credential reset
 
@@ -190,16 +192,16 @@ Background work, meaning scans, metadata refreshes, transcodes and module tasks,
 and interruptible. The owner should never wonder whether the server is doing something.
 
 - **Visibility.** Every running and queued job is listed with what it is, what it is working
-  on and its progress; scans and refreshes are [`library.md`](../library/README.md), module jobs are
-  [`modules.md`](../modules/README.md). A finished job leaves a short trace (succeeded, failed, or
+  on and its progress; scans and refreshes are [`library/`](../library/), module jobs are
+  [`modules/`](../modules/). A finished job leaves a short trace (succeeded, failed, or
   cancelled) so a failure is not silent.
 - **Cancellation.** Any job the owner started, the owner can cancel. Cancellation is safe:
   a cancelled scan leaves the catalogue consistent with what it had already matched, a
   cancelled transcode discards its partial output, and nothing a cancel touches corrupts
-  the library on disk. Scans are read-only ([`library.md`](../library/README.md)) and transcodes
+  the library on disk. Scans are read-only ([`library/`](../library/)) and transcodes
   write only to regenerable cache.
 - **Scheduling.** The little scheduling that exists is per-source scan cadence
-  ([`library.md`](../library/README.md)) and the metadata staleness sweep. These have sane defaults
+  ([`library/`](../library/)) and the metadata staleness sweep. These have sane defaults
   and rarely need touching. The server also declines to pile work on itself: heavy jobs are
   bounded so a large library does not saturate a NAS, and this bound is chosen, not
   configured.
@@ -211,7 +213,7 @@ Status: **AGREED**
 When something is wrong, the owner needs to see it and hand it to someone who can fix it.
 
 - **Health.** A single view answers "is the server well?": are sources reachable, are
-  modules running or crashed ([`modules.md`](../modules/README.md)), is there room on disk, is the
+  modules running or crashed ([`modules/`](../modules/)), is there room on disk, is the
   metadata provider reachable. Green is the normal state; anything else names the specific
   thing that is wrong and, where possible, the action that fixes it.
 - **Logs.** The server keeps a rolling log the owner can read and export. Routine operation
@@ -242,17 +244,17 @@ accounts, the same history and the same settings, without re-teaching it anythin
 
 What a backup **must** contain, because it cannot be regenerated:
 
-- **Accounts.** Owner and users, their bindings and access ([`accounts.md`](../accounts/README.md)).
+- **Accounts.** Owner and users, their bindings and access ([`accounts/`](../accounts/)).
 - **Watch state.** History, resume positions, ratings, and the manual-match bindings the
-  library keeps against files ([`library.md`](../library/README.md)). This is the irreplaceable heart:
+  library keeps against files ([`library/`](../library/)). This is the irreplaceable heart:
   history that outlives the bytes it describes must outlive the server too.
 - **Settings.** Sources, schedules, provider credentials, server identity.
-- **Module data.** Each installed module's own persisted state ([`modules.md`](../modules/README.md)),
+- **Module data.** Each installed module's own persisted state ([`modules/`](../modules/)),
   so a restore brings modules back as they were, not as blank installs.
 
 What a backup **must not** contain, because including it is waste, not safety:
 
-- **Media files.** KROMA never owns the bytes ([`library.md`](../library/README.md)); the library is
+- **Media files.** KROMA never owns the bytes ([`library/`](../library/)); the library is
   the owner's, backed up by the owner however they back up a NAS. A KROMA backup is small.
 - **Regenerable caches and artwork.** Fetched metadata, generated images and transcode
   output all rebuild themselves from the sources and providers after a restore. A backup
@@ -278,7 +280,7 @@ The risk an update carries, and how KROMA bounds it:
   backup before a server update, and a failed migration leaves the previous version
   restorable rather than a half-migrated store.
 - **Module updates** are independent of the server and carry their own compatibility
-  promise ([`modules.md`](../modules/README.md)); a module update never requires a server update and a
+  promise ([`modules/`](../modules/)); a module update never requires a server update and a
   server update never silently updates modules.
 - **Active playback is not a reason an update is blocked, and an update is not a reason
   playback stops**, but because a server update means a restart, the owner is told an update
@@ -287,7 +289,7 @@ The risk an update carries, and how KROMA bounds it:
 
 Open, with a recommendation: how the update actually arrives differs per host, a NAS
 package or a desktop auto-updater or a container image, and that delivery is
-[`surfaces.md`](../surfaces/README.md). Recommended answer: the product rule ("passive notice, owner
+[`surfaces/`](../surfaces/). Recommended answer: the product rule ("passive notice, owner
 chooses, backup first, migrate-forward-or-restore") is fixed here and identical everywhere;
 only the delivery vehicle varies by surface. This split is provisional pending review.
 
@@ -307,7 +309,7 @@ The exceptions are few, honest, and all involve a restart the owner initiates:
 - **Deploy-time parameters** (bind address, store location) cannot change without a restart,
   which is why they are not runtime settings at all (above).
 - **Removing a user or revoking a device** intentionally ends *that* person's sessions
-  immediately ([`accounts.md`](../accounts/README.md)); it is a security action, not a preference, and
+  immediately ([`accounts/`](../accounts/)); it is a security action, not a preference, and
   interrupting the revoked stream is the point. Everyone else plays on.
 
 Everything reachable as an ordinary runtime setting is safe to change at any time, including
@@ -315,8 +317,10 @@ while media is playing. If a change is not safe to make live, it is not a runtim
 
 ## Not in scope
 
-- **Roles, sessions, device binding and account deletion** are [`accounts.md`](../accounts/README.md).
-- **Module lifecycle, the Store and sidecar failure** are [`modules.md`](../modules/README.md).
-- **Scan and refresh behaviour** is [`library.md`](../library/README.md); Admin only starts, shows and
+Status: **AGREED**
+
+- **Roles, sessions, device binding and account deletion** are [`accounts/`](../accounts/).
+- **Module lifecycle, the Store and sidecar failure** are [`modules/`](../modules/).
+- **Scan and refresh behaviour** is [`library/`](../library/); Admin only starts, shows and
   cancels those jobs.
-- **Per-platform packaging and the update delivery vehicle** are [`surfaces.md`](../surfaces/README.md).
+- **Per-platform packaging and the update delivery vehicle** are [`surfaces/`](../surfaces/).

--- a/docs/spec/discovery/README.md
+++ b/docs/spec/discovery/README.md
@@ -1,9 +1,12 @@
 # Discovery
 
+Status: **SHIPPED**, with one deliberate deferral at the end. Sections carry their own
+status below.
+
 How a client finds a server it was never told about, and how a television, which has no
 keyboard worth using, becomes signed in.
 
-Discovery ends where [`accounts.md`](../accounts/README.md) begins: its job is to get a device
+Discovery ends where [`accounts/`](../accounts/) begins: its job is to get a device
 *attached* to a server and *pointed at* an account. What the account then means, and what
 the resulting session may do, is that file. The mechanics, meaning the wire records, the trust
 proofs and the per-shell APIs, are [`../tv-pairing.md`](../../tv-pairing.md); this file states
@@ -13,159 +16,175 @@ the product rules and links there rather than repeating them.
 
 Status: **SHIPPED**
 
-A client on the same network as a server should not have to be told the server's address.
-It announces itself; a client listens; the server appears in a list. Choosing it is the
-whole of setup on the happy path.
+**DISC-1** (SHIPPED) - A client on the same network as a server is never told the server's
+address. The server announces itself, the client listens, and the server appears in a list.
+Choosing it is the whole of setup on the happy path.
 
 "The same network" is a claim the product makes carefully, because it decides who is shown
 which television. A server is a rendezvous, not a resident: a television and a phone in one
-room can pair through a server in another country, so the only addresses that matter are
-the two devices'. The product's rule, stated plainly and specified in full in
+room can pair through a server in another country, so the only addresses that matter are the
+two devices'. Specified in full in
 [`../tv-pairing.md`](../../tv-pairing.md#what-the-same-network-means):
 
-- **On a private network the server sits inside**, "same network" means the same local
-  block: one home, whether a device is on ethernet or on wifi.
-- **When the server is reached from outside**, it means the *exact* same public address,
-  because a household leaves through one and a looser rule would rope in strangers.
-- **Over IPv6**, it means the same delegated prefix: one home's allocation.
+- **DISC-2** (SHIPPED) - On a private network the server sits inside, "the same network" means
+  the same local block: one home, whether a device is on ethernet or on wifi.
+- **DISC-3** (SHIPPED) - When the server is reached from outside, it means the *exact* same
+  public address, because a household leaves through one and a looser rule would rope in
+  strangers.
+- **DISC-4** (SHIPPED) - Over IPv6, it means the same delegated prefix: one home's allocation.
 
-Three homes this cannot place, those split across subnets, dual-stack with the two devices on
-different families, or behind carrier-grade NAT, fall back to Quick Connect below rather
-than guess. This is deliberate: the product would sooner ask a human to carry four digits
-than list a stranger's television.
+**DISC-5** (SHIPPED) - A home this cannot place, split across subnets, dual-stack with the two
+devices on different families, or behind carrier-grade NAT, falls back to Quick Connect rather
+than being guessed at. The product would sooner ask a human to carry four digits than list a
+stranger's television.
 
 ## Who listens, and who must be told
 
 Status: **SHIPPED**
 
 Listening on the network needs an API not every platform grants a sandboxed app, so shells
-divide by capability, not by preference. The product view, with the mechanics and the per-shell
-table are in [`../tv-pairing.md`](../../tv-pairing.md#what-each-shell-can-do):
+divide by capability rather than by preference. The per-shell table is in
+[`../tv-pairing.md`](../../tv-pairing.md#what-each-shell-can-do):
 
-- **Native mobile shells** (iOS, Android) can *browse*: they find nearby televisions and
-  show them in a list. This is where a person usually pairs a TV.
-- **Native TV shells** (Apple TV, Android TV) and webOS can *announce*: they put themselves
-  on the network so a phone can find them. They do not browse for servers themselves.
-- **Web, desktop, and TV-web shells** can do neither from the browser sandbox. They learn a
-  server only from what the server itself tells them, or from an address a person enters.
-- **Tizen** cannot announce at all: its TV profile ships no way to. A Samsung set is
-  therefore only ever found *through the server*, and confirmed by a check string (below).
-  This is a platform limit, not a gap we mean to close; see the deferral section.
+- **DISC-6** (SHIPPED) - Native mobile shells, iOS and Android, can *browse*: they find nearby
+  televisions and show them in a list. This is where a person usually pairs a TV.
+- **DISC-7** (SHIPPED) - Native TV shells, Apple TV and Android TV, and webOS can *announce*:
+  they put themselves on the network so a phone can find them.
+- **DISC-32** (SHIPPED) - Native TV shells also *browse* for a server, so a television that was
+  never told an address finds one itself. Where the platform ships no browser the shell falls
+  back to a typed address.
+- **DISC-8** (SHIPPED) - Web, desktop and TV-web shells can do neither from the browser
+  sandbox. They learn a server only from what the server itself tells them, or from an address
+  a person enters.
+- **DISC-9** (SHIPPED) - Tizen cannot announce at all, because its TV profile ships no way to.
+  A Samsung set is therefore only ever found *through the server*, and confirmed by a check
+  string. This is a platform limit, not a gap we mean to close.
 
-The rule the product holds to: browsing and announcing settle *reach*, whether two devices
-are near enough to pair, and nothing more. Being near is necessary, never sufficient. A
-listed device a server could not physically place still has to prove itself with a check
-string before it may be granted.
+**DISC-10** (SHIPPED) - Browsing and announcing settle *reach*, whether two devices are near
+enough to pair, and nothing more. Being near is necessary, never sufficient: a listed device a
+server could not physically place still has to prove itself with a check string before it may
+be granted.
 
 ## Manual connection
 
 Status: **SHIPPED**
 
-Automatic discovery is a convenience, not a dependency. Every shell offers a manual path,
-because networks lie: multicast is filtered on guest wifi, the server is across a VPN, the
-phone is on cellular. A person can always type an address, hostname or IP with an optional
-port, and connect directly.
+**DISC-11** (SHIPPED) - Every shell offers a manual path: a person can always type an address,
+hostname or IP with an optional port, and connect directly. Automatic discovery is a
+convenience, not a dependency, because networks lie: multicast is filtered on guest wifi, the
+server is across a VPN, the phone is on cellular.
 
-Manual connection is also the only supported path from *outside* the local network. KROMA
-does not run a relay or a discovery cloud; reaching a server across the internet means the
-operator has published it (a port forward, a reverse proxy, a tunnel) and the person knows
-its address. Remote access is thus a property of the *server's* deployment, documented in
-admin, not a discovery feature. What discovery guarantees is that once an address is
-reachable, every sign-in road below works over it, Quick Connect especially, which is
-built to.
+**DISC-12** (SHIPPED) - Manual connection is the only supported path from *outside* the local
+network. KROMA runs no relay and no discovery cloud, so reaching a server across the internet
+means the operator has published it, by a port forward, a reverse proxy or a tunnel, and the
+person knows its address. Remote access is a property of the server's deployment, documented in
+[`admin/`](../admin/).
+
+**DISC-13** (SHIPPED) - Once an address is reachable, every sign-in road below works over it,
+Quick Connect especially, which is built to.
 
 ## The pairing handshake
 
 Status: **SHIPPED**
 
 Signing in a television is the hard case discovery exists for: a device with a screen, a
-network, and no usable keyboard. There are three roads to it, and a television takes
-whichever ones its platform allows. All three end in the same place: the server holds a
-pending request until a signed-in account approves it, then hands the television an ordinary
-session that appears in the account's device list and revokes like any other
-([`accounts.md`](../accounts/README.md)).
+network, and no usable keyboard. There are three roads to it, and a television takes whichever
+ones its platform allows.
 
-**Quick Connect is the floor.** The television prints a short code; the person reads it and
-types it into an already-signed-in client. It is slow by design, and that is exactly why it
-works from anywhere: across subnets, over a tunnel, from a phone on cellular, on a set that
-can do nothing else. It is never removed, on any shell.
+**DISC-14** (SHIPPED) - All three roads end in the same place. The server holds a pending
+request until a signed-in account approves it, then hands the television an ordinary session
+that appears in the account's device list and revokes like any other
+([`accounts/`](../accounts/)).
 
-**Nearby handoff** is the shortcut for televisions the platform lets us find. Instead of
-reading a code, the person opens their phone, sees the television in a list, and taps its
-row. The tap is the approval. This is the fast path, and the one most people use.
+**DISC-15** (SHIPPED) - **Quick Connect is the floor.** The television prints a short code; the
+person reads it and enters it into an already-signed-in client. It is slow by design, which is
+exactly why it works from anywhere: across subnets, over a tunnel, from a phone on cellular, on
+a set that can do nothing else. It is never removed, on any shell.
 
-**Confirmed handoff** covers the listed television a server cannot physically place. The
-Samsung set found only through the server, or any beacon whose position the server cannot
-vouch for. It is listed, but tapping it is not enough: the person is asked for a short check
-string the television is already printing on its own screen. This is Quick Connect's
-guarantee kept *inside* the list rather than replacing it: one confirmation, on exactly the
-platforms that have no safer road in. Why a raw tap is unsafe there, and why the check
-string is the right price, is [`../tv-pairing.md`](../../tv-pairing.md#who-may-raise-a-beacon).
+**DISC-33** (SHIPPED) - A client with a camera may read the code from the television's QR
+instead of asking a person to type it. Scanning is an input method for Quick Connect, not a
+fourth road, so a shell without a camera loses nothing but the typing.
+
+**DISC-16** (SHIPPED) - **Nearby handoff** is the shortcut for televisions the platform lets us
+find. The person opens their phone, sees the television in a list, and taps its row; the tap is
+the approval. This is the fast path, and the one most people use.
+
+**DISC-17** (SHIPPED) - **Confirmed handoff** covers the listed television a server cannot
+physically place. It is listed, but tapping it is not enough: the person is asked for a short
+check string the television is already printing on its own screen. Why a raw tap is unsafe
+there is [`../tv-pairing.md`](../../tv-pairing.md#who-may-raise-a-beacon).
 
 ### When discovery finds nothing
 
-Discovery finding nothing is a normal state, not an error, and every shell has a designed
-fallback into a road above:
+Status: **SHIPPED**
 
-- **A TV shell that can announce but not browse** (Apple TV, Android TV, webOS) is *already*
-  showing its Quick Connect code. Announcing is a bonus for the phone, and the code stands
-  on its own. Nothing found means nothing lost.
-- **A TV shell that cannot announce** (Tizen) shows Quick Connect and, when it is reached
-  through the server, its confirmed-handoff check string. Both are on screen from the start.
-- **A mobile shell** that browses and sees an empty list offers, in that same space, "enter
-  a server address" and "sign a TV in with a code". The empty list is a prompt, not a
-  dead end.
-- **Web and desktop**, which never browse, present the manual address field first, with
-  Quick Connect for pairing a television afterwards.
+**DISC-18** (SHIPPED) - Discovery finding nothing is a normal state, not an error, and every
+shell has a designed fallback into a road above.
 
-The through-line: no shell ever traps a person on a road that failed. There is always a
+- **DISC-19** (SHIPPED) - A TV shell that can announce but not browse is *already* showing its
+  Quick Connect code. Announcing is a bonus for the phone, and the code stands on its own.
+- **DISC-20** (SHIPPED) - A TV shell that cannot announce shows Quick Connect and, when it is
+  reached through the server, its confirmed-handoff check string. Both are on screen from the
+  start.
+- **DISC-21** (SHIPPED) - A mobile shell that browses and sees an empty list offers, in that
+  same space, "enter a server address" and "sign a TV in with a code". The empty list is a
+  prompt, not a dead end.
+- **DISC-22** (SHIPPED) - Web and desktop, which never browse, present the manual address field
+  first, with Quick Connect for pairing a television afterwards.
+
+**DISC-23** (SHIPPED) - No shell ever traps a person on a road that failed. There is always a
 manual address to type and always Quick Connect to fall to.
 
 ### Code lifetime and expiry
 
-A Quick Connect or handoff code is short-lived on purpose, because a short window is what keeps a
-guessable code safe. **A code is valid for five minutes.** While it is live the television
-polls quietly and shows the code plainly.
+Status: **SHIPPED**
 
-When it expires mid-flow the person is not left staring at a stale number wondering why
-approval did nothing. The television replaces the expired code with a clear "this code
-expired" message and a single "show a new code" action; taking it mints a fresh code and
-resets the clock. A code already consumed by a successful sign-in likewise vanishes rather
-than lingering. The rule: an expired code is visibly dead and one tap from being alive
-again, never silently accepted late.
+**DISC-24** (SHIPPED) - A Quick Connect or handoff code is valid for **five minutes**, because
+a short window is what keeps a guessable code safe. While it is live the television polls
+quietly and shows the code plainly.
+
+**DISC-25** (SHIPPED) - A code that expires mid-flow is replaced on the television by a clear
+"this code expired" message and a single "show a new code" action, which mints a fresh code and
+resets the clock.
+
+**DISC-26** (SHIPPED) - A code already consumed by a successful sign-in vanishes rather than
+lingering.
+
+**DISC-27** (SHIPPED) - An expired code is visibly dead and one tap from being alive again,
+never silently accepted late.
 
 ## Trust: what a paired television may do
 
 Status: **SHIPPED**
 
-Approval is one-time and total, then boundaried. The moment an account approves a pairing,
-the television holds an ordinary session and needs no further confirmation for ordinary use
-It browses, plays, and resumes as that account, without asking anyone to re-approve. This
-is the whole point of pairing a device that cannot type: sign in once, stay signed in.
+**DISC-28** (SHIPPED) - Approval is one-time. The moment an account approves a pairing, the
+television holds an ordinary session and needs no further confirmation for ordinary use. It
+browses, plays and resumes as that account without asking anyone to re-approve. This is the
+whole point of pairing a device that cannot type: sign in once, stay signed in.
 
-The boundary is that a paired television is a *device*, not a second key to the account. It
-can act as its account, but it cannot approve *other* devices, change credentials, or do
-anything that would let a set in a guest room mint further sessions. What a session may do,
-and how a television, which cannot practically re-authenticate often, stays valid, is
-[`accounts.md`](../accounts/README.md). Revocation is symmetrical with every other device: the
-account sees the television in its device list and can end its session at any time, from
-anywhere, and the television falls back to unpaired.
+**DISC-29** (SHIPPED) - A paired television is a *device*, not a second key to the account. It
+can act as its account, but it cannot approve other devices, change credentials, or do anything
+that would let a set in a guest room mint further sessions.
+
+**DISC-30** (SHIPPED) - Revocation is symmetrical with every other device. The account sees the
+television in its device list and can end its session at any time, from anywhere, and the
+television falls back to unpaired ([`accounts/`](../accounts/)).
 
 ## Why Tizen and webOS stop at the server
 
 Status: **DESIGN, NOT IMPLEMENTED**
 
-Both Samsung (Tizen) and LG (webOS) televisions pair today, through the server, with a
-check string where needed. What they deliberately do *not* do is reach the deeper
-integration a native set could: being *heard on the link* to settle reach without a check
-string, via each vendor's own multiscreen stack.
+**DISC-31** (DESIGN, NOT IMPLEMENTED) - Samsung and LG televisions do not reach the deeper
+integration a native set could, meaning being *heard on the link* to settle reach without a
+check string, through each vendor's own multiscreen stack.
 
-This is deferred, not overlooked, because it costs more than it buys. Each vendor's stack is
-a separate protocol with no shared discovery, needing a phone-side integration built and
-tested per vendor, against television hardware, some of it documented only for models years
-old. Against that cost, the gain is narrow: the beacon already reaches the server and the
-grant already travels through it, so vendor integration would only remove a check string in
-the minority of homes where the two devices' addresses disagree. The product would rather
-ship the check string everywhere than a fragile fast path on two vendors' terms. The full
-argument, and the seam left open should it ever pay off, is
+Both pair today, through the server, with a check string where needed. The deeper integration is
+deferred, not overlooked, because it costs more than it buys. Each vendor's stack is a separate
+protocol with no shared discovery, needing a phone-side integration built and tested per vendor,
+against television hardware, some of it documented only for models years old. Against that cost
+the gain is narrow: the beacon already reaches the server and the grant already travels through
+it, so vendor integration would only remove a check string in the minority of homes where the
+two devices' addresses disagree. The product would rather ship the check string everywhere than
+a fragile fast path on two vendors' terms. The full argument, and the seam left open should it
+ever pay off, is
 [`../tv-pairing.md`](../../tv-pairing.md#why-tizen-and-webos-stop-at-the-server).

--- a/docs/spec/library/README.md
+++ b/docs/spec/library/README.md
@@ -1,49 +1,54 @@
 # Library
 
-Status: **AGREED** overall, with two sections still **DRAFT** where a product choice
+Status: **AGREED** overall, with one section still **DRAFT** where a product choice
 stays open. Every section carries its own status; the file-level label is the floor.
 
 Sources on disk become titles you can browse. Everything upstream of "there is something
-to play". What a title *is* once matched, meaning streams, codecs and artwork, is [`media.md`](../media/README.md);
-getting bytes onto disk in the first place is a module concern, [`modules.md`](../modules/README.md).
+to play". What a title *is* once matched, meaning streams, codecs and artwork, is
+[`media/`](../media/); getting bytes onto disk in the first place is a module concern,
+[`modules/`](../modules/).
 
 ## Sources
 
 Status: **AGREED**
 
-A **source** is a directory tree the server is told to watch, tagged with exactly one
-content kind: **movies** or **shows**. The kind is chosen when the source is added and
-governs how files inside it are matched. A movie source never produces episodes, a show
-source never produces standalone films. Mixing kinds in one directory is unsupported;
-the answer is two sources.
+**LIB-1** (AGREED) - A **source** is a directory tree the server is told to watch, tagged
+with exactly one content kind, **movies** or **shows**. The kind is chosen when the source
+is added and governs how files inside it are matched.
 
-A server has zero or more sources, and any number of them may point at the same content
-kind. Three "Movies" sources are normal, an SSD of new releases, a NAS of archives, a
-share of home video, and they present as one merged catalogue, deduplicated by matched
-identity, not by folder. A source is just an input; it is not a category the user browses
-by. Filtering the catalogue by source is an admin/diagnostic view, not the primary
-navigation.
+**LIB-2** (AGREED) - A movie source never produces episodes and a show source never produces
+standalone films. Mixing kinds in one directory is unsupported; the answer is two sources.
 
-A source tree may be assembled from symlinks. A curated folder of links into a shared
-pool of files is a source like any other: the link's own name is what the conventions
-below are read from, and the file it points at is what plays. A link the server cannot
-resolve is reported, never silently skipped, because a source built entirely from links
-into an unmounted pool would otherwise scan clean and empty.
+**LIB-3** (AGREED) - A server has zero or more sources, any number of them may point at the
+same content kind, and they present as one merged catalogue deduplicated by matched identity
+rather than by folder. Three "Movies" sources are normal: an SSD of new releases, a NAS of
+archives, a share of home video.
 
-A source records the mount path, its content kind, and its scan schedule. Nothing about a
-source is destructive: removing a source removes its titles from the catalogue and stops
-watching the path, but touches no bytes on disk and, per the deletions rule below,
-preserves the watch history keyed to those files should the source ever return. Adding,
-editing and removing sources is an admin surface, [`admin.md`](../admin/README.md).
+**LIB-4** (AGREED) - A source is an input, not a category a person browses by. Filtering the
+catalogue by source is an admin and diagnostic view, never the primary navigation.
+
+**LIB-5** (SHIPPED) - A source tree may be assembled from symlinks. A curated folder of links
+into a shared pool of files is a source like any other: the link's own name is what the
+conventions below are read from, and the file it points at is what plays.
+
+**LIB-6** (SHIPPED) - A link the server cannot resolve is reported, never silently skipped,
+because a source built entirely from links into an unmounted pool would otherwise scan clean
+and empty.
+
+**LIB-7** (AGREED) - A source records its mount path, its content kind and its scan schedule.
+
+**LIB-8** (AGREED) - Nothing about a source is destructive. Removing one drops its titles
+from the catalogue and stops watching the path, but touches no bytes on disk and preserves
+the watch history keyed to those files should the source ever return. Adding, editing and
+removing sources is an admin surface, [`admin/`](../admin/).
 
 ## Naming conventions understood
 
 Status: **AGREED**
 
-Matching is convention-first: a correctly named file matches offline, with no provider
-call. The conventions below are the contract. A file that follows them is guaranteed to
-match to the right identity; a file that does not is not an error. It lands in the
-unmatched state and is fixable (see below).
+**LIB-9** (AGREED) - Matching is convention-first: a correctly named file matches offline,
+with no provider call. A file that follows the conventions below is guaranteed to match to
+the right identity; a file that does not is not an error, and lands in the unmatched state.
 
 **Movies.** One film per folder, the folder named for the film and its year:
 
@@ -52,13 +57,17 @@ Movies/Blade Runner (1982)/Blade Runner (1982).mkv
 Movies/Dune Part Two (2024)/Dune Part Two (2024) - 2160p.mkv
 ```
 
-The `Title (Year)` stem is what is matched. The year is not decoration. It disambiguates
-remakes and is the difference between a confident match and a guess. A trailing tag after
-` - ` (resolution, edition, source) is preserved as version/edition detail, [`media.md`](../media/README.md),
-and never changes the matched identity. A loose file directly under the source root
-(`Movies/Blade Runner (1982).mkv`, no folder) is accepted with the same stem rules, but the
-folder-per-film layout is the recommended one and the only layout guaranteed to keep
-extras, artwork and sidecars grouped.
+**LIB-10** (SHIPPED) - The `Title (Year)` stem is what is matched. The year is not
+decoration: it disambiguates remakes and is the difference between a confident match and a
+guess.
+
+**LIB-11** (SHIPPED) - A trailing tag after ` - `, a resolution, an edition or a source, is
+preserved as version and edition detail ([`media/`](../media/)) and never changes the matched
+identity.
+
+**LIB-12** (SHIPPED) - A loose file directly under the source root, with no folder, is
+accepted with the same stem rules. The folder-per-film layout is the recommended one and the
+only layout guaranteed to keep extras, artwork and sidecars grouped.
 
 **Shows.** One folder per show, one subfolder per season, episodes carrying the
 `SxxEyy` marker:
@@ -68,24 +77,36 @@ Shows/Severance/Season 02/Severance - S02E01 - Hello, Ms. Cobel.mkv
 Shows/The Bear/Season 01/The Bear - S01E03.mkv
 ```
 
-The season folder is what makes the folder above it the show: with one present, that
-folder names the series and disagreeing filenames inside it still collapse to one show.
-Without one, the folder proves nothing (a flat pool holds many shows side by side) and
-the filename names the series instead; an episode whose filename is only its marker
-(`S01E01.mkv`) takes the name of the folder holding it, so a run of them is one series
-rather than one series per file.
+**LIB-13** (SHIPPED) - A season folder is what makes the folder above it the show. With one
+present, that folder names the series, and disagreeing filenames inside it still collapse to
+one show.
 
-The show folder name and the `SxxEyy` marker are load-bearing; the human episode title
-after the second ` - ` is optional and ignored for matching. `Specials` is accepted as an
-alias for `Season 00`. Multi-episode files are named with a range (`S01E01-E02`) and
-matched to both episodes. A show folder MAY carry a `(Year)` for disambiguation
+**LIB-14** (SHIPPED) - Without a season folder the folder proves nothing, because a flat pool
+holds many shows side by side, so the filename names the series instead.
+
+**LIB-15** (SHIPPED) - An episode whose filename is only its marker (`S01E01.mkv`) takes the
+name of the folder holding it, so a run of them is one series rather than one series per
+file.
+
+**LIB-16** (SHIPPED) - The show folder name and the `SxxEyy` marker are load-bearing; the
+human episode title after the second ` - ` is optional and ignored for matching.
+
+**LIB-17** (SHIPPED) - `Specials` is accepted as an alias for `Season 00`.
+
+**LIB-18** (SHIPPED) - A multi-episode file is named with a range (`S01E01-E02`) and matched
+to both episodes.
+
+**LIB-19** (AGREED) - A show folder MAY carry a `(Year)` for disambiguation
 (`Shows/Ironheart (2025)/…`) and SHOULD when two shows share a name.
 
-**Common to both.** Case is ignored. Separators may be spaces, dots or underscores. Only
-recognised video containers are considered files to match; sidecars (subtitles, artwork,
-`.nfo`) attach to the matched item by shared stem and are never matched on their own.
-These are conventions, not configuration: the scheme is fixed so that a library is
-portable between servers and a rename on disk is a reliable repair, not a gamble.
+**LIB-20** (SHIPPED) - Case is ignored, and separators may be spaces, dots or underscores.
+
+**LIB-21** (SHIPPED) - Only recognised video containers are considered files to match.
+Sidecars, meaning subtitles, artwork and `.nfo`, attach to the matched item by shared stem
+and are never matched on their own.
+
+**LIB-22** (AGREED) - The scheme is a convention rather than configuration, so a library is
+portable between servers and a rename on disk is a reliable repair rather than a gamble.
 
 ## Scanning
 
@@ -93,145 +114,160 @@ Status: **AGREED**
 
 Two scans, one code path, different triggers.
 
-**Initial scan** runs when a source is added: the whole tree is walked once, every
-candidate file matched, the catalogue populated. It is a background job with visible
-progress, [`admin.md`](../admin/README.md); the catalogue fills as it goes rather than appearing all
-at once at the end.
+**LIB-23** (SHIPPED) - An **initial scan** runs when a source is added: the whole tree is
+walked once, every candidate file matched, the catalogue populated. It is a background job
+with visible progress ([`admin/`](../admin/)), and the catalogue fills as it goes rather than
+appearing all at once at the end.
 
-**Incremental rescan** keeps the catalogue true to disk afterwards. It is triggered by,
-in order of preference: filesystem change notifications where the platform and mount
-provide them; a periodic sweep on the source's schedule as the reliable fallback (network
-shares and many container mounts do not deliver events); and an explicit "Scan now" from an
-admin. An incremental rescan only reconsiders what changed: new paths, vanished paths,
-and files whose size or modification time moved. So it is cheap enough to run often.
+**LIB-24** (AGREED) - An **incremental rescan** keeps the catalogue true to disk afterwards.
+It is triggered by, in order of preference: filesystem change notifications where the
+platform and the mount provide them; a periodic sweep on the source's schedule as the
+reliable fallback, because network shares and many container mounts deliver no events; and an
+explicit "Scan now" from an admin.
 
-**The guarantee while a library is being written to.** Scanning is safe to run at
-any time, including while files are being copied, moved or downloaded into a source. The
-guarantee rests on three rules:
+**LIB-25** (AGREED) - An incremental rescan only reconsiders what changed, meaning new paths,
+vanished paths, and files whose size or modification time moved, so it is cheap enough to run
+often.
 
-- A file is only matched once it looks **settled**: its size and modification time are
-  unchanged across the observation window. A file still growing is skipped this pass and
-  picked up on the next, so a half-copied download never enters the catalogue as a broken
-  title.
-- Scanning **reads only**. It never writes, moves, renames or deletes anything in a
-  source. The library is treated as owned by the user; KROMA observes it.
-- A vanished path is **marked absent, not deleted** (see below), so a move that briefly
-  removes then re-adds a file, the shape of most "atomic" replacements, resolves to the
-  same identity without losing anything.
+**LIB-26** (AGREED) - Scanning is safe to run at any time, including while files are being
+copied, moved or downloaded into a source.
 
-The corollary: KROMA never demands exclusive access to a library and never blocks the
-tools writing to it. A module mid-download and a scan mid-sweep coexist by design,
-[`modules.md`](../modules/README.md).
+**LIB-27** (AGREED) - A file is matched only once it looks **settled**, its size and
+modification time unchanged across the observation window. A file still growing is skipped
+this pass and picked up on the next, so a half-copied download never enters the catalogue as
+a broken title.
+
+**LIB-28** (SHIPPED) - Scanning **reads only**. It never writes, moves, renames or deletes
+anything in a source. The library is the person's; KROMA observes it.
+
+**LIB-29** (AGREED) - KROMA never demands exclusive access to a library and never blocks the
+tools writing to it. A module mid-download and a scan mid-sweep coexist by design
+([`modules/`](../modules/)).
+
+A vanished path is marked absent rather than deleted, so a move that briefly removes then
+re-adds a file, the shape of most "atomic" replacements, resolves to the same identity
+without losing anything. That rule is LIB-45 below.
 
 ## Matching and its failure path
 
 Status: **AGREED**
 
-Matching resolves a settled file to an identity: convention parse first (offline,
-authoritative on the stem), then a metadata provider lookup to attach the rich record.
-Two outcomes need a designed product response, and both are first-class UI states, not
+Two outcomes need a designed product response, and both are first-class UI states rather than
 log lines.
 
-**Matches nothing.** A file that parses to no confident identity, whether an unconventional
-name, a film with no year against an ambiguous title, or a provider that returns nothing, becomes
-an **unmatched item**. Unmatched items are not hidden and not discarded. They appear in a
-browsable **Unmatched** view in the library UI, listed by their on-disk path, so the user
-can always see exactly which files the server is holding but cannot place. From there the
-user has two repairs, and both are supported:
+**LIB-30** (AGREED) - Matching resolves a settled file to an identity: a convention parse
+first, offline and authoritative on the stem, then a metadata provider lookup to attach the
+rich record.
 
-- **Manual match.** Search the provider, pick the correct title/episode, and bind this
-  file to it. The binding is remembered against the file so a later rescan does not undo
-  it.
-- **Rename on disk.** Fix the name to the convention above; the next rescan matches it
-  automatically and it leaves the Unmatched view.
+**Matches nothing.**
 
-Answering the skeleton's open question directly: a mis-match is fixable **from the UI**,
-by manual match; renaming on disk is the equivalent, portable repair, and neither is
-privileged over the other.
+**LIB-31** (AGREED) - A file that parses to no confident identity, whether from an
+unconventional name, a film with no year against an ambiguous title, or a provider that
+returns nothing, becomes an **unmatched item**. Unmatched items are neither hidden nor
+discarded.
 
-**Matches two things.** When a file could be more than one identity, a title shared by a
-remake with no year to separate them or two provider records that both fit, KROMA does not
-guess. It records the file as **ambiguous** (a variant of the unmatched state) with the
-competing candidates surfaced, and asks the user to choose. A wrong confident match is
-worse than an honest "which one?", so the tie is never broken silently.
+**LIB-32** (AGREED) - Unmatched items appear in a browsable **Unmatched** view in the library
+UI, listed by their on-disk path, so a person can always see exactly which files the server is
+holding but cannot place.
 
-Nothing about either failure is fatal to the rest of the scan: one unplaceable file never
-stalls a source, and the catalogue is always the set of files that *did* match plus a
-visible tally of those that did not.
+**LIB-33** (AGREED) - **Manual match.** A person searches the provider, picks the correct
+title or episode, and binds the file to it. The binding is remembered against the file, so a
+later rescan does not undo it.
+
+**LIB-34** (AGREED) - **Rename on disk.** A name fixed to the convention above matches
+automatically on the next rescan and leaves the Unmatched view. Neither repair is privileged
+over the other.
+
+**Matches two things.**
+
+**LIB-35** (AGREED) - A file that could be more than one identity, a title shared by a remake
+with no year to separate them or two provider records that both fit, is recorded as
+**ambiguous**, a variant of the unmatched state, with the competing candidates surfaced for a
+person to choose. A wrong confident match is worse than an honest "which one?", so the tie is
+never broken silently.
+
+**LIB-36** (AGREED) - One unplaceable file never stalls a source. The catalogue is always the
+set of files that *did* match plus a visible tally of those that did not.
 
 ## Metadata providers
 
 Status: **AGREED**
 
-The matched identity is enriched from a metadata provider: titles, summaries, cast,
-episode data and artwork. Two rules define the behaviour.
+The matched identity is enriched from a metadata provider: titles, summaries, cast, episode
+data and artwork.
 
-**Fetched once, cached locally, owned locally.** Every field and image a provider returns
-is written to the server's own store on first fetch. After that the catalogue is served
-entirely from the local cache. The provider is a source of truth for *acquiring* metadata,
-never a runtime dependency for *reading* it.
+**LIB-37** (AGREED) - Every field and image a provider returns is written to the server's own
+store on first fetch, and the catalogue is served entirely from that local cache afterwards. A
+provider is a source of truth for *acquiring* metadata, never a runtime dependency for
+*reading* it.
 
-**Offline is a normal state, not a degraded one.** With no internet, everything already
-matched browses and plays exactly as before, because it is all local. Only two things are
-affected offline: a brand-new file that needs a first provider lookup stays unmatched (by
-convention it still parses its stem, so it is placeable and playable, just thin on
-metadata) until connectivity returns; and forced refreshes queue rather than fail. KROMA
-is a media server first and a metadata client second.
+**LIB-38** (AGREED) - With no internet, everything already matched browses and plays exactly
+as before, because it is all local. Offline is a normal state, not a degraded one.
+
+**LIB-39** (AGREED) - Offline, a brand-new file that needs a first provider lookup stays
+unmatched until connectivity returns. Its stem still parses by convention, so it is placeable
+and playable, just thin on metadata.
+
+**LIB-40** (AGREED) - Offline, a forced refresh queues rather than fails.
 
 The specific providers, and whether more than one is consulted, are configuration and
-architecture, not product rules, and are not fixed here.
+architecture rather than product rules, and are not fixed here.
 
 ## Refresh
 
 Status: **DRAFT**, recommended rules provisional
 
-Metadata re-fetches on two automatic triggers and one manual one:
+**LIB-41** (DRAFT) - A newly matched item fetches its metadata once.
 
-- **New need.** A newly matched item fetches its metadata once, as above.
-- **Staleness sweep.** Running series are re-checked on a slow cadence so a new episode's
-  air date and stills appear without user action; completed films are not re-checked on a
-  timer, because their metadata does not change.
-- **User force.** A "Refresh metadata" action on any title, season or whole source
-  re-fetches from the provider and overwrites the cache, letting a user pull a corrected
-  summary or better artwork on demand. A forced refresh **never** discards a manual match
-  or user-chosen artwork; it refreshes the descriptive fields around a binding the user
-  set, it does not overturn the binding.
+**LIB-42** (DRAFT) - Running series are re-checked on a slow cadence, so a new episode's air
+date and stills appear without a person asking. Completed films are not re-checked on a
+timer, because their metadata does not change.
 
-Open, with a recommendation: whether a forced refresh should also re-run *matching* (not
-just re-fetch metadata for the current identity). Recommended answer: keep them separate.
+**LIB-43** (DRAFT) - A "Refresh metadata" action on any title, season or whole source
+re-fetches from the provider and overwrites the cache, so a person can pull a corrected
+summary or better artwork on demand.
+
+**LIB-44** (DRAFT) - A forced refresh **never** discards a manual match or user-chosen
+artwork. It refreshes the descriptive fields around a binding the person set; it does not
+overturn the binding.
+
+Open, with a recommendation: whether a forced refresh should also re-run *matching* rather
+than only re-fetch metadata for the current identity. Recommended answer: keep them separate.
 "Refresh metadata" updates the record, and a distinct "Re-match" action re-runs
-identification, so a user never loses a correct match by asking for fresher artwork. This
-is provisional pending review.
+identification, so a person never loses a correct match by asking for fresher artwork. This is
+provisional pending review.
 
 ## Deletions and moves
 
 Status: **AGREED**
 
-The rule is **mark absent, never destroy user data**, and it is not negotiable enough to
-leave as an open question.
+The rule is **mark absent, never destroy user data**, and it is not negotiable enough to leave
+as an open question.
 
-When a file disappears from a source, its title is **marked absent**: removed from normal
-browsing, but its record and, critically, all watch history, resume positions, ratings
-and manual-match bindings keyed to it are retained. If the same content reappears (a NAS
-remounts, a file is moved back or relocated within the source), it re-matches to the same
-identity and everything the user built up is still there. Watch history survives a file
-outliving its bytes.
+**LIB-45** (AGREED) - When a file disappears from a source, its title is **marked absent**:
+removed from normal browsing, but its record and all watch history, resume positions, ratings
+and manual-match bindings keyed to it are retained. Watch history survives a file outliving
+its bytes.
 
-A **move** is therefore not a special case: it is an absent path plus a new path that
-resolve to one identity, and the history follows the identity, not the path. This is what
-makes reorganising a library on disk safe.
+**LIB-46** (AGREED) - Content that reappears, because a NAS remounts or a file is moved back
+or relocated within the source, re-matches to the same identity, and everything the person
+built up is still there.
 
-Genuine permanent deletion of a title's history is an explicit, user-initiated admin
-action ("Remove and forget"), never a side effect of a scan. Answering the skeleton
-directly: a rescan **only ever marks absent**; it never deletes user data. The one actor
-allowed to destroy history is a human who asks for it, on the admin surface,
-[`admin.md`](../admin/README.md).
+**LIB-47** (AGREED) - A **move** is therefore not a special case. It is an absent path plus a
+new path that resolve to one identity, and the history follows the identity rather than the
+path. This is what makes reorganising a library on disk safe.
+
+**LIB-48** (AGREED) - A rescan **only ever marks absent**. It never deletes user data.
+
+**LIB-49** (AGREED) - Permanently deleting a title's history is an explicit, person-initiated
+admin action ("Remove and forget"), never a side effect of a scan. The one actor allowed to
+destroy history is a human who asks for it, on the admin surface ([`admin/`](../admin/)).
 
 ## Not in scope
 
-- **Acquisition.** Getting files onto disk (downloads, indexers) is a module concern,
-  [`modules.md`](../modules/README.md). The library observes what appears; it does not fetch it.
-- **What a matched title technically is**, meaning containers, codecs, streams and
-  artwork sizes, is [`media.md`](../media/README.md).
-- **Choosing what to send a client** at play time is [`playback.md`](../playback/README.md).
-- **Who may see which source or title** is [`accounts.md`](../accounts/README.md).
+- **Acquisition.** Getting files onto disk, meaning downloads and indexers, is a module
+  concern, [`modules/`](../modules/). The library observes what appears; it does not fetch it.
+- **What a matched title technically is**, meaning containers, codecs, streams and artwork
+  sizes, is [`media/`](../media/).
+- **Choosing what to send a client** at play time is [`playback/`](../playback/).
+- **Who may see which source or title** is [`accounts/`](../accounts/).

--- a/docs/spec/library/README.md
+++ b/docs/spec/library/README.md
@@ -265,6 +265,8 @@ destroy history is a human who asks for it, on the admin surface ([`admin/`](../
 
 ## Not in scope
 
+Status: **AGREED**
+
 - **Acquisition.** Getting files onto disk, meaning downloads and indexers, is a module
   concern, [`modules/`](../modules/). The library observes what appears; it does not fetch it.
 - **What a matched title technically is**, meaning containers, codecs, streams and artwork

--- a/docs/spec/media/README.md
+++ b/docs/spec/media/README.md
@@ -8,8 +8,8 @@ truth is the input to every playback decision. If a file direct-plays, it is bec
 streams match what a client can render; if it cannot, this is where the reason comes from.
 
 This file owns the *vocabulary* of media: the model, the containers, the codecs, the
-stream properties. The per-device capability matrix lives in [`surfaces.md`](../surfaces/README.md)
-and the decision of what to send lives in [`playback.md`](../playback/README.md). Both consume the
+stream properties. The per-device capability matrix lives in [`surfaces/`](../surfaces/)
+and the decision of what to send lives in [`playback/`](../playback/). Both consume the
 terms defined here; neither is redefined here.
 
 ## The media model
@@ -18,171 +18,190 @@ Status: **AGREED**
 
 Five nouns, nested, each the child of the one before:
 
-- **Title.** The work a person searches for: a film, or one episode of a series. The unit
-  the [`library.md`](../library/README.md) matches to metadata. A title carries no bytes.
-- **Edition.** A named cut of a title: theatrical, director's, extended, remastered.
-  Different runtimes, different content. A title with one cut has one unnamed edition.
-- **Media file.** One physical file on disk that realises an edition at a given fidelity.
-  An edition may have several: a 1080p file and a 4K file are two media files of the same
-  edition, not two titles and not two editions.
-- **Stream.** One track inside a media file: exactly one of video, audio, or subtitle.
-  A media file has one or more video streams (usually one), zero or more audio streams,
-  and zero or more subtitle streams.
-- **Stream properties.** The describable facts about a stream (codec, resolution, bit
-  depth, channel layout, language, disposition). These are what a client is matched against.
+- **MEDIA-1** (AGREED) - **Title.** The work a person searches for: a film, or one episode
+  of a series. It is the unit [`library/`](../library/) matches to metadata, and it carries
+  no bytes.
+- **MEDIA-2** (AGREED) - **Edition.** A named cut of a title: theatrical, director's,
+  extended, remastered. Different runtimes, different content. A title with one cut has one
+  unnamed edition.
+- **MEDIA-3** (AGREED) - **Media file.** One physical file on disk that realises an edition
+  at a given fidelity. An edition may have several: a 1080p file and a 4K file are two media
+  files of the same edition, not two titles and not two editions.
+- **MEDIA-4** (AGREED) - **Stream.** One track inside a media file, exactly one of video,
+  audio or subtitle. A media file has one or more video streams (usually one), zero or more
+  audio streams, and zero or more subtitle streams.
+- **MEDIA-5** (AGREED) - **Stream properties.** The describable facts about a stream: codec,
+  resolution, bit depth, channel layout, language, disposition. These are what a client is
+  matched against.
 
-The nesting is strict and total: every stream belongs to exactly one media file, every
-media file to exactly one edition, every edition to exactly one title. Nothing floats.
+**MEDIA-6** (AGREED) - The nesting is strict and total: every stream belongs to exactly one
+media file, every media file to exactly one edition, every edition to exactly one title.
+Nothing floats.
 
 ## Versions of one title
 
 Status: **AGREED**. This resolves the open question on multiple versions.
 
-A 1080p file and a 4K file of the same cut are **two media files of one edition**. They are
-never modelled as separate titles, and the library never shows a duplicate. A person picks
-a title and a cut; the fidelity is chosen for them.
+**MEDIA-7** (AGREED) - A 1080p file and a 4K file of the same cut are **two media files of
+one edition**. They are never modelled as separate titles, and the library never shows a
+duplicate. A person picks a title and a cut; the fidelity is chosen for them.
 
-- KROMA ranks a title's media files and keeps a **preferred** one. Rank order: resolution,
-  then HDR over SDR, then bit depth, then audio channel count, then bitrate. The preferred
-  file is the default source for a play request.
-- The preference is a *default*, not a lock. A client that cannot render the preferred file
-  may be served a lesser file of the same edition instead of falling back to transcoding,
-  a genuinely better outcome, so the model must make the alternative reachable. Which file
-  a given client actually receives is [`playback.md`](../playback/README.md)'s decision; media.md only
-  guarantees the alternatives are enumerated and comparable.
-- Editions are surfaced to the person (they are different content); fidelity variants are
-  not (they are the same content at different quality). A person chooses a cut, never a
-  resolution.
+- **MEDIA-8** (AGREED) - KROMA ranks a title's media files and keeps a **preferred** one.
+  Rank order: resolution, then HDR over SDR, then bit depth, then audio channel count, then
+  bitrate. The preferred file is the default source for a play request.
+- **MEDIA-9** (AGREED) - The preference is a *default*, not a lock. The model enumerates a
+  title's media files and makes them comparable, so a client that cannot render the preferred
+  file can be served a lesser file of the same edition instead of falling back to transcoding.
+  Which file a client actually receives is [`playback/`](../playback/)'s decision.
+- **MEDIA-10** (AGREED) - Editions are surfaced to the person, because they are different
+  content; fidelity variants are not, because they are the same content at different quality.
+  A person chooses a cut, never a resolution.
 
 ## Containers and codecs
 
 Status: **AGREED**
 
-First-class means: KROMA fully describes it, preserves it end to end, and expects direct
-play wherever a client can render it. Everything else is *readable* but not privileged.
+**MEDIA-11** (AGREED) - First-class means KROMA fully describes the format, preserves it end
+to end, and expects direct play wherever a client can render it. Everything else is
+*readable* but not privileged.
 
-First-class containers: **MP4**, **MKV**, **WebM**. First-class video codecs, HEVC first:
+**MEDIA-12** (AGREED) - The first-class containers are **MP4**, **MKV** and **WebM**.
 
-- **HEVC / H.265.** The priority codec. 8-bit and 10-bit, SDR and HDR, are all first-class.
-- **H.264 / AVC.** The universal floor; assumed playable everywhere.
-- **AV1.** First-class where the client generation can render it; treated as first-class
-  media truth regardless, so a capable client direct-plays it.
-- **VP9.** First-class within WebM, chiefly for the browser surface.
+The first-class video codecs, HEVC first:
 
-First-class audio and subtitle codecs are named in their sections below. A codec being
-first-class is a statement about *KROMA's* handling; whether a *particular* device renders
-it is the matrix in [`surfaces.md`](../surfaces/README.md).
+- **MEDIA-13** (AGREED) - **HEVC / H.265** is the priority codec. 8-bit and 10-bit, SDR and
+  HDR, are all first-class.
+- **MEDIA-14** (AGREED) - **H.264 / AVC** is the universal floor, assumed playable
+  everywhere.
+- **MEDIA-15** (AGREED) - **AV1** is first-class media truth whatever the client generation,
+  so a capable client direct-plays it.
+- **MEDIA-16** (AGREED) - **VP9** is first-class within WebM, chiefly for the browser
+  surface.
+
+**MEDIA-17** (AGREED) - A codec being first-class states how *KROMA* handles it, never that a
+particular device renders it. That is the matrix in [`surfaces/`](../surfaces/).
+
+First-class audio and subtitle codecs are named in their sections below.
 
 ## Bit depth and HDR
 
 Status: **AGREED**
 
-HDR is preserved end to end or it is not offered. KROMA never silently flattens HDR to SDR
-as if nothing happened. A tone-mapped picture is a compromise and is surfaced as one by
-[`playback.md`](../playback/README.md).
+**MEDIA-18** (AGREED) - HDR is preserved end to end or it is not offered. KROMA never
+silently flattens HDR to SDR, and a tone-mapped picture is surfaced as the compromise it is
+by [`playback/`](../playback/).
 
-- **Bit depth.** 8-bit and 10-bit are first-class. 10-bit is retained as a first-class
-  property of the video stream, never rounded away in the model.
-- **HDR variants** KROMA distinguishes: **HDR10**, **HDR10+**, **Dolby Vision**, **HLG**.
-  Each is a distinct property, because each has distinct client support. Dolby Vision's
-  profile is recorded, because a profile a client cannot decode is not the same as one it
+- **MEDIA-19** (AGREED) - **Bit depth.** 8-bit and 10-bit are first-class, and 10-bit is
+  retained as a property of the video stream rather than rounded away in the model.
+- **MEDIA-20** (AGREED) - KROMA distinguishes **HDR10**, **HDR10+**, **Dolby Vision** and
+  **HLG** as separate properties, because each has distinct client support, and it records
+  Dolby Vision's profile, because a profile a client cannot decode is not the same as one it
   can.
-- **What is preserved**: colour primaries, transfer characteristics, and matrix
-  coefficients travel with the video stream. A client is matched against the exact HDR
-  variant, not a generic "HDR" flag. Where dynamic metadata (HDR10+, Dolby Vision) cannot
-  be carried to a client, KROMA's position is that the base HDR10 layer is preserved rather
-  than discarding HDR entirely, a fallback [`playback.md`](../playback/README.md) makes visible.
+- **MEDIA-21** (AGREED) - Colour primaries, transfer characteristics and matrix coefficients
+  travel with the video stream, and a client is matched against the exact HDR variant rather
+  than a generic "HDR" flag.
+- **MEDIA-22** (AGREED) - Where dynamic metadata, HDR10+ or Dolby Vision, cannot be carried
+  to a client, the base HDR10 layer is preserved rather than HDR discarded entirely. It is a
+  fallback [`playback/`](../playback/) makes visible.
 
 ## Audio
 
 Status: **AGREED**
 
-First-class audio codecs: **AAC**, **AC-3** and **E-AC-3** (Dolby Digital / Plus),
-**TrueHD**, **DTS** and **DTS-HD**, **FLAC**, **Opus**. Each audio stream's **channel
-layout** (stereo, 5.1, 7.1, Atmos objects) is a first-class property.
+**MEDIA-23** (AGREED) - The first-class audio codecs are **AAC**, **AC-3** and **E-AC-3**
+(Dolby Digital and Plus), **TrueHD**, **DTS** and **DTS-HD**, **FLAC** and **Opus**.
 
-- **Passthrough** is the default for multichannel and lossless audio: the bitstream is sent
-  untouched to a device or receiver that can decode it. This is direct play for audio and is
-  always preferred.
-- **Downmixing** to stereo happens only when the target cannot render the source layout, and
-  only as an explicit fallback, never silently. When it happens, [`playback.md`](../playback/README.md)
-  owns telling the person; media.md defines *what* downmix means (a channel-count reduction
-  that is a compromise) and guarantees the original stream is retained unchanged as the
-  source.
-- Multiple audio streams (languages, commentary) are all enumerated and selectable. The
-  default follows the file's own disposition flags, then profile language preference.
+**MEDIA-24** (AGREED) - An audio stream's **channel layout**, stereo, 5.1, 7.1 or Atmos
+objects, is a first-class property.
+
+- **MEDIA-25** (AGREED) - **Passthrough** is the default for multichannel and lossless audio:
+  the bitstream reaches a device or receiver that can decode it untouched. This is direct play
+  for audio and is always preferred.
+- **MEDIA-26** (AGREED) - **Downmixing** to stereo happens only when the target cannot render
+  the source layout, only as an explicit fallback, and never silently. A downmix is a
+  channel-count reduction and therefore a compromise; the original stream is retained
+  unchanged as the source, and telling the person is [`playback/`](../playback/)'s job.
+- **MEDIA-27** (AGREED) - Multiple audio streams, languages and commentary alike, are all
+  enumerated and selectable. The default follows the file's own disposition flags, then the
+  profile's language preference.
 
 ## Subtitles
 
 Status: **AGREED**
 
-A subtitle stream is either **embedded** (a track inside the media file) or **sidecar** (a
-separate file the library associates with the media file). Both are first-class and both are
-enumerated the same way once known.
+**MEDIA-28** (AGREED) - A subtitle stream is either **embedded**, a track inside the media
+file, or **sidecar**, a separate file the library associates with it. Both are first-class
+and both enumerate the same way once known.
 
-- First-class text formats: **SRT**, **WebVTT**, **ASS/SSA**. First-class image formats:
-  **PGS** and **VobSub**. Text subtitles are the default because they overlay without
-  touching the video; image subtitles are heavier and sometimes force a compromise.
-- **Dispositions** are recorded and honoured: **forced** (only the foreign-language lines a
-  viewer needs) and **SDH** (for the deaf and hard of hearing). These are distinct
-  properties; a person picking "forced" gets forced, not full.
-- **Burning in**, meaning rendering a subtitle permanently into the video, is a last resort, used
-  only when a subtitle cannot be delivered as a selectable overlay to the target. It is
-  never the default and never silent. media.md's rule: the original subtitle stream is
-  always preserved; the burn is a derived output, not a replacement. *When* it happens is
-  [`playback.md`](../playback/README.md).
+- **MEDIA-29** (AGREED) - The first-class subtitle formats are **SRT**, **WebVTT** and
+  **ASS/SSA** as text, **PGS** and **VobSub** as images. Text is the default because it
+  overlays without touching the video; image subtitles are heavier and sometimes force a
+  compromise.
+- **MEDIA-30** (AGREED) - The **forced** disposition, only the foreign-language lines a
+  viewer needs, and the **SDH** disposition, for the deaf and hard of hearing, are recorded
+  and honoured as distinct properties. A person picking forced gets forced, not full.
+- **MEDIA-31** (AGREED) - **Burning in**, rendering a subtitle permanently into the video, is
+  a last resort used only when a subtitle cannot reach the target as a selectable overlay. It
+  is never the default and never silent, the original subtitle stream is always preserved, and
+  the burn is a derived output rather than a replacement. *When* it happens is
+  [`playback/`](../playback/).
 
 ## Artwork and images
 
 Status: **AGREED**
 
-Every title carries images: **poster**, **backdrop**, **logo**, and per-episode **thumb**.
-These are media too, and are treated with the same discipline.
+**MEDIA-32** (AGREED) - Every title carries a **poster**, a **backdrop**, a **logo** and, per
+episode, a **thumb**. These are media too, and are treated with the same discipline.
 
-- **Sources**, in order of trust: images embedded in the media file, sidecar image files
-  next to it, then images fetched by the [`library.md`](../library/README.md) metadata refresh. A
-  local image outranks a fetched one; a person's explicit choice outranks both.
-- **Sizes.** KROMA derives and caches a fixed set of sizes per image (a small grid
-  thumbnail through a full-bleed backdrop) so a client requests a size, never the original.
+- **MEDIA-33** (AGREED) - Image sources rank by trust: embedded in the media file, then a
+  sidecar file next to it, then fetched by the [`library/`](../library/) metadata refresh. A
+  local image outranks a fetched one, and a person's explicit choice outranks both.
+- **MEDIA-34** (AGREED) - KROMA derives a fixed set of sizes per image, a small grid
+  thumbnail through a full-bleed backdrop, so a client requests a size and never the original.
   The original is retained as the master.
-- **Caching.** Derived sizes are cached and served without re-deriving. A source image
-  changing invalidates its derivatives; nothing else. Artwork is never a reason a title
-  fails to appear. A title with no image shows a typed placeholder, never a broken one.
+- **MEDIA-35** (AGREED) - Derived sizes are cached and served without re-deriving, and a
+  source image changing invalidates its own derivatives and nothing else.
+- **MEDIA-36** (AGREED) - Artwork is never a reason a title fails to appear. A title with no
+  image shows a typed placeholder, never a broken one.
 
 ## Probing and trust
 
 Status: **AGREED**. This resolves the open question on probe trust.
 
-KROMA learns a file's streams by **probing** it once, when the library first sees it, and
-**trusts that probe** for playback decisions. Re-probing on every play would tax the server
-for a fact that rarely changes.
+**MEDIA-37** (AGREED) - KROMA learns a file's streams by **probing** it once, when the
+library first sees it, and **trusts that probe** for playback decisions. Re-probing on every
+play would tax the server for a fact that rarely changes.
 
-- The probe result is the authoritative stream truth until the file's bytes change (size or
-  modification time), which invalidates it and schedules a re-probe.
-- **Re-probe on playback failure**: when a direct play fails in a way that implicates the
-  stream description (a codec the probe named but the client could not initialise), KROMA
-  re-probes that file once and records the corrected truth, so the same failure does not
-  recur. A failure that does not implicate the description (network, disk) does not trigger a
+- **MEDIA-38** (AGREED) - A probe is the authoritative stream truth until the file's bytes
+  change, meaning its size or modification time, which invalidates the probe and schedules a
   re-probe.
-- Trust is per-file and durable: a corrected probe is written back, not held in memory for
-  one session.
+- **MEDIA-39** (AGREED) - When a direct play fails in a way that implicates the stream
+  description, such as a codec the probe named but the client could not initialise, KROMA
+  re-probes that file once and records the corrected truth, so the same failure does not
+  recur. A failure that implicates the network or the disk instead does not trigger a
+  re-probe.
+- **MEDIA-40** (AGREED) - Trust is per-file and durable: a corrected probe is written back,
+  not held in memory for one session.
 
 ## Files KROMA can read but not fully describe
 
 Status: **AGREED**. This resolves the "read but not describe" must-answer.
 
-A file whose container opens and whose streams enumerate, but which contains a stream KROMA
-cannot fully describe (an unknown codec, absent or contradictory metadata), is **partially
-known**, never hidden and never silently dropped.
+**MEDIA-41** (AGREED) - A file whose container opens and whose streams enumerate, but which
+carries a stream KROMA cannot fully describe, an unknown codec or absent or contradictory
+metadata, is **partially known**. It is never hidden and never silently dropped.
 
-- The title **appears** in the library with whatever *is* known. A single indescribable
-  stream does not disqualify the file; the describable streams remain first-class.
-- The unknown stream is marked **undescribed** and carries its raw identifier so a person and
-  a diagnostician can see exactly what was not understood. An undescribed stream is treated
-  as *not direct-playable* by [`playback.md`](../playback/README.md), because KROMA will not gamble that a
-  client can render what KROMA itself cannot name.
-- A file that will not open at all, a truncated or corrupt container, is **unreadable**,
-  surfaced as a typed error against the title with the reason, and excluded from play until
-  it is re-scanned. It is a visible fault, not an absence.
-- Undescribed and unreadable are distinct states. The first is "we see it but cannot vouch
-  for it"; the second is "we cannot see it". Both are on record; neither is a blank.
+- **MEDIA-42** (AGREED) - The title **appears** in the library with whatever *is* known. A
+  single indescribable stream does not disqualify the file, and the describable streams remain
+  first-class.
+- **MEDIA-43** (AGREED) - The unknown stream is marked **undescribed** and carries its raw
+  identifier, so a person and a diagnostician can see exactly what was not understood.
+- **MEDIA-44** (AGREED) - An undescribed stream is *not direct-playable*, because KROMA will
+  not gamble that a client renders what KROMA itself cannot name
+  ([`playback/`](../playback/)).
+- **MEDIA-45** (AGREED) - A file that will not open at all, a truncated or corrupt container,
+  is **unreadable**: surfaced as a typed error against the title with the reason, and excluded
+  from play until it is re-scanned. It is a visible fault, not an absence.
+- **MEDIA-46** (AGREED) - Undescribed and unreadable are distinct states. The first is "we
+  see it but cannot vouch for it", the second is "we cannot see it". Both are on record;
+  neither is a blank.

--- a/docs/spec/modules/README.md
+++ b/docs/spec/modules/README.md
@@ -6,11 +6,12 @@ compatibility gate are all released. Two sections stay open and carry their own 
 the trust model for third-party registries, and the abandonment story. Every section
 carries a status; the file-level label is the floor.
 
-The base build ships **zero modules**. Everything past playback and catalogue,
-downloads, indexers, acquisition, VPN, transcription, embeddings, network discovery,
-remote access, arrives as an installable `.kmod` whose backend runs *out of the server
-process*. That is what makes every module uninstallable from Admin, and it is the
-load-bearing decision of this domain, chosen for three reasons:
+**MOD-1** (SHIPPED) - The base build ships **zero modules**. Everything past playback and
+catalogue, meaning downloads, indexers, acquisition, VPN, transcription, embeddings, network
+discovery and remote access, arrives as an installable `.kmod` whose backend runs *out of the
+server process*, and every module is therefore uninstallable from Admin.
+
+That is the load-bearing decision of this domain, chosen for three reasons:
 
 - **Isolation.** A module is a separate program the server spawns and supervises. A
   module that crashes, hangs or is incompatible takes down *itself*. The server keeps
@@ -29,52 +30,62 @@ Mechanics, meaning how a sidecar is spawned, supervised and reverse-proxied, liv
 
 Status: **SHIPPED**
 
-A module is a self-contained capability with a reverse-DNS id (`tv.kroma.torrents`). It
-brings its own backend, its own data, its own settings and, optionally, its own admin UI.
-Within its own process it has wide latitude: it opens the shared database directly, runs
-its own migrations against its own tables, registers services, schedules jobs, and serves
-HTTP the server reverse-proxies under `/api/module/<id>/`.
+**MOD-2** (SHIPPED) - A module is a self-contained capability with a reverse-DNS id
+(`tv.kroma.torrents`). It brings its own backend, its own data, its own settings and,
+optionally, its own admin UI.
 
-What it may **not** do:
+**MOD-3** (SHIPPED) - Within its own process a module has wide latitude: it registers
+services, schedules jobs, and serves HTTP the server reverse-proxies under its own id.
 
-- **It may not reach into the server's process or another module's process.** Every
-  cross-boundary call is an explicit, typed request over the local callback API or a named
-  port, never a direct function call into core internals. The boundary is a wire, not a
-  linker symbol.
-- **It may not replace core.** Playback, catalogue, accounts and the library's
-  read/observe contract are the server's; a module extends the server, it does not
-  substitute for it. A module cannot claim a first-party module id it does not own (see
-  the Store).
-- **It may not assume it is present.** Because any module is uninstallable, core never
-  depends on one. Features that need a module are absent, not broken, when it is gone.
+**MOD-4** (SHIPPED) - A database is a **declared capability**, not something every module
+gets. A module that declares no storage gets none. A module that declares storage gets its own
+file, plus whatever slice of the core data it named, and no more than that slice.
 
-A module *may* depend on another module (hard or optional); that dependency is declared,
-resolved and enforced (below), not discovered at runtime.
+What a module may **not** do:
+
+- **MOD-5** (SHIPPED) - It may not reach into the server's process or another module's
+  process. Every cross-boundary call is an explicit, typed request over the local callback API
+  or a named port, never a direct function call into core internals. The boundary is a wire,
+  not a linker symbol.
+- **MOD-6** (SHIPPED) - It may not replace core. Playback, catalogue, accounts and the
+  library's read-and-observe contract are the server's; a module extends the server, it does
+  not substitute for it.
+- **MOD-7** (SHIPPED) - It may not claim a first-party module id it does not own.
+- **MOD-8** (SHIPPED) - It may not assume it is present. Because any module is uninstallable,
+  core never depends on one, so a feature that needs a module is absent, not broken, when the
+  module is gone.
+
+**MOD-9** (SHIPPED) - A module *may* depend on another module, hard or optional, and that
+dependency is declared, resolved and enforced rather than discovered at runtime.
 
 ## The `.kmod` bundle
 
 Status: **SHIPPED**
 
-A module ships as a single `.kmod` file: a manifest, the native backend binary, an icon,
-and the module's own frontend, packed together. At product level the manifest is the
-contract, and it declares:
+**MOD-10** (SHIPPED) - A module ships as a single `.kmod` file: a manifest, the native
+backend binary, an icon and the module's own frontend, packed together. At product level the
+manifest is the contract.
 
-- **Identity and version.** The reverse-DNS id and a hand-set version. The version is the
-  source of truth for whether an update exists, and the release process refuses to publish
-  changed bytes under an unchanged version, so "there is a newer version" always means
-  "there is genuinely newer code", never a silent re-issue.
-- **`minServer`, the compatibility floor.** The minimum server version the module needs,
-  as a bare version or a range. This is the whole compatibility contract (see below).
-- **Dependencies.** Hard dependencies that must be installed alongside it, and optional
-  ones offered but not required.
-- **Target.** Which platform the backend was built for. A library-only module (manifest
-  and frontend, no native binary) declares no target and runs anywhere; everything else
-  ships per-platform, and the server picks the artifact that fits the host.
+The manifest declares:
 
-Integrity is guaranteed by a published SHA-256 the server checks against the bytes it
-downloads. A bundle whose checksum does not match, or that publishes no checksum, is
-refused. Integrity is not safety: a matching checksum proves the bytes are the ones the
-registry named, not that they are trustworthy.
+- **MOD-11** (SHIPPED) - **Identity and version.** The reverse-DNS id and a hand-set version.
+  The version is the source of truth for whether an update exists.
+- **MOD-12** (SHIPPED) - The release process refuses to publish changed bytes under an
+  unchanged version, so "there is a newer version" always means there is genuinely newer code,
+  never a silent re-issue.
+- **MOD-13** (SHIPPED) - **`minServer`, the compatibility floor.** The minimum server version
+  the module needs, as a bare version or a range. This is the whole compatibility contract.
+- **MOD-14** (SHIPPED) - **Dependencies.** Hard ones that must be installed alongside it, and
+  optional ones offered but not required.
+- **MOD-15** (SHIPPED) - **Target.** Which platform the backend was built for. A library-only
+  module, a manifest and frontend with no native binary, declares no target and runs anywhere;
+  everything else ships per platform and the server picks the artifact that fits the host.
+
+**MOD-16** (SHIPPED) - The server checks the bytes it downloads against a published SHA-256
+and refuses a bundle whose checksum does not match or that publishes none.
+
+**MOD-17** (SHIPPED) - Integrity is not safety: a matching checksum proves the bytes are the
+ones the registry named, not that they are trustworthy.
 
 ## Installation
 
@@ -83,31 +94,32 @@ Status: **SHIPPED**
 Two paths, one outcome: the module is unpacked under the server's data directory and its
 sidecar is spawned:
 
-- **From the Store**, by id. The server resolves hard dependencies automatically,
-  offers optional ones and capability providers (e.g. a module that needs a download
-  engine is offered the engines the catalogue advertises), verifies every download's
+- **MOD-18** (SHIPPED) - **From the Store**, by id. The server resolves hard dependencies
+  automatically, offers optional ones and capability providers, so a module that needs a
+  download engine is offered the engines the catalogue advertises, verifies every download's
   checksum, and enforces `minServer` before it installs anything.
-- **By upload**, handing the server a `.kmod` by hand. Same unpack, same spawn, same
-  `minServer` gate. This is for an air-gapped server, a private build, or a module not on any
-  registry.
+- **MOD-19** (SHIPPED) - **By upload**, handing the server a `.kmod` by hand: same unpack,
+  same spawn, same `minServer` gate. This is for an air-gapped server, a private build, or a
+  module on no registry.
 
-Both are admin actions on the [`admin.md`](../admin/README.md) surface.
+**MOD-20** (SHIPPED) - Both are admin actions on the [`admin/`](../admin/) surface.
 
 ## The Store
 
 Status: **SHIPPED**
 
-The Store (Admin → Modules) is the in-app browser over the configured registries. The
-official registry is pinned first and cannot be removed; operators may add their own. It
-shows the union of every registry's catalogue, and for each module it shows **this
-server's verdict**, not just the catalogue entry:
+**MOD-21** (SHIPPED) - The Store (Admin → Modules) is the in-app browser over the configured
+registries, and shows the union of every registry's catalogue.
 
-- which artifact matches this host's platform,
-- the installed version, if any, and whether an update exists,
-- whether the module is **compatible with this server, and if not, the reason** (a
-  `minServer` the server does not satisfy is named, not hidden).
+**MOD-22** (SHIPPED) - The official registry is pinned first and cannot be removed; operators
+may add their own.
 
-That verdict is the point: a user decides to install or update against what *their* server
+**MOD-23** (SHIPPED) - For each module the Store shows **this server's verdict**, not just the
+catalogue entry: which artifact matches this host's platform, the installed version and whether
+an update exists, and whether the module is compatible with this server and, if not, the
+reason. A `minServer` the server does not satisfy is named, never hidden.
+
+That verdict is the point: a person decides to install or update against what *their* server
 will actually do, before committing. Registry precedence, https requirements, shadowing of
 duplicate ids and the empty-catalogue-is-a-failure rule are specified in
 [`../module-registries.md`](../../module-registries.md).
@@ -120,16 +132,17 @@ The trust model for third-party registries is genuinely open. The shipped integr
 guarantees are settled; the *safety* posture around untrusted publishers is not. The
 proposed position:
 
-- **First-party is trusted by default.** The official registry is pinned, first-party,
-  and curated. A module from it installs without a trust prompt.
-- **A third-party registry is an explicit operator opt-in.** Adding one is admin-only and
-  is *not* a trust grant to its modules; it only makes them visible. The operator is told,
-  in plain terms, that a module is a native binary the server will execute, so adding a
-  registry they do not control is equivalent to trusting its operator with code execution
-  on the host.
-- **Checksums guarantee integrity, never safety.** The server says so where it matters:
-  on the add-registry flow and on installing a non-first-party module. Signing and a
-  curated-vs-community distinction are candidates, not decided.
+- **MOD-24** (DRAFT) - **First-party is trusted by default.** The official registry is
+  pinned, first-party and curated, and a module from it installs without a trust prompt.
+- **MOD-25** (DRAFT) - **A third-party registry is an explicit operator opt-in.** Adding one
+  is admin-only and is *not* a trust grant to its modules; it only makes them visible.
+- **MOD-26** (DRAFT) - The operator is told, in plain terms, that a module is a native binary
+  the server will execute, so adding a registry they do not control is equivalent to trusting
+  its operator with code execution on the host.
+- **MOD-27** (DRAFT) - **Checksums guarantee integrity, never safety**, and the server says so
+  where it matters: on the add-registry flow and on installing a non-first-party module.
+
+Signing and a curated-versus-community distinction are candidates, not decided.
 
 Until this is resolved, the honest line the user is shown is: *the server verifies this is
 the file the registry published; it does not vouch for what the file does.*
@@ -140,23 +153,26 @@ Status: **SHIPPED**
 
 Four actions, and what each does to the module's data:
 
-- **Enable.** The server spawns the sidecar; the module's routes, jobs and UI become
-  live. Enabled is the state that survives a reboot: enabled modules are re-spawned at boot.
-- **Disable.** The sidecar is stopped. The module stops running; its **data is kept
-  untouched**. Enabling again resumes where it left off. Disable is the reversible off
-  switch.
-- **Update.** A newer version replaces the bundle and the sidecar is re-spawned. The
-  module's migrations carry its data forward; settings and stored state persist across the
-  update. `minServer` is re-checked, so an update that outgrows the server is refused with
-  a reason rather than installed into a crash.
-- **Uninstall.** The module is removed entirely. The server refuses to uninstall a module
-  another enabled module still depends on, naming the dependant. Uninstall is the one
-  destructive action: it is the deliberate way to remove a module *and* its data, and it is
-  presented as such.
+- **MOD-28** (SHIPPED) - **Enable.** The server spawns the sidecar and the module's routes,
+  jobs and UI become live. Enabled is the state that survives a reboot: enabled modules are
+  re-spawned at boot.
+- **MOD-29** (SHIPPED) - **Disable.** The sidecar is stopped, the module stops running, and
+  its **data is kept untouched**, so enabling again resumes where it left off. Disable is the
+  reversible off switch.
+- **MOD-30** (SHIPPED) - **Update.** A newer version replaces the bundle and the sidecar is
+  re-spawned. The module's migrations carry its data forward, and settings and stored state
+  persist across the update.
+- **MOD-31** (SHIPPED) - `minServer` is re-checked on update, so an update that outgrows the
+  server is refused with a reason rather than installed into a crash.
+- **MOD-32** (SHIPPED) - **Uninstall.** The module is removed entirely. It is the one
+  destructive action, the deliberate way to remove a module *and* its data, and it is presented
+  as such.
+- **MOD-33** (SHIPPED) - The server refuses to uninstall a module another enabled module still
+  depends on, and names the dependant.
 
-Uninstalling a module never touches media on disk. A downloads module leaves the files it
-fetched exactly where they are, and the library keeps observing them,
-[`library.md`](../library/README.md).
+**MOD-34** (SHIPPED) - Uninstalling a module never touches media on disk. A downloads module
+leaves the files it fetched exactly where they are, and the library keeps observing them
+([`library/`](../library/)).
 
 ## Failure and isolation
 
@@ -164,41 +180,44 @@ Status: **SHIPPED**
 
 This is the guarantee the whole architecture exists to make:
 
-- **A crashed module cannot take down the server.** The sidecar is a supervised child
-  process. If it dies, the server stays up, every other module stays up, and requests to
-  the failed module get a clear error instead of a hung server.
-- **An incompatible module never runs by accident.** `minServer` is enforced at install
-  *and* again at spawn. A stale bundle that no longer fits the server fails to start with a
-  named reason, rather than starting and emitting confusing runtime errors downstream.
-- **Failure is visible, not silent.** A module that will not start or has crashed surfaces
-  on the Admin Modules surface with its state and reason, [`admin.md`](../admin/README.md).
+- **MOD-35** (SHIPPED) - **A crashed module cannot take down the server.** The sidecar is a
+  supervised child process. If it dies, the server stays up, every other module stays up, and
+  requests to the failed module get a clear error instead of a hung server.
+- **MOD-36** (SHIPPED) - **An incompatible module never runs by accident.** `minServer` is
+  enforced at install *and* again at spawn, so a stale bundle that no longer fits the server
+  fails to start with a named reason rather than emitting confusing runtime errors downstream.
+- **MOD-37** (SHIPPED) - **Failure is visible, not silent.** A module that will not start or
+  has crashed surfaces on the Admin Modules surface with its state and its reason
+  ([`admin/`](../admin/)).
 
 ## The compatibility promise
 
 Status: **SHIPPED**
 
-The promise, grounded in `minServer`: **the server is forward-compatible with older
-modules; a module declares the oldest server it can run against, and nothing below that
-floor is ever allowed to run.** Concretely, a module installed today keeps working as the
-server is updated, because the server does not retroactively break the boundary its
-modules were built against. What can require action is the other direction: a *newer*
-module may raise its `minServer`, and the Store says so before you install it. The floor is
-checked at install and at every spawn, so a mismatch is a clear, upfront refusal, never a
-half-running module.
+**MOD-38** (SHIPPED) - The server is forward-compatible with older modules. A module declares
+the oldest server it can run against, and nothing below that floor is ever allowed to run.
+
+**MOD-39** (SHIPPED) - A module installed today keeps working as the server is updated,
+because the server does not retroactively break the boundary its modules were built against.
+
+**MOD-40** (SHIPPED) - A *newer* module may raise its `minServer`, and the Store says so
+before it is installed. The floor is checked at install and at every spawn, so a mismatch is a
+clear, upfront refusal, never a half-running module.
 
 ## Module UI
 
-Status: **AGREED**
+Status: **SHIPPED**
 
-A module **may** ship UI, and the position is deliberate: a module's frontend mounts
-**inside Admin**, under that module's own section, as pages, navigation and settings for
-the capability it provides. The boundary:
+**MOD-41** (SHIPPED) - A module **may** ship UI, and the position is deliberate: a module's
+frontend mounts **inside Admin**, under that module's own section, as pages, navigation and
+settings for the capability it provides.
 
-- A module renders **its own admin surface**: configuration, status, and controls for
-  what it does. It does not reskin core, inject into other modules' surfaces, or take over
-  the end-user playback experience.
-- Its UI is served through the same reverse-proxy as its backend and lives and dies with
-  the module: install adds the section, uninstall removes it, disable hides it.
+- **MOD-42** (AGREED) - A module renders **its own admin surface**: configuration, status and
+  controls for what it does. It does not reskin core, inject into another module's surface, or
+  take over the end-user playback experience.
+- **MOD-43** (SHIPPED) - A module's UI is served through the same reverse proxy as its backend
+  and lives and dies with the module: install adds the section, uninstall removes it, disable
+  hides it.
 
 This keeps a capability's controls next to the capability, while keeping the player and the
 catalogue the server's alone.
@@ -210,16 +229,17 @@ Status: **DRAFT**
 The abandonment story is not fully settled, but the user must never be left guessing, and
 their data must never be at risk. The designed visible signal:
 
-- **The compatibility gate is the early warning.** As the server moves forward, an
-  unmaintained module eventually fails its `minServer` against a newer server it was never
-  updated for. That mismatch is surfaced by name on the Modules surface, as an
-  **incompatible / unmaintained** state, rather than a silent failure to spawn.
-- **Their data is retained.** An incompatible or abandoned module is not auto-removed. It
-  is stopped and flagged, its data kept, so a later fixed build (or a downgrade, or a
-  fork) can pick it back up. Only an explicit uninstall discards module data.
-- **The honest signal.** The user is told the module has not kept pace with the server and
-  is not running, is pointed at its registry entry and version history, and keeps every
-  option: leave it disabled, replace it, or uninstall it deliberately.
+- **MOD-44** (DRAFT) - **The compatibility gate is the early warning.** As the server moves
+  forward, an unmaintained module eventually fails its `minServer` against a newer server it
+  was never updated for, and that mismatch is surfaced by name on the Modules surface as an
+  **incompatible or unmaintained** state rather than a silent failure to spawn.
+- **MOD-45** (DRAFT) - **Data is retained.** An incompatible or abandoned module is not
+  auto-removed. It is stopped and flagged and its data kept, so a later fixed build, a
+  downgrade or a fork can pick it back up. Only an explicit uninstall discards module data.
+- **MOD-46** (DRAFT) - **The signal is honest.** The person is told the module has not kept
+  pace with the server and is not running, is pointed at its registry entry and version
+  history, and keeps every option: leave it disabled, replace it, or uninstall it
+  deliberately.
 
 Open: whether the registry should carry an explicit maintenance/deprecation flag a
 publisher sets, versus inferring abandonment purely from the compatibility gate.
@@ -228,15 +248,15 @@ publisher sets, versus inferring abandonment purely from the compatibility gate.
 
 Status: **SHIPPED**
 
-Every capability below could have been core. Each is a module instead, for the same three
-reasons the base build ships empty, meaning isolation, unsandboxable native dependencies and
-runtime installability, plus one product reason: a server that only ever plays a curated
-library has no need to carry any of it.
+**MOD-47** (SHIPPED) - Every capability below could have been core and is a module instead,
+for the same three reasons the base build ships empty, meaning isolation, unsandboxable native
+dependencies and runtime installability, plus one product reason: a server that only ever plays
+a curated library has no need to carry any of it.
 
 - **Downloads and acquisition** (`tv.kroma.torrents`, `tv.kroma.acquisition`,
   `tv.kroma.indexer`, `tv.kroma.torznab`, `tv.kroma.vpn`, and the download engines
   `tv.kroma.engine.qbittorrent` / `tv.kroma.engine.transmission`). Getting bytes onto disk
-  is out of scope for the library, which only *observes* what appears, [`library.md`](../library/README.md).
+  is out of scope for the library, which only *observes* what appears, [`library/`](../library/).
   This stack carries the heaviest and most legally sensitive native code in the product; it
   is exactly what should be optional, isolated and removable.
 - **Transcription** (`tv.kroma.whisper`). A speech-to-text ML runtime, a large native
@@ -244,7 +264,7 @@ library has no need to carry any of it.
 - **Semantic search** (`tv.kroma.vector`). Vector embeddings and search, again a native
   ML stack, and a feature a plain catalogue does not need.
 - **Network discovery** (`tv.kroma.mdns`). Advertising the server on the LAN for pairing,
-  [`discovery.md`](../discovery/README.md), a capability an operator may deliberately not want
+  [`discovery/`](../discovery/), a capability an operator may deliberately not want
   running, so it is opt-in.
 - **Remote access** (`tv.kroma.remote`). Reaching the server from outside the LAN, a
   security-relevant surface that should be an explicit, removable choice, not always-on.
@@ -254,10 +274,12 @@ library has no need to carry any of it.
 
 ## Not in scope
 
+Status: **AGREED**
+
 - **Getting bytes onto disk** as a library concern, covering matching, scanning and deletions, is
-  [`library.md`](../library/README.md). The library observes; modules acquire.
+  [`library/`](../library/). The library observes; modules acquire.
 - **Running the server**, meaning installing, enabling and diagnosing modules from the
-  admin surface, is [`admin.md`](../admin/README.md).
+  admin surface, is [`admin/`](../admin/).
 - **Registry wiring and precedence**, covering official-vs-added, shadowing, https and
   autodiscovery, is [`../module-registries.md`](../../module-registries.md).
 - **How a sidecar is built, packed, spawned and released** is

--- a/docs/spec/playback/README.md
+++ b/docs/spec/playback/README.md
@@ -1,201 +1,234 @@
 # Playback
 
-Status: **DRAFT**. Sections carry their own status below.
+Status: **AGREED**. Sections carry their own status below.
 
 The core promise: the file plays, unmodified, wherever possible. Everything else is a
 fallback, and every fallback is a compromise that is made visible and explained. KROMA
 never quietly degrades a stream and hopes nobody notices.
 
-Codec truth, what a stream actually is, lives in [`media.md`](../media/README.md). The per-device
-capability matrix lives in [`surfaces.md`](../surfaces/README.md). Who is allowed to watch a title at
-all lives in [`accounts.md`](../accounts/README.md). This file owns the *decision*: given a file, a
+Codec truth, what a stream actually is, lives in [`media/`](../media/). The per-device
+capability matrix lives in [`surfaces/`](../surfaces/). Who is allowed to watch a title at
+all lives in [`accounts/`](../accounts/). This file owns the *decision*: given a file, a
 client and a network, what gets sent, and what is given up to send it.
 
 ## Direct play
 
 Status: **AGREED**
 
-Direct play means the client fetches the original file, byte for byte, and decodes it
-itself. The server does nothing but serve bytes and honour range requests. This is the
-default, the goal, and the only path with no compromise.
+**PLAY-1** (SHIPPED) - Direct play means the client fetches the original file, byte for byte,
+and decodes it itself. The server does nothing but serve bytes and honour range requests.
+This is the default, the goal, and the only path with no compromise.
 
 A file direct-plays when **all** of the following hold:
 
-1. The client declares it can demux the **container** (per [`surfaces.md`](../surfaces/README.md)).
-2. The client can decode the **video stream**, meaning codec, profile, level, bit depth
-   and HDR variant, in hardware, as declared for that device generation.
-3. Every **audio stream the user might select** is decodable by the client, at its native
-   channel layout, or is passthrough-capable to a connected receiver.
-4. The chosen **subtitle**, if any, is either a format the client renders itself or is a
-   sidecar it can fetch alongside.
-5. The **link** sustains the file's peak bitrate. Local network: always assumed. Remote:
-   only when measured throughput clears peak with headroom.
+- **PLAY-2** (AGREED) - The client declares it can demux the **container**
+  ([`surfaces/`](../surfaces/)).
+- **PLAY-3** (AGREED) - The client can decode the **video stream**, meaning codec, profile,
+  level, bit depth and HDR variant, in hardware, as declared for that device generation.
+- **PLAY-4** (AGREED) - Every **audio stream the person might select** is decodable by the
+  client at its native channel layout, or is passthrough-capable to a connected receiver.
+- **PLAY-5** (AGREED) - The chosen **subtitle**, if any, is either a format the client renders
+  itself or a sidecar it can fetch alongside.
+- **PLAY-6** (AGREED) - The **link** sustains the file's peak bitrate. On a local network this
+  is assumed; on a remote one it holds only when measured throughput clears peak with
+  headroom.
 
-The capability inputs (1–4) are surface facts and are not restated here; KROMA reads them
-from the device profile. The decision below is what KROMA does with them.
+The capability inputs are surface facts and are not restated here; KROMA reads them from the
+device profile. The decision below is what KROMA does with them.
 
 ## The fallback ladder
 
 Status: **AGREED**
 
-When a title cannot direct-play, KROMA walks a fixed ladder and stops at the first rung
-that works. Each rung gives up strictly more than the one above it. The rule: **change the
-least, and never touch the video stream while a cheaper change on another stream would do.**
+**PLAY-7** (AGREED) - When a title cannot direct-play, KROMA walks a fixed ladder and stops at
+the first rung that works. Each rung gives up strictly more than the one above it.
 
-1. **Direct play.** The original file, untouched. No compromise.
-2. **Remux (direct stream).** The video and audio *bitstreams* are copied unchanged into a
-   container the client can demux (e.g. an unsupported container holding a supported codec).
-   Nothing is re-encoded; picture and sound are bit-identical. Cheap, near-instant, no
-   quality loss.
-3. **Audio-only fallback.** The video is still copied, but one audio stream is dealt with:
-   - **passthrough** to a receiver if the client can pass the bitstream on; else
-   - **downmix** a multichannel track to stereo when the client cannot decode the layout;
-     else
-   - **transcode the audio** to a codec the client decodes. Video is never touched to solve
-     an audio problem.
-4. **Subtitle burn-in.** Only when a selected subtitle cannot be rendered by the client and
-   cannot be delivered as a sidecar (e.g. bitmap subs on a client without an overlay). This
-   forces re-encoding the video, so it sits below audio fixes: a subtitle preference must
-   not silently cost picture quality. See *What is never done silently*.
-5. **Video transcode.** The last resort. The video stream is re-encoded to a codec, profile
-   and bitrate the client can decode, downscaling resolution and tone-mapping HDR to SDR only
-   as far as required. Everything above has failed; this rung always loses quality and costs
-   the server real work.
+**PLAY-8** (AGREED) - Change the least: the video stream is never touched while a cheaper
+change on another stream would do.
 
-KROMA takes the highest rung that satisfies the client. It does not skip rungs for
-convenience: if remux suffices, it remuxes; it does not transcode because a session is
-already warm.
+- **PLAY-9** (SHIPPED) - Rung 1, **direct play**. The original file, untouched. No compromise.
+- **PLAY-10** (SHIPPED) - Rung 2, **remux**, also called direct stream. The video and audio
+  *bitstreams* are copied unchanged into a container the client can demux. Nothing is
+  re-encoded, picture and sound are bit-identical, and it is cheap and near-instant.
+- **PLAY-11** (SHIPPED) - Rung 3, **audio-only fallback**. The video is still copied and one
+  audio stream is dealt with: passthrough to a receiver if the client can pass the bitstream
+  on, else a downmix of a multichannel track to stereo when the client cannot decode the
+  layout, else transcoding the audio to a codec the client decodes.
+- **PLAY-12** (AGREED) - Video is never touched to solve an audio problem.
+- **PLAY-13** (AGREED) - Rung 4, **subtitle burn-in**. Only when a selected subtitle can
+  neither be rendered by the client nor delivered as a sidecar, such as bitmap subs on a client
+  with no overlay. It forces re-encoding the video, so it sits below audio fixes: a subtitle
+  preference must not silently cost picture quality.
+- **PLAY-14** (SHIPPED) - Rung 5, **video transcode**, the last resort. The video stream is
+  re-encoded to a codec, profile and bitrate the client can decode, downscaling resolution and
+  tone-mapping HDR to SDR only as far as required. This rung always loses quality and costs
+  the server real work.
+
+**PLAY-15** (AGREED) - KROMA takes the highest rung that satisfies the client and does not
+skip rungs for convenience. If remux suffices it remuxes; it does not transcode because a
+session is already warm.
 
 ### Is transcoding a feature or a last resort?
 
-**Decision:** a tolerated last resort, not a headline feature. KROMA is built so the original
-plays; transcode exists so a title is *never unplayable* on a client the user actually owns,
-not so KROMA can pretend any file suits any screen. Consequences on record:
+Status: **AGREED**
 
-- Transcode is always the lowest rung and is never the default for a capable client.
-- An admin may **cap or disable** video transcode per server and per user
-  ([`accounts.md`](../accounts/README.md), [`admin.md`](../admin/README.md)); disabling it means an incompatible
-  file reports as unplayable on that client rather than degrading.
-- We do not invest in adaptive multi-bitrate ladders, quality knobs, or bandwidth-based
-  auto-transcode. The product's answer to "it won't play" is "get a client that direct-plays
-  it", and the honest message below says exactly that.
+**PLAY-16** (AGREED) - Transcode is a tolerated last resort, not a headline feature. KROMA is
+built so the original plays, and transcode exists so a title is never unplayable on a client a
+person actually owns, not so KROMA can pretend any file suits any screen.
+
+- **PLAY-17** (AGREED) - Transcode is always the lowest rung and is never the default for a
+  capable client.
+- **PLAY-18** (AGREED) - An admin may **cap or disable** video transcode per server and per
+  person ([`accounts/`](../accounts/), [`admin/`](../admin/)). Disabling it means an
+  incompatible file reports as unplayable on that client rather than degrading.
+- **PLAY-19** (AGREED) - KROMA ships no adaptive multi-bitrate ladder, no quality knobs and no
+  bandwidth-based auto-transcode. The product's answer to "it won't play" is "use a client that
+  direct-plays it", and the honest message below says exactly that.
 
 ## What is never done silently
 
 Status: **AGREED**
 
-Any rung below direct play is a compromise, and the client always shows which one is active
-before or at the moment playback starts, as a small honest badge rather than a buried log line:
+**PLAY-20** (AGREED) - Any rung below direct play is a compromise, and the client always shows
+which one is active before or at the moment playback starts, as a small honest badge rather
+than a buried log line.
 
-- **Video transcode** and **subtitle burn-in** are shown as *reduced quality* with the reason
-  (codec / resolution / HDR / subtitle). These change the picture and are the loudest.
-- **Audio downmix** and **audio transcode** are shown as *audio adjusted*.
-- **Remux** is shown as *repackaged*. Quality is untouched, so this is informational, not a
-  warning.
-- Direct play shows nothing; the absence of a badge *is* the signal that the file is pristine.
+- **PLAY-21** (AGREED) - **Video transcode** and **subtitle burn-in** are shown as *reduced
+  quality* with the reason, meaning codec, resolution, HDR or subtitle. These change the
+  picture and are the loudest.
+- **PLAY-22** (AGREED) - **Audio downmix** and **audio transcode** are shown as *audio
+  adjusted*.
+- **PLAY-23** (AGREED) - **Remux** is shown as *repackaged*. Quality is untouched, so this is
+  informational rather than a warning.
+- **PLAY-24** (AGREED) - Direct play shows nothing. The absence of a badge *is* the signal
+  that the file is pristine.
 
-KROMA never re-encodes video to save bandwidth without the user's device profile forcing it,
-never tone-maps HDR without saying so, and never burns in subtitles the user did not ask to
-see. If the only playable path is one the user or admin has disabled, playback fails loudly
-(see *Failure*) rather than falling further down the ladder.
+**PLAY-25** (AGREED) - KROMA never re-encodes video to save bandwidth unless the device
+profile forces it.
+
+**PLAY-26** (AGREED) - KROMA never tone-maps HDR without saying so.
+
+**PLAY-27** (AGREED) - KROMA never burns in subtitles the person did not ask to see.
+
+**PLAY-28** (AGREED) - When the only playable path is one a person or an admin has disabled,
+playback fails loudly rather than falling further down the ladder.
 
 ## Seeking
 
 Status: **AGREED**
 
-- **Direct play and remux:** seeking is instant and exact. The client issues a range request
-  against a fully-known file; any position is reachable immediately, including scrubbing.
-- **Transcode (audio or video):** the stream is produced live from a play position, so a seek
-  outside the buffered window **re-anchors** the transcode at the target and resumes there.
-  This costs a short re-buffer, and backward seeks are as expensive as forward ones. KROMA
-  favours anchoring at the requested position over pre-producing the whole file, so a user who
-  jumps around pays a small pause each time rather than waiting once for a full encode.
-
-Seeking accuracy is never silently coarsened; a transcoded seek lands on the requested frame's
-keyframe, not a rounded chapter.
+- **PLAY-29** (SHIPPED) - Under **direct play and remux**, seeking is instant and exact. The
+  client issues a range request against a fully-known file, so any position is reachable
+  immediately, scrubbing included.
+- **PLAY-30** (AGREED) - Under **transcode**, the stream is produced live from a play position,
+  so a seek outside the buffered window **re-anchors** the transcode at the target and resumes
+  there. That costs a short re-buffer, and a backward seek is as expensive as a forward one.
+- **PLAY-31** (AGREED) - KROMA anchors at the requested position rather than pre-producing the
+  whole file, so a person who jumps around pays a small pause each time instead of waiting once
+  for a full encode.
+- **PLAY-32** (AGREED) - Seeking accuracy is never silently coarsened. A transcoded seek lands
+  on the requested frame's keyframe, not a rounded chapter.
 
 ## Resume and continue watching
 
 Status: **AGREED**
 
-Progress is **per user, per media version**, stored on the server. It is the server's watch
-state, not a device's ([`accounts.md`](../accounts/README.md)). Any client the user signs into sees the
-same resume point.
+**PLAY-33** (SHIPPED) - Progress is **per person, per media version**, stored on the server. It
+is the server's watch state, not a device's ([`accounts/`](../accounts/)), so any client the
+person signs into sees the same resume point.
 
-**When progress is written.** The playing client reports position on a steady heartbeat while
-playing (a small fixed interval), on pause, on seek settling, and on stop. A crash loses at
-most one heartbeat interval. The write is idempotent on `(user, version, position, wall-clock
-time)` so a replayed or offline-queued report cannot move progress backwards.
+**PLAY-34** (SHIPPED) - The playing client reports position on a steady heartbeat while
+playing, on pause, on a settled seek, and on stop, so a crash loses at most one heartbeat
+interval.
 
-**Resume point.** Reopening a title in progress offers *Resume* from the stored position and
-*Play from start*; resume is the default. The stored position is the reported one, not a
+**PLAY-35** (AGREED) - The write is idempotent on the person, the version, the position and
+the wall-clock time, so a replayed or offline-queued report cannot move progress backwards.
+
+**PLAY-36** (SHIPPED) - Reopening a title in progress offers *Resume* from the stored position
+and *Play from start*, with resume the default. The stored position is the reported one, not a
 rounded chapter.
 
-**The "watched" threshold.** A title is **watched** at **≥ 90% of runtime**, or at reaching a
-credits/end marker if the media has one. At that point continue-watching drops the title and,
-for episodic content, surfaces the next episode instead. 90% is chosen because trailing credits
+**PLAY-37** (AGREED) - A title is **watched** at **90% of runtime or more**, or at reaching a
+credits or end marker where the media has one. 90% is chosen because trailing credits
 routinely run the last several minutes: requiring 100% would strand finished titles in the row
-forever, and a fixed "last N minutes" misjudges both a 22-minute episode and a 200-minute film.
-Below 90%, progress is retained and the title stays in continue-watching. Starting a watched
-title again resets it to unwatched and clears the stored position.
+forever, and a fixed "last N minutes" misjudges both a 22-minute episode and a 200-minute
+film.
 
-**Offline reconciliation.** Mobile downloads let a user watch with no server connection, and two
-devices can each accrue progress offline against the same version. Downloads survive app kills
-and are re-adopted on launch (see
-[`../architecture/mobile-offline-system-storage.md`](../../architecture/mobile-offline-system-storage.md)),
-and so does the **queue of unsent progress reports**. On reconnect each device flushes its queue,
-every report stamped with the **wall-clock time the user was actually at that position**.
+**PLAY-38** (SHIPPED) - At the watched threshold, continue-watching drops the title and, for
+episodic content, surfaces the next episode instead.
+
+**PLAY-39** (AGREED) - Below the threshold, progress is retained and the title stays in
+continue-watching.
+
+**PLAY-40** (AGREED) - Starting a watched title again resets it to unwatched and clears the
+stored position.
+
+**PLAY-41** (SHIPPED) - A device watching offline queues its unsent progress reports and, on
+reconnect, flushes the queue with every report stamped with the wall-clock time the person was
+actually at that position
+([`../architecture/mobile-offline-system-storage.md`](../../architecture/mobile-offline-system-storage.md)).
 
 ### Who wins when two devices disagree?
 
-**Decision: furthest-position-wins, not last-writer-wins.** When queued reports from two offline
-sessions land for the same `(user, version)`, KROMA keeps the **furthest position reached**, not
-the one whose report arrived or was stamped last. Rationale: watch progress is monotonic in
-intent: a user who watched to 0:55 on a plane and to 0:20 on a phone has *seen* up to 0:55, and
-resuming there loses nothing, whereas last-writer-wins would rewind them to 0:20 because that
-sync happened to flush second. The one exception is an explicit **reset to start** (finishing a
-title, or "play from start"), which is an intent, not a position, and always wins over a stale
-higher position. If either device crossed the watched threshold, the title is watched.
+Status: **AGREED**
+
+**PLAY-42** (AGREED) - When queued reports from two offline sessions land for the same person
+and version, KROMA keeps the **furthest position reached**, not the report that arrived or was
+stamped last. Watch progress is monotonic in intent: a person who watched to 0:55 on a plane
+and to 0:20 on a phone has *seen* up to 0:55, and last-writer-wins would rewind them because
+that sync happened to flush second.
+
+**PLAY-43** (AGREED) - An explicit **reset to start**, from finishing a title or choosing
+"play from start", is an intent rather than a position, and always wins over a stale higher
+position.
+
+**PLAY-44** (AGREED) - If either device crossed the watched threshold, the title is watched.
 
 ## Multiple clients at once
 
 Status: **AGREED**
 
-One account may play on several clients simultaneously; KROMA does not enforce a concurrent-stream
-limit as a product rule (an admin may cap server load, [`admin.md`](../admin/README.md)). Each playing
-client is an independent session with its own fallback decision: the same title may direct-play on
-a phone and transcode on a television at the same moment, because the decision is per device, not
-per title.
+**PLAY-45** (AGREED) - One account may play on several clients at once. KROMA enforces no
+concurrent-stream limit as a product rule, though an admin may cap server load
+([`admin/`](../admin/)).
 
-Shared progress means the sessions interleave into one continue-watching state under the
-furthest-position rule above; two devices on the same title do not fight, they simply both advance
-it. KROMA does not "hand off" an active session between devices as a first-class gesture. A user
-resumes on the second device from shared progress, which achieves the same end without a pairing
-dance.
+**PLAY-46** (AGREED) - Each playing client is an independent session with its own fallback
+decision, so the same title may direct-play on a phone and transcode on a television at the
+same moment. The decision is per device, not per title.
+
+**PLAY-47** (AGREED) - Sessions interleave into one continue-watching state under the
+furthest-position rule, so two devices on the same title do not fight; they both advance it.
+
+**PLAY-48** (AGREED) - KROMA does not hand off an active session between devices as a
+first-class gesture. A person resumes on the second device from shared progress, which
+achieves the same end without a pairing dance.
 
 ## Failure
 
 Status: **AGREED**
 
-When a stream dies mid-playback, whether the network drops, a transcode process fails or the
-source file becomes unreadable, the client shows a plain, specific message and keeps the last known position
-so the user resumes exactly where they were, never from the start.
+**PLAY-49** (AGREED) - When a stream dies mid-playback, whether the network drops, a transcode
+process fails or the source file becomes unreadable, the client shows a plain, specific message
+and keeps the last known position, so the person resumes exactly where they were rather than
+from the start.
 
-- **Transient (network, brief server hiccup):** the client retries quietly for a few seconds
-  behind the scrubber before surfacing anything; most recover invisibly.
-- **Fatal (source gone, transcode cannot start, path disabled by policy):** playback stops with a
-  reason, either *This file can't be played on this device* or *This title is no longer available*,
-  never a raw error code.
+- **PLAY-50** (AGREED) - A **transient** failure, a network drop or a brief server hiccup, is
+  retried quietly for a few seconds behind the scrubber before anything surfaces. Most recover
+  invisibly.
+- **PLAY-51** (AGREED) - A **fatal** failure, a source gone, a transcode that cannot start, or
+  a path a policy has disabled, stops playback with a reason, either *This file can't be played
+  on this device* or *This title is no longer available*, never a raw error code.
 
 ### When the television can't play what the phone can
 
-This is the common, honest case: a modern phone direct-plays a file a television's older decoder
-cannot, and the server is configured not to transcode it (or the admin disabled transcode). The
-television must not fail with a blank error. It says, plainly:
+Status: **AGREED**
+
+**PLAY-52** (AGREED) - When a television's older decoder cannot play a file a modern phone
+can, and the server is configured not to transcode it, the television names the device as the
+cause, points at a surface that does play it, and names the one lever that would fix it. It
+never blames the person and never implies the file is broken.
 
 > **Can't play this here.** This TV can't decode this file. It plays fine on the KROMA phone and
 > web apps, or ask the server owner to enable conversion for this device.
 
-The message names the real cause (the device, not the file), points at a surface that *does* work,
-and names the one lever that would fix it (admin-enabled transcode). It never blames the user, and
-it never pretends the file is broken. The file is fine; this screen just can't decode it.
+The file is fine; this screen just cannot decode it.

--- a/docs/spec/playback/README.md
+++ b/docs/spec/playback/README.md
@@ -13,7 +13,7 @@ client and a network, what gets sent, and what is given up to send it.
 
 ## Direct play
 
-Status: **AGREED**
+Status: **SHIPPED**. The path is built; the conditions it tests are **AGREED**.
 
 **PLAY-1** (SHIPPED) - Direct play means the client fetches the original file, byte for byte,
 and decodes it itself. The server does nothing but serve bytes and honour range requests.
@@ -38,7 +38,7 @@ device profile. The decision below is what KROMA does with them.
 
 ## The fallback ladder
 
-Status: **AGREED**
+Status: **SHIPPED** for the rungs, **AGREED** for the rules about choosing one.
 
 **PLAY-7** (AGREED) - When a title cannot direct-play, KROMA walks a fixed ladder and stops at
 the first rung that works. Each rung gives up strictly more than the one above it.
@@ -115,7 +115,7 @@ playback fails loudly rather than falling further down the ladder.
 
 ## Seeking
 
-Status: **AGREED**
+Status: **SHIPPED** under direct play and remux, **AGREED** under transcode.
 
 - **PLAY-29** (SHIPPED) - Under **direct play and remux**, seeking is instant and exact. The
   client issues a range request against a fully-known file, so any position is reachable
@@ -131,7 +131,7 @@ Status: **AGREED**
 
 ## Resume and continue watching
 
-Status: **AGREED**
+Status: **SHIPPED**, with the reconciliation rules **AGREED**.
 
 **PLAY-33** (SHIPPED) - Progress is **per person, per media version**, stored on the server. It
 is the server's watch state, not a device's ([`accounts/`](../accounts/)), so any client the

--- a/docs/spec/requirements.json
+++ b/docs/spec/requirements.json
@@ -1,5 +1,335 @@
 [
   {
+    "id": "ACCT-1",
+    "domain": "ACCT",
+    "space": "accounts",
+    "number": 1,
+    "status": "SHIPPED",
+    "text": "An **account** is a person. It has credentials, its own watch state,",
+    "file": "docs/spec/accounts/README.md",
+    "line": 16
+  },
+  {
+    "id": "ACCT-2",
+    "domain": "ACCT",
+    "space": "accounts",
+    "number": 2,
+    "status": "SHIPPED",
+    "text": "The first account created at first-run is the **owner**, an account",
+    "file": "docs/spec/accounts/README.md",
+    "line": 19
+  },
+  {
+    "id": "ACCT-3",
+    "domain": "ACCT",
+    "space": "accounts",
+    "number": 3,
+    "status": "SHIPPED",
+    "text": "Every subsequent account is an ordinary **user**, created by invitation",
+    "file": "docs/spec/accounts/README.md",
+    "line": 22
+  },
+  {
+    "id": "ACCT-4",
+    "domain": "ACCT",
+    "space": "accounts",
+    "number": 4,
+    "status": "SHIPPED",
+    "text": "There are no profiles under an account, and there will not be. A person",
+    "file": "docs/spec/accounts/README.md",
+    "line": 25
+  },
+  {
+    "id": "ACCT-5",
+    "domain": "ACCT",
+    "space": "accounts",
+    "number": 5,
+    "status": "SHIPPED",
+    "text": "A person proves who they are with a **username and password**. That is",
+    "file": "docs/spec/accounts/README.md",
+    "line": 44
+  },
+  {
+    "id": "ACCT-6",
+    "domain": "ACCT",
+    "space": "accounts",
+    "number": 6,
+    "status": "SHIPPED",
+    "text": "A successful authentication mints a **session**: a long-lived,",
+    "file": "docs/spec/accounts/README.md",
+    "line": 49
+  },
+  {
+    "id": "ACCT-7",
+    "domain": "ACCT",
+    "space": "accounts",
+    "number": 7,
+    "status": "SHIPPED",
+    "text": "**Sessions do not expire on a clock.** A session lives until it is",
+    "file": "docs/spec/accounts/README.md",
+    "line": 53
+  },
+  {
+    "id": "ACCT-8",
+    "domain": "ACCT",
+    "space": "accounts",
+    "number": 8,
+    "status": "SHIPPED",
+    "text": "A session is per device, not per account, so one can be revoked without",
+    "file": "docs/spec/accounts/README.md",
+    "line": 57
+  },
+  {
+    "id": "ACCT-9",
+    "domain": "ACCT",
+    "space": "accounts",
+    "number": 9,
+    "status": "SHIPPED",
+    "text": "A **device** is where a session lives. Signing in on a phone, a browser",
+    "file": "docs/spec/accounts/README.md",
+    "line": 66
+  },
+  {
+    "id": "ACCT-10",
+    "domain": "ACCT",
+    "space": "accounts",
+    "number": 10,
+    "status": "AGREED",
+    "text": "Every session appears in the account's **device list** with enough to",
+    "file": "docs/spec/accounts/README.md",
+    "line": 69
+  },
+  {
+    "id": "ACCT-11",
+    "domain": "ACCT",
+    "space": "accounts",
+    "number": 11,
+    "status": "SHIPPED",
+    "text": "A television binds to an account through the pairing handshake rather",
+    "file": "docs/spec/accounts/README.md",
+    "line": 72
+  },
+  {
+    "id": "ACCT-12",
+    "domain": "ACCT",
+    "space": "accounts",
+    "number": 12,
+    "status": "AGREED",
+    "text": "A paired television is not a special class of trust. It lands in the",
+    "file": "docs/spec/accounts/README.md",
+    "line": 76
+  },
+  {
+    "id": "ACCT-13",
+    "domain": "ACCT",
+    "space": "accounts",
+    "number": 13,
+    "status": "SHIPPED",
+    "text": "**Unbinding is revocation.** Revoking a device's session ends its",
+    "file": "docs/spec/accounts/README.md",
+    "line": 80
+  },
+  {
+    "id": "ACCT-14",
+    "domain": "ACCT",
+    "space": "accounts",
+    "number": 14,
+    "status": "SHIPPED",
+    "text": "A revoked device that returns must pair or sign in afresh.",
+    "file": "docs/spec/accounts/README.md",
+    "line": 84
+  },
+  {
+    "id": "ACCT-15",
+    "domain": "ACCT",
+    "space": "accounts",
+    "number": 15,
+    "status": "SHIPPED",
+    "text": "A television session is long-lived and revocable, and is **never",
+    "file": "docs/spec/accounts/README.md",
+    "line": 90
+  },
+  {
+    "id": "ACCT-16",
+    "domain": "ACCT",
+    "space": "accounts",
+    "number": 16,
+    "status": "AGREED",
+    "text": "The device list is the control that replaces expiry: security comes",
+    "file": "docs/spec/accounts/README.md",
+    "line": 93
+  },
+  {
+    "id": "ACCT-17",
+    "domain": "ACCT",
+    "space": "accounts",
+    "number": 17,
+    "status": "SHIPPED",
+    "text": "An **owner or admin** runs the server: users, settings, jobs and",
+    "file": "docs/spec/accounts/README.md",
+    "line": 106
+  },
+  {
+    "id": "ACCT-18",
+    "domain": "ACCT",
+    "space": "accounts",
+    "number": 18,
+    "status": "AGREED",
+    "text": "The owner is the founding admin, the owner may grant admin to another",
+    "file": "docs/spec/accounts/README.md",
+    "line": 109
+  },
+  {
+    "id": "ACCT-19",
+    "domain": "ACCT",
+    "space": "accounts",
+    "number": 19,
+    "status": "SHIPPED",
+    "text": "A **user** uses the server: browses and plays what they are permitted",
+    "file": "docs/spec/accounts/README.md",
+    "line": 112
+  },
+  {
+    "id": "ACCT-20",
+    "domain": "ACCT",
+    "space": "accounts",
+    "number": 20,
+    "status": "AGREED",
+    "text": "**Library visibility is per user.** An admin decides which libraries a",
+    "file": "docs/spec/accounts/README.md",
+    "line": 115
+  },
+  {
+    "id": "ACCT-21",
+    "domain": "ACCT",
+    "space": "accounts",
+    "number": 21,
+    "status": "AGREED",
+    "text": "Visibility gates browsing, search and playback alike. A title a user",
+    "file": "docs/spec/accounts/README.md",
+    "line": 118
+  },
+  {
+    "id": "ACCT-22",
+    "domain": "ACCT",
+    "space": "accounts",
+    "number": 22,
+    "status": "SHIPPED",
+    "text": "Installing a module is an **admin** right, because it runs new",
+    "file": "docs/spec/accounts/README.md",
+    "line": 121
+  },
+  {
+    "id": "ACCT-23",
+    "domain": "ACCT",
+    "space": "accounts",
+    "number": 23,
+    "status": "AGREED",
+    "text": "The matrix below is the whole of what each role may do. A user's power",
+    "file": "docs/spec/accounts/README.md",
+    "line": 130
+  },
+  {
+    "id": "ACCT-24",
+    "domain": "ACCT",
+    "space": "accounts",
+    "number": 24,
+    "status": "SHIPPED",
+    "text": "**Per-user**: watch state, meaning resume points, watched flags and",
+    "file": "docs/spec/accounts/README.md",
+    "line": 157
+  },
+  {
+    "id": "ACCT-25",
+    "domain": "ACCT",
+    "space": "accounts",
+    "number": 25,
+    "status": "SHIPPED",
+    "text": "**Per-server**: the libraries and their contents, metadata and",
+    "file": "docs/spec/accounts/README.md",
+    "line": 162
+  },
+  {
+    "id": "ACCT-26",
+    "domain": "ACCT",
+    "space": "accounts",
+    "number": 26,
+    "status": "SHIPPED",
+    "text": "Watch state is per user and never per device: resume a film on the",
+    "file": "docs/spec/accounts/README.md",
+    "line": 166
+  },
+  {
+    "id": "ACCT-27",
+    "domain": "ACCT",
+    "space": "accounts",
+    "number": 27,
+    "status": "SHIPPED",
+    "text": "Deletion destroys the account's credentials, all of its sessions and",
+    "file": "docs/spec/accounts/README.md",
+    "line": 176
+  },
+  {
+    "id": "ACCT-28",
+    "domain": "ACCT",
+    "space": "accounts",
+    "number": 28,
+    "status": "SHIPPED",
+    "text": "Everything per-server survives. Libraries, media, metadata and",
+    "file": "docs/spec/accounts/README.md",
+    "line": 180
+  },
+  {
+    "id": "ACCT-29",
+    "domain": "ACCT",
+    "space": "accounts",
+    "number": 29,
+    "status": "AGREED",
+    "text": "The owner account cannot be deleted while it is the only admin.",
+    "file": "docs/spec/accounts/README.md",
+    "line": 184
+  },
+  {
+    "id": "ACCT-30",
+    "domain": "ACCT",
+    "space": "accounts",
+    "number": 30,
+    "status": "AGREED",
+    "text": "A user may request deletion of their own account, which revokes their",
+    "file": "docs/spec/accounts/README.md",
+    "line": 188
+  },
+  {
+    "id": "ACCT-31",
+    "domain": "ACCT",
+    "space": "accounts",
+    "number": 31,
+    "status": "SHIPPED",
+    "text": "Revocation stops a session doing anything new. It cannot fetch, refresh",
+    "file": "docs/spec/accounts/README.md",
+    "line": 197
+  },
+  {
+    "id": "ACCT-32",
+    "domain": "ACCT",
+    "space": "accounts",
+    "number": 32,
+    "status": "AGREED",
+    "text": "Bytes already downloaded for offline viewing sit in local storage the",
+    "file": "docs/spec/accounts/README.md",
+    "line": 200
+  },
+  {
+    "id": "ACCT-33",
+    "domain": "ACCT",
+    "space": "accounts",
+    "number": 33,
+    "status": "AGREED",
+    "text": "The guarantee is that a revoked device gains nothing new and loses its",
+    "file": "docs/spec/accounts/README.md",
+    "line": 204
+  },
+  {
     "id": "ADMIN-1",
     "domain": "ADMIN",
     "space": "admin",
@@ -1828,6 +2158,526 @@
     "text": "Undescribed and unreadable are distinct states. The first is \"we",
     "file": "docs/spec/media/README.md",
     "line": 205
+  },
+  {
+    "id": "PLAY-1",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 1,
+    "status": "SHIPPED",
+    "text": "Direct play means the client fetches the original file, byte for byte,",
+    "file": "docs/spec/playback/README.md",
+    "line": 18
+  },
+  {
+    "id": "PLAY-2",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 2,
+    "status": "AGREED",
+    "text": "The client declares it can demux the **container**",
+    "file": "docs/spec/playback/README.md",
+    "line": 24
+  },
+  {
+    "id": "PLAY-3",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 3,
+    "status": "AGREED",
+    "text": "The client can decode the **video stream**, meaning codec, profile,",
+    "file": "docs/spec/playback/README.md",
+    "line": 26
+  },
+  {
+    "id": "PLAY-4",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 4,
+    "status": "AGREED",
+    "text": "Every **audio stream the person might select** is decodable by the",
+    "file": "docs/spec/playback/README.md",
+    "line": 28
+  },
+  {
+    "id": "PLAY-5",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 5,
+    "status": "AGREED",
+    "text": "The chosen **subtitle**, if any, is either a format the client renders",
+    "file": "docs/spec/playback/README.md",
+    "line": 30
+  },
+  {
+    "id": "PLAY-6",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 6,
+    "status": "AGREED",
+    "text": "The **link** sustains the file's peak bitrate. On a local network this",
+    "file": "docs/spec/playback/README.md",
+    "line": 32
+  },
+  {
+    "id": "PLAY-7",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 7,
+    "status": "AGREED",
+    "text": "When a title cannot direct-play, KROMA walks a fixed ladder and stops at",
+    "file": "docs/spec/playback/README.md",
+    "line": 43
+  },
+  {
+    "id": "PLAY-8",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 8,
+    "status": "AGREED",
+    "text": "Change the least: the video stream is never touched while a cheaper",
+    "file": "docs/spec/playback/README.md",
+    "line": 46
+  },
+  {
+    "id": "PLAY-9",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 9,
+    "status": "SHIPPED",
+    "text": "Rung 1, **direct play**. The original file, untouched. No compromise.",
+    "file": "docs/spec/playback/README.md",
+    "line": 49
+  },
+  {
+    "id": "PLAY-10",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 10,
+    "status": "SHIPPED",
+    "text": "Rung 2, **remux**, also called direct stream. The video and audio",
+    "file": "docs/spec/playback/README.md",
+    "line": 50
+  },
+  {
+    "id": "PLAY-11",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 11,
+    "status": "SHIPPED",
+    "text": "Rung 3, **audio-only fallback**. The video is still copied and one",
+    "file": "docs/spec/playback/README.md",
+    "line": 53
+  },
+  {
+    "id": "PLAY-12",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 12,
+    "status": "AGREED",
+    "text": "Video is never touched to solve an audio problem.",
+    "file": "docs/spec/playback/README.md",
+    "line": 57
+  },
+  {
+    "id": "PLAY-13",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 13,
+    "status": "AGREED",
+    "text": "Rung 4, **subtitle burn-in**. Only when a selected subtitle can",
+    "file": "docs/spec/playback/README.md",
+    "line": 58
+  },
+  {
+    "id": "PLAY-14",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 14,
+    "status": "SHIPPED",
+    "text": "Rung 5, **video transcode**, the last resort. The video stream is",
+    "file": "docs/spec/playback/README.md",
+    "line": 62
+  },
+  {
+    "id": "PLAY-15",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 15,
+    "status": "AGREED",
+    "text": "KROMA takes the highest rung that satisfies the client and does not",
+    "file": "docs/spec/playback/README.md",
+    "line": 67
+  },
+  {
+    "id": "PLAY-16",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 16,
+    "status": "AGREED",
+    "text": "Transcode is a tolerated last resort, not a headline feature. KROMA is",
+    "file": "docs/spec/playback/README.md",
+    "line": 75
+  },
+  {
+    "id": "PLAY-17",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 17,
+    "status": "AGREED",
+    "text": "Transcode is always the lowest rung and is never the default for a",
+    "file": "docs/spec/playback/README.md",
+    "line": 79
+  },
+  {
+    "id": "PLAY-18",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 18,
+    "status": "AGREED",
+    "text": "An admin may **cap or disable** video transcode per server and per",
+    "file": "docs/spec/playback/README.md",
+    "line": 81
+  },
+  {
+    "id": "PLAY-19",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 19,
+    "status": "AGREED",
+    "text": "KROMA ships no adaptive multi-bitrate ladder, no quality knobs and no",
+    "file": "docs/spec/playback/README.md",
+    "line": 84
+  },
+  {
+    "id": "PLAY-20",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 20,
+    "status": "AGREED",
+    "text": "Any rung below direct play is a compromise, and the client always shows",
+    "file": "docs/spec/playback/README.md",
+    "line": 92
+  },
+  {
+    "id": "PLAY-21",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 21,
+    "status": "AGREED",
+    "text": "**Video transcode** and **subtitle burn-in** are shown as *reduced",
+    "file": "docs/spec/playback/README.md",
+    "line": 96
+  },
+  {
+    "id": "PLAY-22",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 22,
+    "status": "AGREED",
+    "text": "**Audio downmix** and **audio transcode** are shown as *audio",
+    "file": "docs/spec/playback/README.md",
+    "line": 99
+  },
+  {
+    "id": "PLAY-23",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 23,
+    "status": "AGREED",
+    "text": "**Remux** is shown as *repackaged*. Quality is untouched, so this is",
+    "file": "docs/spec/playback/README.md",
+    "line": 101
+  },
+  {
+    "id": "PLAY-24",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 24,
+    "status": "AGREED",
+    "text": "Direct play shows nothing. The absence of a badge *is* the signal",
+    "file": "docs/spec/playback/README.md",
+    "line": 103
+  },
+  {
+    "id": "PLAY-25",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 25,
+    "status": "AGREED",
+    "text": "KROMA never re-encodes video to save bandwidth unless the device",
+    "file": "docs/spec/playback/README.md",
+    "line": 106
+  },
+  {
+    "id": "PLAY-26",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 26,
+    "status": "AGREED",
+    "text": "KROMA never tone-maps HDR without saying so.",
+    "file": "docs/spec/playback/README.md",
+    "line": 109
+  },
+  {
+    "id": "PLAY-27",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 27,
+    "status": "AGREED",
+    "text": "KROMA never burns in subtitles the person did not ask to see.",
+    "file": "docs/spec/playback/README.md",
+    "line": 111
+  },
+  {
+    "id": "PLAY-28",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 28,
+    "status": "AGREED",
+    "text": "When the only playable path is one a person or an admin has disabled,",
+    "file": "docs/spec/playback/README.md",
+    "line": 113
+  },
+  {
+    "id": "PLAY-29",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 29,
+    "status": "SHIPPED",
+    "text": "Under **direct play and remux**, seeking is instant and exact. The",
+    "file": "docs/spec/playback/README.md",
+    "line": 120
+  },
+  {
+    "id": "PLAY-30",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 30,
+    "status": "AGREED",
+    "text": "Under **transcode**, the stream is produced live from a play position,",
+    "file": "docs/spec/playback/README.md",
+    "line": 123
+  },
+  {
+    "id": "PLAY-31",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 31,
+    "status": "AGREED",
+    "text": "KROMA anchors at the requested position rather than pre-producing the",
+    "file": "docs/spec/playback/README.md",
+    "line": 126
+  },
+  {
+    "id": "PLAY-32",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 32,
+    "status": "AGREED",
+    "text": "Seeking accuracy is never silently coarsened. A transcoded seek lands",
+    "file": "docs/spec/playback/README.md",
+    "line": 129
+  },
+  {
+    "id": "PLAY-33",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 33,
+    "status": "SHIPPED",
+    "text": "Progress is **per person, per media version**, stored on the server. It",
+    "file": "docs/spec/playback/README.md",
+    "line": 136
+  },
+  {
+    "id": "PLAY-34",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 34,
+    "status": "SHIPPED",
+    "text": "The playing client reports position on a steady heartbeat while",
+    "file": "docs/spec/playback/README.md",
+    "line": 140
+  },
+  {
+    "id": "PLAY-35",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 35,
+    "status": "AGREED",
+    "text": "The write is idempotent on the person, the version, the position and",
+    "file": "docs/spec/playback/README.md",
+    "line": 144
+  },
+  {
+    "id": "PLAY-36",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 36,
+    "status": "SHIPPED",
+    "text": "Reopening a title in progress offers *Resume* from the stored position",
+    "file": "docs/spec/playback/README.md",
+    "line": 147
+  },
+  {
+    "id": "PLAY-37",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 37,
+    "status": "AGREED",
+    "text": "A title is **watched** at **90% of runtime or more**, or at reaching a",
+    "file": "docs/spec/playback/README.md",
+    "line": 151
+  },
+  {
+    "id": "PLAY-38",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 38,
+    "status": "SHIPPED",
+    "text": "At the watched threshold, continue-watching drops the title and, for",
+    "file": "docs/spec/playback/README.md",
+    "line": 157
+  },
+  {
+    "id": "PLAY-39",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 39,
+    "status": "AGREED",
+    "text": "Below the threshold, progress is retained and the title stays in",
+    "file": "docs/spec/playback/README.md",
+    "line": 160
+  },
+  {
+    "id": "PLAY-40",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 40,
+    "status": "AGREED",
+    "text": "Starting a watched title again resets it to unwatched and clears the",
+    "file": "docs/spec/playback/README.md",
+    "line": 163
+  },
+  {
+    "id": "PLAY-41",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 41,
+    "status": "SHIPPED",
+    "text": "A device watching offline queues its unsent progress reports and, on",
+    "file": "docs/spec/playback/README.md",
+    "line": 166
+  },
+  {
+    "id": "PLAY-42",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 42,
+    "status": "AGREED",
+    "text": "When queued reports from two offline sessions land for the same person",
+    "file": "docs/spec/playback/README.md",
+    "line": 175
+  },
+  {
+    "id": "PLAY-43",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 43,
+    "status": "AGREED",
+    "text": "An explicit **reset to start**, from finishing a title or choosing",
+    "file": "docs/spec/playback/README.md",
+    "line": 181
+  },
+  {
+    "id": "PLAY-44",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 44,
+    "status": "AGREED",
+    "text": "If either device crossed the watched threshold, the title is watched.",
+    "file": "docs/spec/playback/README.md",
+    "line": 185
+  },
+  {
+    "id": "PLAY-45",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 45,
+    "status": "AGREED",
+    "text": "One account may play on several clients at once. KROMA enforces no",
+    "file": "docs/spec/playback/README.md",
+    "line": 191
+  },
+  {
+    "id": "PLAY-46",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 46,
+    "status": "AGREED",
+    "text": "Each playing client is an independent session with its own fallback",
+    "file": "docs/spec/playback/README.md",
+    "line": 195
+  },
+  {
+    "id": "PLAY-47",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 47,
+    "status": "AGREED",
+    "text": "Sessions interleave into one continue-watching state under the",
+    "file": "docs/spec/playback/README.md",
+    "line": 199
+  },
+  {
+    "id": "PLAY-48",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 48,
+    "status": "AGREED",
+    "text": "KROMA does not hand off an active session between devices as a",
+    "file": "docs/spec/playback/README.md",
+    "line": 202
+  },
+  {
+    "id": "PLAY-49",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 49,
+    "status": "AGREED",
+    "text": "When a stream dies mid-playback, whether the network drops, a transcode",
+    "file": "docs/spec/playback/README.md",
+    "line": 210
+  },
+  {
+    "id": "PLAY-50",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 50,
+    "status": "AGREED",
+    "text": "A **transient** failure, a network drop or a brief server hiccup, is",
+    "file": "docs/spec/playback/README.md",
+    "line": 215
+  },
+  {
+    "id": "PLAY-51",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 51,
+    "status": "AGREED",
+    "text": "A **fatal** failure, a source gone, a transcode that cannot start, or",
+    "file": "docs/spec/playback/README.md",
+    "line": 218
+  },
+  {
+    "id": "PLAY-52",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 52,
+    "status": "AGREED",
+    "text": "When a television's older decoder cannot play a file a modern phone",
+    "file": "docs/spec/playback/README.md",
+    "line": 226
   },
   {
     "id": "SURF-1",

--- a/docs/spec/requirements.json
+++ b/docs/spec/requirements.json
@@ -878,5 +878,435 @@
     "text": "A user who cannot sign in can ask for a reset from the sign-in",
     "file": "docs/spec/admin/README.md",
     "line": 136
+  },
+  {
+    "id": "SURF-1",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 1,
+    "status": "SHIPPED",
+    "text": "Every client KROMA ships is one of the surfaces named here, and each",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 20
+  },
+  {
+    "id": "SURF-2",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 2,
+    "status": "AGREED",
+    "text": "A build that cannot do all six rungs below is a preview, not a",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 42
+  },
+  {
+    "id": "SURF-3",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 3,
+    "status": "SHIPPED",
+    "text": "**Sign in or pair.** A surface reaches a server and becomes an",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 45
+  },
+  {
+    "id": "SURF-4",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 4,
+    "status": "SHIPPED",
+    "text": "**Browse the library.** A surface moves through the titles the",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 49
+  },
+  {
+    "id": "SURF-5",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 5,
+    "status": "SHIPPED",
+    "text": "**View a title.** A surface shows a title's artwork, its metadata,",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 51
+  },
+  {
+    "id": "SURF-6",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 6,
+    "status": "SHIPPED",
+    "text": "**Start playback.** A surface plays the title, taking whatever rung",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 53
+  },
+  {
+    "id": "SURF-7",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 7,
+    "status": "SHIPPED",
+    "text": "**Resume.** A surface reopens an in-progress title at the",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 55
+  },
+  {
+    "id": "SURF-8",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 8,
+    "status": "SHIPPED",
+    "text": "**Sign out.** A surface ends the session and drops the server from",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 57
+  },
+  {
+    "id": "SURF-9",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 9,
+    "status": "AGREED",
+    "text": "Everything past the six rungs is a *may*, not a *must*. A surface that",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 60
+  },
+  {
+    "id": "SURF-10",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 10,
+    "status": "SHIPPED",
+    "text": "Web is the reference implementation. Where two surfaces disagree on",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 72
+  },
+  {
+    "id": "SURF-11",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 11,
+    "status": "AGREED",
+    "text": "A feature is not shipped until web has it.",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 76
+  },
+  {
+    "id": "SURF-12",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 12,
+    "status": "SHIPPED",
+    "text": "**First-class.** Web, mobile, desktop and the native television",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 78
+  },
+  {
+    "id": "SURF-13",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 13,
+    "status": "AGREED",
+    "text": "A baseline regression on a first-class surface blocks the release.",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 80
+  },
+  {
+    "id": "SURF-14",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 14,
+    "status": "AGREED",
+    "text": "A first-class surface may diverge from web where its input model",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 81
+  },
+  {
+    "id": "SURF-15",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 15,
+    "status": "SHIPPED",
+    "text": "**Best-effort.** The sandboxed television shells, Samsung and LG,",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 83
+  },
+  {
+    "id": "SURF-16",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 16,
+    "status": "AGREED",
+    "text": "A capability a best-effort surface's platform cannot express, such",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 86
+  },
+  {
+    "id": "SURF-17",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 17,
+    "status": "SHIPPED",
+    "text": "**The NAS package is not a surface.** It puts the *server* on a",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 89
+  },
+  {
+    "id": "SURF-18",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 18,
+    "status": "AGREED",
+    "text": "The matrix below is the record of what each surface must, may and may",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 97
+  },
+  {
+    "id": "SURF-19",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 19,
+    "status": "SHIPPED",
+    "text": "**Browser-backed surfaces**, web and the sandboxed television",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 123
+  },
+  {
+    "id": "SURF-20",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 20,
+    "status": "SHIPPED",
+    "text": "**Native surfaces**, mobile, desktop and the native television",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 127
+  },
+  {
+    "id": "SURF-21",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 21,
+    "status": "AGREED",
+    "text": "When a television's older decoder cannot play a file a modern phone",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 130
+  },
+  {
+    "id": "SURF-22",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 22,
+    "status": "AGREED",
+    "text": "KROMA never papers over a generation gap by silently transcoding for",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 133
+  },
+  {
+    "id": "SURF-23",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 23,
+    "status": "SHIPPED",
+    "text": "**Pointer**, on web and desktop, is the reference model: dense",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 148
+  },
+  {
+    "id": "SURF-24",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 24,
+    "status": "SHIPPED",
+    "text": "**Touch**, on mobile, means targets sized for a thumb, gestures for",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 151
+  },
+  {
+    "id": "SURF-25",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 25,
+    "status": "SHIPPED",
+    "text": "**Remote, 10-foot**, on every television, is a directional focus",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 154
+  },
+  {
+    "id": "SURF-26",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 26,
+    "status": "SHIPPED",
+    "text": "A television signs in through the pairing handshake precisely",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 157
+  },
+  {
+    "id": "SURF-27",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 27,
+    "status": "AGREED",
+    "text": "A television build that ships a pointer-shaped screen has not met",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 159
+  },
+  {
+    "id": "SURF-28",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 28,
+    "status": "AGREED",
+    "text": "A surface serving more than one model, such as a tablet with a",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 161
+  },
+  {
+    "id": "SURF-29",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 29,
+    "status": "SHIPPED",
+    "text": "**Only mobile is offline.** Web, desktop and every television hold no",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 168
+  },
+  {
+    "id": "SURF-30",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 30,
+    "status": "SHIPPED",
+    "text": "A download is a progressive file, the raw original when the device",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 175
+  },
+  {
+    "id": "SURF-31",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 31,
+    "status": "SHIPPED",
+    "text": "Downloads survive backgrounding and app kills, and are re-adopted",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 178
+  },
+  {
+    "id": "SURF-32",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 32,
+    "status": "SHIPPED",
+    "text": "Progress reports that could not be sent queue on the device and",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 180
+  },
+  {
+    "id": "SURF-33",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 33,
+    "status": "DESIGN, NOT IMPLEMENTED",
+    "text": "Per-title rows in the OS storage manager, deletable",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 188
+  },
+  {
+    "id": "SURF-34",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 34,
+    "status": "AGREED",
+    "text": "A surface stays current without asking a person to babysit it.",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 206
+  },
+  {
+    "id": "SURF-35",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 35,
+    "status": "SHIPPED",
+    "text": "**Web.** The server serves the web surface itself. There is no",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 208
+  },
+  {
+    "id": "SURF-36",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 36,
+    "status": "SHIPPED",
+    "text": "**Desktop.** The app checks for, fetches and applies updates in the",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 211
+  },
+  {
+    "id": "SURF-37",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 37,
+    "status": "AGREED",
+    "text": "**Mobile.** The app updates on the store's cadence, so a server",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 213
+  },
+  {
+    "id": "SURF-38",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 38,
+    "status": "AGREED",
+    "text": "**Televisions.** Each television updates through its own platform's",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 216
+  },
+  {
+    "id": "SURF-39",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 39,
+    "status": "SHIPPED",
+    "text": "**NAS.** The Synology package installs and updates through Package",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 218
+  },
+  {
+    "id": "SURF-40",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 40,
+    "status": "AGREED",
+    "text": "A surface is dropped when its host platform can no longer meet the",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 225
+  },
+  {
+    "id": "SURF-41",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 41,
+    "status": "AGREED",
+    "text": "**Notice first.** A surface entering deprecation tells its users *in",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 230
+  },
+  {
+    "id": "SURF-42",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 42,
+    "status": "AGREED",
+    "text": "**Sessions survive the app.** A deprecated surface's sessions are",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 233
+  },
+  {
+    "id": "SURF-43",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 43,
+    "status": "AGREED",
+    "text": "**The library outlives any surface.** Nothing about a person's",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 237
   }
 ]

--- a/docs/spec/requirements.json
+++ b/docs/spec/requirements.json
@@ -1210,6 +1210,336 @@
     "line": 136
   },
   {
+    "id": "DISC-1",
+    "domain": "DISC",
+    "space": "discovery",
+    "number": 1,
+    "status": "SHIPPED",
+    "text": "A client on the same network as a server is never told the server's",
+    "file": "docs/spec/discovery/README.md",
+    "line": 19
+  },
+  {
+    "id": "DISC-2",
+    "domain": "DISC",
+    "space": "discovery",
+    "number": 2,
+    "status": "SHIPPED",
+    "text": "On a private network the server sits inside, \"the same network\" means",
+    "file": "docs/spec/discovery/README.md",
+    "line": 29
+  },
+  {
+    "id": "DISC-3",
+    "domain": "DISC",
+    "space": "discovery",
+    "number": 3,
+    "status": "SHIPPED",
+    "text": "When the server is reached from outside, it means the *exact* same",
+    "file": "docs/spec/discovery/README.md",
+    "line": 31
+  },
+  {
+    "id": "DISC-4",
+    "domain": "DISC",
+    "space": "discovery",
+    "number": 4,
+    "status": "SHIPPED",
+    "text": "Over IPv6, it means the same delegated prefix: one home's allocation.",
+    "file": "docs/spec/discovery/README.md",
+    "line": 34
+  },
+  {
+    "id": "DISC-5",
+    "domain": "DISC",
+    "space": "discovery",
+    "number": 5,
+    "status": "SHIPPED",
+    "text": "A home this cannot place, split across subnets, dual-stack with the two",
+    "file": "docs/spec/discovery/README.md",
+    "line": 36
+  },
+  {
+    "id": "DISC-6",
+    "domain": "DISC",
+    "space": "discovery",
+    "number": 6,
+    "status": "SHIPPED",
+    "text": "Native mobile shells, iOS and Android, can *browse*: they find nearby",
+    "file": "docs/spec/discovery/README.md",
+    "line": 49
+  },
+  {
+    "id": "DISC-7",
+    "domain": "DISC",
+    "space": "discovery",
+    "number": 7,
+    "status": "SHIPPED",
+    "text": "Native TV shells, Apple TV and Android TV, and webOS can *announce*:",
+    "file": "docs/spec/discovery/README.md",
+    "line": 51
+  },
+  {
+    "id": "DISC-8",
+    "domain": "DISC",
+    "space": "discovery",
+    "number": 8,
+    "status": "SHIPPED",
+    "text": "Web, desktop and TV-web shells can do neither from the browser",
+    "file": "docs/spec/discovery/README.md",
+    "line": 56
+  },
+  {
+    "id": "DISC-9",
+    "domain": "DISC",
+    "space": "discovery",
+    "number": 9,
+    "status": "SHIPPED",
+    "text": "Tizen cannot announce at all, because its TV profile ships no way to.",
+    "file": "docs/spec/discovery/README.md",
+    "line": 59
+  },
+  {
+    "id": "DISC-10",
+    "domain": "DISC",
+    "space": "discovery",
+    "number": 10,
+    "status": "SHIPPED",
+    "text": "Browsing and announcing settle *reach*, whether two devices are near",
+    "file": "docs/spec/discovery/README.md",
+    "line": 63
+  },
+  {
+    "id": "DISC-11",
+    "domain": "DISC",
+    "space": "discovery",
+    "number": 11,
+    "status": "SHIPPED",
+    "text": "Every shell offers a manual path: a person can always type an address,",
+    "file": "docs/spec/discovery/README.md",
+    "line": 72
+  },
+  {
+    "id": "DISC-12",
+    "domain": "DISC",
+    "space": "discovery",
+    "number": 12,
+    "status": "SHIPPED",
+    "text": "Manual connection is the only supported path from *outside* the local",
+    "file": "docs/spec/discovery/README.md",
+    "line": 77
+  },
+  {
+    "id": "DISC-13",
+    "domain": "DISC",
+    "space": "discovery",
+    "number": 13,
+    "status": "SHIPPED",
+    "text": "Once an address is reachable, every sign-in road below works over it,",
+    "file": "docs/spec/discovery/README.md",
+    "line": 83
+  },
+  {
+    "id": "DISC-14",
+    "domain": "DISC",
+    "space": "discovery",
+    "number": 14,
+    "status": "SHIPPED",
+    "text": "All three roads end in the same place. The server holds a pending",
+    "file": "docs/spec/discovery/README.md",
+    "line": 94
+  },
+  {
+    "id": "DISC-15",
+    "domain": "DISC",
+    "space": "discovery",
+    "number": 15,
+    "status": "SHIPPED",
+    "text": "**Quick Connect is the floor.** The television prints a short code; the",
+    "file": "docs/spec/discovery/README.md",
+    "line": 99
+  },
+  {
+    "id": "DISC-16",
+    "domain": "DISC",
+    "space": "discovery",
+    "number": 16,
+    "status": "SHIPPED",
+    "text": "**Nearby handoff** is the shortcut for televisions the platform lets us",
+    "file": "docs/spec/discovery/README.md",
+    "line": 108
+  },
+  {
+    "id": "DISC-17",
+    "domain": "DISC",
+    "space": "discovery",
+    "number": 17,
+    "status": "SHIPPED",
+    "text": "**Confirmed handoff** covers the listed television a server cannot",
+    "file": "docs/spec/discovery/README.md",
+    "line": 112
+  },
+  {
+    "id": "DISC-18",
+    "domain": "DISC",
+    "space": "discovery",
+    "number": 18,
+    "status": "SHIPPED",
+    "text": "Discovery finding nothing is a normal state, not an error, and every",
+    "file": "docs/spec/discovery/README.md",
+    "line": 121
+  },
+  {
+    "id": "DISC-19",
+    "domain": "DISC",
+    "space": "discovery",
+    "number": 19,
+    "status": "SHIPPED",
+    "text": "A TV shell that can announce but not browse is *already* showing its",
+    "file": "docs/spec/discovery/README.md",
+    "line": 124
+  },
+  {
+    "id": "DISC-20",
+    "domain": "DISC",
+    "space": "discovery",
+    "number": 20,
+    "status": "SHIPPED",
+    "text": "A TV shell that cannot announce shows Quick Connect and, when it is",
+    "file": "docs/spec/discovery/README.md",
+    "line": 126
+  },
+  {
+    "id": "DISC-21",
+    "domain": "DISC",
+    "space": "discovery",
+    "number": 21,
+    "status": "SHIPPED",
+    "text": "A mobile shell that browses and sees an empty list offers, in that",
+    "file": "docs/spec/discovery/README.md",
+    "line": 129
+  },
+  {
+    "id": "DISC-22",
+    "domain": "DISC",
+    "space": "discovery",
+    "number": 22,
+    "status": "SHIPPED",
+    "text": "Web and desktop, which never browse, present the manual address field",
+    "file": "docs/spec/discovery/README.md",
+    "line": 132
+  },
+  {
+    "id": "DISC-23",
+    "domain": "DISC",
+    "space": "discovery",
+    "number": 23,
+    "status": "SHIPPED",
+    "text": "No shell ever traps a person on a road that failed. There is always a",
+    "file": "docs/spec/discovery/README.md",
+    "line": 135
+  },
+  {
+    "id": "DISC-24",
+    "domain": "DISC",
+    "space": "discovery",
+    "number": 24,
+    "status": "SHIPPED",
+    "text": "A Quick Connect or handoff code is valid for **five minutes**, because",
+    "file": "docs/spec/discovery/README.md",
+    "line": 142
+  },
+  {
+    "id": "DISC-25",
+    "domain": "DISC",
+    "space": "discovery",
+    "number": 25,
+    "status": "SHIPPED",
+    "text": "A code that expires mid-flow is replaced on the television by a clear",
+    "file": "docs/spec/discovery/README.md",
+    "line": 146
+  },
+  {
+    "id": "DISC-26",
+    "domain": "DISC",
+    "space": "discovery",
+    "number": 26,
+    "status": "SHIPPED",
+    "text": "A code already consumed by a successful sign-in vanishes rather than",
+    "file": "docs/spec/discovery/README.md",
+    "line": 150
+  },
+  {
+    "id": "DISC-27",
+    "domain": "DISC",
+    "space": "discovery",
+    "number": 27,
+    "status": "SHIPPED",
+    "text": "An expired code is visibly dead and one tap from being alive again,",
+    "file": "docs/spec/discovery/README.md",
+    "line": 153
+  },
+  {
+    "id": "DISC-28",
+    "domain": "DISC",
+    "space": "discovery",
+    "number": 28,
+    "status": "SHIPPED",
+    "text": "Approval is one-time. The moment an account approves a pairing, the",
+    "file": "docs/spec/discovery/README.md",
+    "line": 160
+  },
+  {
+    "id": "DISC-29",
+    "domain": "DISC",
+    "space": "discovery",
+    "number": 29,
+    "status": "SHIPPED",
+    "text": "A paired television is a *device*, not a second key to the account. It",
+    "file": "docs/spec/discovery/README.md",
+    "line": 165
+  },
+  {
+    "id": "DISC-30",
+    "domain": "DISC",
+    "space": "discovery",
+    "number": 30,
+    "status": "SHIPPED",
+    "text": "Revocation is symmetrical with every other device. The account sees the",
+    "file": "docs/spec/discovery/README.md",
+    "line": 169
+  },
+  {
+    "id": "DISC-31",
+    "domain": "DISC",
+    "space": "discovery",
+    "number": 31,
+    "status": "DESIGN, NOT IMPLEMENTED",
+    "text": "Samsung and LG televisions do not reach the deeper",
+    "file": "docs/spec/discovery/README.md",
+    "line": 177
+  },
+  {
+    "id": "DISC-32",
+    "domain": "DISC",
+    "space": "discovery",
+    "number": 32,
+    "status": "SHIPPED",
+    "text": "Native TV shells also *browse* for a server, so a television that was",
+    "file": "docs/spec/discovery/README.md",
+    "line": 53
+  },
+  {
+    "id": "DISC-33",
+    "domain": "DISC",
+    "space": "discovery",
+    "number": 33,
+    "status": "SHIPPED",
+    "text": "A client with a camera may read the code from the television's QR",
+    "file": "docs/spec/discovery/README.md",
+    "line": 104
+  },
+  {
     "id": "LIB-1",
     "domain": "LIB",
     "space": "library",
@@ -2685,9 +3015,9 @@
     "space": "surfaces",
     "number": 1,
     "status": "SHIPPED",
-    "text": "Every client KROMA ships is one of the surfaces named here, and each",
+    "text": "Every client KROMA ships is one of the surfaces named here. A client",
     "file": "docs/spec/surfaces/README.md",
-    "line": 20
+    "line": 21
   },
   {
     "id": "SURF-2",
@@ -2695,9 +3025,9 @@
     "space": "surfaces",
     "number": 2,
     "status": "AGREED",
-    "text": "A build that cannot do all six rungs below is a preview, not a",
+    "text": "A build that cannot do all six rungs below is a **preview**, not a",
     "file": "docs/spec/surfaces/README.md",
-    "line": 42
+    "line": 44
   },
   {
     "id": "SURF-3",
@@ -2707,7 +3037,7 @@
     "status": "SHIPPED",
     "text": "**Sign in or pair.** A surface reaches a server and becomes an",
     "file": "docs/spec/surfaces/README.md",
-    "line": 45
+    "line": 48
   },
   {
     "id": "SURF-4",
@@ -2717,7 +3047,7 @@
     "status": "SHIPPED",
     "text": "**Browse the library.** A surface moves through the titles the",
     "file": "docs/spec/surfaces/README.md",
-    "line": 49
+    "line": 52
   },
   {
     "id": "SURF-5",
@@ -2725,9 +3055,9 @@
     "space": "surfaces",
     "number": 5,
     "status": "SHIPPED",
-    "text": "**View a title.** A surface shows a title's artwork, its metadata,",
+    "text": "**View a title.** A surface shows a title's artwork, its metadata",
     "file": "docs/spec/surfaces/README.md",
-    "line": 51
+    "line": 54
   },
   {
     "id": "SURF-6",
@@ -2737,7 +3067,7 @@
     "status": "SHIPPED",
     "text": "**Start playback.** A surface plays the title, taking whatever rung",
     "file": "docs/spec/surfaces/README.md",
-    "line": 53
+    "line": 57
   },
   {
     "id": "SURF-7",
@@ -2747,7 +3077,7 @@
     "status": "SHIPPED",
     "text": "**Resume.** A surface reopens an in-progress title at the",
     "file": "docs/spec/surfaces/README.md",
-    "line": 55
+    "line": 59
   },
   {
     "id": "SURF-8",
@@ -2757,7 +3087,7 @@
     "status": "SHIPPED",
     "text": "**Sign out.** A surface ends the session and drops the server from",
     "file": "docs/spec/surfaces/README.md",
-    "line": 57
+    "line": 61
   },
   {
     "id": "SURF-9",
@@ -2765,19 +3095,19 @@
     "space": "surfaces",
     "number": 9,
     "status": "AGREED",
-    "text": "Everything past the six rungs is a *may*, not a *must*. A surface that",
+    "text": "Every capability past the six rungs is a *may*, not a *must*, and a",
     "file": "docs/spec/surfaces/README.md",
-    "line": 60
+    "line": 64
   },
   {
     "id": "SURF-10",
     "domain": "SURF",
     "space": "surfaces",
     "number": 10,
-    "status": "SHIPPED",
-    "text": "Web is the reference implementation. Where two surfaces disagree on",
+    "status": "AGREED",
+    "text": "Web is the reference implementation. Where two surfaces disagree on a",
     "file": "docs/spec/surfaces/README.md",
-    "line": 72
+    "line": 75
   },
   {
     "id": "SURF-11",
@@ -2785,9 +3115,9 @@
     "space": "surfaces",
     "number": 11,
     "status": "AGREED",
-    "text": "A feature is not shipped until web has it.",
+    "text": "A feature that belongs on more than one surface is not shipped until",
     "file": "docs/spec/surfaces/README.md",
-    "line": 76
+    "line": 78
   },
   {
     "id": "SURF-12",
@@ -2797,7 +3127,7 @@
     "status": "SHIPPED",
     "text": "**First-class.** Web, mobile, desktop and the native television",
     "file": "docs/spec/surfaces/README.md",
-    "line": 78
+    "line": 85
   },
   {
     "id": "SURF-13",
@@ -2807,7 +3137,7 @@
     "status": "AGREED",
     "text": "A baseline regression on a first-class surface blocks the release.",
     "file": "docs/spec/surfaces/README.md",
-    "line": 80
+    "line": 87
   },
   {
     "id": "SURF-14",
@@ -2817,7 +3147,7 @@
     "status": "AGREED",
     "text": "A first-class surface may diverge from web where its input model",
     "file": "docs/spec/surfaces/README.md",
-    "line": 81
+    "line": 88
   },
   {
     "id": "SURF-15",
@@ -2827,7 +3157,7 @@
     "status": "SHIPPED",
     "text": "**Best-effort.** The sandboxed television shells, Samsung and LG,",
     "file": "docs/spec/surfaces/README.md",
-    "line": 83
+    "line": 90
   },
   {
     "id": "SURF-16",
@@ -2837,7 +3167,7 @@
     "status": "AGREED",
     "text": "A capability a best-effort surface's platform cannot express, such",
     "file": "docs/spec/surfaces/README.md",
-    "line": 86
+    "line": 93
   },
   {
     "id": "SURF-17",
@@ -2847,17 +3177,17 @@
     "status": "SHIPPED",
     "text": "**The NAS package is not a surface.** It puts the *server* on a",
     "file": "docs/spec/surfaces/README.md",
-    "line": 89
+    "line": 98
   },
   {
     "id": "SURF-18",
     "domain": "SURF",
     "space": "surfaces",
     "number": 18,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "The matrix below is the record of what each surface must, may and may",
     "file": "docs/spec/surfaces/README.md",
-    "line": 97
+    "line": 106
   },
   {
     "id": "SURF-19",
@@ -2867,7 +3197,7 @@
     "status": "SHIPPED",
     "text": "**Browser-backed surfaces**, web and the sandboxed television",
     "file": "docs/spec/surfaces/README.md",
-    "line": 123
+    "line": 133
   },
   {
     "id": "SURF-20",
@@ -2877,7 +3207,7 @@
     "status": "SHIPPED",
     "text": "**Native surfaces**, mobile, desktop and the native television",
     "file": "docs/spec/surfaces/README.md",
-    "line": 127
+    "line": 137
   },
   {
     "id": "SURF-21",
@@ -2887,7 +3217,7 @@
     "status": "AGREED",
     "text": "When a television's older decoder cannot play a file a modern phone",
     "file": "docs/spec/surfaces/README.md",
-    "line": 130
+    "line": 140
   },
   {
     "id": "SURF-22",
@@ -2897,7 +3227,7 @@
     "status": "AGREED",
     "text": "KROMA never papers over a generation gap by silently transcoding for",
     "file": "docs/spec/surfaces/README.md",
-    "line": 133
+    "line": 143
   },
   {
     "id": "SURF-23",
@@ -2907,7 +3237,7 @@
     "status": "SHIPPED",
     "text": "**Pointer**, on web and desktop, is the reference model: dense",
     "file": "docs/spec/surfaces/README.md",
-    "line": 148
+    "line": 158
   },
   {
     "id": "SURF-24",
@@ -2917,7 +3247,7 @@
     "status": "SHIPPED",
     "text": "**Touch**, on mobile, means targets sized for a thumb, gestures for",
     "file": "docs/spec/surfaces/README.md",
-    "line": 151
+    "line": 161
   },
   {
     "id": "SURF-25",
@@ -2927,7 +3257,7 @@
     "status": "SHIPPED",
     "text": "**Remote, 10-foot**, on every television, is a directional focus",
     "file": "docs/spec/surfaces/README.md",
-    "line": 154
+    "line": 164
   },
   {
     "id": "SURF-26",
@@ -2937,7 +3267,7 @@
     "status": "SHIPPED",
     "text": "A television signs in through the pairing handshake precisely",
     "file": "docs/spec/surfaces/README.md",
-    "line": 157
+    "line": 167
   },
   {
     "id": "SURF-27",
@@ -2947,7 +3277,7 @@
     "status": "AGREED",
     "text": "A television build that ships a pointer-shaped screen has not met",
     "file": "docs/spec/surfaces/README.md",
-    "line": 159
+    "line": 169
   },
   {
     "id": "SURF-28",
@@ -2957,7 +3287,7 @@
     "status": "AGREED",
     "text": "A surface serving more than one model, such as a tablet with a",
     "file": "docs/spec/surfaces/README.md",
-    "line": 161
+    "line": 171
   },
   {
     "id": "SURF-29",
@@ -2967,7 +3297,7 @@
     "status": "SHIPPED",
     "text": "**Only mobile is offline.** Web, desktop and every television hold no",
     "file": "docs/spec/surfaces/README.md",
-    "line": 168
+    "line": 178
   },
   {
     "id": "SURF-30",
@@ -2975,9 +3305,9 @@
     "space": "surfaces",
     "number": 30,
     "status": "SHIPPED",
-    "text": "A download is a progressive file, the raw original when the device",
+    "text": "A downloaded title plays with no server connection.",
     "file": "docs/spec/surfaces/README.md",
-    "line": 175
+    "line": 185
   },
   {
     "id": "SURF-31",
@@ -2987,7 +3317,7 @@
     "status": "SHIPPED",
     "text": "Downloads survive backgrounding and app kills, and are re-adopted",
     "file": "docs/spec/surfaces/README.md",
-    "line": 178
+    "line": 189
   },
   {
     "id": "SURF-32",
@@ -2997,7 +3327,7 @@
     "status": "SHIPPED",
     "text": "Progress reports that could not be sent queue on the device and",
     "file": "docs/spec/surfaces/README.md",
-    "line": 180
+    "line": 191
   },
   {
     "id": "SURF-33",
@@ -3007,7 +3337,7 @@
     "status": "DESIGN, NOT IMPLEMENTED",
     "text": "Per-title rows in the OS storage manager, deletable",
     "file": "docs/spec/surfaces/README.md",
-    "line": 188
+    "line": 199
   },
   {
     "id": "SURF-34",
@@ -3017,7 +3347,7 @@
     "status": "AGREED",
     "text": "A surface stays current without asking a person to babysit it.",
     "file": "docs/spec/surfaces/README.md",
-    "line": 206
+    "line": 217
   },
   {
     "id": "SURF-35",
@@ -3027,7 +3357,7 @@
     "status": "SHIPPED",
     "text": "**Web.** The server serves the web surface itself. There is no",
     "file": "docs/spec/surfaces/README.md",
-    "line": 208
+    "line": 219
   },
   {
     "id": "SURF-36",
@@ -3037,7 +3367,7 @@
     "status": "SHIPPED",
     "text": "**Desktop.** The app checks for, fetches and applies updates in the",
     "file": "docs/spec/surfaces/README.md",
-    "line": 211
+    "line": 222
   },
   {
     "id": "SURF-37",
@@ -3047,7 +3377,7 @@
     "status": "AGREED",
     "text": "**Mobile.** The app updates on the store's cadence, so a server",
     "file": "docs/spec/surfaces/README.md",
-    "line": 213
+    "line": 224
   },
   {
     "id": "SURF-38",
@@ -3057,17 +3387,17 @@
     "status": "AGREED",
     "text": "**Televisions.** Each television updates through its own platform's",
     "file": "docs/spec/surfaces/README.md",
-    "line": 216
+    "line": 227
   },
   {
     "id": "SURF-39",
     "domain": "SURF",
     "space": "surfaces",
     "number": 39,
-    "status": "SHIPPED",
+    "status": "AGREED",
     "text": "**NAS.** The Synology package installs and updates through Package",
     "file": "docs/spec/surfaces/README.md",
-    "line": 218
+    "line": 229
   },
   {
     "id": "SURF-40",
@@ -3077,7 +3407,7 @@
     "status": "AGREED",
     "text": "A surface is dropped when its host platform can no longer meet the",
     "file": "docs/spec/surfaces/README.md",
-    "line": 225
+    "line": 238
   },
   {
     "id": "SURF-41",
@@ -3087,7 +3417,7 @@
     "status": "AGREED",
     "text": "**Notice first.** A surface entering deprecation tells its users *in",
     "file": "docs/spec/surfaces/README.md",
-    "line": 230
+    "line": 243
   },
   {
     "id": "SURF-42",
@@ -3097,7 +3427,7 @@
     "status": "AGREED",
     "text": "**Sessions survive the app.** A deprecated surface's sessions are",
     "file": "docs/spec/surfaces/README.md",
-    "line": 233
+    "line": 246
   },
   {
     "id": "SURF-43",
@@ -3107,6 +3437,56 @@
     "status": "AGREED",
     "text": "**The library outlives any surface.** Nothing about a person's",
     "file": "docs/spec/surfaces/README.md",
-    "line": 237
+    "line": 250
+  },
+  {
+    "id": "SURF-44",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 44,
+    "status": "AGREED",
+    "text": "Web is where the baseline is defined, so web is first-class by",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 82
+  },
+  {
+    "id": "SURF-45",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 45,
+    "status": "AGREED",
+    "text": "A best-effort surface ships when its platform allows and may lag the",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 96
+  },
+  {
+    "id": "SURF-46",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 46,
+    "status": "AGREED",
+    "text": "KROMA never claims a panel decodes a codec its generation predates.",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 145
+  },
+  {
+    "id": "SURF-47",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 47,
+    "status": "SHIPPED",
+    "text": "The input model is the one thing a surface may *not* copy from web,",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 154
+  },
+  {
+    "id": "SURF-48",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 48,
+    "status": "SHIPPED",
+    "text": "A download is a single progressive file: the raw original when the",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 186
   }
 ]

--- a/docs/spec/requirements.json
+++ b/docs/spec/requirements.json
@@ -880,6 +880,956 @@
     "line": 136
   },
   {
+    "id": "LIB-1",
+    "domain": "LIB",
+    "space": "library",
+    "number": 1,
+    "status": "AGREED",
+    "text": "A **source** is a directory tree the server is told to watch, tagged",
+    "file": "docs/spec/library/README.md",
+    "line": 15
+  },
+  {
+    "id": "LIB-2",
+    "domain": "LIB",
+    "space": "library",
+    "number": 2,
+    "status": "AGREED",
+    "text": "A movie source never produces episodes and a show source never produces",
+    "file": "docs/spec/library/README.md",
+    "line": 19
+  },
+  {
+    "id": "LIB-3",
+    "domain": "LIB",
+    "space": "library",
+    "number": 3,
+    "status": "AGREED",
+    "text": "A server has zero or more sources, any number of them may point at the",
+    "file": "docs/spec/library/README.md",
+    "line": 22
+  },
+  {
+    "id": "LIB-4",
+    "domain": "LIB",
+    "space": "library",
+    "number": 4,
+    "status": "AGREED",
+    "text": "A source is an input, not a category a person browses by. Filtering the",
+    "file": "docs/spec/library/README.md",
+    "line": 27
+  },
+  {
+    "id": "LIB-5",
+    "domain": "LIB",
+    "space": "library",
+    "number": 5,
+    "status": "SHIPPED",
+    "text": "A source tree may be assembled from symlinks. A curated folder of links",
+    "file": "docs/spec/library/README.md",
+    "line": 30
+  },
+  {
+    "id": "LIB-6",
+    "domain": "LIB",
+    "space": "library",
+    "number": 6,
+    "status": "SHIPPED",
+    "text": "A link the server cannot resolve is reported, never silently skipped,",
+    "file": "docs/spec/library/README.md",
+    "line": 34
+  },
+  {
+    "id": "LIB-7",
+    "domain": "LIB",
+    "space": "library",
+    "number": 7,
+    "status": "AGREED",
+    "text": "A source records its mount path, its content kind and its scan schedule.",
+    "file": "docs/spec/library/README.md",
+    "line": 38
+  },
+  {
+    "id": "LIB-8",
+    "domain": "LIB",
+    "space": "library",
+    "number": 8,
+    "status": "AGREED",
+    "text": "Nothing about a source is destructive. Removing one drops its titles",
+    "file": "docs/spec/library/README.md",
+    "line": 40
+  },
+  {
+    "id": "LIB-9",
+    "domain": "LIB",
+    "space": "library",
+    "number": 9,
+    "status": "AGREED",
+    "text": "Matching is convention-first: a correctly named file matches offline,",
+    "file": "docs/spec/library/README.md",
+    "line": 49
+  },
+  {
+    "id": "LIB-10",
+    "domain": "LIB",
+    "space": "library",
+    "number": 10,
+    "status": "SHIPPED",
+    "text": "The `Title (Year)` stem is what is matched. The year is not",
+    "file": "docs/spec/library/README.md",
+    "line": 60
+  },
+  {
+    "id": "LIB-11",
+    "domain": "LIB",
+    "space": "library",
+    "number": 11,
+    "status": "SHIPPED",
+    "text": "A trailing tag after ` - `, a resolution, an edition or a source, is",
+    "file": "docs/spec/library/README.md",
+    "line": 64
+  },
+  {
+    "id": "LIB-12",
+    "domain": "LIB",
+    "space": "library",
+    "number": 12,
+    "status": "SHIPPED",
+    "text": "A loose file directly under the source root, with no folder, is",
+    "file": "docs/spec/library/README.md",
+    "line": 68
+  },
+  {
+    "id": "LIB-13",
+    "domain": "LIB",
+    "space": "library",
+    "number": 13,
+    "status": "SHIPPED",
+    "text": "A season folder is what makes the folder above it the show. With one",
+    "file": "docs/spec/library/README.md",
+    "line": 80
+  },
+  {
+    "id": "LIB-14",
+    "domain": "LIB",
+    "space": "library",
+    "number": 14,
+    "status": "SHIPPED",
+    "text": "Without a season folder the folder proves nothing, because a flat pool",
+    "file": "docs/spec/library/README.md",
+    "line": 84
+  },
+  {
+    "id": "LIB-15",
+    "domain": "LIB",
+    "space": "library",
+    "number": 15,
+    "status": "SHIPPED",
+    "text": "An episode whose filename is only its marker (`S01E01.mkv`) takes the",
+    "file": "docs/spec/library/README.md",
+    "line": 87
+  },
+  {
+    "id": "LIB-16",
+    "domain": "LIB",
+    "space": "library",
+    "number": 16,
+    "status": "SHIPPED",
+    "text": "The show folder name and the `SxxEyy` marker are load-bearing; the",
+    "file": "docs/spec/library/README.md",
+    "line": 91
+  },
+  {
+    "id": "LIB-17",
+    "domain": "LIB",
+    "space": "library",
+    "number": 17,
+    "status": "SHIPPED",
+    "text": "`Specials` is accepted as an alias for `Season 00`.",
+    "file": "docs/spec/library/README.md",
+    "line": 94
+  },
+  {
+    "id": "LIB-18",
+    "domain": "LIB",
+    "space": "library",
+    "number": 18,
+    "status": "SHIPPED",
+    "text": "A multi-episode file is named with a range (`S01E01-E02`) and matched",
+    "file": "docs/spec/library/README.md",
+    "line": 96
+  },
+  {
+    "id": "LIB-19",
+    "domain": "LIB",
+    "space": "library",
+    "number": 19,
+    "status": "AGREED",
+    "text": "A show folder MAY carry a `(Year)` for disambiguation",
+    "file": "docs/spec/library/README.md",
+    "line": 99
+  },
+  {
+    "id": "LIB-20",
+    "domain": "LIB",
+    "space": "library",
+    "number": 20,
+    "status": "SHIPPED",
+    "text": "Case is ignored, and separators may be spaces, dots or underscores.",
+    "file": "docs/spec/library/README.md",
+    "line": 102
+  },
+  {
+    "id": "LIB-21",
+    "domain": "LIB",
+    "space": "library",
+    "number": 21,
+    "status": "SHIPPED",
+    "text": "Only recognised video containers are considered files to match.",
+    "file": "docs/spec/library/README.md",
+    "line": 104
+  },
+  {
+    "id": "LIB-22",
+    "domain": "LIB",
+    "space": "library",
+    "number": 22,
+    "status": "AGREED",
+    "text": "The scheme is a convention rather than configuration, so a library is",
+    "file": "docs/spec/library/README.md",
+    "line": 108
+  },
+  {
+    "id": "LIB-23",
+    "domain": "LIB",
+    "space": "library",
+    "number": 23,
+    "status": "SHIPPED",
+    "text": "An **initial scan** runs when a source is added: the whole tree is",
+    "file": "docs/spec/library/README.md",
+    "line": 117
+  },
+  {
+    "id": "LIB-24",
+    "domain": "LIB",
+    "space": "library",
+    "number": 24,
+    "status": "AGREED",
+    "text": "An **incremental rescan** keeps the catalogue true to disk afterwards.",
+    "file": "docs/spec/library/README.md",
+    "line": 122
+  },
+  {
+    "id": "LIB-25",
+    "domain": "LIB",
+    "space": "library",
+    "number": 25,
+    "status": "AGREED",
+    "text": "An incremental rescan only reconsiders what changed, meaning new paths,",
+    "file": "docs/spec/library/README.md",
+    "line": 128
+  },
+  {
+    "id": "LIB-26",
+    "domain": "LIB",
+    "space": "library",
+    "number": 26,
+    "status": "AGREED",
+    "text": "Scanning is safe to run at any time, including while files are being",
+    "file": "docs/spec/library/README.md",
+    "line": 132
+  },
+  {
+    "id": "LIB-27",
+    "domain": "LIB",
+    "space": "library",
+    "number": 27,
+    "status": "AGREED",
+    "text": "A file is matched only once it looks **settled**, its size and",
+    "file": "docs/spec/library/README.md",
+    "line": 135
+  },
+  {
+    "id": "LIB-28",
+    "domain": "LIB",
+    "space": "library",
+    "number": 28,
+    "status": "SHIPPED",
+    "text": "Scanning **reads only**. It never writes, moves, renames or deletes",
+    "file": "docs/spec/library/README.md",
+    "line": 140
+  },
+  {
+    "id": "LIB-29",
+    "domain": "LIB",
+    "space": "library",
+    "number": 29,
+    "status": "AGREED",
+    "text": "KROMA never demands exclusive access to a library and never blocks the",
+    "file": "docs/spec/library/README.md",
+    "line": 143
+  },
+  {
+    "id": "LIB-30",
+    "domain": "LIB",
+    "space": "library",
+    "number": 30,
+    "status": "AGREED",
+    "text": "Matching resolves a settled file to an identity: a convention parse",
+    "file": "docs/spec/library/README.md",
+    "line": 158
+  },
+  {
+    "id": "LIB-31",
+    "domain": "LIB",
+    "space": "library",
+    "number": 31,
+    "status": "AGREED",
+    "text": "A file that parses to no confident identity, whether from an",
+    "file": "docs/spec/library/README.md",
+    "line": 164
+  },
+  {
+    "id": "LIB-32",
+    "domain": "LIB",
+    "space": "library",
+    "number": 32,
+    "status": "AGREED",
+    "text": "Unmatched items appear in a browsable **Unmatched** view in the library",
+    "file": "docs/spec/library/README.md",
+    "line": 169
+  },
+  {
+    "id": "LIB-33",
+    "domain": "LIB",
+    "space": "library",
+    "number": 33,
+    "status": "AGREED",
+    "text": "**Manual match.** A person searches the provider, picks the correct",
+    "file": "docs/spec/library/README.md",
+    "line": 173
+  },
+  {
+    "id": "LIB-34",
+    "domain": "LIB",
+    "space": "library",
+    "number": 34,
+    "status": "AGREED",
+    "text": "**Rename on disk.** A name fixed to the convention above matches",
+    "file": "docs/spec/library/README.md",
+    "line": 177
+  },
+  {
+    "id": "LIB-35",
+    "domain": "LIB",
+    "space": "library",
+    "number": 35,
+    "status": "AGREED",
+    "text": "A file that could be more than one identity, a title shared by a remake",
+    "file": "docs/spec/library/README.md",
+    "line": 183
+  },
+  {
+    "id": "LIB-36",
+    "domain": "LIB",
+    "space": "library",
+    "number": 36,
+    "status": "AGREED",
+    "text": "One unplaceable file never stalls a source. The catalogue is always the",
+    "file": "docs/spec/library/README.md",
+    "line": 189
+  },
+  {
+    "id": "LIB-37",
+    "domain": "LIB",
+    "space": "library",
+    "number": 37,
+    "status": "AGREED",
+    "text": "Every field and image a provider returns is written to the server's own",
+    "file": "docs/spec/library/README.md",
+    "line": 199
+  },
+  {
+    "id": "LIB-38",
+    "domain": "LIB",
+    "space": "library",
+    "number": 38,
+    "status": "AGREED",
+    "text": "With no internet, everything already matched browses and plays exactly",
+    "file": "docs/spec/library/README.md",
+    "line": 204
+  },
+  {
+    "id": "LIB-39",
+    "domain": "LIB",
+    "space": "library",
+    "number": 39,
+    "status": "AGREED",
+    "text": "Offline, a brand-new file that needs a first provider lookup stays",
+    "file": "docs/spec/library/README.md",
+    "line": 207
+  },
+  {
+    "id": "LIB-40",
+    "domain": "LIB",
+    "space": "library",
+    "number": 40,
+    "status": "AGREED",
+    "text": "Offline, a forced refresh queues rather than fails.",
+    "file": "docs/spec/library/README.md",
+    "line": 211
+  },
+  {
+    "id": "LIB-41",
+    "domain": "LIB",
+    "space": "library",
+    "number": 41,
+    "status": "DRAFT",
+    "text": "A newly matched item fetches its metadata once.",
+    "file": "docs/spec/library/README.md",
+    "line": 220
+  },
+  {
+    "id": "LIB-42",
+    "domain": "LIB",
+    "space": "library",
+    "number": 42,
+    "status": "DRAFT",
+    "text": "Running series are re-checked on a slow cadence, so a new episode's air",
+    "file": "docs/spec/library/README.md",
+    "line": 222
+  },
+  {
+    "id": "LIB-43",
+    "domain": "LIB",
+    "space": "library",
+    "number": 43,
+    "status": "DRAFT",
+    "text": "A \"Refresh metadata\" action on any title, season or whole source",
+    "file": "docs/spec/library/README.md",
+    "line": 226
+  },
+  {
+    "id": "LIB-44",
+    "domain": "LIB",
+    "space": "library",
+    "number": 44,
+    "status": "DRAFT",
+    "text": "A forced refresh **never** discards a manual match or user-chosen",
+    "file": "docs/spec/library/README.md",
+    "line": 230
+  },
+  {
+    "id": "LIB-45",
+    "domain": "LIB",
+    "space": "library",
+    "number": 45,
+    "status": "AGREED",
+    "text": "When a file disappears from a source, its title is **marked absent**:",
+    "file": "docs/spec/library/README.md",
+    "line": 247
+  },
+  {
+    "id": "LIB-46",
+    "domain": "LIB",
+    "space": "library",
+    "number": 46,
+    "status": "AGREED",
+    "text": "Content that reappears, because a NAS remounts or a file is moved back",
+    "file": "docs/spec/library/README.md",
+    "line": 252
+  },
+  {
+    "id": "LIB-47",
+    "domain": "LIB",
+    "space": "library",
+    "number": 47,
+    "status": "AGREED",
+    "text": "A **move** is therefore not a special case. It is an absent path plus a",
+    "file": "docs/spec/library/README.md",
+    "line": 256
+  },
+  {
+    "id": "LIB-48",
+    "domain": "LIB",
+    "space": "library",
+    "number": 48,
+    "status": "AGREED",
+    "text": "A rescan **only ever marks absent**. It never deletes user data.",
+    "file": "docs/spec/library/README.md",
+    "line": 260
+  },
+  {
+    "id": "LIB-49",
+    "domain": "LIB",
+    "space": "library",
+    "number": 49,
+    "status": "AGREED",
+    "text": "Permanently deleting a title's history is an explicit, person-initiated",
+    "file": "docs/spec/library/README.md",
+    "line": 262
+  },
+  {
+    "id": "MEDIA-1",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 1,
+    "status": "AGREED",
+    "text": "**Title.** The work a person searches for: a film, or one episode",
+    "file": "docs/spec/media/README.md",
+    "line": 21
+  },
+  {
+    "id": "MEDIA-2",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 2,
+    "status": "AGREED",
+    "text": "**Edition.** A named cut of a title: theatrical, director's,",
+    "file": "docs/spec/media/README.md",
+    "line": 24
+  },
+  {
+    "id": "MEDIA-3",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 3,
+    "status": "AGREED",
+    "text": "**Media file.** One physical file on disk that realises an edition",
+    "file": "docs/spec/media/README.md",
+    "line": 27
+  },
+  {
+    "id": "MEDIA-4",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 4,
+    "status": "AGREED",
+    "text": "**Stream.** One track inside a media file, exactly one of video,",
+    "file": "docs/spec/media/README.md",
+    "line": 30
+  },
+  {
+    "id": "MEDIA-5",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 5,
+    "status": "AGREED",
+    "text": "**Stream properties.** The describable facts about a stream: codec,",
+    "file": "docs/spec/media/README.md",
+    "line": 33
+  },
+  {
+    "id": "MEDIA-6",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 6,
+    "status": "AGREED",
+    "text": "The nesting is strict and total: every stream belongs to exactly one",
+    "file": "docs/spec/media/README.md",
+    "line": 37
+  },
+  {
+    "id": "MEDIA-7",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 7,
+    "status": "AGREED",
+    "text": "A 1080p file and a 4K file of the same cut are **two media files of",
+    "file": "docs/spec/media/README.md",
+    "line": 45
+  },
+  {
+    "id": "MEDIA-8",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 8,
+    "status": "AGREED",
+    "text": "KROMA ranks a title's media files and keeps a **preferred** one.",
+    "file": "docs/spec/media/README.md",
+    "line": 49
+  },
+  {
+    "id": "MEDIA-9",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 9,
+    "status": "AGREED",
+    "text": "The preference is a *default*, not a lock. The model enumerates a",
+    "file": "docs/spec/media/README.md",
+    "line": 52
+  },
+  {
+    "id": "MEDIA-10",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 10,
+    "status": "AGREED",
+    "text": "Editions are surfaced to the person, because they are different",
+    "file": "docs/spec/media/README.md",
+    "line": 56
+  },
+  {
+    "id": "MEDIA-11",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 11,
+    "status": "AGREED",
+    "text": "First-class means KROMA fully describes the format, preserves it end",
+    "file": "docs/spec/media/README.md",
+    "line": 64
+  },
+  {
+    "id": "MEDIA-12",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 12,
+    "status": "AGREED",
+    "text": "The first-class containers are **MP4**, **MKV** and **WebM**.",
+    "file": "docs/spec/media/README.md",
+    "line": 68
+  },
+  {
+    "id": "MEDIA-13",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 13,
+    "status": "AGREED",
+    "text": "**HEVC / H.265** is the priority codec. 8-bit and 10-bit, SDR and",
+    "file": "docs/spec/media/README.md",
+    "line": 72
+  },
+  {
+    "id": "MEDIA-14",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 14,
+    "status": "AGREED",
+    "text": "**H.264 / AVC** is the universal floor, assumed playable",
+    "file": "docs/spec/media/README.md",
+    "line": 74
+  },
+  {
+    "id": "MEDIA-15",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 15,
+    "status": "AGREED",
+    "text": "**AV1** is first-class media truth whatever the client generation,",
+    "file": "docs/spec/media/README.md",
+    "line": 76
+  },
+  {
+    "id": "MEDIA-16",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 16,
+    "status": "AGREED",
+    "text": "**VP9** is first-class within WebM, chiefly for the browser",
+    "file": "docs/spec/media/README.md",
+    "line": 78
+  },
+  {
+    "id": "MEDIA-17",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 17,
+    "status": "AGREED",
+    "text": "A codec being first-class states how *KROMA* handles it, never that a",
+    "file": "docs/spec/media/README.md",
+    "line": 81
+  },
+  {
+    "id": "MEDIA-18",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 18,
+    "status": "AGREED",
+    "text": "HDR is preserved end to end or it is not offered. KROMA never",
+    "file": "docs/spec/media/README.md",
+    "line": 90
+  },
+  {
+    "id": "MEDIA-19",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 19,
+    "status": "AGREED",
+    "text": "**Bit depth.** 8-bit and 10-bit are first-class, and 10-bit is",
+    "file": "docs/spec/media/README.md",
+    "line": 94
+  },
+  {
+    "id": "MEDIA-20",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 20,
+    "status": "AGREED",
+    "text": "KROMA distinguishes **HDR10**, **HDR10+**, **Dolby Vision** and",
+    "file": "docs/spec/media/README.md",
+    "line": 96
+  },
+  {
+    "id": "MEDIA-21",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 21,
+    "status": "AGREED",
+    "text": "Colour primaries, transfer characteristics and matrix coefficients",
+    "file": "docs/spec/media/README.md",
+    "line": 100
+  },
+  {
+    "id": "MEDIA-22",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 22,
+    "status": "AGREED",
+    "text": "Where dynamic metadata, HDR10+ or Dolby Vision, cannot be carried",
+    "file": "docs/spec/media/README.md",
+    "line": 103
+  },
+  {
+    "id": "MEDIA-23",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 23,
+    "status": "AGREED",
+    "text": "The first-class audio codecs are **AAC**, **AC-3** and **E-AC-3**",
+    "file": "docs/spec/media/README.md",
+    "line": 111
+  },
+  {
+    "id": "MEDIA-24",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 24,
+    "status": "AGREED",
+    "text": "An audio stream's **channel layout**, stereo, 5.1, 7.1 or Atmos",
+    "file": "docs/spec/media/README.md",
+    "line": 114
+  },
+  {
+    "id": "MEDIA-25",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 25,
+    "status": "AGREED",
+    "text": "**Passthrough** is the default for multichannel and lossless audio:",
+    "file": "docs/spec/media/README.md",
+    "line": 117
+  },
+  {
+    "id": "MEDIA-26",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 26,
+    "status": "AGREED",
+    "text": "**Downmixing** to stereo happens only when the target cannot render",
+    "file": "docs/spec/media/README.md",
+    "line": 120
+  },
+  {
+    "id": "MEDIA-27",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 27,
+    "status": "AGREED",
+    "text": "Multiple audio streams, languages and commentary alike, are all",
+    "file": "docs/spec/media/README.md",
+    "line": 124
+  },
+  {
+    "id": "MEDIA-28",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 28,
+    "status": "AGREED",
+    "text": "A subtitle stream is either **embedded**, a track inside the media",
+    "file": "docs/spec/media/README.md",
+    "line": 132
+  },
+  {
+    "id": "MEDIA-29",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 29,
+    "status": "AGREED",
+    "text": "The first-class subtitle formats are **SRT**, **WebVTT** and",
+    "file": "docs/spec/media/README.md",
+    "line": 136
+  },
+  {
+    "id": "MEDIA-30",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 30,
+    "status": "AGREED",
+    "text": "The **forced** disposition, only the foreign-language lines a",
+    "file": "docs/spec/media/README.md",
+    "line": 140
+  },
+  {
+    "id": "MEDIA-31",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 31,
+    "status": "AGREED",
+    "text": "**Burning in**, rendering a subtitle permanently into the video, is",
+    "file": "docs/spec/media/README.md",
+    "line": 143
+  },
+  {
+    "id": "MEDIA-32",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 32,
+    "status": "AGREED",
+    "text": "Every title carries a **poster**, a **backdrop**, a **logo** and, per",
+    "file": "docs/spec/media/README.md",
+    "line": 153
+  },
+  {
+    "id": "MEDIA-33",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 33,
+    "status": "AGREED",
+    "text": "Image sources rank by trust: embedded in the media file, then a",
+    "file": "docs/spec/media/README.md",
+    "line": 156
+  },
+  {
+    "id": "MEDIA-34",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 34,
+    "status": "AGREED",
+    "text": "KROMA derives a fixed set of sizes per image, a small grid",
+    "file": "docs/spec/media/README.md",
+    "line": 159
+  },
+  {
+    "id": "MEDIA-35",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 35,
+    "status": "AGREED",
+    "text": "Derived sizes are cached and served without re-deriving, and a",
+    "file": "docs/spec/media/README.md",
+    "line": 162
+  },
+  {
+    "id": "MEDIA-36",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 36,
+    "status": "AGREED",
+    "text": "Artwork is never a reason a title fails to appear. A title with no",
+    "file": "docs/spec/media/README.md",
+    "line": 164
+  },
+  {
+    "id": "MEDIA-37",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 37,
+    "status": "AGREED",
+    "text": "KROMA learns a file's streams by **probing** it once, when the",
+    "file": "docs/spec/media/README.md",
+    "line": 171
+  },
+  {
+    "id": "MEDIA-38",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 38,
+    "status": "AGREED",
+    "text": "A probe is the authoritative stream truth until the file's bytes",
+    "file": "docs/spec/media/README.md",
+    "line": 175
+  },
+  {
+    "id": "MEDIA-39",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 39,
+    "status": "AGREED",
+    "text": "When a direct play fails in a way that implicates the stream",
+    "file": "docs/spec/media/README.md",
+    "line": 178
+  },
+  {
+    "id": "MEDIA-40",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 40,
+    "status": "AGREED",
+    "text": "Trust is per-file and durable: a corrected probe is written back,",
+    "file": "docs/spec/media/README.md",
+    "line": 183
+  },
+  {
+    "id": "MEDIA-41",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 41,
+    "status": "AGREED",
+    "text": "A file whose container opens and whose streams enumerate, but which",
+    "file": "docs/spec/media/README.md",
+    "line": 190
+  },
+  {
+    "id": "MEDIA-42",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 42,
+    "status": "AGREED",
+    "text": "The title **appears** in the library with whatever *is* known. A",
+    "file": "docs/spec/media/README.md",
+    "line": 194
+  },
+  {
+    "id": "MEDIA-43",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 43,
+    "status": "AGREED",
+    "text": "The unknown stream is marked **undescribed** and carries its raw",
+    "file": "docs/spec/media/README.md",
+    "line": 197
+  },
+  {
+    "id": "MEDIA-44",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 44,
+    "status": "AGREED",
+    "text": "An undescribed stream is *not direct-playable*, because KROMA will",
+    "file": "docs/spec/media/README.md",
+    "line": 199
+  },
+  {
+    "id": "MEDIA-45",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 45,
+    "status": "AGREED",
+    "text": "A file that will not open at all, a truncated or corrupt container,",
+    "file": "docs/spec/media/README.md",
+    "line": 202
+  },
+  {
+    "id": "MEDIA-46",
+    "domain": "MEDIA",
+    "space": "media",
+    "number": 46,
+    "status": "AGREED",
+    "text": "Undescribed and unreadable are distinct states. The first is \"we",
+    "file": "docs/spec/media/README.md",
+    "line": 205
+  },
+  {
     "id": "SURF-1",
     "domain": "SURF",
     "space": "surfaces",

--- a/docs/spec/requirements.json
+++ b/docs/spec/requirements.json
@@ -1117,7 +1117,7 @@
     "status": "AGREED",
     "text": "A reset is a single-use, time-limited link plus a short one-time",
     "file": "docs/spec/admin/README.md",
-    "line": 110
+    "line": 112
   },
   {
     "id": "ADMIN-80",
@@ -1127,7 +1127,7 @@
     "status": "AGREED",
     "text": "The code is eight characters from a thirty-two-symbol alphabet with",
     "file": "docs/spec/admin/README.md",
-    "line": 116
+    "line": 118
   },
   {
     "id": "ADMIN-81",
@@ -1137,7 +1137,7 @@
     "status": "AGREED",
     "text": "A new reset invalidates any unused previous one for the same account.",
     "file": "docs/spec/admin/README.md",
-    "line": 120
+    "line": 122
   },
   {
     "id": "ADMIN-82",
@@ -1147,7 +1147,7 @@
     "status": "AGREED",
     "text": "Delivery is the owner's choice, per server: copy the link and code",
     "file": "docs/spec/admin/README.md",
-    "line": 124
+    "line": 126
   },
   {
     "id": "ADMIN-83",
@@ -1157,7 +1157,7 @@
     "status": "AGREED",
     "text": "The kroma.tv relay sees the destination address and the link, never",
     "file": "docs/spec/admin/README.md",
-    "line": 132
+    "line": 134
   },
   {
     "id": "ADMIN-84",
@@ -1167,7 +1167,7 @@
     "status": "AGREED",
     "text": "The owner can clear a user's profile PIN. Clearing is the only PIN",
     "file": "docs/spec/admin/README.md",
-    "line": 147
+    "line": 149
   },
   {
     "id": "ADMIN-85",
@@ -1177,7 +1177,7 @@
     "status": "AGREED",
     "text": "An address on an account is unverified until the mailbox proves",
     "file": "docs/spec/admin/README.md",
-    "line": 157
+    "line": 159
   },
   {
     "id": "ADMIN-86",
@@ -1187,7 +1187,7 @@
     "status": "AGREED",
     "text": "The owner sends a verification from the member editor, with the",
     "file": "docs/spec/admin/README.md",
-    "line": 162
+    "line": 164
   },
   {
     "id": "ADMIN-87",
@@ -1197,7 +1197,7 @@
     "status": "AGREED",
     "text": "Changing the address clears the verified state: the proof belongs",
     "file": "docs/spec/admin/README.md",
-    "line": 167
+    "line": 169
   },
   {
     "id": "ADMIN-88",
@@ -1207,7 +1207,7 @@
     "status": "AGREED",
     "text": "A user who cannot sign in can ask for a reset from the sign-in",
     "file": "docs/spec/admin/README.md",
-    "line": 136
+    "line": 138
   },
   {
     "id": "DISC-1",
@@ -2488,6 +2488,476 @@
     "text": "Undescribed and unreadable are distinct states. The first is \"we",
     "file": "docs/spec/media/README.md",
     "line": 205
+  },
+  {
+    "id": "MOD-1",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 1,
+    "status": "SHIPPED",
+    "text": "The base build ships **zero modules**. Everything past playback and",
+    "file": "docs/spec/modules/README.md",
+    "line": 9
+  },
+  {
+    "id": "MOD-2",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 2,
+    "status": "SHIPPED",
+    "text": "A module is a self-contained capability with a reverse-DNS id",
+    "file": "docs/spec/modules/README.md",
+    "line": 33
+  },
+  {
+    "id": "MOD-3",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 3,
+    "status": "SHIPPED",
+    "text": "Within its own process a module has wide latitude: it registers",
+    "file": "docs/spec/modules/README.md",
+    "line": 37
+  },
+  {
+    "id": "MOD-4",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 4,
+    "status": "SHIPPED",
+    "text": "A database is a **declared capability**, not something every module",
+    "file": "docs/spec/modules/README.md",
+    "line": 40
+  },
+  {
+    "id": "MOD-5",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 5,
+    "status": "SHIPPED",
+    "text": "It may not reach into the server's process or another module's",
+    "file": "docs/spec/modules/README.md",
+    "line": 46
+  },
+  {
+    "id": "MOD-6",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 6,
+    "status": "SHIPPED",
+    "text": "It may not replace core. Playback, catalogue, accounts and the",
+    "file": "docs/spec/modules/README.md",
+    "line": 50
+  },
+  {
+    "id": "MOD-7",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 7,
+    "status": "SHIPPED",
+    "text": "It may not claim a first-party module id it does not own.",
+    "file": "docs/spec/modules/README.md",
+    "line": 53
+  },
+  {
+    "id": "MOD-8",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 8,
+    "status": "SHIPPED",
+    "text": "It may not assume it is present. Because any module is uninstallable,",
+    "file": "docs/spec/modules/README.md",
+    "line": 54
+  },
+  {
+    "id": "MOD-9",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 9,
+    "status": "SHIPPED",
+    "text": "A module *may* depend on another module, hard or optional, and that",
+    "file": "docs/spec/modules/README.md",
+    "line": 58
+  },
+  {
+    "id": "MOD-10",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 10,
+    "status": "SHIPPED",
+    "text": "A module ships as a single `.kmod` file: a manifest, the native",
+    "file": "docs/spec/modules/README.md",
+    "line": 65
+  },
+  {
+    "id": "MOD-11",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 11,
+    "status": "SHIPPED",
+    "text": "**Identity and version.** The reverse-DNS id and a hand-set version.",
+    "file": "docs/spec/modules/README.md",
+    "line": 71
+  },
+  {
+    "id": "MOD-12",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 12,
+    "status": "SHIPPED",
+    "text": "The release process refuses to publish changed bytes under an",
+    "file": "docs/spec/modules/README.md",
+    "line": 73
+  },
+  {
+    "id": "MOD-13",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 13,
+    "status": "SHIPPED",
+    "text": "**`minServer`, the compatibility floor.** The minimum server version",
+    "file": "docs/spec/modules/README.md",
+    "line": 76
+  },
+  {
+    "id": "MOD-14",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 14,
+    "status": "SHIPPED",
+    "text": "**Dependencies.** Hard ones that must be installed alongside it, and",
+    "file": "docs/spec/modules/README.md",
+    "line": 78
+  },
+  {
+    "id": "MOD-15",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 15,
+    "status": "SHIPPED",
+    "text": "**Target.** Which platform the backend was built for. A library-only",
+    "file": "docs/spec/modules/README.md",
+    "line": 80
+  },
+  {
+    "id": "MOD-16",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 16,
+    "status": "SHIPPED",
+    "text": "The server checks the bytes it downloads against a published SHA-256",
+    "file": "docs/spec/modules/README.md",
+    "line": 84
+  },
+  {
+    "id": "MOD-17",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 17,
+    "status": "SHIPPED",
+    "text": "Integrity is not safety: a matching checksum proves the bytes are the",
+    "file": "docs/spec/modules/README.md",
+    "line": 87
+  },
+  {
+    "id": "MOD-18",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 18,
+    "status": "SHIPPED",
+    "text": "**From the Store**, by id. The server resolves hard dependencies",
+    "file": "docs/spec/modules/README.md",
+    "line": 97
+  },
+  {
+    "id": "MOD-19",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 19,
+    "status": "SHIPPED",
+    "text": "**By upload**, handing the server a `.kmod` by hand: same unpack,",
+    "file": "docs/spec/modules/README.md",
+    "line": 101
+  },
+  {
+    "id": "MOD-20",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 20,
+    "status": "SHIPPED",
+    "text": "Both are admin actions on the [`admin/`](../admin/) surface.",
+    "file": "docs/spec/modules/README.md",
+    "line": 105
+  },
+  {
+    "id": "MOD-21",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 21,
+    "status": "SHIPPED",
+    "text": "The Store (Admin → Modules) is the in-app browser over the configured",
+    "file": "docs/spec/modules/README.md",
+    "line": 111
+  },
+  {
+    "id": "MOD-22",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 22,
+    "status": "SHIPPED",
+    "text": "The official registry is pinned first and cannot be removed; operators",
+    "file": "docs/spec/modules/README.md",
+    "line": 114
+  },
+  {
+    "id": "MOD-23",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 23,
+    "status": "SHIPPED",
+    "text": "For each module the Store shows **this server's verdict**, not just the",
+    "file": "docs/spec/modules/README.md",
+    "line": 117
+  },
+  {
+    "id": "MOD-24",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 24,
+    "status": "DRAFT",
+    "text": "**First-party is trusted by default.** The official registry is",
+    "file": "docs/spec/modules/README.md",
+    "line": 135
+  },
+  {
+    "id": "MOD-25",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 25,
+    "status": "DRAFT",
+    "text": "**A third-party registry is an explicit operator opt-in.** Adding one",
+    "file": "docs/spec/modules/README.md",
+    "line": 137
+  },
+  {
+    "id": "MOD-26",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 26,
+    "status": "DRAFT",
+    "text": "The operator is told, in plain terms, that a module is a native binary",
+    "file": "docs/spec/modules/README.md",
+    "line": 139
+  },
+  {
+    "id": "MOD-27",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 27,
+    "status": "DRAFT",
+    "text": "**Checksums guarantee integrity, never safety**, and the server says so",
+    "file": "docs/spec/modules/README.md",
+    "line": 142
+  },
+  {
+    "id": "MOD-28",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 28,
+    "status": "SHIPPED",
+    "text": "**Enable.** The server spawns the sidecar and the module's routes,",
+    "file": "docs/spec/modules/README.md",
+    "line": 156
+  },
+  {
+    "id": "MOD-29",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 29,
+    "status": "SHIPPED",
+    "text": "**Disable.** The sidecar is stopped, the module stops running, and",
+    "file": "docs/spec/modules/README.md",
+    "line": 159
+  },
+  {
+    "id": "MOD-30",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 30,
+    "status": "SHIPPED",
+    "text": "**Update.** A newer version replaces the bundle and the sidecar is",
+    "file": "docs/spec/modules/README.md",
+    "line": 162
+  },
+  {
+    "id": "MOD-31",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 31,
+    "status": "SHIPPED",
+    "text": "`minServer` is re-checked on update, so an update that outgrows the",
+    "file": "docs/spec/modules/README.md",
+    "line": 165
+  },
+  {
+    "id": "MOD-32",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 32,
+    "status": "SHIPPED",
+    "text": "**Uninstall.** The module is removed entirely. It is the one",
+    "file": "docs/spec/modules/README.md",
+    "line": 167
+  },
+  {
+    "id": "MOD-33",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 33,
+    "status": "SHIPPED",
+    "text": "The server refuses to uninstall a module another enabled module still",
+    "file": "docs/spec/modules/README.md",
+    "line": 170
+  },
+  {
+    "id": "MOD-34",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 34,
+    "status": "SHIPPED",
+    "text": "Uninstalling a module never touches media on disk. A downloads module",
+    "file": "docs/spec/modules/README.md",
+    "line": 173
+  },
+  {
+    "id": "MOD-35",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 35,
+    "status": "SHIPPED",
+    "text": "**A crashed module cannot take down the server.** The sidecar is a",
+    "file": "docs/spec/modules/README.md",
+    "line": 183
+  },
+  {
+    "id": "MOD-36",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 36,
+    "status": "SHIPPED",
+    "text": "**An incompatible module never runs by accident.** `minServer` is",
+    "file": "docs/spec/modules/README.md",
+    "line": 186
+  },
+  {
+    "id": "MOD-37",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 37,
+    "status": "SHIPPED",
+    "text": "**Failure is visible, not silent.** A module that will not start or",
+    "file": "docs/spec/modules/README.md",
+    "line": 189
+  },
+  {
+    "id": "MOD-38",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 38,
+    "status": "SHIPPED",
+    "text": "The server is forward-compatible with older modules. A module declares",
+    "file": "docs/spec/modules/README.md",
+    "line": 197
+  },
+  {
+    "id": "MOD-39",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 39,
+    "status": "SHIPPED",
+    "text": "A module installed today keeps working as the server is updated,",
+    "file": "docs/spec/modules/README.md",
+    "line": 200
+  },
+  {
+    "id": "MOD-40",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 40,
+    "status": "SHIPPED",
+    "text": "A *newer* module may raise its `minServer`, and the Store says so",
+    "file": "docs/spec/modules/README.md",
+    "line": 203
+  },
+  {
+    "id": "MOD-41",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 41,
+    "status": "SHIPPED",
+    "text": "A module **may** ship UI, and the position is deliberate: a module's",
+    "file": "docs/spec/modules/README.md",
+    "line": 211
+  },
+  {
+    "id": "MOD-42",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 42,
+    "status": "AGREED",
+    "text": "A module renders **its own admin surface**: configuration, status and",
+    "file": "docs/spec/modules/README.md",
+    "line": 215
+  },
+  {
+    "id": "MOD-43",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 43,
+    "status": "SHIPPED",
+    "text": "A module's UI is served through the same reverse proxy as its backend",
+    "file": "docs/spec/modules/README.md",
+    "line": 218
+  },
+  {
+    "id": "MOD-44",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 44,
+    "status": "DRAFT",
+    "text": "**The compatibility gate is the early warning.** As the server moves",
+    "file": "docs/spec/modules/README.md",
+    "line": 232
+  },
+  {
+    "id": "MOD-45",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 45,
+    "status": "DRAFT",
+    "text": "**Data is retained.** An incompatible or abandoned module is not",
+    "file": "docs/spec/modules/README.md",
+    "line": 236
+  },
+  {
+    "id": "MOD-46",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 46,
+    "status": "DRAFT",
+    "text": "**The signal is honest.** The person is told the module has not kept",
+    "file": "docs/spec/modules/README.md",
+    "line": 239
+  },
+  {
+    "id": "MOD-47",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 47,
+    "status": "SHIPPED",
+    "text": "Every capability below could have been core and is a module instead,",
+    "file": "docs/spec/modules/README.md",
+    "line": 251
   },
   {
     "id": "PLAY-1",

--- a/docs/spec/surfaces/README.md
+++ b/docs/spec/surfaces/README.md
@@ -8,12 +8,18 @@ allowed *not* to do, so a missing feature is a decision on record rather than a 
 
 It owns the *surface* view: which surfaces exist, what they promise, and which class of
 media each can direct-play. It does not own the codec decision. Given a file, a client and
-a network, what gets sent is [`playback.md`](../playback/README.md)'s job, and what a stream *is* comes
-from [`media.md`](../media/README.md). This file reads those as facts and states the consequence per
+a network, what gets sent is [`playback/`](../playback/)'s job, and what a stream *is* comes
+from [`media/`](../media/). This file reads those as facts and states the consequence per
 surface. The shared component kit that makes the surfaces look alike is architecture, not
 spec. See [`packages/ui`](../../../packages/ui).
 
 ## The surfaces
+
+Status: **SHIPPED**
+
+**SURF-1** (SHIPPED) - Every client KROMA ships is one of the surfaces named here, and each
+surface names the shell that implements it. A client that is not in this table is a
+prototype, and adding or retiring a surface is a change to this section.
 
 | Surface | Shell | Notes |
 |---|---|---|
@@ -29,46 +35,58 @@ spec. See [`packages/ui`](../../../packages/ui).
 
 Status: **AGREED**
 
-There is one baseline, and it is the whole definition of the word *KROMA* on a surface. A
-build that runs but cannot do all six is a preview, not a surface, and the capability matrix
-below records exactly which rung it is missing. Every first-class surface does all six; a
-best-effort surface that drops one says so here rather than failing silently.
+There is one baseline, and it is the whole definition of the word *KROMA* on a surface.
+Every first-class surface does all six rungs; a best-effort surface that drops one says so
+here rather than failing silently.
 
-1. **Sign in / pair.** Reach a server and become an account on it. On a surface with a
-   keyboard this is address-plus-credentials; on a television it is the pairing handshake
-   ([`discovery.md`](../discovery/README.md), [`docs/tv-pairing.md`](../../tv-pairing.md)).
-2. **Browse the library.** Move through titles the account may see, by section and by search.
-3. **View a title.** Its artwork, its metadata, its editions and available fidelities.
-4. **Start playback.** Play the title, taking whatever rung the device needs
-   ([`playback.md`](../playback/README.md)).
-5. **Resume.** Reopen an in-progress title at the server-held position, per user, per version.
-6. **Sign out.** End the session and drop the server from the surface, revocably.
+**SURF-2** (AGREED) - A build that cannot do all six rungs below is a preview, not a
+surface, and the capability matrix records exactly which rung it is missing.
 
-Everything past these six is a *may*, not a *must*. "Not on TV yet" is measurable against
-this list and nothing else: name the rung, and the gap is a line in the matrix rather than an
-argument.
+- **SURF-3** (SHIPPED) - **Sign in or pair.** A surface reaches a server and becomes an
+  account on it. Where there is a keyboard this is address plus credentials; on a television
+  it is the pairing handshake ([`discovery/`](../discovery/),
+  [`docs/tv-pairing.md`](../../tv-pairing.md)).
+- **SURF-4** (SHIPPED) - **Browse the library.** A surface moves through the titles the
+  account may see, by section and by search.
+- **SURF-5** (SHIPPED) - **View a title.** A surface shows a title's artwork, its metadata,
+  its editions and its available fidelities.
+- **SURF-6** (SHIPPED) - **Start playback.** A surface plays the title, taking whatever rung
+  the device needs ([`playback/`](../playback/)).
+- **SURF-7** (SHIPPED) - **Resume.** A surface reopens an in-progress title at the
+  server-held position, per user and per version.
+- **SURF-8** (SHIPPED) - **Sign out.** A surface ends the session and drops the server from
+  the device, revocably.
+
+**SURF-9** (AGREED) - Everything past the six rungs is a *may*, not a *must*. A surface that
+lacks one of them records the absence in the capability matrix, so "not on TV yet" is
+answered by naming the rung rather than by argument.
 
 ## First-class and best-effort
 
 Status: **AGREED**
 
-Surfaces are tiered, and the tier is a commitment, not a description of current polish.
+Surfaces are tiered, and the tier is a commitment, not a description of current polish. Web
+is where the baseline is *defined*, so web is first-class by construction and cannot regress
+below it.
 
-**Web is the reference implementation.** A behaviour is correct when it matches web; a
-feature is not shipped until web has it; a disagreement between surfaces is resolved in web's
-favour unless the input model forbids it. Web is where the baseline is *defined*, so web is
-first-class by construction and cannot regress below it.
+**SURF-10** (SHIPPED) - Web is the reference implementation. Where two surfaces disagree on
+a behaviour, web's is the correct one, unless the other surface's input model forbids
+copying it.
 
-- **First-class.** Web, Mobile, Desktop, and the native television shells (`tv-native`,
-  Apple TV / Android TV). They carry the full baseline, ship on the release train, and a
-  baseline regression on one of them blocks the release. Each is allowed to *diverge* where
-  its input model demands (below), never to *drop* a baseline rung.
-- **Best-effort.** The sandboxed television shells (`tizen`, `webos`) and the generic
-  `tv-web` fallback. They carry the baseline but are held to the platform's ceiling, not to
-  web's: a capability the platform cannot express (LAN discovery on Tizen; a codec the panel's
-  decoder lacks) is a recorded absence here, not a defect. They ship when the platform allows
-  and may lag the train.
-- **NAS is not a surface.** `clients/synology` is packaging. It puts the *server* on a
+**SURF-11** (AGREED) - A feature is not shipped until web has it.
+
+- **SURF-12** (SHIPPED) - **First-class.** Web, mobile, desktop and the native television
+  shells carry the whole baseline and ship on the release train.
+- **SURF-13** (AGREED) - A baseline regression on a first-class surface blocks the release.
+- **SURF-14** (AGREED) - A first-class surface may diverge from web where its input model
+  demands it, and may never drop a baseline rung.
+- **SURF-15** (SHIPPED) - **Best-effort.** The sandboxed television shells, Samsung and LG,
+  and the generic web fallback for other televisions carry the baseline but are held to their
+  platform's ceiling rather than to web's.
+- **SURF-16** (AGREED) - A capability a best-effort surface's platform cannot express, such
+  as LAN discovery on Samsung or a codec the panel's decoder lacks, is a recorded absence
+  here rather than a defect, and such a surface may ship behind the release train.
+- **SURF-17** (SHIPPED) - **The NAS package is not a surface.** It puts the *server* on a
   Synology box. Its users reach KROMA through one of the surfaces above; it has no UI of its
   own and no baseline to meet. It appears here so the reader stops looking for one.
 
@@ -76,7 +94,9 @@ first-class by construction and cannot regress below it.
 
 Status: **AGREED**
 
-What each surface must, may, and may not do, beyond the baseline all of them share.
+**SURF-18** (AGREED) - The matrix below is the record of what each surface must, may and may
+not do beyond the baseline. A surface that fails a cell is a defect; a cell saying a surface
+does not do something is a decision on record.
 
 | Capability | Web | Mobile | Desktop | TV native | TV sandboxed (Tizen/webOS) |
 |---|---|---|---|---|---|
@@ -87,128 +107,134 @@ What each surface must, may, and may not do, beyond the baseline all of them sha
 | Offline downloads | no | yes | no | no | no |
 | Direct-play ceiling | browser codecs | device generation | browser codecs | panel generation | panel generation |
 
-"Discover" and "pair" are the surface's *reach*, and the per-shell truth, meaning who publishes,
-who browses and why Tizen cannot, is [`discovery.md`](../discovery/README.md)'s, grounded in
-[`docs/tv-pairing.md`](../../tv-pairing.md). This table names the outcome; that file names the
-mechanism.
+"Discover" and "pair" are the surface's *reach*. The per-shell truth, meaning who publishes,
+who browses and why Samsung cannot, is [`discovery/`](../discovery/)'s, grounded in
+[`docs/tv-pairing.md`](../../tv-pairing.md). This table names the outcome; that file names
+the mechanism.
 
 ### Direct-play by device generation
 
 Status: **AGREED**
 
-Whether a file direct-plays is decided per session by [`playback.md`](../playback/README.md) against a
-device profile; the *class* of media a surface can decode is a surface fact, and it is the
-device's generation, not the surface's brand, that sets it. The rule KROMA holds to:
+Whether a file direct-plays is decided per session by [`playback/`](../playback/) against a
+device profile. The *class* of media a surface can decode is a surface fact, and it is the
+device's generation, not the surface's brand, that sets it.
 
-- **Browser-backed surfaces** (Web, and the sandboxed television shells) direct-play what the
-  host browser's media stack exposes: reliably H.264 and, on a current engine, HEVC, VP9 and
-  AV1 where hardware-backed. They inherit the browser's ceiling exactly, including its HDR and
-  channel-layout limits, and cannot exceed it.
-- **Native surfaces** (Mobile, Desktop, `tv-native`) direct-play to the *device's* decoder,
-  which is where generation bites: a current phone decodes 10-bit HEVC and Dolby Vision in
-  hardware that a three-year-old panel of the same brand cannot. KROMA reads the generation
-  from the profile and never assumes newer than it measures.
-- **The honest consequence** is on record in [`playback.md`](../playback/README.md): when a television's
-  older decoder cannot play a file a modern phone can, and transcode is capped or disabled, the
-  television says so plainly and points at a surface that *does* play it. The matrix here is the
-  input to that message; it is not a promise every surface plays everything.
+- **SURF-19** (SHIPPED) - **Browser-backed surfaces**, web and the sandboxed television
+  shells, direct-play what the host browser's media stack exposes and cannot exceed it:
+  reliably H.264, and on a current engine HEVC, VP9 and AV1 where hardware-backed, inheriting
+  that engine's HDR and channel-layout limits exactly.
+- **SURF-20** (SHIPPED) - **Native surfaces**, mobile, desktop and the native television
+  shells, direct-play to the *device's* own decoder. KROMA reads the generation from the
+  device profile and never assumes a newer one than it measures.
+- **SURF-21** (AGREED) - When a television's older decoder cannot play a file a modern phone
+  can, and transcode is capped or disabled, the television says so plainly and names a surface
+  that does play it ([`playback/`](../playback/)).
+- **SURF-22** (AGREED) - KROMA never papers over a generation gap by silently transcoding for
+  a surface that could direct-play, and never claims a panel decodes a codec its generation
+  predates.
 
-KROMA does not paper over a generation gap by silently transcoding for a capable surface, and
-it does not pretend a panel decodes a codec its generation predates. The first-class media
-truth (which codecs, containers, HDR variants exist) is [`media.md`](../media/README.md); this section
-only says which surface can take it unmodified.
+The first-class media truth, which codecs, containers and HDR variants exist, is
+[`media/`](../media/); this section only says which surface can take it unmodified.
 
 ## Input models
 
 Status: **AGREED**
 
 The input model is the one thing a surface may *not* copy from web, because copying it would
-break the surface. Three models, and each rewrites the UI, not just the event handling.
+break the surface. Three models, and each rewrites the UI rather than only the event
+handling.
 
-- **Pointer** (Web, Desktop) is the reference model. Dense layouts, hover affordances, a
-  visible cursor, right-click and keyboard shortcuts. This is what every other model is a
-  deliberate departure *from*.
-- **Touch** (Mobile) means targets sized for a thumb, gestures for scrub and dismiss, no hover
-  state to depend on, and layouts that reflow to a held phone. Anything that only works with a
-  cursor is redesigned, not shrunk.
-- **Remote, 10-foot** (all televisions) is a directional focus ring rather than a cursor: everything
-  reachable by up/down/left/right and OK, legible across a room, and no interaction that
-  assumes text entry the remote cannot supply. Sign-in is the pairing handshake precisely
-  because a television keyboard is unusable ([`discovery.md`](../discovery/README.md)). A television
-  build that ships a pointer-shaped screen has not met the baseline's *view* and *browse*
-  rungs, however complete it looks on a monitor.
-
-One product surface may serve more than one model, since a hybrid tablet is touch-first with a
-pointer attached, and the surface adapts to the *active* input rather than the hardware badge.
+- **SURF-23** (SHIPPED) - **Pointer**, on web and desktop, is the reference model: dense
+  layouts, hover affordances, a visible cursor, right-click and keyboard shortcuts. Every
+  other model is a deliberate departure from it.
+- **SURF-24** (SHIPPED) - **Touch**, on mobile, means targets sized for a thumb, gestures for
+  scrub and dismiss, no hover state to depend on, and layouts that reflow to a held phone.
+  Anything that only works with a cursor is redesigned, not shrunk.
+- **SURF-25** (SHIPPED) - **Remote, 10-foot**, on every television, is a directional focus
+  ring rather than a cursor: everything reachable by up, down, left, right and OK, legible
+  across a room, and no interaction that assumes text entry the remote cannot supply.
+- **SURF-26** (SHIPPED) - A television signs in through the pairing handshake precisely
+  because a television keyboard is unusable ([`discovery/`](../discovery/)).
+- **SURF-27** (AGREED) - A television build that ships a pointer-shaped screen has not met
+  the baseline's *view* and *browse* rungs, however complete it looks on a monitor.
+- **SURF-28** (AGREED) - A surface serving more than one model, such as a tablet with a
+  pointer attached, adapts to the *active* input rather than to the hardware badge.
 
 ## Offline
 
 Status: **AGREED**
 
-**Only Mobile is offline.** Web, Desktop and every television are online surfaces: they hold
-no library on the device and do nothing without a reachable server, and this is a decision,
-not a gap. A browser tab and a shared-living-room television are the wrong places to accrue
-gigabytes of a personal library, and the storage, eviction and reconciliation cost is not
-worth paying five times.
+**SURF-29** (SHIPPED) - **Only mobile is offline.** Web, desktop and every television hold no
+library on the device and do nothing without a reachable server.
 
-On Mobile, offline means **downloads**: a title is fetched to the phone as a progressive
-file, the raw original when the device direct-plays it, else a server-side remux to a single
-fMP4, and plays with no server connection. Downloads survive backgrounding and app kills and
-are re-adopted on next launch, and so is the queue of unsent progress reports, which flushes
-under the furthest-position rule when the server is reachable again
-([`playback.md`](../playback/README.md),
-[`../architecture/mobile-offline-system-storage.md`](../../architecture/mobile-offline-system-storage.md)).
+That is a decision, not a gap. A browser tab and a shared living-room television are the
+wrong places to accrue gigabytes of a personal library, and the storage, eviction and
+reconciliation cost is not worth paying five times.
+
+- **SURF-30** (SHIPPED) - A download is a progressive file, the raw original when the device
+  direct-plays it and otherwise a server-side remux to a single fMP4, and it plays with no
+  server connection.
+- **SURF-31** (SHIPPED) - Downloads survive backgrounding and app kills, and are re-adopted
+  on the next launch.
+- **SURF-32** (SHIPPED) - Progress reports that could not be sent queue on the device and
+  flush under the furthest-position rule once the server is reachable
+  ([`playback/`](../playback/)).
 
 ### OS-managed download rows
 
 Status: **DESIGN, NOT IMPLEMENTED**
 
-Netflix-style per-title rows in the OS storage manager (iOS Settings ▸ iPhone Storage,
-deletable by the system with the app closed) did **not** ship. What shipped instead is the
-background-transfer pipeline above, meaning transfers that outlive the app, which is the half users
-feel. The OS rows need system-managed HLS assets (`AVAssetDownloadTask`, a finite VOD playlist,
-tokenised segment URLs, delete-reconciliation on every launch): a server-plus-native-plus-player
-project, iOS-only, with no Android equivalent to match. It is deferred as a unit rather than
-half-built. The full record, and what it would take, is in
+**SURF-33** (DESIGN, NOT IMPLEMENTED) - Per-title rows in the OS storage manager, deletable
+by the system with the app closed, are deferred as a unit.
+
+Netflix-style rows in iOS Settings ▸ iPhone Storage did **not** ship. What shipped instead
+is the background-transfer pipeline above, transfers that outlive the app, which is the half
+users feel. The OS rows need system-managed HLS assets (`AVAssetDownloadTask`, a finite VOD
+playlist, tokenised segment URLs, delete-reconciliation on every launch): a
+server-plus-native-plus-player project, iOS-only, with no Android equivalent to match. It is
+deferred as a unit rather than half-built. The full record, and what it would take, is in
 [`../architecture/mobile-offline-system-storage.md`](../../architecture/mobile-offline-system-storage.md).
 
 ## Packaging and updates
 
 Status: **AGREED**
 
-Each surface ships and updates the way its host expects; the product rule is only that a
-surface stays current without asking a person to babysit it. Deploy mechanics are
-[`admin.md`](../admin/README.md)'s; here is the product-level shape.
+Each surface ships and updates the way its host expects. Deploy mechanics are
+[`admin/`](../admin/)'s; here is the product-level shape.
 
-- **Web.** Served by the server itself; the server embeds the web build. There is no separate
-  install and no version skew: updating the server updates the web surface, and a browser
-  always loads the version its server ships.
-- **Desktop.** Auto-updates. The app checks, fetches and applies updates in the background and
-  a person is never asked to reinstall to stay current.
-- **Mobile.** The app stores (App Store, Play Store). Update cadence is the store's, and a
-  server must tolerate a range of shipped app versions because a person's phone updates on its
-  own schedule.
-- **Televisions.** Each platform's own channel: Samsung and LG through their TV app stores,
-  Apple TV and Android TV through theirs. KROMA does not self-update a television; the platform
-  does, on its terms.
-- **NAS.** A Synology `.spk` package installed and updated through Package Center. This ships
-  the *server*, so the same "server embeds web" rule applies to everything it serves.
+**SURF-34** (AGREED) - A surface stays current without asking a person to babysit it.
+
+- **SURF-35** (SHIPPED) - **Web.** The server serves the web surface itself. There is no
+  separate install and no version skew: updating the server updates the web surface, and a
+  browser always loads the version its server ships.
+- **SURF-36** (SHIPPED) - **Desktop.** The app checks for, fetches and applies updates in the
+  background, and a person is never asked to reinstall to stay current.
+- **SURF-37** (AGREED) - **Mobile.** The app updates on the store's cadence, so a server
+  tolerates a range of shipped app versions because a person's phone updates on its own
+  schedule.
+- **SURF-38** (AGREED) - **Televisions.** Each television updates through its own platform's
+  channel. KROMA never self-updates a television; the platform does, on its terms.
+- **SURF-39** (SHIPPED) - **NAS.** The Synology package installs and updates through Package
+  Center. It ships the *server*, so everything it serves follows the web rule above.
 
 ## Deprecation
 
 Status: **AGREED**
 
-A surface is dropped when its host platform can no longer meet the baseline: a browser
-generation KROMA can no longer target, a television OS the vendor has abandoned, a mobile OS
-below the floor the app can build against. Deprecation is announced, never silent.
+**SURF-40** (AGREED) - A surface is dropped when its host platform can no longer meet the
+baseline, such as a browser generation KROMA can no longer target, a television OS the vendor
+has abandoned, or a mobile OS below the floor the app can build against. Deprecation is
+announced, never silent.
 
-- **Notice first.** A surface entering deprecation tells its users *in the surface* before it
-  stops working: what is ending, when, and which surface to move to. A person is never met with
-  a dead app and no explanation.
-- **Sessions survive the app.** A deprecated surface's sessions are ordinary sessions; they
-  keep working until the surface is retired and revoke like any other from the device list
-  ([`accounts.md`](../accounts/README.md)). Retiring a surface does not strand an account.
-- **The library outlives any surface.** Nothing about a person's library, watch state or
-  account is tied to a surface, since it is the server's, so moving to another surface loses only
-  the retired app, never the account behind it. That is the point of stating the baseline once:
-  every surface is a replaceable window onto the same server.
+- **SURF-41** (AGREED) - **Notice first.** A surface entering deprecation tells its users *in
+  the surface* before it stops working: what is ending, when, and which surface to move to. A
+  person is never met with a dead app and no explanation.
+- **SURF-42** (AGREED) - **Sessions survive the app.** A deprecated surface's sessions are
+  ordinary sessions. They keep working until the surface is retired and revoke from the device
+  list like any other ([`accounts/`](../accounts/)). Retiring a surface does not strand an
+  account.
+- **SURF-43** (AGREED) - **The library outlives any surface.** Nothing about a person's
+  library, watch state or account is tied to a surface, since it is the server's, so moving to
+  another surface loses only the retired app, never the account behind it. Every surface is a
+  replaceable window onto the same server.

--- a/docs/spec/surfaces/README.md
+++ b/docs/spec/surfaces/README.md
@@ -1,6 +1,7 @@
 # Surfaces
 
-Status: **AGREED**. Sections carry their own status below.
+Status: **SHIPPED** overall. Sections carry their own status below, and so does every
+requirement, because the tiering rules are decided while most of the behaviour already ships.
 
 KROMA runs on a television, a phone, a browser, a desktop and a NAS. This file says what
 every surface must do, what each may do differently, and what a surface is explicitly
@@ -11,15 +12,16 @@ media each can direct-play. It does not own the codec decision. Given a file, a 
 a network, what gets sent is [`playback/`](../playback/)'s job, and what a stream *is* comes
 from [`media/`](../media/). This file reads those as facts and states the consequence per
 surface. The shared component kit that makes the surfaces look alike is architecture, not
-spec. See [`packages/ui`](../../../packages/ui).
+spec.
 
 ## The surfaces
 
 Status: **SHIPPED**
 
-**SURF-1** (SHIPPED) - Every client KROMA ships is one of the surfaces named here, and each
-surface names the shell that implements it. A client that is not in this table is a
-prototype, and adding or retiring a surface is a change to this section.
+**SURF-1** (SHIPPED) - Every client KROMA ships is one of the surfaces named here. A client
+that is not in this table is a prototype. The Shell column is a convenience for a reader
+looking for the code and is not part of the requirement; the mapping lives in
+[`ARCHITECTURE.md`](../../../ARCHITECTURE.md).
 
 | Surface | Shell | Notes |
 |---|---|---|
@@ -33,14 +35,15 @@ prototype, and adding or retiring a surface is a change to this section.
 
 ## The baseline
 
-Status: **AGREED**
+Status: **SHIPPED**. The six rungs are built; the rules about them are **AGREED**.
 
 There is one baseline, and it is the whole definition of the word *KROMA* on a surface.
 Every first-class surface does all six rungs; a best-effort surface that drops one says so
 here rather than failing silently.
 
-**SURF-2** (AGREED) - A build that cannot do all six rungs below is a preview, not a
-surface, and the capability matrix records exactly which rung it is missing.
+**SURF-2** (AGREED) - A build that cannot do all six rungs below is a **preview**, not a
+surface. A preview does not appear in the surfaces table and makes none of this file's
+promises.
 
 - **SURF-3** (SHIPPED) - **Sign in or pair.** A surface reaches a server and becomes an
   account on it. Where there is a keyboard this is address plus credentials; on a television
@@ -48,8 +51,9 @@ surface, and the capability matrix records exactly which rung it is missing.
   [`docs/tv-pairing.md`](../../tv-pairing.md)).
 - **SURF-4** (SHIPPED) - **Browse the library.** A surface moves through the titles the
   account may see, by section and by search.
-- **SURF-5** (SHIPPED) - **View a title.** A surface shows a title's artwork, its metadata,
-  its editions and its available fidelities.
+- **SURF-5** (SHIPPED) - **View a title.** A surface shows a title's artwork, its metadata
+  and its editions. Fidelity variants are not offered to a person to choose between
+  (MEDIA-10).
 - **SURF-6** (SHIPPED) - **Start playback.** A surface plays the title, taking whatever rung
   the device needs ([`playback/`](../playback/)).
 - **SURF-7** (SHIPPED) - **Resume.** A surface reopens an in-progress title at the
@@ -57,23 +61,26 @@ surface, and the capability matrix records exactly which rung it is missing.
 - **SURF-8** (SHIPPED) - **Sign out.** A surface ends the session and drops the server from
   the device, revocably.
 
-**SURF-9** (AGREED) - Everything past the six rungs is a *may*, not a *must*. A surface that
-lacks one of them records the absence in the capability matrix, so "not on TV yet" is
-answered by naming the rung rather than by argument.
+**SURF-9** (AGREED) - Every capability past the six rungs is a *may*, not a *must*, and a
+surface that lacks one records the absence in the capability matrix. The six rungs themselves
+are never optional, so "not on TV yet" is answered either by naming the missing capability in
+the matrix or, for a rung, by admitting the build is a preview.
 
 ## First-class and best-effort
 
-Status: **AGREED**
+Status: **SHIPPED** for who is in which tier, **AGREED** for what a tier commits to.
 
-Surfaces are tiered, and the tier is a commitment, not a description of current polish. Web
-is where the baseline is *defined*, so web is first-class by construction and cannot regress
-below it.
+Surfaces are tiered, and the tier is a commitment, not a description of current polish.
 
-**SURF-10** (SHIPPED) - Web is the reference implementation. Where two surfaces disagree on
-a behaviour, web's is the correct one, unless the other surface's input model forbids
-copying it.
+**SURF-10** (AGREED) - Web is the reference implementation. Where two surfaces disagree on a
+behaviour, web's is the correct one, unless the other surface's input model forbids copying it.
 
-**SURF-11** (AGREED) - A feature is not shipped until web has it.
+**SURF-11** (AGREED) - A feature that belongs on more than one surface is not shipped until
+web has it. A feature only one surface can carry, offline downloads on mobile or pairing on a
+television, is exempt.
+
+**SURF-44** (AGREED) - Web is where the baseline is defined, so web is first-class by
+construction and can never regress below it.
 
 - **SURF-12** (SHIPPED) - **First-class.** Web, mobile, desktop and the native television
   shells carry the whole baseline and ship on the release train.
@@ -84,17 +91,19 @@ copying it.
   and the generic web fallback for other televisions carry the baseline but are held to their
   platform's ceiling rather than to web's.
 - **SURF-16** (AGREED) - A capability a best-effort surface's platform cannot express, such
-  as LAN discovery on Samsung or a codec the panel's decoder lacks, is a recorded absence
-  here rather than a defect, and such a surface may ship behind the release train.
+  as LAN discovery on Samsung or a codec the panel's decoder lacks, is a recorded absence here
+  rather than a defect.
+- **SURF-45** (AGREED) - A best-effort surface ships when its platform allows and may lag the
+  release train.
 - **SURF-17** (SHIPPED) - **The NAS package is not a surface.** It puts the *server* on a
   Synology box. Its users reach KROMA through one of the surfaces above; it has no UI of its
   own and no baseline to meet. It appears here so the reader stops looking for one.
 
 ## Capability matrix
 
-Status: **AGREED**
+Status: **SHIPPED**. The table records what the surfaces do today.
 
-**SURF-18** (AGREED) - The matrix below is the record of what each surface must, may and may
+**SURF-18** (SHIPPED) - The matrix below is the record of what each surface must, may and may
 not do beyond the baseline. A surface that fails a cell is a defect; a cell saying a surface
 does not do something is a decision on record.
 
@@ -102,15 +111,16 @@ does not do something is a decision on record.
 |---|---|---|---|---|---|
 | Baseline (six above) | must | must | must | must | must |
 | Input model | pointer | touch | pointer | remote | remote |
-| Discover a server on the LAN | no | browses | no | publishes | Tizen no / webOS publishes |
-| Pair a television *to* this surface | n/a | yes (scanner) | n/a | is the TV | is the TV |
+| Browses for a server on the LAN | no | yes | no | yes | no |
+| Announces itself on the LAN | n/a | n/a | n/a | yes | Tizen no / webOS yes |
+| Approves a television's pairing | yes (code) | yes (code or scan) | yes (code) | is the TV | is the TV |
 | Offline downloads | no | yes | no | no | no |
 | Direct-play ceiling | browser codecs | device generation | browser codecs | panel generation | panel generation |
 
-"Discover" and "pair" are the surface's *reach*. The per-shell truth, meaning who publishes,
+Browsing and announcing are the surface's *reach*. The per-shell truth, meaning who announces,
 who browses and why Samsung cannot, is [`discovery/`](../discovery/)'s, grounded in
-[`docs/tv-pairing.md`](../../tv-pairing.md). This table names the outcome; that file names
-the mechanism.
+[`docs/tv-pairing.md`](../../tv-pairing.md). This table names the outcome; that file names the
+mechanism.
 
 ### Direct-play by device generation
 
@@ -131,19 +141,19 @@ device's generation, not the surface's brand, that sets it.
   can, and transcode is capped or disabled, the television says so plainly and names a surface
   that does play it ([`playback/`](../playback/)).
 - **SURF-22** (AGREED) - KROMA never papers over a generation gap by silently transcoding for
-  a surface that could direct-play, and never claims a panel decodes a codec its generation
-  predates.
+  a surface that could direct-play.
+- **SURF-46** (AGREED) - KROMA never claims a panel decodes a codec its generation predates.
 
 The first-class media truth, which codecs, containers and HDR variants exist, is
 [`media/`](../media/); this section only says which surface can take it unmodified.
 
 ## Input models
 
-Status: **AGREED**
+Status: **SHIPPED**. The three models are built; SURF-27 and SURF-28 are **AGREED**.
 
-The input model is the one thing a surface may *not* copy from web, because copying it would
-break the surface. Three models, and each rewrites the UI rather than only the event
-handling.
+**SURF-47** (SHIPPED) - The input model is the one thing a surface may *not* copy from web,
+because copying it would break the surface. Each of the three models below rewrites the UI
+rather than only the event handling.
 
 - **SURF-23** (SHIPPED) - **Pointer**, on web and desktop, is the reference model: dense
   layouts, hover affordances, a visible cursor, right-click and keyboard shortcuts. Every
@@ -163,7 +173,7 @@ handling.
 
 ## Offline
 
-Status: **AGREED**
+Status: **SHIPPED**, with the OS-managed rows below deliberately deferred.
 
 **SURF-29** (SHIPPED) - **Only mobile is offline.** Web, desktop and every television hold no
 library on the device and do nothing without a reachable server.
@@ -172,9 +182,10 @@ That is a decision, not a gap. A browser tab and a shared living-room television
 wrong places to accrue gigabytes of a personal library, and the storage, eviction and
 reconciliation cost is not worth paying five times.
 
-- **SURF-30** (SHIPPED) - A download is a progressive file, the raw original when the device
-  direct-plays it and otherwise a server-side remux to a single fMP4, and it plays with no
-  server connection.
+- **SURF-30** (SHIPPED) - A downloaded title plays with no server connection.
+- **SURF-48** (SHIPPED) - A download is a single progressive file: the raw original when the
+  device direct-plays it, and otherwise one the server produces without re-encoding the picture
+  ([`playback/`](../playback/)).
 - **SURF-31** (SHIPPED) - Downloads survive backgrounding and app kills, and are re-adopted
   on the next launch.
 - **SURF-32** (SHIPPED) - Progress reports that could not be sent queue on the device and
@@ -198,7 +209,7 @@ deferred as a unit rather than half-built. The full record, and what it would ta
 
 ## Packaging and updates
 
-Status: **AGREED**
+Status: **SHIPPED** for web, desktop and the NAS package; **AGREED** for the stores.
 
 Each surface ships and updates the way its host expects. Deploy mechanics are
 [`admin/`](../admin/)'s; here is the product-level shape.
@@ -215,8 +226,10 @@ Each surface ships and updates the way its host expects. Deploy mechanics are
   schedule.
 - **SURF-38** (AGREED) - **Televisions.** Each television updates through its own platform's
   channel. KROMA never self-updates a television; the platform does, on its terms.
-- **SURF-39** (SHIPPED) - **NAS.** The Synology package installs and updates through Package
-  Center. It ships the *server*, so everything it serves follows the web rule above.
+- **SURF-39** (AGREED) - **NAS.** The Synology package installs and updates through Package
+  Center. It ships the *server*, so everything it serves follows the web rule above. Today a
+  person installs it by hand from a downloaded package ([`INSTALL.md`](../../../INSTALL.md));
+  a published source URL is what turns this SHIPPED.
 
 ## Deprecation
 


### PR DESCRIPTION
## What

Every normative line in the spec now carries a stable requirement id and its own status.
396 of them across the eight domains, where `admin` was the only space that had any.

That was the one thing blocking all eight epics equally. `docs/spec/README.md` says an id is
the join key between the spec and the board, and that an issue links a requirement instead of
restating it. With no ids outside admin, no sub-issue of #67 to #74 could be written without
copying spec text, which is the one thing that file forbids.

| Space | Prefix | Requirements |
|---|---|---|
| accounts | `ACCT` | 33 |
| admin | `ADMIN` | 88, unchanged |
| discovery | `DISC` | 33 |
| library | `LIB` | 49 |
| media | `MEDIA` | 46 |
| modules | `MOD` | 47 |
| playback | `PLAY` | 52 |
| surfaces | `SURF` | 48 |

Giving each line an id forced a status onto each line, and that is where the spec started
disagreeing with itself and with the code. Everything below was found that way, not hunted for.

**Three places the spec was wrong about what ships.**

- Native TV shells do browse for a server. `clients/tv-native/modules/server-discovery`
  browses `_kroma._tcp` and `App.tsx` hands the result to the shell, while the discovery
  chapter said they never do. Split into DISC-7 (announces) and DISC-32 (browses).
- Web can approve a television's pairing. `clients/web/src/routes/_app.connect.tsx` calls
  `quickConnect.authorize`, while the surfaces capability matrix said `n/a`.
- A module does not open the shared database. Storage became a declared capability, so a
  manifest with no `storage` gets no database and does not link SQLite at all
  (`kroma-module-manifest/src/manifest.rs`). The modules chapter still described ambient
  access. MOD-4 says what is actually true.

**Two places the spec contradicted itself.** Surfaces said a title view offers "available
fidelities" while MEDIA-10 says a person chooses a cut and never a resolution; media wins.
SURF-11 said nothing ships until web has it, which its own shipped offline-downloads
requirements falsify; it now covers features that belong on more than one surface.

**Statuses that were stale.** Playback's file header said DRAFT while all eight of its
sections said AGREED and both embedded questions had been answered with "Decision:". Accounts
and discovery had no file-level status at all. Nine sections were labelled AGREED, which means
"decided, not built", while holding behaviour that ships. Four sections carried no status,
which `docs/spec/README.md` calls a bug in the spec. Every section in every chapter has one
now, and `spec:index` cannot catch this class on its own because it only validates statuses
inside requirement lines.

**Also**: the capability matrix asked "discover a server on the LAN" and answered it with who
announces, which are two questions, so it is two rows; the `LIB-4` in the README's example
never existed, and now quotes the real LIB-48; cross-domain links said `accounts.md` and
pointed at `../accounts/README.md`, a name the spec has not used since it became one folder
per domain.

Nothing here decides an open product question. The four that are still open stay DRAFT and
are listed under Risk.

## Closes

Does not close any of them. It unblocks all eight (#67 #68 #69 #70 #71 #72 #73 #74) by
satisfying the requirement-id half of each epic, and closes the "no section carries DRAFT"
box for accounts, discovery, media, playback and surfaces.

Still open, and each needs a decision rather than a commit:

- **LIB-41 to LIB-44** (library refresh): should a forced refresh also re-run matching? The
  chapter recommends keeping "Refresh metadata" and "Re-match" separate.
- **MOD-24 to MOD-27** (module trust): the safety posture for third-party registries.
- **MOD-44 to MOD-46** (abandonment): should a registry carry an explicit deprecation flag, or
  is the compatibility gate enough?
- **admin** update delivery, already DRAFT before this branch.

## Checks

- [x] `bun run spec:check` passes: 396 requirements, index and `requirements.json` in step
- [x] Every section in `docs/spec/` carries a status
- [x] No duplicate id, no prefix shared by two spaces, no space mixing prefixes
- [ ] `bun run lint` / `bun run test` not run: this branch touches `docs/spec/` only
- [x] One idea

## Risk

Low to break, higher to be wrong. Nothing here is code, so nothing can fail at runtime.

The real risk is a status that overclaims. Every SHIPPED was set against something in the
repo, and where the evidence ran out the requirement stayed AGREED, which is why library
visibility (ACCT-20, ACCT-21) is AGREED despite living in a section full of shipped
behaviour, and why media is AGREED throughout: its edition layer has no type in
`kroma-domain`. A reviewer who knows a surface better than the code shows should push back on
a specific id rather than the batch.

Ids are assigned once and never renumbered, so this is the cheapest moment to argue about
which line deserved one. After merge, a wrong id is a retired number rather than an edit.

**One thing this branch deliberately did not touch.** `clients/desktop/src/main.tsx` mounts
`@kromatv/tv`, the 10-foot experience, so the desktop shell is remote-driven today. The
surfaces matrix says its input model is `pointer` and SURF-23 calls desktop part of the
reference pointer model. One of those is wrong, and which one is a product decision rather
than a spec edit, so the matrix is unchanged and this is the flag.
