### PR TITLE
docs(spec): the four open questions get answers, and nothing is DRAFT

### DIFF
--- a/docs/spec/INDEX.md
+++ b/docs/spec/INDEX.md
@@ -3,7 +3,7 @@
 
 # Requirement index
 
-396 requirements across the spec. The machine-readable source is [`requirements.json`](requirements.json).
+406 requirements across the spec. The machine-readable source is [`requirements.json`](requirements.json).
 
 ## ACCT - [accounts](accounts/)
 
@@ -131,6 +131,11 @@
 - **ADMIN-86** (AGREED) - The owner sends a verification from the member editor, with the <sub>[README.md](admin/README.md)</sub>
 - **ADMIN-87** (AGREED) - Changing the address clears the verified state: the proof belongs <sub>[README.md](admin/README.md)</sub>
 - **ADMIN-88** (AGREED) - A user who cannot sign in can ask for a reset from the sign-in <sub>[README.md](admin/README.md)</sub>
+- **ADMIN-89** (AGREED) - A server learns it is out of date by checking for a newer release and <sub>[README.md](admin/README.md)</sub>
+- **ADMIN-90** (AGREED) - A server update migrates the persistent store forward <sub>[README.md](admin/README.md)</sub>
+- **ADMIN-91** (AGREED) - Module updates are independent of the server and carry their own <sub>[README.md](admin/README.md)</sub>
+- **ADMIN-92** (AGREED) - Active playback neither blocks an update nor is stopped by one <sub>[README.md](admin/README.md)</sub>
+- **ADMIN-93** (AGREED) - The rule above is identical on every host. Only the delivery vehicle <sub>[README.md](admin/README.md)</sub>
 
 ## DISC - [discovery](discovery/)
 
@@ -210,15 +215,16 @@
 - **LIB-38** (AGREED) - With no internet, everything already matched browses and plays exactly
 - **LIB-39** (AGREED) - Offline, a brand-new file that needs a first provider lookup stays
 - **LIB-40** (AGREED) - Offline, a forced refresh queues rather than fails.
-- **LIB-41** (DRAFT) - A newly matched item fetches its metadata once.
-- **LIB-42** (DRAFT) - Running series are re-checked on a slow cadence, so a new episode's air
-- **LIB-43** (DRAFT) - A "Refresh metadata" action on any title, season or whole source
-- **LIB-44** (DRAFT) - A forced refresh **never** discards a manual match or user-chosen
+- **LIB-41** (SHIPPED) - A newly matched item fetches its metadata once.
+- **LIB-42** (AGREED) - Running series are re-checked on a slow cadence, so a new episode's air
+- **LIB-43** (AGREED) - A "Refresh metadata" action on any title, season or whole source
+- **LIB-44** (AGREED) - A forced refresh **never** discards a manual match or user-chosen
 - **LIB-45** (AGREED) - When a file disappears from a source, its title is **marked absent**:
 - **LIB-46** (AGREED) - Content that reappears, because a NAS remounts or a file is moved back
 - **LIB-47** (AGREED) - A **move** is therefore not a special case. It is an absent path plus a
 - **LIB-48** (AGREED) - A rescan **only ever marks absent**. It never deletes user data.
 - **LIB-49** (AGREED) - Permanently deleting a title's history is an explicit, person-initiated
+- **LIB-50** (SHIPPED) - Refreshing metadata and re-running identification are two actions, and
 
 ## MEDIA - [media](media/)
 
@@ -294,10 +300,10 @@
 - **MOD-21** (SHIPPED) - The Store (Admin → Modules) is the in-app browser over the configured
 - **MOD-22** (SHIPPED) - The official registry is pinned first and cannot be removed; operators
 - **MOD-23** (SHIPPED) - For each module the Store shows **this server's verdict**, not just the
-- **MOD-24** (DRAFT) - **First-party is trusted by default.** The official registry is
-- **MOD-25** (DRAFT) - **A third-party registry is an explicit operator opt-in.** Adding one
-- **MOD-26** (DRAFT) - The operator is told, in plain terms, that a module is a native binary
-- **MOD-27** (DRAFT) - **Checksums guarantee integrity, never safety**, and the server says so
+- **MOD-24** (AGREED) - **First-party is trusted by default.** The official registry is
+- **MOD-25** (AGREED) - **A third-party registry is an explicit operator opt-in.** Adding one
+- **MOD-26** (AGREED) - The operator is told, in plain terms, that a module is a native binary
+- **MOD-27** (AGREED) - **Checksums guarantee integrity, never safety**, and the server says so
 - **MOD-28** (SHIPPED) - **Enable.** The server spawns the sidecar and the module's routes,
 - **MOD-29** (SHIPPED) - **Disable.** The sidecar is stopped, the module stops running, and
 - **MOD-30** (SHIPPED) - **Update.** A newer version replaces the bundle and the sidecar is
@@ -314,10 +320,13 @@
 - **MOD-41** (SHIPPED) - A module **may** ship UI, and the position is deliberate: a module's
 - **MOD-42** (AGREED) - A module renders **its own admin surface**: configuration, status and
 - **MOD-43** (SHIPPED) - A module's UI is served through the same reverse proxy as its backend
-- **MOD-44** (DRAFT) - **The compatibility gate is the early warning.** As the server moves
-- **MOD-45** (DRAFT) - **Data is retained.** An incompatible or abandoned module is not
-- **MOD-46** (DRAFT) - **The signal is honest.** The person is told the module has not kept
+- **MOD-44** (AGREED) - **The compatibility gate is the early warning.** As the server moves
+- **MOD-45** (AGREED) - **Data is retained.** An incompatible or abandoned module is not
+- **MOD-46** (AGREED) - **The signal is honest.** The person is told the module has not kept
 - **MOD-47** (SHIPPED) - Every capability below could have been core and is a module instead,
+- **MOD-48** (AGREED) - The Store names the registry every module came from, on the listing and
+- **MOD-49** (AGREED) - Installing from a registry the operator added is gated once, per
+- **MOD-50** (AGREED) - A module that has disappeared from every configured registry is flagged
 
 ## PLAY - [playback](playback/)
 
@@ -398,9 +407,9 @@
 - **SURF-20** (SHIPPED) - **Native surfaces**, mobile, desktop and the native television
 - **SURF-21** (AGREED) - When a television's older decoder cannot play a file a modern phone
 - **SURF-22** (AGREED) - KROMA never papers over a generation gap by silently transcoding for
-- **SURF-23** (SHIPPED) - **Pointer**, on web and desktop, is the reference model: dense
+- **SURF-23** (SHIPPED) - **Pointer**, on web, is the reference model: dense layouts, hover
 - **SURF-24** (SHIPPED) - **Touch**, on mobile, means targets sized for a thumb, gestures for
-- **SURF-25** (SHIPPED) - **Remote, 10-foot**, on every television, is a directional focus
+- **SURF-25** (SHIPPED) - **Directional, 10-foot**, on every television and on desktop, is a
 - **SURF-26** (SHIPPED) - A television signs in through the pairing handshake precisely
 - **SURF-27** (AGREED) - A television build that ships a pointer-shaped screen has not met
 - **SURF-28** (AGREED) - A surface serving more than one model, such as a tablet with a
@@ -424,3 +433,4 @@
 - **SURF-46** (AGREED) - KROMA never claims a panel decodes a codec its generation predates.
 - **SURF-47** (SHIPPED) - The input model is the one thing a surface may *not* copy from web,
 - **SURF-48** (SHIPPED) - A download is a single progressive file: the raw original when the
+- **SURF-49** (SHIPPED) - A remote, a gamepad and a keyboard's arrow keys are the same input

