### PR TITLE
fix(push): the relay's deploy script runs from the workspace root

### DIFF
--- a/packages/push-relay/README.md
+++ b/packages/push-relay/README.md
@@ -49,8 +49,7 @@ else is transient and must not cost a reader their registration.
 ## Deploy
 
 ```sh
-cd packages/push-relay/worker
-bunx wrangler deploy
+bun run --filter '@kromatv/push-relay' deploy
 ```
 
 ## Secrets

--- a/packages/push-relay/package.json
+++ b/packages/push-relay/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "deploy": "wrangler deploy"
+    "deploy": "wrangler deploy --config worker/wrangler.jsonc"
   },
   "dependencies": {
     "@hono/zod-validator": "^0.9.0",


### PR DESCRIPTION
## What

`packages/push-relay/wrangler.jsonc` lives under `worker/`, but bun runs a package
script from the package root, so `bun run --filter '@kromatv/push-relay' deploy` has
always died with "No configuration file found". Every deploy this relay has had was
typed by hand after a `cd`, which is why nobody noticed. The script names the config
now, and the README points at the script rather than at the `cd` it was hiding.

Same fault and same fix as the stats collector in #207, found while fixing that one.
Split off because it is a different package and #207 is about what the heartbeat
reports.

## Closes

No issue. Found while deploying the stats collector.

## Checks

- [x] `bun run check` passes; no TS or Rust changed, so the rest is untouched
- [x] `wrangler deploy --config worker/wrangler.jsonc --dry-run` from the package root
  resolves `main`, both rate limiters and `APNS_TOPIC`
- [x] Follows `CODE_STYLE.md`
- [x] One idea

## Risk

None that reaches a running service. The script was unusable before, so nothing can
regress by it working; the deployed Worker is untouched until somebody runs it.