--- a/docs/spec/admin/README.md
+++ b/docs/spec/admin/README.md
@@ -1,7 +1,6 @@
 # Admin
 
-Status: **AGREED** overall, with the update mechanism still **DRAFT** where a delivery
-choice stays open. Every section carries its own status; the file-level label is the floor.
+Status: **AGREED**. Every section carries its own status; the file-level label is the floor.
 
 Running a KROMA server. The audience is one person with a NAS, not an operations team.
 That framing decides everything below: expose little, default sanely, and never add a knob
@@ -267,31 +266,34 @@ the backup remembers, so watch history reattaches to media the moment it is scan
 
 ## Updates
 
-Status: **DRAFT**, delivery mechanism provisional
+Status: **AGREED**
 
-A server learns it is out of date by checking for a newer release and saying so, quietly, in
-Admin, as a passive notice and never an automatic action. The owner decides when. Nothing on a
-self-hosted media server should update itself under the family mid-film.
+**ADMIN-89** (AGREED) - A server learns it is out of date by checking for a newer release and
+saying so, quietly, in Admin, as a passive notice and never an automatic action. The owner
+decides when. Nothing on a self-hosted media server updates itself under the family mid-film.
 
 The risk an update carries, and how KROMA bounds it:
 
-- **Server updates** may change the persistent store. The rule: an update migrates forward
-  automatically and a backup is the safety net, so the owner is nudged to have a current
-  backup before a server update, and a failed migration leaves the previous version
-  restorable rather than a half-migrated store.
-- **Module updates** are independent of the server and carry their own compatibility
-  promise ([`modules/`](../modules/)); a module update never requires a server update and a
-  server update never silently updates modules.
-- **Active playback is not a reason an update is blocked, and an update is not a reason
-  playback stops**, but because a server update means a restart, the owner is told an update
-  will interrupt streams and chooses the moment. Updates are the one deliberate exception to
-  the live-change guarantee below.
+- **ADMIN-90** (AGREED) - A server update migrates the persistent store forward
+  automatically, and a backup is the safety net: the owner is nudged to have a current backup
+  before one, and a failed migration leaves the previous version restorable rather than a
+  half-migrated store.
+- **ADMIN-91** (AGREED) - Module updates are independent of the server and carry their own
+  compatibility promise ([`modules/`](../modules/)). A module update never requires a server
+  update, and a server update never silently updates modules.
+- **ADMIN-92** (AGREED) - Active playback neither blocks an update nor is stopped by one
+  being available. Because a server update means a restart, the owner is told an update will
+  interrupt streams and chooses the moment. Updates are the one deliberate exception to the
+  live-change guarantee below.
 
-Open, with a recommendation: how the update actually arrives differs per host, a NAS
-package or a desktop auto-updater or a container image, and that delivery is
-[`surfaces/`](../surfaces/). Recommended answer: the product rule ("passive notice, owner
-chooses, backup first, migrate-forward-or-restore") is fixed here and identical everywhere;
-only the delivery vehicle varies by surface. This split is provisional pending review.
+**ADMIN-93** (AGREED) - The rule above is identical on every host. Only the delivery vehicle
+varies, a NAS package or a desktop auto-updater or a container image, and which vehicle a
+surface uses is [`surfaces/`](../surfaces/)'s (SURF-34 to SURF-39).
+
+The alternative was to let each host's packaging carry its own update policy, which is how a
+product ends up with a NAS that asks and a container that does not. Passive notice, owner
+chooses, backup first, migrate forward or restore: one rule, stated once, and a vehicle is
+only a vehicle.
 
 ## Changing settings while media plays
 

--- a/docs/spec/library/README.md
+++ b/docs/spec/library/README.md
@@ -1,7 +1,6 @@
 # Library
 
-Status: **AGREED** overall, with one section still **DRAFT** where a product choice
-stays open. Every section carries its own status; the file-level label is the floor.
+Status: **AGREED**. Every section carries its own status; the file-level label is the floor.
 
 Sources on disk become titles you can browse. Everything upstream of "there is something
 to play". What a title *is* once matched, meaning streams, codecs and artwork, is
@@ -215,27 +214,32 @@ architecture rather than product rules, and are not fixed here.
 
 ## Refresh
 
-Status: **DRAFT**, recommended rules provisional
+Status: **AGREED**
 
-**LIB-41** (DRAFT) - A newly matched item fetches its metadata once.
+**LIB-41** (SHIPPED) - A newly matched item fetches its metadata once.
 
-**LIB-42** (DRAFT) - Running series are re-checked on a slow cadence, so a new episode's air
+**LIB-42** (AGREED) - Running series are re-checked on a slow cadence, so a new episode's air
 date and stills appear without a person asking. Completed films are not re-checked on a
 timer, because their metadata does not change.
 
-**LIB-43** (DRAFT) - A "Refresh metadata" action on any title, season or whole source
+**LIB-43** (AGREED) - A "Refresh metadata" action on any title, season or whole source
 re-fetches from the provider and overwrites the cache, so a person can pull a corrected
 summary or better artwork on demand.
 
-**LIB-44** (DRAFT) - A forced refresh **never** discards a manual match or user-chosen
+**LIB-44** (AGREED) - A forced refresh **never** discards a manual match or user-chosen
 artwork. It refreshes the descriptive fields around a binding the person set; it does not
 overturn the binding.
 
-Open, with a recommendation: whether a forced refresh should also re-run *matching* rather
-than only re-fetch metadata for the current identity. Recommended answer: keep them separate.
-"Refresh metadata" updates the record, and a distinct "Re-match" action re-runs
-identification, so a person never loses a correct match by asking for fresher artwork. This is
-provisional pending review.
+**LIB-50** (SHIPPED) - Refreshing metadata and re-running identification are two actions, and
+a metadata refresh never re-runs matching. "Re-match" is its own action, on a title, and it is
+the only thing that can change a binding.
+
+Two actions rather than one, because they fail in opposite directions. A person asking for
+better artwork is asking about the *record*; a person fixing a wrong film is asking about the
+*identity*. Folding them together means the cheap, frequent, safe request carries the risk of
+the rare, deliberate, destructive one, and the first time a refresh silently re-matched a
+correctly-bound file the person would stop trusting refresh entirely. Splitting them costs one
+menu entry.
 
 ## Deletions and moves
 

--- a/docs/spec/modules/README.md
+++ b/docs/spec/modules/README.md
@@ -2,9 +2,9 @@
 
 Status: **SHIPPED** overall. The out-of-process model, the `.kmod` bundle, the Store,
 install-by-id and by-upload, checksum verification, dependency resolution and the
-compatibility gate are all released. Two sections stay open and carry their own status:
-the trust model for third-party registries, and the abandonment story. Every section
-carries a status; the file-level label is the floor.
+compatibility gate are all released. The trust posture and the abandonment story are decided
+but not yet built, and say so. Every section carries a status; the file-level label is the
+floor.
 
 **MOD-1** (SHIPPED) - The base build ships **zero modules**. Everything past playback and
 catalogue, meaning downloads, indexers, acquisition, VPN, transcription, embeddings, network
@@ -126,26 +126,41 @@ duplicate ids and the empty-catalogue-is-a-failure rule are specified in
 
 ## Trust
 
-Status: **DRAFT**
+Status: **AGREED**
 
-The trust model for third-party registries is genuinely open. The shipped integrity
-guarantees are settled; the *safety* posture around untrusted publishers is not. The
-proposed position:
+**The registry is the trust boundary, not the module.** A module is a native binary the
+server executes, and nothing KROMA can check about the bytes changes that. So the one place
+consent is asked is where a source of modules is added, and it is asked in those terms.
 
-- **MOD-24** (DRAFT) - **First-party is trusted by default.** The official registry is
+- **MOD-24** (AGREED) - **First-party is trusted by default.** The official registry is
   pinned, first-party and curated, and a module from it installs without a trust prompt.
-- **MOD-25** (DRAFT) - **A third-party registry is an explicit operator opt-in.** Adding one
+- **MOD-25** (AGREED) - **A third-party registry is an explicit operator opt-in.** Adding one
   is admin-only and is *not* a trust grant to its modules; it only makes them visible.
-- **MOD-26** (DRAFT) - The operator is told, in plain terms, that a module is a native binary
+- **MOD-26** (AGREED) - The operator is told, in plain terms, that a module is a native binary
   the server will execute, so adding a registry they do not control is equivalent to trusting
   its operator with code execution on the host.
-- **MOD-27** (DRAFT) - **Checksums guarantee integrity, never safety**, and the server says so
+- **MOD-27** (AGREED) - **Checksums guarantee integrity, never safety**, and the server says so
   where it matters: on the add-registry flow and on installing a non-first-party module.
 
-Signing and a curated-versus-community distinction are candidates, not decided.
+**MOD-48** (AGREED) - The Store names the registry every module came from, on the listing and
+on the module's own page, so an operator can always see whose code they are about to run.
 
-Until this is resolved, the honest line the user is shown is: *the server verifies this is
-the file the registry published; it does not vouch for what the file does.*
+**MOD-49** (AGREED) - Installing from a registry the operator added is gated once, per
+registry, on an explicit acknowledgement that its modules run as native code on this host. The
+acknowledgement is recorded; it is not asked again per module.
+
+**KROMA does not sign modules, and the official catalogue has no curated-versus-community
+tier.** Both were candidates and both are declined. A signature proves a publisher is the same
+publisher as last time, which the registry already establishes, and it does not make a module
+safe: a signed malicious module is malicious. Paying for key management, a signing service and
+a barrier to every third-party author, to buy continuity the registry already gives, is the
+wrong trade for a product where the operator owns the machine and installs by choice. A
+curated tier is worse than nothing, because it puts KROMA's name on a safety claim about code
+KROMA did not write.
+
+The line the person is shown stays what it always was: *the server verifies this is the file
+the registry published; it does not vouch for what the file does.* That sentence is now the
+whole policy rather than a placeholder for one.
 
 ## Lifecycle
 
@@ -224,25 +239,33 @@ catalogue the server's alone.
 
 ## When a module stops being maintained
 
-Status: **DRAFT**
+Status: **AGREED**
 
-The abandonment story is not fully settled, but the user must never be left guessing, and
-their data must never be at risk. The designed visible signal:
+**Abandonment is inferred, never declared.** The person must never be left guessing, and their
+data must never be at risk:
 
-- **MOD-44** (DRAFT) - **The compatibility gate is the early warning.** As the server moves
+- **MOD-44** (AGREED) - **The compatibility gate is the early warning.** As the server moves
   forward, an unmaintained module eventually fails its `minServer` against a newer server it
   was never updated for, and that mismatch is surfaced by name on the Modules surface as an
   **incompatible or unmaintained** state rather than a silent failure to spawn.
-- **MOD-45** (DRAFT) - **Data is retained.** An incompatible or abandoned module is not
+- **MOD-45** (AGREED) - **Data is retained.** An incompatible or abandoned module is not
   auto-removed. It is stopped and flagged and its data kept, so a later fixed build, a
   downgrade or a fork can pick it back up. Only an explicit uninstall discards module data.
-- **MOD-46** (DRAFT) - **The signal is honest.** The person is told the module has not kept
+- **MOD-46** (AGREED) - **The signal is honest.** The person is told the module has not kept
   pace with the server and is not running, is pointed at its registry entry and version
   history, and keeps every option: leave it disabled, replace it, or uninstall it
   deliberately.
 
-Open: whether the registry should carry an explicit maintenance/deprecation flag a
-publisher sets, versus inferring abandonment purely from the compatibility gate.
+**MOD-50** (AGREED) - A module that has disappeared from every configured registry is flagged
+the same way a module that fails its floor is, and for the same reason: it is a signal the
+server can read without anyone's cooperation.
+
+**A registry carries no publisher-set deprecation flag.** It was the other candidate and it is
+declined, because a flag has to be set at exactly the moment the publisher has stopped caring.
+A signal that only conscientious publishers raise does not cover the case it exists for, and
+shipping it would let an unflagged abandoned module read as maintained. The compatibility gate
+and a vanished catalogue entry both fire on their own, so those are the two signals, and both
+are honest about being inferences rather than announcements.
 
 ## The first-party set, and why each is a module
 

--- a/docs/spec/requirements.json
+++ b/docs/spec/requirements.json
@@ -1117,7 +1117,7 @@
     "status": "AGREED",
     "text": "A reset is a single-use, time-limited link plus a short one-time",
     "file": "docs/spec/admin/README.md",
-    "line": 112
+    "line": 111
   },
   {
     "id": "ADMIN-80",
@@ -1127,7 +1127,7 @@
     "status": "AGREED",
     "text": "The code is eight characters from a thirty-two-symbol alphabet with",
     "file": "docs/spec/admin/README.md",
-    "line": 118
+    "line": 117
   },
   {
     "id": "ADMIN-81",
@@ -1137,7 +1137,7 @@
     "status": "AGREED",
     "text": "A new reset invalidates any unused previous one for the same account.",
     "file": "docs/spec/admin/README.md",
-    "line": 122
+    "line": 121
   },
   {
     "id": "ADMIN-82",
@@ -1147,7 +1147,7 @@
     "status": "AGREED",
     "text": "Delivery is the owner's choice, per server: copy the link and code",
     "file": "docs/spec/admin/README.md",
-    "line": 126
+    "line": 125
   },
   {
     "id": "ADMIN-83",
@@ -1157,7 +1157,7 @@
     "status": "AGREED",
     "text": "The kroma.tv relay sees the destination address and the link, never",
     "file": "docs/spec/admin/README.md",
-    "line": 134
+    "line": 133
   },
   {
     "id": "ADMIN-84",
@@ -1167,7 +1167,7 @@
     "status": "AGREED",
     "text": "The owner can clear a user's profile PIN. Clearing is the only PIN",
     "file": "docs/spec/admin/README.md",
-    "line": 149
+    "line": 148
   },
   {
     "id": "ADMIN-85",
@@ -1177,7 +1177,7 @@
     "status": "AGREED",
     "text": "An address on an account is unverified until the mailbox proves",
     "file": "docs/spec/admin/README.md",
-    "line": 159
+    "line": 158
   },
   {
     "id": "ADMIN-86",
@@ -1187,7 +1187,7 @@
     "status": "AGREED",
     "text": "The owner sends a verification from the member editor, with the",
     "file": "docs/spec/admin/README.md",
-    "line": 164
+    "line": 163
   },
   {
     "id": "ADMIN-87",
@@ -1197,7 +1197,7 @@
     "status": "AGREED",
     "text": "Changing the address clears the verified state: the proof belongs",
     "file": "docs/spec/admin/README.md",
-    "line": 169
+    "line": 168
   },
   {
     "id": "ADMIN-88",
@@ -1207,7 +1207,57 @@
     "status": "AGREED",
     "text": "A user who cannot sign in can ask for a reset from the sign-in",
     "file": "docs/spec/admin/README.md",
-    "line": 138
+    "line": 137
+  },
+  {
+    "id": "ADMIN-89",
+    "domain": "ADMIN",
+    "space": "admin",
+    "number": 89,
+    "status": "AGREED",
+    "text": "A server learns it is out of date by checking for a newer release and",
+    "file": "docs/spec/admin/README.md",
+    "line": 271
+  },
+  {
+    "id": "ADMIN-90",
+    "domain": "ADMIN",
+    "space": "admin",
+    "number": 90,
+    "status": "AGREED",
+    "text": "A server update migrates the persistent store forward",
+    "file": "docs/spec/admin/README.md",
+    "line": 277
+  },
+  {
+    "id": "ADMIN-91",
+    "domain": "ADMIN",
+    "space": "admin",
+    "number": 91,
+    "status": "AGREED",
+    "text": "Module updates are independent of the server and carry their own",
+    "file": "docs/spec/admin/README.md",
+    "line": 281
+  },
+  {
+    "id": "ADMIN-92",
+    "domain": "ADMIN",
+    "space": "admin",
+    "number": 92,
+    "status": "AGREED",
+    "text": "Active playback neither blocks an update nor is stopped by one",
+    "file": "docs/spec/admin/README.md",
+    "line": 284
+  },
+  {
+    "id": "ADMIN-93",
+    "domain": "ADMIN",
+    "space": "admin",
+    "number": 93,
+    "status": "AGREED",
+    "text": "The rule above is identical on every host. Only the delivery vehicle",
+    "file": "docs/spec/admin/README.md",
+    "line": 289
   },
   {
     "id": "DISC-1",
@@ -1547,7 +1597,7 @@
     "status": "AGREED",
     "text": "A **source** is a directory tree the server is told to watch, tagged",
     "file": "docs/spec/library/README.md",
-    "line": 15
+    "line": 14
   },
   {
     "id": "LIB-2",
@@ -1557,7 +1607,7 @@
     "status": "AGREED",
     "text": "A movie source never produces episodes and a show source never produces",
     "file": "docs/spec/library/README.md",
-    "line": 19
+    "line": 18
   },
   {
     "id": "LIB-3",
@@ -1567,7 +1617,7 @@
     "status": "AGREED",
     "text": "A server has zero or more sources, any number of them may point at the",
     "file": "docs/spec/library/README.md",
-    "line": 22
+    "line": 21
   },
   {
     "id": "LIB-4",
@@ -1577,7 +1627,7 @@
     "status": "AGREED",
     "text": "A source is an input, not a category a person browses by. Filtering the",
     "file": "docs/spec/library/README.md",
-    "line": 27
+    "line": 26
   },
   {
     "id": "LIB-5",
@@ -1587,7 +1637,7 @@
     "status": "SHIPPED",
     "text": "A source tree may be assembled from symlinks. A curated folder of links",
     "file": "docs/spec/library/README.md",
-    "line": 30
+    "line": 29
   },
   {
     "id": "LIB-6",
@@ -1597,7 +1647,7 @@
     "status": "SHIPPED",
     "text": "A link the server cannot resolve is reported, never silently skipped,",
     "file": "docs/spec/library/README.md",
-    "line": 34
+    "line": 33
   },
   {
     "id": "LIB-7",
@@ -1607,7 +1657,7 @@
     "status": "AGREED",
     "text": "A source records its mount path, its content kind and its scan schedule.",
     "file": "docs/spec/library/README.md",
-    "line": 38
+    "line": 37
   },
   {
     "id": "LIB-8",
@@ -1617,7 +1667,7 @@
     "status": "AGREED",
     "text": "Nothing about a source is destructive. Removing one drops its titles",
     "file": "docs/spec/library/README.md",
-    "line": 40
+    "line": 39
   },
   {
     "id": "LIB-9",
@@ -1627,7 +1677,7 @@
     "status": "AGREED",
     "text": "Matching is convention-first: a correctly named file matches offline,",
     "file": "docs/spec/library/README.md",
-    "line": 49
+    "line": 48
   },
   {
     "id": "LIB-10",
@@ -1637,7 +1687,7 @@
     "status": "SHIPPED",
     "text": "The `Title (Year)` stem is what is matched. The year is not",
     "file": "docs/spec/library/README.md",
-    "line": 60
+    "line": 59
   },
   {
     "id": "LIB-11",
@@ -1647,7 +1697,7 @@
     "status": "SHIPPED",
     "text": "A trailing tag after ` - `, a resolution, an edition or a source, is",
     "file": "docs/spec/library/README.md",
-    "line": 64
+    "line": 63
   },
   {
     "id": "LIB-12",
@@ -1657,7 +1707,7 @@
     "status": "SHIPPED",
     "text": "A loose file directly under the source root, with no folder, is",
     "file": "docs/spec/library/README.md",
-    "line": 68
+    "line": 67
   },
   {
     "id": "LIB-13",
@@ -1667,7 +1717,7 @@
     "status": "SHIPPED",
     "text": "A season folder is what makes the folder above it the show. With one",
     "file": "docs/spec/library/README.md",
-    "line": 80
+    "line": 79
   },
   {
     "id": "LIB-14",
@@ -1677,7 +1727,7 @@
     "status": "SHIPPED",
     "text": "Without a season folder the folder proves nothing, because a flat pool",
     "file": "docs/spec/library/README.md",
-    "line": 84
+    "line": 83
   },
   {
     "id": "LIB-15",
@@ -1687,7 +1737,7 @@
     "status": "SHIPPED",
     "text": "An episode whose filename is only its marker (`S01E01.mkv`) takes the",
     "file": "docs/spec/library/README.md",
-    "line": 87
+    "line": 86
   },
   {
     "id": "LIB-16",
@@ -1697,7 +1747,7 @@
     "status": "SHIPPED",
     "text": "The show folder name and the `SxxEyy` marker are load-bearing; the",
     "file": "docs/spec/library/README.md",
-    "line": 91
+    "line": 90
   },
   {
     "id": "LIB-17",
@@ -1707,7 +1757,7 @@
     "status": "SHIPPED",
     "text": "`Specials` is accepted as an alias for `Season 00`.",
     "file": "docs/spec/library/README.md",
-    "line": 94
+    "line": 93
   },
   {
     "id": "LIB-18",
@@ -1717,7 +1767,7 @@
     "status": "SHIPPED",
     "text": "A multi-episode file is named with a range (`S01E01-E02`) and matched",
     "file": "docs/spec/library/README.md",
-    "line": 96
+    "line": 95
   },
   {
     "id": "LIB-19",
@@ -1727,7 +1777,7 @@
     "status": "AGREED",
     "text": "A show folder MAY carry a `(Year)` for disambiguation",
     "file": "docs/spec/library/README.md",
-    "line": 99
+    "line": 98
   },
   {
     "id": "LIB-20",
@@ -1737,7 +1787,7 @@
     "status": "SHIPPED",
     "text": "Case is ignored, and separators may be spaces, dots or underscores.",
     "file": "docs/spec/library/README.md",
-    "line": 102
+    "line": 101
   },
   {
     "id": "LIB-21",
@@ -1747,7 +1797,7 @@
     "status": "SHIPPED",
     "text": "Only recognised video containers are considered files to match.",
     "file": "docs/spec/library/README.md",
-    "line": 104
+    "line": 103
   },
   {
     "id": "LIB-22",
@@ -1757,7 +1807,7 @@
     "status": "AGREED",
     "text": "The scheme is a convention rather than configuration, so a library is",
     "file": "docs/spec/library/README.md",
-    "line": 108
+    "line": 107
   },
   {
     "id": "LIB-23",
@@ -1767,7 +1817,7 @@
     "status": "SHIPPED",
     "text": "An **initial scan** runs when a source is added: the whole tree is",
     "file": "docs/spec/library/README.md",
-    "line": 117
+    "line": 116
   },
   {
     "id": "LIB-24",
@@ -1777,7 +1827,7 @@
     "status": "AGREED",
     "text": "An **incremental rescan** keeps the catalogue true to disk afterwards.",
     "file": "docs/spec/library/README.md",
-    "line": 122
+    "line": 121
   },
   {
     "id": "LIB-25",
@@ -1787,7 +1837,7 @@
     "status": "AGREED",
     "text": "An incremental rescan only reconsiders what changed, meaning new paths,",
     "file": "docs/spec/library/README.md",
-    "line": 128
+    "line": 127
   },
   {
     "id": "LIB-26",
@@ -1797,7 +1847,7 @@
     "status": "AGREED",
     "text": "Scanning is safe to run at any time, including while files are being",
     "file": "docs/spec/library/README.md",
-    "line": 132
+    "line": 131
   },
   {
     "id": "LIB-27",
@@ -1807,7 +1857,7 @@
     "status": "AGREED",
     "text": "A file is matched only once it looks **settled**, its size and",
     "file": "docs/spec/library/README.md",
-    "line": 135
+    "line": 134
   },
   {
     "id": "LIB-28",
@@ -1817,7 +1867,7 @@
     "status": "SHIPPED",
     "text": "Scanning **reads only**. It never writes, moves, renames or deletes",
     "file": "docs/spec/library/README.md",
-    "line": 140
+    "line": 139
   },
   {
     "id": "LIB-29",
@@ -1827,7 +1877,7 @@
     "status": "AGREED",
     "text": "KROMA never demands exclusive access to a library and never blocks the",
     "file": "docs/spec/library/README.md",
-    "line": 143
+    "line": 142
   },
   {
     "id": "LIB-30",
@@ -1837,7 +1887,7 @@
     "status": "AGREED",
     "text": "Matching resolves a settled file to an identity: a convention parse",
     "file": "docs/spec/library/README.md",
-    "line": 158
+    "line": 157
   },
   {
     "id": "LIB-31",
@@ -1847,7 +1897,7 @@
     "status": "AGREED",
     "text": "A file that parses to no confident identity, whether from an",
     "file": "docs/spec/library/README.md",
-    "line": 164
+    "line": 163
   },
   {
     "id": "LIB-32",
@@ -1857,7 +1907,7 @@
     "status": "AGREED",
     "text": "Unmatched items appear in a browsable **Unmatched** view in the library",
     "file": "docs/spec/library/README.md",
-    "line": 169
+    "line": 168
   },
   {
     "id": "LIB-33",
@@ -1867,7 +1917,7 @@
     "status": "AGREED",
     "text": "**Manual match.** A person searches the provider, picks the correct",
     "file": "docs/spec/library/README.md",
-    "line": 173
+    "line": 172
   },
   {
     "id": "LIB-34",
@@ -1877,7 +1927,7 @@
     "status": "AGREED",
     "text": "**Rename on disk.** A name fixed to the convention above matches",
     "file": "docs/spec/library/README.md",
-    "line": 177
+    "line": 176
   },
   {
     "id": "LIB-35",
@@ -1887,7 +1937,7 @@
     "status": "AGREED",
     "text": "A file that could be more than one identity, a title shared by a remake",
     "file": "docs/spec/library/README.md",
-    "line": 183
+    "line": 182
   },
   {
     "id": "LIB-36",
@@ -1897,7 +1947,7 @@
     "status": "AGREED",
     "text": "One unplaceable file never stalls a source. The catalogue is always the",
     "file": "docs/spec/library/README.md",
-    "line": 189
+    "line": 188
   },
   {
     "id": "LIB-37",
@@ -1907,7 +1957,7 @@
     "status": "AGREED",
     "text": "Every field and image a provider returns is written to the server's own",
     "file": "docs/spec/library/README.md",
-    "line": 199
+    "line": 198
   },
   {
     "id": "LIB-38",
@@ -1917,7 +1967,7 @@
     "status": "AGREED",
     "text": "With no internet, everything already matched browses and plays exactly",
     "file": "docs/spec/library/README.md",
-    "line": 204
+    "line": 203
   },
   {
     "id": "LIB-39",
@@ -1927,7 +1977,7 @@
     "status": "AGREED",
     "text": "Offline, a brand-new file that needs a first provider lookup stays",
     "file": "docs/spec/library/README.md",
-    "line": 207
+    "line": 206
   },
   {
     "id": "LIB-40",
@@ -1937,47 +1987,47 @@
     "status": "AGREED",
     "text": "Offline, a forced refresh queues rather than fails.",
     "file": "docs/spec/library/README.md",
-    "line": 211
+    "line": 210
   },
   {
     "id": "LIB-41",
     "domain": "LIB",
     "space": "library",
     "number": 41,
-    "status": "DRAFT",
+    "status": "SHIPPED",
     "text": "A newly matched item fetches its metadata once.",
     "file": "docs/spec/library/README.md",
-    "line": 220
+    "line": 219
   },
   {
     "id": "LIB-42",
     "domain": "LIB",
     "space": "library",
     "number": 42,
-    "status": "DRAFT",
+    "status": "AGREED",
     "text": "Running series are re-checked on a slow cadence, so a new episode's air",
     "file": "docs/spec/library/README.md",
-    "line": 222
+    "line": 221
   },
   {
     "id": "LIB-43",
     "domain": "LIB",
     "space": "library",
     "number": 43,
-    "status": "DRAFT",
+    "status": "AGREED",
     "text": "A \"Refresh metadata\" action on any title, season or whole source",
     "file": "docs/spec/library/README.md",
-    "line": 226
+    "line": 225
   },
   {
     "id": "LIB-44",
     "domain": "LIB",
     "space": "library",
     "number": 44,
-    "status": "DRAFT",
+    "status": "AGREED",
     "text": "A forced refresh **never** discards a manual match or user-chosen",
     "file": "docs/spec/library/README.md",
-    "line": 230
+    "line": 229
   },
   {
     "id": "LIB-45",
@@ -1987,7 +2037,7 @@
     "status": "AGREED",
     "text": "When a file disappears from a source, its title is **marked absent**:",
     "file": "docs/spec/library/README.md",
-    "line": 247
+    "line": 251
   },
   {
     "id": "LIB-46",
@@ -1997,7 +2047,7 @@
     "status": "AGREED",
     "text": "Content that reappears, because a NAS remounts or a file is moved back",
     "file": "docs/spec/library/README.md",
-    "line": 252
+    "line": 256
   },
   {
     "id": "LIB-47",
@@ -2007,7 +2057,7 @@
     "status": "AGREED",
     "text": "A **move** is therefore not a special case. It is an absent path plus a",
     "file": "docs/spec/library/README.md",
-    "line": 256
+    "line": 260
   },
   {
     "id": "LIB-48",
@@ -2017,7 +2067,7 @@
     "status": "AGREED",
     "text": "A rescan **only ever marks absent**. It never deletes user data.",
     "file": "docs/spec/library/README.md",
-    "line": 260
+    "line": 264
   },
   {
     "id": "LIB-49",
@@ -2027,7 +2077,17 @@
     "status": "AGREED",
     "text": "Permanently deleting a title's history is an explicit, person-initiated",
     "file": "docs/spec/library/README.md",
-    "line": 262
+    "line": 266
+  },
+  {
+    "id": "LIB-50",
+    "domain": "LIB",
+    "space": "library",
+    "number": 50,
+    "status": "SHIPPED",
+    "text": "Refreshing metadata and re-running identification are two actions, and",
+    "file": "docs/spec/library/README.md",
+    "line": 233
   },
   {
     "id": "MEDIA-1",
@@ -2724,7 +2784,7 @@
     "domain": "MOD",
     "space": "modules",
     "number": 24,
-    "status": "DRAFT",
+    "status": "AGREED",
     "text": "**First-party is trusted by default.** The official registry is",
     "file": "docs/spec/modules/README.md",
     "line": 135
@@ -2734,7 +2794,7 @@
     "domain": "MOD",
     "space": "modules",
     "number": 25,
-    "status": "DRAFT",
+    "status": "AGREED",
     "text": "**A third-party registry is an explicit operator opt-in.** Adding one",
     "file": "docs/spec/modules/README.md",
     "line": 137
@@ -2744,7 +2804,7 @@
     "domain": "MOD",
     "space": "modules",
     "number": 26,
-    "status": "DRAFT",
+    "status": "AGREED",
     "text": "The operator is told, in plain terms, that a module is a native binary",
     "file": "docs/spec/modules/README.md",
     "line": 139
@@ -2754,7 +2814,7 @@
     "domain": "MOD",
     "space": "modules",
     "number": 27,
-    "status": "DRAFT",
+    "status": "AGREED",
     "text": "**Checksums guarantee integrity, never safety**, and the server says so",
     "file": "docs/spec/modules/README.md",
     "line": 142
@@ -2767,7 +2827,7 @@
     "status": "SHIPPED",
     "text": "**Enable.** The server spawns the sidecar and the module's routes,",
     "file": "docs/spec/modules/README.md",
-    "line": 156
+    "line": 171
   },
   {
     "id": "MOD-29",
@@ -2777,7 +2837,7 @@
     "status": "SHIPPED",
     "text": "**Disable.** The sidecar is stopped, the module stops running, and",
     "file": "docs/spec/modules/README.md",
-    "line": 159
+    "line": 174
   },
   {
     "id": "MOD-30",
@@ -2787,7 +2847,7 @@
     "status": "SHIPPED",
     "text": "**Update.** A newer version replaces the bundle and the sidecar is",
     "file": "docs/spec/modules/README.md",
-    "line": 162
+    "line": 177
   },
   {
     "id": "MOD-31",
@@ -2797,7 +2857,7 @@
     "status": "SHIPPED",
     "text": "`minServer` is re-checked on update, so an update that outgrows the",
     "file": "docs/spec/modules/README.md",
-    "line": 165
+    "line": 180
   },
   {
     "id": "MOD-32",
@@ -2807,7 +2867,7 @@
     "status": "SHIPPED",
     "text": "**Uninstall.** The module is removed entirely. It is the one",
     "file": "docs/spec/modules/README.md",
-    "line": 167
+    "line": 182
   },
   {
     "id": "MOD-33",
@@ -2817,7 +2877,7 @@
     "status": "SHIPPED",
     "text": "The server refuses to uninstall a module another enabled module still",
     "file": "docs/spec/modules/README.md",
-    "line": 170
+    "line": 185
   },
   {
     "id": "MOD-34",
@@ -2827,7 +2887,7 @@
     "status": "SHIPPED",
     "text": "Uninstalling a module never touches media on disk. A downloads module",
     "file": "docs/spec/modules/README.md",
-    "line": 173
+    "line": 188
   },
   {
     "id": "MOD-35",
@@ -2837,7 +2897,7 @@
     "status": "SHIPPED",
     "text": "**A crashed module cannot take down the server.** The sidecar is a",
     "file": "docs/spec/modules/README.md",
-    "line": 183
+    "line": 198
   },
   {
     "id": "MOD-36",
@@ -2847,7 +2907,7 @@
     "status": "SHIPPED",
     "text": "**An incompatible module never runs by accident.** `minServer` is",
     "file": "docs/spec/modules/README.md",
-    "line": 186
+    "line": 201
   },
   {
     "id": "MOD-37",
@@ -2857,7 +2917,7 @@
     "status": "SHIPPED",
     "text": "**Failure is visible, not silent.** A module that will not start or",
     "file": "docs/spec/modules/README.md",
-    "line": 189
+    "line": 204
   },
   {
     "id": "MOD-38",
@@ -2867,7 +2927,7 @@
     "status": "SHIPPED",
     "text": "The server is forward-compatible with older modules. A module declares",
     "file": "docs/spec/modules/README.md",
-    "line": 197
+    "line": 212
   },
   {
     "id": "MOD-39",
@@ -2877,7 +2937,7 @@
     "status": "SHIPPED",
     "text": "A module installed today keeps working as the server is updated,",
     "file": "docs/spec/modules/README.md",
-    "line": 200
+    "line": 215
   },
   {
     "id": "MOD-40",
@@ -2887,7 +2947,7 @@
     "status": "SHIPPED",
     "text": "A *newer* module may raise its `minServer`, and the Store says so",
     "file": "docs/spec/modules/README.md",
-    "line": 203
+    "line": 218
   },
   {
     "id": "MOD-41",
@@ -2897,7 +2957,7 @@
     "status": "SHIPPED",
     "text": "A module **may** ship UI, and the position is deliberate: a module's",
     "file": "docs/spec/modules/README.md",
-    "line": 211
+    "line": 226
   },
   {
     "id": "MOD-42",
@@ -2907,7 +2967,7 @@
     "status": "AGREED",
     "text": "A module renders **its own admin surface**: configuration, status and",
     "file": "docs/spec/modules/README.md",
-    "line": 215
+    "line": 230
   },
   {
     "id": "MOD-43",
@@ -2917,37 +2977,37 @@
     "status": "SHIPPED",
     "text": "A module's UI is served through the same reverse proxy as its backend",
     "file": "docs/spec/modules/README.md",
-    "line": 218
+    "line": 233
   },
   {
     "id": "MOD-44",
     "domain": "MOD",
     "space": "modules",
     "number": 44,
-    "status": "DRAFT",
+    "status": "AGREED",
     "text": "**The compatibility gate is the early warning.** As the server moves",
     "file": "docs/spec/modules/README.md",
-    "line": 232
+    "line": 247
   },
   {
     "id": "MOD-45",
     "domain": "MOD",
     "space": "modules",
     "number": 45,
-    "status": "DRAFT",
+    "status": "AGREED",
     "text": "**Data is retained.** An incompatible or abandoned module is not",
     "file": "docs/spec/modules/README.md",
-    "line": 236
+    "line": 251
   },
   {
     "id": "MOD-46",
     "domain": "MOD",
     "space": "modules",
     "number": 46,
-    "status": "DRAFT",
+    "status": "AGREED",
     "text": "**The signal is honest.** The person is told the module has not kept",
     "file": "docs/spec/modules/README.md",
-    "line": 239
+    "line": 254
   },
   {
     "id": "MOD-47",
@@ -2957,7 +3017,37 @@
     "status": "SHIPPED",
     "text": "Every capability below could have been core and is a module instead,",
     "file": "docs/spec/modules/README.md",
-    "line": 251
+    "line": 274
+  },
+  {
+    "id": "MOD-48",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 48,
+    "status": "AGREED",
+    "text": "The Store names the registry every module came from, on the listing and",
+    "file": "docs/spec/modules/README.md",
+    "line": 145
+  },
+  {
+    "id": "MOD-49",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 49,
+    "status": "AGREED",
+    "text": "Installing from a registry the operator added is gated once, per",
+    "file": "docs/spec/modules/README.md",
+    "line": 148
+  },
+  {
+    "id": "MOD-50",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 50,
+    "status": "AGREED",
+    "text": "A module that has disappeared from every configured registry is flagged",
+    "file": "docs/spec/modules/README.md",
+    "line": 259
   },
   {
     "id": "PLAY-1",
@@ -3705,9 +3795,9 @@
     "space": "surfaces",
     "number": 23,
     "status": "SHIPPED",
-    "text": "**Pointer**, on web and desktop, is the reference model: dense",
+    "text": "**Pointer**, on web, is the reference model: dense layouts, hover",
     "file": "docs/spec/surfaces/README.md",
-    "line": 158
+    "line": 163
   },
   {
     "id": "SURF-24",
@@ -3717,7 +3807,7 @@
     "status": "SHIPPED",
     "text": "**Touch**, on mobile, means targets sized for a thumb, gestures for",
     "file": "docs/spec/surfaces/README.md",
-    "line": 161
+    "line": 166
   },
   {
     "id": "SURF-25",
@@ -3725,9 +3815,9 @@
     "space": "surfaces",
     "number": 25,
     "status": "SHIPPED",
-    "text": "**Remote, 10-foot**, on every television, is a directional focus",
+    "text": "**Directional, 10-foot**, on every television and on desktop, is a",
     "file": "docs/spec/surfaces/README.md",
-    "line": 164
+    "line": 169
   },
   {
     "id": "SURF-26",
@@ -3737,7 +3827,7 @@
     "status": "SHIPPED",
     "text": "A television signs in through the pairing handshake precisely",
     "file": "docs/spec/surfaces/README.md",
-    "line": 167
+    "line": 175
   },
   {
     "id": "SURF-27",
@@ -3747,7 +3837,7 @@
     "status": "AGREED",
     "text": "A television build that ships a pointer-shaped screen has not met",
     "file": "docs/spec/surfaces/README.md",
-    "line": 169
+    "line": 177
   },
   {
     "id": "SURF-28",
@@ -3757,7 +3847,7 @@
     "status": "AGREED",
     "text": "A surface serving more than one model, such as a tablet with a",
     "file": "docs/spec/surfaces/README.md",
-    "line": 171
+    "line": 179
   },
   {
     "id": "SURF-29",
@@ -3767,7 +3857,7 @@
     "status": "SHIPPED",
     "text": "**Only mobile is offline.** Web, desktop and every television hold no",
     "file": "docs/spec/surfaces/README.md",
-    "line": 178
+    "line": 186
   },
   {
     "id": "SURF-30",
@@ -3777,7 +3867,7 @@
     "status": "SHIPPED",
     "text": "A downloaded title plays with no server connection.",
     "file": "docs/spec/surfaces/README.md",
-    "line": 185
+    "line": 193
   },
   {
     "id": "SURF-31",
@@ -3787,7 +3877,7 @@
     "status": "SHIPPED",
     "text": "Downloads survive backgrounding and app kills, and are re-adopted",
     "file": "docs/spec/surfaces/README.md",
-    "line": 189
+    "line": 197
   },
   {
     "id": "SURF-32",
@@ -3797,7 +3887,7 @@
     "status": "SHIPPED",
     "text": "Progress reports that could not be sent queue on the device and",
     "file": "docs/spec/surfaces/README.md",
-    "line": 191
+    "line": 199
   },
   {
     "id": "SURF-33",
@@ -3807,7 +3897,7 @@
     "status": "DESIGN, NOT IMPLEMENTED",
     "text": "Per-title rows in the OS storage manager, deletable",
     "file": "docs/spec/surfaces/README.md",
-    "line": 199
+    "line": 207
   },
   {
     "id": "SURF-34",
@@ -3817,7 +3907,7 @@
     "status": "AGREED",
     "text": "A surface stays current without asking a person to babysit it.",
     "file": "docs/spec/surfaces/README.md",
-    "line": 217
+    "line": 225
   },
   {
     "id": "SURF-35",
@@ -3827,7 +3917,7 @@
     "status": "SHIPPED",
     "text": "**Web.** The server serves the web surface itself. There is no",
     "file": "docs/spec/surfaces/README.md",
-    "line": 219
+    "line": 227
   },
   {
     "id": "SURF-36",
@@ -3837,7 +3927,7 @@
     "status": "SHIPPED",
     "text": "**Desktop.** The app checks for, fetches and applies updates in the",
     "file": "docs/spec/surfaces/README.md",
-    "line": 222
+    "line": 230
   },
   {
     "id": "SURF-37",
@@ -3847,7 +3937,7 @@
     "status": "AGREED",
     "text": "**Mobile.** The app updates on the store's cadence, so a server",
     "file": "docs/spec/surfaces/README.md",
-    "line": 224
+    "line": 232
   },
   {
     "id": "SURF-38",
@@ -3857,7 +3947,7 @@
     "status": "AGREED",
     "text": "**Televisions.** Each television updates through its own platform's",
     "file": "docs/spec/surfaces/README.md",
-    "line": 227
+    "line": 235
   },
   {
     "id": "SURF-39",
@@ -3867,7 +3957,7 @@
     "status": "AGREED",
     "text": "**NAS.** The Synology package installs and updates through Package",
     "file": "docs/spec/surfaces/README.md",
-    "line": 229
+    "line": 237
   },
   {
     "id": "SURF-40",
@@ -3877,7 +3967,7 @@
     "status": "AGREED",
     "text": "A surface is dropped when its host platform can no longer meet the",
     "file": "docs/spec/surfaces/README.md",
-    "line": 238
+    "line": 246
   },
   {
     "id": "SURF-41",
@@ -3887,7 +3977,7 @@
     "status": "AGREED",
     "text": "**Notice first.** A surface entering deprecation tells its users *in",
     "file": "docs/spec/surfaces/README.md",
-    "line": 243
+    "line": 251
   },
   {
     "id": "SURF-42",
@@ -3897,7 +3987,7 @@
     "status": "AGREED",
     "text": "**Sessions survive the app.** A deprecated surface's sessions are",
     "file": "docs/spec/surfaces/README.md",
-    "line": 246
+    "line": 254
   },
   {
     "id": "SURF-43",
@@ -3907,7 +3997,7 @@
     "status": "AGREED",
     "text": "**The library outlives any surface.** Nothing about a person's",
     "file": "docs/spec/surfaces/README.md",
-    "line": 250
+    "line": 258
   },
   {
     "id": "SURF-44",
@@ -3957,6 +4047,16 @@
     "status": "SHIPPED",
     "text": "A download is a single progressive file: the raw original when the",
     "file": "docs/spec/surfaces/README.md",
-    "line": 186
+    "line": 194
+  },
+  {
+    "id": "SURF-49",
+    "domain": "SURF",
+    "space": "surfaces",
+    "number": 49,
+    "status": "SHIPPED",
+    "text": "A remote, a gamepad and a keyboard's arrow keys are the same input",
+    "file": "docs/spec/surfaces/README.md",
+    "line": 172
   }
 ]

--- a/docs/spec/surfaces/README.md
+++ b/docs/spec/surfaces/README.md
@@ -30,7 +30,7 @@ looking for the code and is not part of the requirement; the mapping lives in
 | LG TV | `clients/webos` | 10-foot UI, remote-only input |
 | Other TV | `clients/tv-web`, `clients/tv-native` | Apple TV / Android TV native; generic web fallback |
 | Mobile | `clients/mobile` | Offline downloads |
-| Desktop | `clients/desktop` | Auto-update |
+| Desktop | `clients/desktop` | 10-foot UI, gamepad or remote; auto-update |
 | NAS | `clients/synology` | Packaging, not a client |
 
 ## The baseline
@@ -110,12 +110,12 @@ does not do something is a decision on record.
 | Capability | Web | Mobile | Desktop | TV native | TV sandboxed (Tizen/webOS) |
 |---|---|---|---|---|---|
 | Baseline (six above) | must | must | must | must | must |
-| Input model | pointer | touch | pointer | remote | remote |
+| Input model | pointer | touch | directional | directional | directional |
 | Browses for a server on the LAN | no | yes | no | yes | no |
 | Announces itself on the LAN | n/a | n/a | n/a | yes | Tizen no / webOS yes |
 | Approves a television's pairing | yes (code) | yes (code or scan) | yes (code) | is the TV | is the TV |
 | Offline downloads | no | yes | no | no | no |
-| Direct-play ceiling | browser codecs | device generation | browser codecs | panel generation | panel generation |
+| Direct-play ceiling | browser codecs | device generation | device generation | panel generation | panel generation |
 
 Browsing and announcing are the surface's *reach*. The per-shell truth, meaning who announces,
 who browses and why Samsung cannot, is [`discovery/`](../discovery/)'s, grounded in
@@ -155,15 +155,23 @@ Status: **SHIPPED**. The three models are built; SURF-27 and SURF-28 are **AGREE
 because copying it would break the surface. Each of the three models below rewrites the UI
 rather than only the event handling.
 
-- **SURF-23** (SHIPPED) - **Pointer**, on web and desktop, is the reference model: dense
-  layouts, hover affordances, a visible cursor, right-click and keyboard shortcuts. Every
-  other model is a deliberate departure from it.
+Desktop is a directional surface, not a pointer one. The shell renders the same 10-foot
+experience the televisions render, on a fixed stage, and bridges a gamepad onto the same
+events a remote raises. A window with a mouse attached does not make it a pointer app, and
+web is where the pointer model lives.
+
+- **SURF-23** (SHIPPED) - **Pointer**, on web, is the reference model: dense layouts, hover
+  affordances, a visible cursor, right-click and keyboard shortcuts. Every other model is a
+  deliberate departure from it. Web is the only pointer surface.
 - **SURF-24** (SHIPPED) - **Touch**, on mobile, means targets sized for a thumb, gestures for
   scrub and dismiss, no hover state to depend on, and layouts that reflow to a held phone.
   Anything that only works with a cursor is redesigned, not shrunk.
-- **SURF-25** (SHIPPED) - **Remote, 10-foot**, on every television, is a directional focus
-  ring rather than a cursor: everything reachable by up, down, left, right and OK, legible
-  across a room, and no interaction that assumes text entry the remote cannot supply.
+- **SURF-25** (SHIPPED) - **Directional, 10-foot**, on every television and on desktop, is a
+  focus ring rather than a cursor: everything reachable by up, down, left, right and OK,
+  legible across a room, and no interaction that assumes text entry the input cannot supply.
+- **SURF-49** (SHIPPED) - A remote, a gamepad and a keyboard's arrow keys are the same input
+  model, because each produces the same directional events. A surface serves the directional
+  model by answering those events, whatever device raised them.
 - **SURF-26** (SHIPPED) - A television signs in through the pairing handshake precisely
   because a television keyboard is unusable ([`discovery/`](../discovery/)).
 - **SURF-27** (AGREED) - A television build that ships a pointer-shaped screen has not met


### PR DESCRIPTION
## What

The five open product decisions, decided. After #205 gave every requirement an id, what was
left on five of the eight epics was not work but choices, each sitting in the spec as
"recommended, provisional pending review" since #76. Nothing in the spec is DRAFT any more.

**Refresh does not re-match** (LIB-50, library `Refresh` DRAFT to AGREED). Refreshing metadata
and re-running identification stay two actions. They fail in opposite directions: a person
asking for better artwork is asking about the *record*, a person fixing a wrong film is asking
about the *identity*. Folding them together makes the cheap, frequent, safe request carry the
risk of the rare, deliberate, destructive one, and the first time a refresh silently re-matched
a correctly-bound file, the person would stop trusting refresh at all. Splitting them costs one
menu entry, and re-match already ships as its own handler (`server/src/api/rematch.rs`).

**The registry is the trust boundary, not the module** (MOD-48, MOD-49, modules `Trust` DRAFT
to AGREED). A module is a native binary the server executes and nothing KROMA can check about
the bytes changes that, so consent is asked once, where a registry is added, in exactly those
terms. **No module signing and no curated-versus-community tier**, both declined on merit: a
signature proves a publisher is the same publisher as last time, which the registry already
establishes, and it does not make a module safe, so key management plus a signing service plus
a barrier to every third-party author buys continuity we already have; and a curated tier puts
KROMA's name on a safety claim about code KROMA did not write. What ships instead is
provenance: the Store names the registry every module came from, and an added registry is
acknowledged once rather than per module.

**Abandonment is inferred, never declared** (MOD-50, modules `When a module stops being
maintained` DRAFT to AGREED). The publisher-set deprecation flag is declined because it has to
be set at the exact moment the publisher has stopped caring. A signal only conscientious
publishers raise does not cover the case it exists for, and worse, shipping it makes an
unflagged abandoned module read as maintained. Two signals that need nobody's cooperation
instead: the compatibility gate, which already fires, and a module that has vanished from every
configured registry, which now does too.

**One update rule, many vehicles** (ADMIN-89 to ADMIN-93, admin `Updates` DRAFT to AGREED).
Passive notice, owner chooses, backup first, migrate forward or restore. Identical on every
host; only the delivery vehicle varies, and which one a surface uses is surfaces' (SURF-34 to
SURF-39). The alternative was letting each host's packaging carry its own policy, which is how
a product ends up with a NAS that asks and a container that does not. That section carried no
requirement ids at all, so it has five now.

**Desktop is a directional surface, not a pointer one** (SURF-49). Less a choice than reading
what was built: `clients/desktop` is a Tauri window over the shared `@kromatv/tv` 10-foot
experience on a fixed 1920x1080 stage, it bridges the Gamepad API onto the same events a remote
raises, and its README names the Steam Deck as the primary target. A mouse in the room does not
make it a pointer app. Pointer is web, and only web. A remote, a gamepad and arrow keys are one
model because they raise one kind of event.

While the capability matrix was open: it also capped desktop at "browser codecs", which is
backwards. Desktop decodes through mpv, which is the entire reason the shell exists, and SURF-20
already said so in the same section.

## Closes

Closes the first Done-when box on #67, #72, #73 and #74, and settles the open question flagged
on #74. No epic closes outright: the third box, behaviour matching what the spec claims, is an
audit rather than a decision, and #68 (media) is the cheapest place to start on it.

| Epic | Was | Now |
|---|---|---|
| #67 library | `Refresh` DRAFT | no DRAFT |
| #72 modules | `Trust` + abandonment DRAFT | no DRAFT |
| #73 admin | `Updates` DRAFT | no DRAFT, and 5 ids where there were none |
| #74 surfaces | desktop input model unanswered | answered, matrix corrected |

## Checks

- [x] `bun run spec:check`: 406 requirements, index and `requirements.json` in step
- [x] No section and no requirement anywhere in `docs/spec/` is DRAFT
- [ ] `bun run lint` / `bun run test` not run: `docs/spec/` only
- [x] One idea

## Risk

These are decisions, so the risk is that one is wrong, not that something breaks. Each says
what it declined and why, so disagreeing means arguing with a stated reason rather than
guessing at intent.

The desktop one is the most likely to be contested, and it is the only one that changes what a
reader thinks the product *is* rather than what it will do. If the intent was always that
desktop grows a pointer UI and the `@kromatv/tv` mount is a stopgap, then SURF-23, SURF-25,
SURF-49 and two matrix cells go back the other way and this is the PR to say so in. The code
as it stands says otherwise.

MOD-48 and MOD-49 are new behaviour, not just a label: the Store does not name a module's
registry today, and there is no per-registry acknowledgement. Both are AGREED, so they are
sub-issues of #72 rather than claims about today.
