### PR TITLE
docs(spec): statuses audited against the code, not guessed

### DIFF
--- a/docs/spec/INDEX.md
+++ b/docs/spec/INDEX.md
@@ -3,7 +3,7 @@
 
 # Requirement index
 
-406 requirements across the spec. The machine-readable source is [`requirements.json`](requirements.json).
+407 requirements across the spec. The machine-readable source is [`requirements.json`](requirements.json).
 
 ## ACCT - [accounts](accounts/)
 
@@ -47,78 +47,78 @@
 - **ADMIN-2** (SHIPPED) - With nothing playing, the section says so in one sentence rather <sub>[dashboard-live.md](admin/dashboard-live.md)</sub>
 - **ADMIN-3** (SHIPPED) - Each session names the viewer, the title, the position against the <sub>[dashboard-live.md](admin/dashboard-live.md)</sub>
 - **ADMIN-4** (SHIPPED) - An owner with permission to manage users can end any session, and <sub>[dashboard-live.md](admin/dashboard-live.md)</sub>
-- **ADMIN-5** (AGREED) - Every resource chart carries a **scope** control naming which series <sub>[dashboard-live.md](admin/dashboard-live.md)</sub>
-- **ADMIN-6** (AGREED) - Every resource chart carries a footer stating the mean of each series <sub>[dashboard-live.md](admin/dashboard-live.md)</sub>
-- **ADMIN-7** (AGREED) - Hovering any point reveals every series' value at that instant, <sub>[dashboard-live.md](admin/dashboard-live.md)</sub>
-- **ADMIN-8** (AGREED) - The range control offers, in this order: live, the last 12 hours, <sub>[dashboard-live.md](admin/dashboard-live.md)</sub>
-- **ADMIN-9** (AGREED) - "Live" is the rolling in-memory window the server samples at its own <sub>[dashboard-live.md](admin/dashboard-live.md)</sub>
+- **ADMIN-5** (SHIPPED) - Every resource chart carries a **scope** control naming which series <sub>[dashboard-live.md](admin/dashboard-live.md)</sub>
+- **ADMIN-6** (SHIPPED) - Every resource chart carries a footer stating the mean of each series <sub>[dashboard-live.md](admin/dashboard-live.md)</sub>
+- **ADMIN-7** (SHIPPED) - Hovering any point reveals every series' value at that instant, <sub>[dashboard-live.md](admin/dashboard-live.md)</sub>
+- **ADMIN-8** (SHIPPED) - The range control offers, in this order: live, the last 12 hours, <sub>[dashboard-live.md](admin/dashboard-live.md)</sub>
+- **ADMIN-9** (SHIPPED) - "Live" is the rolling in-memory window the server samples at its own <sub>[dashboard-live.md](admin/dashboard-live.md)</sub>
 - **ADMIN-10** (AGREED) - A range with no stored samples says the server has not been running <sub>[dashboard-live.md](admin/dashboard-live.md)</sub>
-- **ADMIN-11** (AGREED) - Persisted samples are downsampled as they age, so a year of history <sub>[dashboard-live.md](admin/dashboard-live.md)</sub>
+- **ADMIN-11** (SHIPPED) - Persisted samples are downsampled as they age, so a year of history <sub>[dashboard-live.md](admin/dashboard-live.md)</sub>
 - **ADMIN-12** (SHIPPED) - The bandwidth chart draws two series, traffic to clients on the <sub>[dashboard-live.md](admin/dashboard-live.md)</sub>
 - **ADMIN-13** (SHIPPED) - Bandwidth is measured from bytes the delivery handlers actually <sub>[dashboard-live.md](admin/dashboard-live.md)</sub>
-- **ADMIN-14** (AGREED) - The bandwidth scope control offers all traffic, local only, or <sub>[dashboard-live.md](admin/dashboard-live.md)</sub>
+- **ADMIN-14** (SHIPPED) - The bandwidth scope control offers all traffic, local only, or <sub>[dashboard-live.md](admin/dashboard-live.md)</sub>
 - **ADMIN-15** (AGREED) - The vertical scale is chosen from the data in the window and <sub>[dashboard-live.md](admin/dashboard-live.md)</sub>
-- **ADMIN-16** (AGREED) - The processor chart draws two series, what KROMA costs and what the <sub>[dashboard-resources.md](admin/dashboard-resources.md)</sub>
+- **ADMIN-16** (SHIPPED) - The processor chart draws two series, what KROMA costs and what the <sub>[dashboard-resources.md](admin/dashboard-resources.md)</sub>
 - **ADMIN-17** (SHIPPED) - KROMA's figure is the whole process tree, the server and every <sub>[dashboard-resources.md](admin/dashboard-resources.md)</sub>
-- **ADMIN-18** (AGREED) - The processor scope control offers both series, KROMA alone, or the <sub>[dashboard-resources.md](admin/dashboard-resources.md)</sub>
+- **ADMIN-18** (SHIPPED) - The processor scope control offers both series, KROMA alone, or the <sub>[dashboard-resources.md](admin/dashboard-resources.md)</sub>
 - **ADMIN-19** (SHIPPED) - A third series names the share of KROMA's own figure that is media <sub>[dashboard-resources.md](admin/dashboard-resources.md)</sub>
-- **ADMIN-20** (AGREED) - The memory chart draws the same two series as the processor chart, <sub>[dashboard-resources.md](admin/dashboard-resources.md)</sub>
+- **ADMIN-20** (SHIPPED) - The memory chart draws the same two series as the processor chart, <sub>[dashboard-resources.md](admin/dashboard-resources.md)</sub>
 - **ADMIN-21** (SHIPPED) - KROMA's memory is the resident set of the whole process tree, for <sub>[dashboard-resources.md](admin/dashboard-resources.md)</sub>
-- **ADMIN-22** (AGREED) - The memory scope control offers both series, KROMA alone, or the <sub>[dashboard-resources.md](admin/dashboard-resources.md)</sub>
-- **ADMIN-23** (AGREED) - Each series keeps one colour for the life of the product. A reader <sub>[dashboard-resources.md](admin/dashboard-resources.md)</sub>
+- **ADMIN-22** (SHIPPED) - The memory scope control offers both series, KROMA alone, or the <sub>[dashboard-resources.md](admin/dashboard-resources.md)</sub>
+- **ADMIN-23** (SHIPPED) - Each series keeps one colour for the life of the product. A reader <sub>[dashboard-resources.md](admin/dashboard-resources.md)</sub>
 - **ADMIN-24** (AGREED) - Sampling runs whether or not anyone is looking, because the history <sub>[dashboard-resources.md](admin/dashboard-resources.md)</sub>
 - **ADMIN-25** (AGREED) - The server states its own sample interval alongside the data, so a <sub>[dashboard-resources.md](admin/dashboard-resources.md)</sub>
-- **ADMIN-26** (AGREED) - The panel ranks accounts by time watched over a chosen window, most <sub>[dashboard-audience.md](admin/dashboard-audience.md)</sub>
-- **ADMIN-27** (AGREED) - Each card breaks its total down by kind of media, one row for movies <sub>[dashboard-audience.md](admin/dashboard-audience.md)</sub>
+- **ADMIN-26** (SHIPPED) - The panel ranks accounts by time watched over a chosen window, most <sub>[dashboard-audience.md](admin/dashboard-audience.md)</sub>
+- **ADMIN-27** (SHIPPED) - Each card breaks its total down by kind of media, one row for movies <sub>[dashboard-audience.md](admin/dashboard-audience.md)</sub>
 - **ADMIN-28** (AGREED) - An account that watched nothing in the window still appears, with <sub>[dashboard-audience.md](admin/dashboard-audience.md)</sub>
-- **ADMIN-29** (AGREED) - The window control offers the last 24 hours, 7 days, 30 days, 90 <sub>[dashboard-audience.md](admin/dashboard-audience.md)</sub>
-- **ADMIN-30** (AGREED) - With more accounts than fit, the panel pages through them rather <sub>[dashboard-audience.md](admin/dashboard-audience.md)</sub>
-- **ADMIN-31** (AGREED) - Each card carries the account's avatar where it has one, and falls <sub>[dashboard-audience.md](admin/dashboard-audience.md)</sub>
-- **ADMIN-32** (AGREED) - The panel plots time watched per bucket over a chosen window, <sub>[dashboard-audience.md](admin/dashboard-audience.md)</sub>
-- **ADMIN-33** (AGREED) - The bucket width is chosen from the window so the chart always <sub>[dashboard-audience.md](admin/dashboard-audience.md)</sub>
-- **ADMIN-34** (AGREED) - The panel carries three independent filters: kind of media, account, <sub>[dashboard-audience.md](admin/dashboard-audience.md)</sub>
-- **ADMIN-35** (AGREED) - The account filter lists every account with history in the window, <sub>[dashboard-audience.md](admin/dashboard-audience.md)</sub>
-- **ADMIN-36** (AGREED) - A footer states the total time for each kind of media over the whole <sub>[dashboard-audience.md](admin/dashboard-audience.md)</sub>
-- **ADMIN-37** (AGREED) - The panel links to the full history screen <sub>[dashboard-audience.md](admin/dashboard-audience.md)</sub>
-- **ADMIN-38** (AGREED) - Each kind of media keeps one colour across this panel, the top-viewer <sub>[dashboard-audience.md](admin/dashboard-audience.md)</sub>
-- **ADMIN-39** (AGREED) - The panel ranks titles by number of plays over a chosen window, most <sub>[dashboard-most-watched.md](admin/dashboard-most-watched.md)</sub>
-- **ADMIN-40** (AGREED) - Each column is headed by the artwork of its own top title, labelled <sub>[dashboard-most-watched.md](admin/dashboard-most-watched.md)</sub>
-- **ADMIN-41** (AGREED) - Each entry names the title, its play count, and how many distinct <sub>[dashboard-most-watched.md](admin/dashboard-most-watched.md)</sub>
+- **ADMIN-29** (SHIPPED) - The window control offers the last 24 hours, 7 days, 30 days, 90 <sub>[dashboard-audience.md](admin/dashboard-audience.md)</sub>
+- **ADMIN-30** (SHIPPED) - With more accounts than fit, the panel pages through them rather <sub>[dashboard-audience.md](admin/dashboard-audience.md)</sub>
+- **ADMIN-31** (SHIPPED) - Each card carries the account's avatar where it has one, and falls <sub>[dashboard-audience.md](admin/dashboard-audience.md)</sub>
+- **ADMIN-32** (SHIPPED) - The panel plots time watched per bucket over a chosen window, <sub>[dashboard-audience.md](admin/dashboard-audience.md)</sub>
+- **ADMIN-33** (SHIPPED) - The bucket width is chosen from the window so the chart always <sub>[dashboard-audience.md](admin/dashboard-audience.md)</sub>
+- **ADMIN-34** (SHIPPED) - The panel carries three independent filters: kind of media, account, <sub>[dashboard-audience.md](admin/dashboard-audience.md)</sub>
+- **ADMIN-35** (SHIPPED) - The account filter lists every account with history in the window, <sub>[dashboard-audience.md](admin/dashboard-audience.md)</sub>
+- **ADMIN-36** (SHIPPED) - A footer states the total time for each kind of media over the whole <sub>[dashboard-audience.md](admin/dashboard-audience.md)</sub>
+- **ADMIN-37** (SHIPPED) - The panel links to the full history screen <sub>[dashboard-audience.md](admin/dashboard-audience.md)</sub>
+- **ADMIN-38** (SHIPPED) - Each kind of media keeps one colour across this panel, the top-viewer <sub>[dashboard-audience.md](admin/dashboard-audience.md)</sub>
+- **ADMIN-39** (SHIPPED) - The panel ranks titles by number of plays over a chosen window, most <sub>[dashboard-most-watched.md](admin/dashboard-most-watched.md)</sub>
+- **ADMIN-40** (SHIPPED) - Each column is headed by the artwork of its own top title, labelled <sub>[dashboard-most-watched.md](admin/dashboard-most-watched.md)</sub>
+- **ADMIN-41** (SHIPPED) - Each entry names the title, its play count, and how many distinct <sub>[dashboard-most-watched.md](admin/dashboard-most-watched.md)</sub>
 - **ADMIN-42** (AGREED) - An entry is a series where the plays were episodes, not a row per <sub>[dashboard-most-watched.md](admin/dashboard-most-watched.md)</sub>
-- **ADMIN-43** (AGREED) - Each entry carries its poster, and falls back to a title-seeded <sub>[dashboard-most-watched.md](admin/dashboard-most-watched.md)</sub>
+- **ADMIN-43** (SHIPPED) - Each entry carries its poster, and falls back to a title-seeded <sub>[dashboard-most-watched.md](admin/dashboard-most-watched.md)</sub>
 - **ADMIN-44** (AGREED) - A column with no plays in the window says so in its own words rather <sub>[dashboard-most-watched.md](admin/dashboard-most-watched.md)</sub>
-- **ADMIN-45** (AGREED) - The panel carries two filters, account and window, defaulting to <sub>[dashboard-most-watched.md](admin/dashboard-most-watched.md)</sub>
-- **ADMIN-46** (AGREED) - Selecting an entry opens that title's own watch history <sub>[dashboard-most-watched.md](admin/dashboard-most-watched.md)</sub>
+- **ADMIN-45** (SHIPPED) - The panel carries two filters, account and window, defaulting to <sub>[dashboard-most-watched.md](admin/dashboard-most-watched.md)</sub>
+- **ADMIN-46** (SHIPPED) - Selecting an entry opens that title's own watch history <sub>[dashboard-most-watched.md](admin/dashboard-most-watched.md)</sub>
 - **ADMIN-47** (AGREED) - A play is one finished session in the log, whatever fraction of the <sub>[dashboard-most-watched.md](admin/dashboard-most-watched.md)</sub>
 - **ADMIN-48** (AGREED) - Two sessions of the same title by the same account count as two <sub>[dashboard-most-watched.md](admin/dashboard-most-watched.md)</sub>
-- **ADMIN-49** (AGREED) - The view is the full history screen ([`watch-history.md`](watch-history.md)) <sub>[watch-history-item.md](admin/watch-history-item.md)</sub>
-- **ADMIN-50** (AGREED) - The header names the title beside the number of plays in scope, so <sub>[watch-history-item.md](admin/watch-history-item.md)</sub>
+- **ADMIN-49** (SHIPPED) - The view is the full history screen ([`watch-history.md`](watch-history.md)) <sub>[watch-history-item.md](admin/watch-history-item.md)</sub>
+- **ADMIN-50** (SHIPPED) - The header names the title beside the number of plays in scope, so <sub>[watch-history-item.md](admin/watch-history-item.md)</sub>
 - **ADMIN-51** (AGREED) - The table drops the title column, which is the same on every row, <sub>[watch-history-item.md](admin/watch-history-item.md)</sub>
-- **ADMIN-52** (AGREED) - Rows are ordered by when they were watched, most recent first, and <sub>[watch-history-item.md](admin/watch-history-item.md)</sub>
+- **ADMIN-52** (SHIPPED) - Rows are ordered by when they were watched, most recent first, and <sub>[watch-history-item.md](admin/watch-history-item.md)</sub>
 - **ADMIN-53** (AGREED) - A title nobody has played says so, rather than showing an empty <sub>[watch-history-item.md](admin/watch-history-item.md)</sub>
 - **ADMIN-54** (AGREED) - The view is reachable from every surface that names a title with a <sub>[watch-history-item.md](admin/watch-history-item.md)</sub>
-- **ADMIN-55** (AGREED) - The view has its own address. An owner can send it to someone, or <sub>[watch-history-item.md](admin/watch-history-item.md)</sub>
+- **ADMIN-55** (SHIPPED) - The view has its own address. An owner can send it to someone, or <sub>[watch-history-item.md](admin/watch-history-item.md)</sub>
 - **ADMIN-56** (AGREED) - For a series, the view covers every episode of that series, and <sub>[watch-history-item.md](admin/watch-history-item.md)</sub>
-- **ADMIN-57** (AGREED) - Watch history is a first-class admin screen with its own entry in <sub>[watch-history.md](admin/watch-history.md)</sub>
-- **ADMIN-58** (AGREED) - The screen shows every session in scope as a table, one row per <sub>[watch-history.md](admin/watch-history.md)</sub>
-- **ADMIN-59** (AGREED) - The header states how many rows the current filters match, before <sub>[watch-history.md](admin/watch-history.md)</sub>
-- **ADMIN-60** (AGREED) - The columns are the account, the kind of media, the title, the <sub>[watch-history.md](admin/watch-history.md)</sub>
+- **ADMIN-57** (SHIPPED) - Watch history is a first-class admin screen with its own entry in <sub>[watch-history.md](admin/watch-history.md)</sub>
+- **ADMIN-58** (SHIPPED) - The screen shows every session in scope as a table, one row per <sub>[watch-history.md](admin/watch-history.md)</sub>
+- **ADMIN-59** (SHIPPED) - The header states how many rows the current filters match, before <sub>[watch-history.md](admin/watch-history.md)</sub>
+- **ADMIN-60** (SHIPPED) - The columns are the account, the kind of media, the title, the <sub>[watch-history.md](admin/watch-history.md)</sub>
 - **ADMIN-61** (AGREED) - An episode's title names its series, its season, its episode number <sub>[watch-history.md](admin/watch-history.md)</sub>
-- **ADMIN-62** (AGREED) - Any column can order the table, ascending or descending, and the <sub>[watch-history.md](admin/watch-history.md)</sub>
-- **ADMIN-63** (AGREED) - The table pages or virtualises rather than rendering everything. <sub>[watch-history.md](admin/watch-history.md)</sub>
-- **ADMIN-64** (AGREED) - The screen filters by library, by account, and by window, each <sub>[watch-history.md](admin/watch-history.md)</sub>
-- **ADMIN-65** (AGREED) - The window control offers the same choices as the dashboard's, plus <sub>[watch-history.md](admin/watch-history.md)</sub>
-- **ADMIN-66** (AGREED) - Filters live in the address, so a filtered view can be sent to <sub>[watch-history.md](admin/watch-history.md)</sub>
-- **ADMIN-67** (AGREED) - Arriving from a dashboard panel applies the filters that panel sent, <sub>[watch-history.md](admin/watch-history.md)</sub>
+- **ADMIN-62** (SHIPPED) - Any column can order the table, ascending or descending, and the <sub>[watch-history.md](admin/watch-history.md)</sub>
+- **ADMIN-63** (SHIPPED) - The table pages or virtualises rather than rendering everything. <sub>[watch-history.md](admin/watch-history.md)</sub>
+- **ADMIN-64** (SHIPPED) - The screen filters by library, by account, and by window, each <sub>[watch-history.md](admin/watch-history.md)</sub>
+- **ADMIN-65** (SHIPPED) - The window control offers the same choices as the dashboard's, plus <sub>[watch-history.md](admin/watch-history.md)</sub>
+- **ADMIN-66** (SHIPPED) - Filters live in the address, so a filtered view can be sent to <sub>[watch-history.md](admin/watch-history.md)</sub>
+- **ADMIN-67** (SHIPPED) - Arriving from a dashboard panel applies the filters that panel sent, <sub>[watch-history.md](admin/watch-history.md)</sub>
 - **ADMIN-68** (AGREED) - A session is written to the log when it ends, carrying everything <sub>[watch-history.md](admin/watch-history.md)</sub>
 - **ADMIN-69** (AGREED) - The log is kept indefinitely by default. It is small, it is the only <sub>[watch-history.md](admin/watch-history.md)</sub>
 - **ADMIN-70** (AGREED) - The log survives a backup and restore, because a restored server <sub>[watch-history.md](admin/watch-history.md)</sub>
 - **ADMIN-71** (AGREED) - An account deleted from the server keeps its rows, attributed to the <sub>[watch-history.md](admin/watch-history.md)</sub>
-- **ADMIN-72** (AGREED) - The screen requires the permission to manage users. A watch history <sub>[watch-history.md](admin/watch-history.md)</sub>
+- **ADMIN-72** (SHIPPED) - The screen requires the permission to manage users. A watch history <sub>[watch-history.md](admin/watch-history.md)</sub>
 - **ADMIN-73** (AGREED) - A member can always read their own history. What the product does <sub>[watch-history.md](admin/watch-history.md)</sub>
 - **ADMIN-74** (AGREED) - A column is bounded in height and scrolls inside that bound. The <sub>[dashboard-most-watched.md](admin/dashboard-most-watched.md)</sub>
-- **ADMIN-75** (AGREED) - A card opens the full history screen <sub>[dashboard-audience.md](admin/dashboard-audience.md)</sub>
-- **ADMIN-76** (AGREED) - A screen narrowed to one title names that title in the filter row <sub>[watch-history.md](admin/watch-history.md)</sub>
+- **ADMIN-75** (SHIPPED) - A card opens the full history screen <sub>[dashboard-audience.md](admin/dashboard-audience.md)</sub>
+- **ADMIN-76** (SHIPPED) - A screen narrowed to one title names that title in the filter row <sub>[watch-history.md](admin/watch-history.md)</sub>
 - **ADMIN-77** (AGREED) - When a session was watched is written out in full, the date and the <sub>[watch-history.md](admin/watch-history.md)</sub>
 - **ADMIN-78** (AGREED) - A row opens the title it names, at that title's own page, wherever <sub>[watch-history.md](admin/watch-history.md)</sub>
 - **ADMIN-79** (AGREED) - A reset is a single-use, time-limited link plus a short one-time <sub>[README.md](admin/README.md)</sub>
@@ -228,43 +228,43 @@
 
 ## MEDIA - [media](media/)
 
-- **MEDIA-1** (AGREED) - **Title.** The work a person searches for: a film, or one episode
+- **MEDIA-1** (SHIPPED) - **Title.** The work a person searches for: a film, or one episode
 - **MEDIA-2** (AGREED) - **Edition.** A named cut of a title: theatrical, director's,
-- **MEDIA-3** (AGREED) - **Media file.** One physical file on disk that realises an edition
+- **MEDIA-3** (SHIPPED) - **Media file.** One physical file on disk that realises an edition
 - **MEDIA-4** (AGREED) - **Stream.** One track inside a media file, exactly one of video,
 - **MEDIA-5** (AGREED) - **Stream properties.** The describable facts about a stream: codec,
 - **MEDIA-6** (AGREED) - The nesting is strict and total: every stream belongs to exactly one
-- **MEDIA-7** (AGREED) - A 1080p file and a 4K file of the same cut are **two media files of
+- **MEDIA-7** (SHIPPED) - A 1080p file and a 4K file of the same cut are **two media files of
 - **MEDIA-8** (AGREED) - KROMA ranks a title's media files and keeps a **preferred** one.
 - **MEDIA-9** (AGREED) - The preference is a *default*, not a lock. The model enumerates a
 - **MEDIA-10** (AGREED) - Editions are surfaced to the person, because they are different
-- **MEDIA-11** (AGREED) - First-class means KROMA fully describes the format, preserves it end
-- **MEDIA-12** (AGREED) - The first-class containers are **MP4**, **MKV** and **WebM**.
-- **MEDIA-13** (AGREED) - **HEVC / H.265** is the priority codec. 8-bit and 10-bit, SDR and
-- **MEDIA-14** (AGREED) - **H.264 / AVC** is the universal floor, assumed playable
-- **MEDIA-15** (AGREED) - **AV1** is first-class media truth whatever the client generation,
-- **MEDIA-16** (AGREED) - **VP9** is first-class within WebM, chiefly for the browser
-- **MEDIA-17** (AGREED) - A codec being first-class states how *KROMA* handles it, never that a
+- **MEDIA-11** (SHIPPED) - First-class means KROMA fully describes the format, preserves it end
+- **MEDIA-12** (SHIPPED) - The first-class containers are **MP4**, **MKV** and **WebM**.
+- **MEDIA-13** (SHIPPED) - **HEVC / H.265** is the priority codec. 8-bit and 10-bit, SDR and
+- **MEDIA-14** (SHIPPED) - **H.264 / AVC** is the universal floor, assumed playable
+- **MEDIA-15** (SHIPPED) - **AV1** is first-class media truth whatever the client generation,
+- **MEDIA-16** (SHIPPED) - **VP9** is first-class within WebM, chiefly for the browser
+- **MEDIA-17** (SHIPPED) - A codec being first-class states how *KROMA* handles it, never that a
 - **MEDIA-18** (AGREED) - HDR is preserved end to end or it is not offered. KROMA never
-- **MEDIA-19** (AGREED) - **Bit depth.** 8-bit and 10-bit are first-class, and 10-bit is
+- **MEDIA-19** (SHIPPED) - **Bit depth.** 8-bit and 10-bit are first-class, and 10-bit is
 - **MEDIA-20** (AGREED) - KROMA distinguishes **HDR10**, **HDR10+**, **Dolby Vision** and
 - **MEDIA-21** (AGREED) - Colour primaries, transfer characteristics and matrix coefficients
 - **MEDIA-22** (AGREED) - Where dynamic metadata, HDR10+ or Dolby Vision, cannot be carried
 - **MEDIA-23** (AGREED) - The first-class audio codecs are **AAC**, **AC-3** and **E-AC-3**
 - **MEDIA-24** (AGREED) - An audio stream's **channel layout**, stereo, 5.1, 7.1 or Atmos
-- **MEDIA-25** (AGREED) - **Passthrough** is the default for multichannel and lossless audio:
+- **MEDIA-25** (SHIPPED) - **Passthrough** is the default for multichannel and lossless audio:
 - **MEDIA-26** (AGREED) - **Downmixing** to stereo happens only when the target cannot render
-- **MEDIA-27** (AGREED) - Multiple audio streams, languages and commentary alike, are all
+- **MEDIA-27** (SHIPPED) - Multiple audio streams, languages and commentary alike, are all
 - **MEDIA-28** (AGREED) - A subtitle stream is either **embedded**, a track inside the media
 - **MEDIA-29** (AGREED) - The first-class subtitle formats are **SRT**, **WebVTT** and
 - **MEDIA-30** (AGREED) - The **forced** disposition, only the foreign-language lines a
 - **MEDIA-31** (AGREED) - **Burning in**, rendering a subtitle permanently into the video, is
-- **MEDIA-32** (AGREED) - Every title carries a **poster**, a **backdrop**, a **logo** and, per
+- **MEDIA-32** (SHIPPED) - Every title carries a **poster**, a **backdrop**, a **logo** and, per
 - **MEDIA-33** (AGREED) - Image sources rank by trust: embedded in the media file, then a
 - **MEDIA-34** (AGREED) - KROMA derives a fixed set of sizes per image, a small grid
 - **MEDIA-35** (AGREED) - Derived sizes are cached and served without re-deriving, and a
 - **MEDIA-36** (AGREED) - Artwork is never a reason a title fails to appear. A title with no
-- **MEDIA-37** (AGREED) - KROMA learns a file's streams by **probing** it once, when the
+- **MEDIA-37** (SHIPPED) - KROMA learns a file's streams by **probing** it once, when the
 - **MEDIA-38** (AGREED) - A probe is the authoritative stream truth until the file's bytes
 - **MEDIA-39** (AGREED) - When a direct play fails in a way that implicates the stream
 - **MEDIA-40** (AGREED) - Trust is per-file and durable: a corrected probe is written back,
@@ -351,9 +351,9 @@
 - **PLAY-19** (AGREED) - KROMA ships no adaptive multi-bitrate ladder, no quality knobs and no
 - **PLAY-20** (AGREED) - Any rung below direct play is a compromise, and the client always shows
 - **PLAY-21** (AGREED) - **Video transcode** and **subtitle burn-in** are shown as *reduced
-- **PLAY-22** (AGREED) - **Audio downmix** and **audio transcode** are shown as *audio
+- **PLAY-22** (SHIPPED) - **Audio downmix** and **audio transcode** are shown as *audio
 - **PLAY-23** (AGREED) - **Remux** is shown as *repackaged*. Quality is untouched, so this is
-- **PLAY-24** (AGREED) - Direct play shows nothing. The absence of a badge *is* the signal
+- **PLAY-24** (SHIPPED) - Direct play may announce itself, naming the codec it is playing
 - **PLAY-25** (AGREED) - KROMA never re-encodes video to save bandwidth unless the device
 - **PLAY-26** (AGREED) - KROMA never tone-maps HDR without saying so.
 - **PLAY-27** (AGREED) - KROMA never burns in subtitles the person did not ask to see.
@@ -366,7 +366,7 @@
 - **PLAY-34** (SHIPPED) - The playing client reports position on a steady heartbeat while
 - **PLAY-35** (AGREED) - The write is idempotent on the person, the version, the position and
 - **PLAY-36** (SHIPPED) - Reopening a title in progress offers *Resume* from the stored position
-- **PLAY-37** (AGREED) - A title is **watched** at **90% of runtime or more**, or at reaching a
+- **PLAY-37** (SHIPPED) - A title is **watched** at a credits or end marker where the media has
 - **PLAY-38** (SHIPPED) - At the watched threshold, continue-watching drops the title and, for
 - **PLAY-39** (AGREED) - Below the threshold, progress is retained and the title stays in
 - **PLAY-40** (AGREED) - Starting a watched title again resets it to unwatched and clears the
@@ -380,8 +380,9 @@
 - **PLAY-48** (AGREED) - KROMA does not hand off an active session between devices as a
 - **PLAY-49** (AGREED) - When a stream dies mid-playback, whether the network drops, a transcode
 - **PLAY-50** (AGREED) - A **transient** failure, a network drop or a brief server hiccup, is
-- **PLAY-51** (AGREED) - A **fatal** failure, a source gone, a transcode that cannot start, or
+- **PLAY-51** (SHIPPED) - A **fatal** failure, a source gone, a transcode that cannot start, or
 - **PLAY-52** (AGREED) - When a television's older decoder cannot play a file a modern phone
+- **PLAY-53** (AGREED) - A settled seek also reports, so jumping and then losing the client does
 
 ## SURF - [surfaces](surfaces/)
 

--- a/docs/spec/accounts/README.md
+++ b/docs/spec/accounts/README.md
@@ -190,7 +190,7 @@ access on the spot. An admin deleting another user is an [`admin/`](../admin/) a
 
 ### Does a revoked or deleted device lose downloaded content?
 
-Status: **AGREED**
+Status: **SHIPPED** in part; each requirement carries its own.
 
 Honestly: not immediately, and the server cannot make it.
 

--- a/docs/spec/admin/README.md
+++ b/docs/spec/admin/README.md
@@ -1,6 +1,8 @@
 # Admin
 
-Status: **AGREED**. Every section carries its own status; the file-level label is the floor.
+Status: **SHIPPED** in part. The dashboard and the watch-history screens are built; the
+verbs around sources, users, jobs, backup and updates are decided. Every section and every
+requirement carries its own status.
 
 Running a KROMA server. The audience is one person with a NAS, not an operations team.
 That framing decides everything below: expose little, default sanely, and never add a knob

--- a/docs/spec/admin/dashboard-audience.md
+++ b/docs/spec/admin/dashboard-audience.md
@@ -9,12 +9,12 @@ Both read the play log, so both are only as good as what the log kept. What it k
 
 ## Top viewers
 
-Status: **AGREED**
+Status: **SHIPPED** in part; each requirement carries its own.
 
-**ADMIN-26** (AGREED) - The panel ranks accounts by time watched over a chosen window, most
+**ADMIN-26** (SHIPPED) - The panel ranks accounts by time watched over a chosen window, most
 first, and shows each one's play count beside their total.
 
-**ADMIN-27** (AGREED) - Each card breaks its total down by kind of media, one row for movies
+**ADMIN-27** (SHIPPED) - Each card breaks its total down by kind of media, one row for movies
 and one for shows, and marks the kind that account spent most of its time on. A kind with no
 time keeps its row, so an account that watched only shows is visibly an account that watched
 no movies.
@@ -22,16 +22,16 @@ no movies.
 **ADMIN-28** (AGREED) - An account that watched nothing in the window still appears, with
 zeroes. An owner comparing members needs the absences as much as the totals.
 
-**ADMIN-29** (AGREED) - The window control offers the last 24 hours, 7 days, 30 days, 90
+**ADMIN-29** (SHIPPED) - The window control offers the last 24 hours, 7 days, 30 days, 90
 days, the last year, and everything the log holds. Seven days is the default.
 
-**ADMIN-30** (AGREED) - With more accounts than fit, the panel pages through them rather
+**ADMIN-30** (SHIPPED) - With more accounts than fit, the panel pages through them rather
 than shrinking the cards or scrolling the page sideways.
 
-**ADMIN-31** (AGREED) - Each card carries the account's avatar where it has one, and falls
+**ADMIN-31** (SHIPPED) - Each card carries the account's avatar where it has one, and falls
 back to a name-seeded mark rather than a blank.
 
-**ADMIN-75** (AGREED) - A card opens the full history screen
+**ADMIN-75** (SHIPPED) - A card opens the full history screen
 ([`watch-history.md`](watch-history.md)) narrowed to that account, and the whole card is
 the place to press. It carries everything the log holds for that member rather than the
 window the panel is showing, because the question a card raises is what this person
@@ -40,28 +40,28 @@ has nobody to open and stays a card.
 
 ## Playback over time
 
-Status: **AGREED**
+Status: **SHIPPED**
 
-**ADMIN-32** (AGREED) - The panel plots time watched per bucket over a chosen window,
+**ADMIN-32** (SHIPPED) - The panel plots time watched per bucket over a chosen window,
 stacked by kind of media, so the height of a bucket is that period's total and the bands
 are its composition.
 
-**ADMIN-33** (AGREED) - The bucket width is chosen from the window so the chart always
+**ADMIN-33** (SHIPPED) - The bucket width is chosen from the window so the chart always
 holds a readable number of bars: days for a short window, weeks for a long one. Each bucket
 is labelled with the dates it covers.
 
-**ADMIN-34** (AGREED) - The panel carries three independent filters: kind of media, account,
+**ADMIN-34** (SHIPPED) - The panel carries three independent filters: kind of media, account,
 and window. Any combination is valid, and changing one never resets another.
 
-**ADMIN-35** (AGREED) - The account filter lists every account with history in the window,
+**ADMIN-35** (SHIPPED) - The account filter lists every account with history in the window,
 plus an "everyone" entry, which is the default.
 
-**ADMIN-36** (AGREED) - A footer states the total time for each kind of media over the whole
+**ADMIN-36** (SHIPPED) - A footer states the total time for each kind of media over the whole
 window, so the reader gets the totals the stacked bars only imply.
 
-**ADMIN-37** (AGREED) - The panel links to the full history screen
+**ADMIN-37** (SHIPPED) - The panel links to the full history screen
 ([`watch-history.md`](watch-history.md)), carrying its current filters across, so a reader
 who has narrowed the chart does not narrow it again on arrival.
 
-**ADMIN-38** (AGREED) - Each kind of media keeps one colour across this panel, the top-viewer
+**ADMIN-38** (SHIPPED) - Each kind of media keeps one colour across this panel, the top-viewer
 cards and the history screen, for the reason given in ADMIN-23.

--- a/docs/spec/admin/dashboard-live.md
+++ b/docs/spec/admin/dashboard-live.md
@@ -26,26 +26,26 @@ is offered a message the viewer will see.
 
 ## The three resource charts share one shape
 
-Status: **AGREED**
+Status: **SHIPPED** in part; each requirement carries its own.
 
 Bandwidth, processor and memory are the same plot over different series. They therefore
 share one contract, and a reader who learns to read one has learned all three.
 
-**ADMIN-5** (AGREED) - Every resource chart carries a **scope** control naming which series
+**ADMIN-5** (SHIPPED) - Every resource chart carries a **scope** control naming which series
 are drawn, and a **range** control naming the window of time drawn. The two are
 independent: changing one never resets the other.
 
-**ADMIN-6** (AGREED) - Every resource chart carries a footer stating the mean of each series
+**ADMIN-6** (SHIPPED) - Every resource chart carries a footer stating the mean of each series
 over the window on screen, so a reader gets a number without hovering.
 
-**ADMIN-7** (AGREED) - Hovering any point reveals every series' value at that instant,
+**ADMIN-7** (SHIPPED) - Hovering any point reveals every series' value at that instant,
 labelled by how long ago it was.
 
-**ADMIN-8** (AGREED) - The range control offers, in this order: live, the last 12 hours,
+**ADMIN-8** (SHIPPED) - The range control offers, in this order: live, the last 12 hours,
 the last 24 hours, the last 7 days, the last 30 days, the last 90 days, the last year, and
 everything the server has kept. Live is the default.
 
-**ADMIN-9** (AGREED) - "Live" is the rolling in-memory window the server samples at its own
+**ADMIN-9** (SHIPPED) - "Live" is the rolling in-memory window the server samples at its own
 interval. Every other range is read from samples the server has persisted, so it survives a
 restart. An owner asking what happened last Tuesday gets an answer.
 
@@ -53,7 +53,7 @@ restart. An owner asking what happened last Tuesday gets an answer.
 long enough, rather than drawing a flat line at zero. A gap in the record is not a period of
 inactivity and must never be drawn as one.
 
-**ADMIN-11** (AGREED) - Persisted samples are downsampled as they age, so a year of history
+**ADMIN-11** (SHIPPED) - Persisted samples are downsampled as they age, so a year of history
 costs a bounded amount of disk. The product promises the shape of the past, not every
 sample of it.
 
@@ -69,7 +69,7 @@ that costs the owner's uplink.
 put on the wire, not from a title's nominal bitrate. What the chart shows is what left the
 machine.
 
-**ADMIN-14** (AGREED) - The bandwidth scope control offers all traffic, local only, or
+**ADMIN-14** (SHIPPED) - The bandwidth scope control offers all traffic, local only, or
 remote only.
 
 **ADMIN-15** (AGREED) - The vertical scale is chosen from the data in the window and

--- a/docs/spec/admin/dashboard-most-watched.md
+++ b/docs/spec/admin/dashboard-most-watched.md
@@ -8,9 +8,9 @@ and what to add.
 
 ## The panel
 
-Status: **AGREED**
+Status: **SHIPPED** in part; each requirement carries its own.
 
-**ADMIN-39** (AGREED) - The panel ranks titles by number of plays over a chosen window, most
+**ADMIN-39** (SHIPPED) - The panel ranks titles by number of plays over a chosen window, most
 first, in one column for movies and one for shows. Equal play counts rank alphabetically by
 title, so two readers of the same window see the same order.
 
@@ -18,10 +18,10 @@ title, so two readers of the same window see the same order.
 panel keeps its size whatever the ranking holds, and a reader reaches every entry in it
 rather than the first few.
 
-**ADMIN-40** (AGREED) - Each column is headed by the artwork of its own top title, labelled
+**ADMIN-40** (SHIPPED) - Each column is headed by the artwork of its own top title, labelled
 with the kind of media, so a reader recognises the column before reading a word of it.
 
-**ADMIN-41** (AGREED) - Each entry names the title, its play count, and how many distinct
+**ADMIN-41** (SHIPPED) - Each entry names the title, its play count, and how many distinct
 accounts played it. One person watching a series eight times and eight people watching it
 once are different facts about a household, and the panel must not collapse them.
 
@@ -29,17 +29,17 @@ once are different facts about a household, and the panel must not collapse them
 episode. A household watches a show, and a chart that lists nine episodes of one show has
 buried the answer.
 
-**ADMIN-43** (AGREED) - Each entry carries its poster, and falls back to a title-seeded
+**ADMIN-43** (SHIPPED) - Each entry carries its poster, and falls back to a title-seeded
 gradient rather than a blank or a broken image.
 
 **ADMIN-44** (AGREED) - A column with no plays in the window says so in its own words rather
 than disappearing. A missing column reads as a broken panel; an empty one reads as an
 answer.
 
-**ADMIN-45** (AGREED) - The panel carries two filters, account and window, defaulting to
+**ADMIN-45** (SHIPPED) - The panel carries two filters, account and window, defaulting to
 everyone over the last 30 days.
 
-**ADMIN-46** (AGREED) - Selecting an entry opens that title's own watch history
+**ADMIN-46** (SHIPPED) - Selecting an entry opens that title's own watch history
 ([`watch-history.md`](watch-history.md)), because "who watched this, and on what" is the
 next question every time.
 

--- a/docs/spec/admin/dashboard-resources.md
+++ b/docs/spec/admin/dashboard-resources.md
@@ -14,7 +14,7 @@ only what is particular to the two resource charts.
 
 Status: **SHIPPED** for the live window, scope and ranges **AGREED**
 
-**ADMIN-16** (AGREED) - The processor chart draws two series, what KROMA costs and what the
+**ADMIN-16** (SHIPPED) - The processor chart draws two series, what KROMA costs and what the
 whole machine costs, on a scale of nought to a hundred percent of the host.
 
 **ADMIN-17** (SHIPPED) - KROMA's figure is the whole process tree, the server and every
@@ -22,7 +22,7 @@ child it spawned. A transcode is a child ffmpeg, so a figure that counted only t
 process reported single digits while the machine was saturated, which is worse than no
 figure at all.
 
-**ADMIN-18** (AGREED) - The processor scope control offers both series, KROMA alone, or the
+**ADMIN-18** (SHIPPED) - The processor scope control offers both series, KROMA alone, or the
 system alone.
 
 **ADMIN-19** (SHIPPED) - A third series names the share of KROMA's own figure that is media
@@ -32,16 +32,16 @@ work, so a box at a hundred percent names its culprit rather than only its size.
 
 Status: **SHIPPED** for the live window, scope and ranges **AGREED**
 
-**ADMIN-20** (AGREED) - The memory chart draws the same two series as the processor chart,
+**ADMIN-20** (SHIPPED) - The memory chart draws the same two series as the processor chart,
 as a percentage of the host's total memory, so the two read the same way.
 
 **ADMIN-21** (SHIPPED) - KROMA's memory is the resident set of the whole process tree, for
 the reason given in ADMIN-17.
 
-**ADMIN-22** (AGREED) - The memory scope control offers both series, KROMA alone, or the
+**ADMIN-22** (SHIPPED) - The memory scope control offers both series, KROMA alone, or the
 system alone.
 
-**ADMIN-23** (AGREED) - Each series keeps one colour for the life of the product. A reader
+**ADMIN-23** (SHIPPED) - Each series keeps one colour for the life of the product. A reader
 who learned that one hue means the system does not find it repainted on the next release,
 and a series dropping out never shifts another series' colour.
 

--- a/docs/spec/admin/watch-history-item.md
+++ b/docs/spec/admin/watch-history-item.md
@@ -8,20 +8,20 @@ names it.
 
 ## The view
 
-Status: **AGREED**
+Status: **SHIPPED** in part; each requirement carries its own.
 
-**ADMIN-49** (AGREED) - The view is the full history screen ([`watch-history.md`](watch-history.md))
+**ADMIN-49** (SHIPPED) - The view is the full history screen ([`watch-history.md`](watch-history.md))
 narrowed to one title. It is the same screen, the same table and the same sorting, with the
 title pinned as a filter the reader can drop (ADMIN-76), so a reader who learned one has
 learned both.
 
-**ADMIN-50** (AGREED) - The header names the title beside the number of plays in scope, so
+**ADMIN-50** (SHIPPED) - The header names the title beside the number of plays in scope, so
 the count that led the reader here is confirmed on arrival.
 
 **ADMIN-51** (AGREED) - The table drops the title column, which is the same on every row,
 and keeps the account, the player, the platform and when it was watched.
 
-**ADMIN-52** (AGREED) - Rows are ordered by when they were watched, most recent first, and
+**ADMIN-52** (SHIPPED) - Rows are ordered by when they were watched, most recent first, and
 the reader can reverse that.
 
 **ADMIN-53** (AGREED) - A title nobody has played says so, rather than showing an empty
@@ -29,13 +29,13 @@ table with headers. The reader arrived expecting rows and is owed the reason the
 
 ## Reaching it
 
-Status: **AGREED**
+Status: **SHIPPED** in part; each requirement carries its own.
 
 **ADMIN-54** (AGREED) - The view is reachable from every surface that names a title with a
 count against it: the most-watched panel, the full history screen, and a title's own detail
 page in the admin.
 
-**ADMIN-55** (AGREED) - The view has its own address. An owner can send it to someone, or
+**ADMIN-55** (SHIPPED) - The view has its own address. An owner can send it to someone, or
 keep it open in a tab, and reloading it returns the same view.
 
 **ADMIN-56** (AGREED) - For a series, the view covers every episode of that series, and

--- a/docs/spec/admin/watch-history.md
+++ b/docs/spec/admin/watch-history.md
@@ -9,19 +9,19 @@ household's whole history is not something to scroll past on the way to a chart.
 
 ## The screen
 
-Status: **AGREED**
+Status: **SHIPPED** in part; each requirement carries its own.
 
-**ADMIN-57** (AGREED) - Watch history is a first-class admin screen with its own entry in
+**ADMIN-57** (SHIPPED) - Watch history is a first-class admin screen with its own entry in
 the navigation and its own address, not a section of the dashboard.
 
-**ADMIN-58** (AGREED) - The screen shows every session in scope as a table, one row per
+**ADMIN-58** (SHIPPED) - The screen shows every session in scope as a table, one row per
 session, ordered by when it was watched with the most recent first.
 
-**ADMIN-59** (AGREED) - The header states how many rows the current filters match, before
+**ADMIN-59** (SHIPPED) - The header states how many rows the current filters match, before
 paging. A reader narrowing filters watches that number move, which is how they know the
 filter did anything.
 
-**ADMIN-60** (AGREED) - The columns are the account, the kind of media, the title, the
+**ADMIN-60** (SHIPPED) - The columns are the account, the kind of media, the title, the
 player, the platform, and when it was watched. Every one of these was known while the
 session was live, and none of it can be recovered afterwards, so the log records all of it.
 
@@ -30,7 +30,7 @@ and its own name in one cell, including a row logged before the log kept any of 
 long as the catalog still holds the title. A row that said only "Chikhai Bardo" would make
 the reader go and look it up.
 
-**ADMIN-62** (AGREED) - Any column can order the table, ascending or descending, and the
+**ADMIN-62** (SHIPPED) - Any column can order the table, ascending or descending, and the
 column currently ordering it says which way.
 
 **ADMIN-77** (AGREED) - When a session was watched is written out in full, the date and the
@@ -42,28 +42,28 @@ the catalog still holds it. An episode opens its series, which is the page a ser
 row whose title has left the catalog offers nothing rather than a link to a page that is
 gone, because the log outlives the library.
 
-**ADMIN-63** (AGREED) - The table pages or virtualises rather than rendering everything.
+**ADMIN-63** (SHIPPED) - The table pages or virtualises rather than rendering everything.
 A server with years of history holds tens of thousands of rows, and the screen must open in
 the same time on the last day as on the first.
 
 ## Filters
 
-Status: **AGREED**
+Status: **SHIPPED**
 
-**ADMIN-64** (AGREED) - The screen filters by library, by account, and by window, each
+**ADMIN-64** (SHIPPED) - The screen filters by library, by account, and by window, each
 independent of the others, each with an "all" entry, and all three defaulting to everything.
 
-**ADMIN-65** (AGREED) - The window control offers the same choices as the dashboard's, plus
+**ADMIN-65** (SHIPPED) - The window control offers the same choices as the dashboard's, plus
 everything the log holds, which is the default here. The dashboard is about now; this screen
 is about the record.
 
-**ADMIN-66** (AGREED) - Filters live in the address, so a filtered view can be sent to
+**ADMIN-66** (SHIPPED) - Filters live in the address, so a filtered view can be sent to
 someone or reloaded without being rebuilt.
 
-**ADMIN-67** (AGREED) - Arriving from a dashboard panel applies the filters that panel sent,
+**ADMIN-67** (SHIPPED) - Arriving from a dashboard panel applies the filters that panel sent,
 as ADMIN-37 and ADMIN-75 require.
 
-**ADMIN-76** (AGREED) - A screen narrowed to one title names that title in the filter row
+**ADMIN-76** (SHIPPED) - A screen narrowed to one title names that title in the filter row
 beside the other three, and drops it in one action, returning to the whole log with the
 library, account and window the reader had chosen still applied. A filter a reader can
 enter and never leave is a trap.
@@ -90,9 +90,9 @@ removing their access.
 
 ## Who may read it
 
-Status: **AGREED**
+Status: **SHIPPED** in part; each requirement carries its own.
 
-**ADMIN-72** (AGREED) - The screen requires the permission to manage users. A watch history
+**ADMIN-72** (SHIPPED) - The screen requires the permission to manage users. A watch history
 is the most personal record the server holds, and it is the owner's to read, not every
 member's.
 

--- a/docs/spec/library/README.md
+++ b/docs/spec/library/README.md
@@ -1,6 +1,7 @@
 # Library
 
-Status: **AGREED**. Every section carries its own status; the file-level label is the floor.
+Status: **SHIPPED** in part. The scan, the walk and most of the naming conventions are built;
+the rest is decided. Every section and every requirement carries its own status.
 
 Sources on disk become titles you can browse. Everything upstream of "there is something
 to play". What a title *is* once matched, meaning streams, codecs and artwork, is
@@ -9,7 +10,7 @@ to play". What a title *is* once matched, meaning streams, codecs and artwork, i
 
 ## Sources
 
-Status: **AGREED**
+Status: **SHIPPED** in part; each requirement carries its own.
 
 **LIB-1** (AGREED) - A **source** is a directory tree the server is told to watch, tagged
 with exactly one content kind, **movies** or **shows**. The kind is chosen when the source
@@ -43,7 +44,7 @@ removing sources is an admin surface, [`admin/`](../admin/).
 
 ## Naming conventions understood
 
-Status: **AGREED**
+Status: **SHIPPED** in part; each requirement carries its own.
 
 **LIB-9** (AGREED) - Matching is convention-first: a correctly named file matches offline,
 with no provider call. A file that follows the conventions below is guaranteed to match to
@@ -109,7 +110,7 @@ portable between servers and a rename on disk is a reliable repair rather than a
 
 ## Scanning
 
-Status: **AGREED**
+Status: **SHIPPED** in part; each requirement carries its own.
 
 Two scans, one code path, different triggers.
 
@@ -214,7 +215,7 @@ architecture rather than product rules, and are not fixed here.
 
 ## Refresh
 
-Status: **AGREED**
+Status: **SHIPPED** in part; each requirement carries its own.
 
 **LIB-41** (SHIPPED) - A newly matched item fetches its metadata once.
 

--- a/docs/spec/media/README.md
+++ b/docs/spec/media/README.md
@@ -1,7 +1,7 @@
 # Media
 
-Status: **AGREED**. The media model and the first-class codec/stream truth are decided.
-Per-section status is called out where it differs.
+Status: **AGREED**, with the codec and stream truth **SHIPPED**. The model's edition level is
+decided and not built. Per-section and per-requirement status is called out where it differs.
 
 What a title *is* once KROMA knows about it: the technical truth about its streams. That
 truth is the input to every playback decision. If a file direct-plays, it is because its
@@ -14,17 +14,17 @@ terms defined here; neither is redefined here.
 
 ## The media model
 
-Status: **AGREED**
+Status: **SHIPPED** in part; each requirement carries its own.
 
 Five nouns, nested, each the child of the one before:
 
-- **MEDIA-1** (AGREED) - **Title.** The work a person searches for: a film, or one episode
+- **MEDIA-1** (SHIPPED) - **Title.** The work a person searches for: a film, or one episode
   of a series. It is the unit [`library/`](../library/) matches to metadata, and it carries
   no bytes.
 - **MEDIA-2** (AGREED) - **Edition.** A named cut of a title: theatrical, director's,
   extended, remastered. Different runtimes, different content. A title with one cut has one
   unnamed edition.
-- **MEDIA-3** (AGREED) - **Media file.** One physical file on disk that realises an edition
+- **MEDIA-3** (SHIPPED) - **Media file.** One physical file on disk that realises an edition
   at a given fidelity. An edition may have several: a 1080p file and a 4K file are two media
   files of the same edition, not two titles and not two editions.
 - **MEDIA-4** (AGREED) - **Stream.** One track inside a media file, exactly one of video,
@@ -38,11 +38,14 @@ Five nouns, nested, each the child of the one before:
 media file, every media file to exactly one edition, every edition to exactly one title.
 Nothing floats.
 
+Today a media file hangs off a title directly and names its edition as a tag rather than
+belonging to one, so the middle level of this nesting is the part still AGREED.
+
 ## Versions of one title
 
-Status: **AGREED**. This resolves the open question on multiple versions.
+Status: **SHIPPED** in part; each requirement carries its own.. This resolves the open question on multiple versions.
 
-**MEDIA-7** (AGREED) - A 1080p file and a 4K file of the same cut are **two media files of
+**MEDIA-7** (SHIPPED) - A 1080p file and a 4K file of the same cut are **two media files of
 one edition**. They are never modelled as separate titles, and the library never shows a
 duplicate. A person picks a title and a cut; the fidelity is chosen for them.
 
@@ -59,44 +62,44 @@ duplicate. A person picks a title and a cut; the fidelity is chosen for them.
 
 ## Containers and codecs
 
-Status: **AGREED**
+Status: **SHIPPED**
 
-**MEDIA-11** (AGREED) - First-class means KROMA fully describes the format, preserves it end
+**MEDIA-11** (SHIPPED) - First-class means KROMA fully describes the format, preserves it end
 to end, and expects direct play wherever a client can render it. Everything else is
 *readable* but not privileged.
 
-**MEDIA-12** (AGREED) - The first-class containers are **MP4**, **MKV** and **WebM**.
+**MEDIA-12** (SHIPPED) - The first-class containers are **MP4**, **MKV** and **WebM**.
 
 The first-class video codecs, HEVC first:
 
-- **MEDIA-13** (AGREED) - **HEVC / H.265** is the priority codec. 8-bit and 10-bit, SDR and
+- **MEDIA-13** (SHIPPED) - **HEVC / H.265** is the priority codec. 8-bit and 10-bit, SDR and
   HDR, are all first-class.
-- **MEDIA-14** (AGREED) - **H.264 / AVC** is the universal floor, assumed playable
+- **MEDIA-14** (SHIPPED) - **H.264 / AVC** is the universal floor, assumed playable
   everywhere.
-- **MEDIA-15** (AGREED) - **AV1** is first-class media truth whatever the client generation,
+- **MEDIA-15** (SHIPPED) - **AV1** is first-class media truth whatever the client generation,
   so a capable client direct-plays it.
-- **MEDIA-16** (AGREED) - **VP9** is first-class within WebM, chiefly for the browser
+- **MEDIA-16** (SHIPPED) - **VP9** is first-class within WebM, chiefly for the browser
   surface.
 
-**MEDIA-17** (AGREED) - A codec being first-class states how *KROMA* handles it, never that a
+**MEDIA-17** (SHIPPED) - A codec being first-class states how *KROMA* handles it, never that a
 particular device renders it. That is the matrix in [`surfaces/`](../surfaces/).
 
 First-class audio and subtitle codecs are named in their sections below.
 
 ## Bit depth and HDR
 
-Status: **AGREED**
+Status: **SHIPPED** in part; each requirement carries its own.
 
 **MEDIA-18** (AGREED) - HDR is preserved end to end or it is not offered. KROMA never
 silently flattens HDR to SDR, and a tone-mapped picture is surfaced as the compromise it is
 by [`playback/`](../playback/).
 
-- **MEDIA-19** (AGREED) - **Bit depth.** 8-bit and 10-bit are first-class, and 10-bit is
+- **MEDIA-19** (SHIPPED) - **Bit depth.** 8-bit and 10-bit are first-class, and 10-bit is
   retained as a property of the video stream rather than rounded away in the model.
 - **MEDIA-20** (AGREED) - KROMA distinguishes **HDR10**, **HDR10+**, **Dolby Vision** and
   **HLG** as separate properties, because each has distinct client support, and it records
   Dolby Vision's profile, because a profile a client cannot decode is not the same as one it
-  can.
+  can. Today a video stream carries one HDR flag, so the variants are the part not built.
 - **MEDIA-21** (AGREED) - Colour primaries, transfer characteristics and matrix coefficients
   travel with the video stream, and a client is matched against the exact HDR variant rather
   than a generic "HDR" flag.
@@ -106,22 +109,23 @@ by [`playback/`](../playback/).
 
 ## Audio
 
-Status: **AGREED**
+Status: **SHIPPED** in part; each requirement carries its own.
 
 **MEDIA-23** (AGREED) - The first-class audio codecs are **AAC**, **AC-3** and **E-AC-3**
-(Dolby Digital and Plus), **TrueHD**, **DTS** and **DTS-HD**, **FLAC** and **Opus**.
+(Dolby Digital and Plus), **TrueHD**, **DTS** and **DTS-HD**, **FLAC** and **Opus**. Only the
+first three and Opus are handled first-class today; the rest are the part still AGREED.
 
 **MEDIA-24** (AGREED) - An audio stream's **channel layout**, stereo, 5.1, 7.1 or Atmos
 objects, is a first-class property.
 
-- **MEDIA-25** (AGREED) - **Passthrough** is the default for multichannel and lossless audio:
+- **MEDIA-25** (SHIPPED) - **Passthrough** is the default for multichannel and lossless audio:
   the bitstream reaches a device or receiver that can decode it untouched. This is direct play
   for audio and is always preferred.
 - **MEDIA-26** (AGREED) - **Downmixing** to stereo happens only when the target cannot render
   the source layout, only as an explicit fallback, and never silently. A downmix is a
   channel-count reduction and therefore a compromise; the original stream is retained
   unchanged as the source, and telling the person is [`playback/`](../playback/)'s job.
-- **MEDIA-27** (AGREED) - Multiple audio streams, languages and commentary alike, are all
+- **MEDIA-27** (SHIPPED) - Multiple audio streams, languages and commentary alike, are all
   enumerated and selectable. The default follows the file's own disposition flags, then the
   profile's language preference.
 
@@ -148,9 +152,9 @@ and both enumerate the same way once known.
 
 ## Artwork and images
 
-Status: **AGREED**
+Status: **SHIPPED** in part; each requirement carries its own.
 
-**MEDIA-32** (AGREED) - Every title carries a **poster**, a **backdrop**, a **logo** and, per
+**MEDIA-32** (SHIPPED) - Every title carries a **poster**, a **backdrop**, a **logo** and, per
 episode, a **thumb**. These are media too, and are treated with the same discipline.
 
 - **MEDIA-33** (AGREED) - Image sources rank by trust: embedded in the media file, then a
@@ -166,9 +170,9 @@ episode, a **thumb**. These are media too, and are treated with the same discipl
 
 ## Probing and trust
 
-Status: **AGREED**. This resolves the open question on probe trust.
+Status: **SHIPPED** in part; each requirement carries its own.. This resolves the open question on probe trust.
 
-**MEDIA-37** (AGREED) - KROMA learns a file's streams by **probing** it once, when the
+**MEDIA-37** (SHIPPED) - KROMA learns a file's streams by **probing** it once, when the
 library first sees it, and **trusts that probe** for playback decisions. Re-probing on every
 play would tax the server for a fact that rarely changes.
 

--- a/docs/spec/playback/README.md
+++ b/docs/spec/playback/README.md
@@ -1,6 +1,8 @@
 # Playback
 
-Status: **AGREED**. Sections carry their own status below.
+Status: **SHIPPED** in part. Direct play, the rungs, resume and the failure messages are
+built; the compromise badges and the reconciliation rules are decided. Sections and
+requirements carry their own status below.
 
 The core promise: the file plays, unmodified, wherever possible. Everything else is a
 fallback, and every fallback is a compromise that is made visible and explained. KROMA
@@ -87,7 +89,7 @@ person actually owns, not so KROMA can pretend any file suits any screen.
 
 ## What is never done silently
 
-Status: **AGREED**
+Status: **SHIPPED** in part; each requirement carries its own.
 
 **PLAY-20** (AGREED) - Any rung below direct play is a compromise, and the client always shows
 which one is active before or at the moment playback starts, as a small honest badge rather
@@ -96,12 +98,17 @@ than a buried log line.
 - **PLAY-21** (AGREED) - **Video transcode** and **subtitle burn-in** are shown as *reduced
   quality* with the reason, meaning codec, resolution, HDR or subtitle. These change the
   picture and are the loudest.
-- **PLAY-22** (AGREED) - **Audio downmix** and **audio transcode** are shown as *audio
-  adjusted*.
+- **PLAY-22** (SHIPPED) - **Audio downmix** and **audio transcode** are shown as *audio
+  adjusted*, naming the codec that was re-encoded.
 - **PLAY-23** (AGREED) - **Remux** is shown as *repackaged*. Quality is untouched, so this is
   informational rather than a warning.
-- **PLAY-24** (AGREED) - Direct play shows nothing. The absence of a badge *is* the signal
-  that the file is pristine.
+- **PLAY-24** (SHIPPED) - Direct play may announce itself, naming the codec it is playing
+  untouched. The guarantee is the absence of a *compromise* notice, not the absence of all
+  notice: a badge that says a compromise is active is the thing that must never be missing.
+
+Direct play announcing itself is deliberate rather than noise. Playing the file unmodified is
+the product's whole claim, so saying "direct play in H.265" is the product showing its work. The
+rule that carries weight is that a compromise is never silent, not that a success always is.
 
 **PLAY-25** (AGREED) - KROMA never re-encodes video to save bandwidth unless the device
 profile forces it.
@@ -138,8 +145,10 @@ is the server's watch state, not a device's ([`accounts/`](../accounts/)), so an
 person signs into sees the same resume point.
 
 **PLAY-34** (SHIPPED) - The playing client reports position on a steady heartbeat while
-playing, on pause, on a settled seek, and on stop, so a crash loses at most one heartbeat
-interval.
+playing, on pause, and on stop, so a crash loses at most one heartbeat interval.
+
+**PLAY-53** (AGREED) - A settled seek also reports, so jumping and then losing the client does
+not roll the position back to the last heartbeat.
 
 **PLAY-35** (AGREED) - The write is idempotent on the person, the version, the position and
 the wall-clock time, so a replayed or offline-queued report cannot move progress backwards.
@@ -148,11 +157,14 @@ the wall-clock time, so a replayed or offline-queued report cannot move progress
 and *Play from start*, with resume the default. The stored position is the reported one, not a
 rounded chapter.
 
-**PLAY-37** (AGREED) - A title is **watched** at **90% of runtime or more**, or at reaching a
-credits or end marker where the media has one. 90% is chosen because trailing credits
-routinely run the last several minutes: requiring 100% would strand finished titles in the row
-forever, and a fixed "last N minutes" misjudges both a 22-minute episode and a 200-minute
-film.
+**PLAY-37** (SHIPPED) - A title is **watched** at a credits or end marker where the media has
+one, and otherwise at **97% of runtime or more**.
+
+The marker is the real signal and the percentage is only the fallback for media without one,
+which is why the fallback errs tight rather than generous. Requiring 100% would strand finished
+titles in the row forever. Going the other way, a loose threshold marks a long film watched
+while twenty minutes are left, and losing a person's place in a film they had not finished is a
+worse failure than leaving a finished episode in a row they can dismiss.
 
 **PLAY-38** (SHIPPED) - At the watched threshold, continue-watching drops the title and, for
 episodic content, surfaces the next episode instead.
@@ -205,7 +217,7 @@ achieves the same end without a pairing dance.
 
 ## Failure
 
-Status: **AGREED**
+Status: **SHIPPED** in part; each requirement carries its own.
 
 **PLAY-49** (AGREED) - When a stream dies mid-playback, whether the network drops, a transcode
 process fails or the source file becomes unreadable, the client shows a plain, specific message
@@ -215,7 +227,7 @@ from the start.
 - **PLAY-50** (AGREED) - A **transient** failure, a network drop or a brief server hiccup, is
   retried quietly for a few seconds behind the scrubber before anything surfaces. Most recover
   invisibly.
-- **PLAY-51** (AGREED) - A **fatal** failure, a source gone, a transcode that cannot start, or
+- **PLAY-51** (SHIPPED) - A **fatal** failure, a source gone, a transcode that cannot start, or
   a path a policy has disabled, stops playback with a reason, either *This file can't be played
   on this device* or *This title is no longer available*, never a raw error code.
 
@@ -226,7 +238,9 @@ Status: **AGREED**
 **PLAY-52** (AGREED) - When a television's older decoder cannot play a file a modern phone
 can, and the server is configured not to transcode it, the television names the device as the
 cause, points at a surface that does play it, and names the one lever that would fix it. It
-never blames the person and never implies the file is broken.
+never blames the person and never implies the file is broken. Today the codec refusal points at
+"another device" without naming one, which is the part still AGREED; the audio refusal already
+names two.
 
 > **Can't play this here.** This TV can't decode this file. It plays fine on the KROMA phone and
 > web apps, or ask the server owner to enable conversion for this device.

--- a/docs/spec/requirements.json
+++ b/docs/spec/requirements.json
@@ -374,7 +374,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 5,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "Every resource chart carries a **scope** control naming which series",
     "file": "docs/spec/admin/dashboard-live.md",
     "line": 34
@@ -384,7 +384,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 6,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "Every resource chart carries a footer stating the mean of each series",
     "file": "docs/spec/admin/dashboard-live.md",
     "line": 38
@@ -394,7 +394,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 7,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "Hovering any point reveals every series' value at that instant,",
     "file": "docs/spec/admin/dashboard-live.md",
     "line": 41
@@ -404,7 +404,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 8,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "The range control offers, in this order: live, the last 12 hours,",
     "file": "docs/spec/admin/dashboard-live.md",
     "line": 44
@@ -414,7 +414,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 9,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "\"Live\" is the rolling in-memory window the server samples at its own",
     "file": "docs/spec/admin/dashboard-live.md",
     "line": 48
@@ -434,7 +434,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 11,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "Persisted samples are downsampled as they age, so a year of history",
     "file": "docs/spec/admin/dashboard-live.md",
     "line": 56
@@ -464,7 +464,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 14,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "The bandwidth scope control offers all traffic, local only, or",
     "file": "docs/spec/admin/dashboard-live.md",
     "line": 72
@@ -484,7 +484,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 16,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "The processor chart draws two series, what KROMA costs and what the",
     "file": "docs/spec/admin/dashboard-resources.md",
     "line": 17
@@ -504,7 +504,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 18,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "The processor scope control offers both series, KROMA alone, or the",
     "file": "docs/spec/admin/dashboard-resources.md",
     "line": 25
@@ -524,7 +524,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 20,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "The memory chart draws the same two series as the processor chart,",
     "file": "docs/spec/admin/dashboard-resources.md",
     "line": 35
@@ -544,7 +544,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 22,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "The memory scope control offers both series, KROMA alone, or the",
     "file": "docs/spec/admin/dashboard-resources.md",
     "line": 41
@@ -554,7 +554,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 23,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "Each series keeps one colour for the life of the product. A reader",
     "file": "docs/spec/admin/dashboard-resources.md",
     "line": 44
@@ -584,7 +584,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 26,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "The panel ranks accounts by time watched over a chosen window, most",
     "file": "docs/spec/admin/dashboard-audience.md",
     "line": 14
@@ -594,7 +594,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 27,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "Each card breaks its total down by kind of media, one row for movies",
     "file": "docs/spec/admin/dashboard-audience.md",
     "line": 17
@@ -614,7 +614,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 29,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "The window control offers the last 24 hours, 7 days, 30 days, 90",
     "file": "docs/spec/admin/dashboard-audience.md",
     "line": 25
@@ -624,7 +624,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 30,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "With more accounts than fit, the panel pages through them rather",
     "file": "docs/spec/admin/dashboard-audience.md",
     "line": 28
@@ -634,7 +634,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 31,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "Each card carries the account's avatar where it has one, and falls",
     "file": "docs/spec/admin/dashboard-audience.md",
     "line": 31
@@ -644,7 +644,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 32,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "The panel plots time watched per bucket over a chosen window,",
     "file": "docs/spec/admin/dashboard-audience.md",
     "line": 45
@@ -654,7 +654,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 33,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "The bucket width is chosen from the window so the chart always",
     "file": "docs/spec/admin/dashboard-audience.md",
     "line": 49
@@ -664,7 +664,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 34,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "The panel carries three independent filters: kind of media, account,",
     "file": "docs/spec/admin/dashboard-audience.md",
     "line": 53
@@ -674,7 +674,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 35,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "The account filter lists every account with history in the window,",
     "file": "docs/spec/admin/dashboard-audience.md",
     "line": 56
@@ -684,7 +684,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 36,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "A footer states the total time for each kind of media over the whole",
     "file": "docs/spec/admin/dashboard-audience.md",
     "line": 59
@@ -694,7 +694,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 37,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "The panel links to the full history screen",
     "file": "docs/spec/admin/dashboard-audience.md",
     "line": 62
@@ -704,7 +704,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 38,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "Each kind of media keeps one colour across this panel, the top-viewer",
     "file": "docs/spec/admin/dashboard-audience.md",
     "line": 66
@@ -714,7 +714,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 39,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "The panel ranks titles by number of plays over a chosen window, most",
     "file": "docs/spec/admin/dashboard-most-watched.md",
     "line": 13
@@ -724,7 +724,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 40,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "Each column is headed by the artwork of its own top title, labelled",
     "file": "docs/spec/admin/dashboard-most-watched.md",
     "line": 21
@@ -734,7 +734,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 41,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "Each entry names the title, its play count, and how many distinct",
     "file": "docs/spec/admin/dashboard-most-watched.md",
     "line": 24
@@ -754,7 +754,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 43,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "Each entry carries its poster, and falls back to a title-seeded",
     "file": "docs/spec/admin/dashboard-most-watched.md",
     "line": 32
@@ -774,7 +774,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 45,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "The panel carries two filters, account and window, defaulting to",
     "file": "docs/spec/admin/dashboard-most-watched.md",
     "line": 39
@@ -784,7 +784,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 46,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "Selecting an entry opens that title's own watch history",
     "file": "docs/spec/admin/dashboard-most-watched.md",
     "line": 42
@@ -814,7 +814,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 49,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "The view is the full history screen ([`watch-history.md`](watch-history.md))",
     "file": "docs/spec/admin/watch-history-item.md",
     "line": 13
@@ -824,7 +824,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 50,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "The header names the title beside the number of plays in scope, so",
     "file": "docs/spec/admin/watch-history-item.md",
     "line": 18
@@ -844,7 +844,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 52,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "Rows are ordered by when they were watched, most recent first, and",
     "file": "docs/spec/admin/watch-history-item.md",
     "line": 24
@@ -874,7 +874,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 55,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "The view has its own address. An owner can send it to someone, or",
     "file": "docs/spec/admin/watch-history-item.md",
     "line": 38
@@ -894,7 +894,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 57,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "Watch history is a first-class admin screen with its own entry in",
     "file": "docs/spec/admin/watch-history.md",
     "line": 14
@@ -904,7 +904,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 58,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "The screen shows every session in scope as a table, one row per",
     "file": "docs/spec/admin/watch-history.md",
     "line": 17
@@ -914,7 +914,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 59,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "The header states how many rows the current filters match, before",
     "file": "docs/spec/admin/watch-history.md",
     "line": 20
@@ -924,7 +924,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 60,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "The columns are the account, the kind of media, the title, the",
     "file": "docs/spec/admin/watch-history.md",
     "line": 24
@@ -944,7 +944,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 62,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "Any column can order the table, ascending or descending, and the",
     "file": "docs/spec/admin/watch-history.md",
     "line": 33
@@ -954,7 +954,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 63,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "The table pages or virtualises rather than rendering everything.",
     "file": "docs/spec/admin/watch-history.md",
     "line": 45
@@ -964,7 +964,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 64,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "The screen filters by library, by account, and by window, each",
     "file": "docs/spec/admin/watch-history.md",
     "line": 53
@@ -974,7 +974,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 65,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "The window control offers the same choices as the dashboard's, plus",
     "file": "docs/spec/admin/watch-history.md",
     "line": 56
@@ -984,7 +984,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 66,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "Filters live in the address, so a filtered view can be sent to",
     "file": "docs/spec/admin/watch-history.md",
     "line": 60
@@ -994,7 +994,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 67,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "Arriving from a dashboard panel applies the filters that panel sent,",
     "file": "docs/spec/admin/watch-history.md",
     "line": 63
@@ -1044,7 +1044,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 72,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "The screen requires the permission to manage users. A watch history",
     "file": "docs/spec/admin/watch-history.md",
     "line": 95
@@ -1074,7 +1074,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 75,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "A card opens the full history screen",
     "file": "docs/spec/admin/dashboard-audience.md",
     "line": 34
@@ -1084,7 +1084,7 @@
     "domain": "ADMIN",
     "space": "admin",
     "number": 76,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "A screen narrowed to one title names that title in the filter row",
     "file": "docs/spec/admin/watch-history.md",
     "line": 66
@@ -1117,7 +1117,7 @@
     "status": "AGREED",
     "text": "A reset is a single-use, time-limited link plus a short one-time",
     "file": "docs/spec/admin/README.md",
-    "line": 111
+    "line": 113
   },
   {
     "id": "ADMIN-80",
@@ -1127,7 +1127,7 @@
     "status": "AGREED",
     "text": "The code is eight characters from a thirty-two-symbol alphabet with",
     "file": "docs/spec/admin/README.md",
-    "line": 117
+    "line": 119
   },
   {
     "id": "ADMIN-81",
@@ -1137,7 +1137,7 @@
     "status": "AGREED",
     "text": "A new reset invalidates any unused previous one for the same account.",
     "file": "docs/spec/admin/README.md",
-    "line": 121
+    "line": 123
   },
   {
     "id": "ADMIN-82",
@@ -1147,7 +1147,7 @@
     "status": "AGREED",
     "text": "Delivery is the owner's choice, per server: copy the link and code",
     "file": "docs/spec/admin/README.md",
-    "line": 125
+    "line": 127
   },
   {
     "id": "ADMIN-83",
@@ -1157,7 +1157,7 @@
     "status": "AGREED",
     "text": "The kroma.tv relay sees the destination address and the link, never",
     "file": "docs/spec/admin/README.md",
-    "line": 133
+    "line": 135
   },
   {
     "id": "ADMIN-84",
@@ -1167,7 +1167,7 @@
     "status": "AGREED",
     "text": "The owner can clear a user's profile PIN. Clearing is the only PIN",
     "file": "docs/spec/admin/README.md",
-    "line": 148
+    "line": 150
   },
   {
     "id": "ADMIN-85",
@@ -1177,7 +1177,7 @@
     "status": "AGREED",
     "text": "An address on an account is unverified until the mailbox proves",
     "file": "docs/spec/admin/README.md",
-    "line": 158
+    "line": 160
   },
   {
     "id": "ADMIN-86",
@@ -1187,7 +1187,7 @@
     "status": "AGREED",
     "text": "The owner sends a verification from the member editor, with the",
     "file": "docs/spec/admin/README.md",
-    "line": 163
+    "line": 165
   },
   {
     "id": "ADMIN-87",
@@ -1197,7 +1197,7 @@
     "status": "AGREED",
     "text": "Changing the address clears the verified state: the proof belongs",
     "file": "docs/spec/admin/README.md",
-    "line": 168
+    "line": 170
   },
   {
     "id": "ADMIN-88",
@@ -1207,7 +1207,7 @@
     "status": "AGREED",
     "text": "A user who cannot sign in can ask for a reset from the sign-in",
     "file": "docs/spec/admin/README.md",
-    "line": 137
+    "line": 139
   },
   {
     "id": "ADMIN-89",
@@ -1217,7 +1217,7 @@
     "status": "AGREED",
     "text": "A server learns it is out of date by checking for a newer release and",
     "file": "docs/spec/admin/README.md",
-    "line": 271
+    "line": 273
   },
   {
     "id": "ADMIN-90",
@@ -1227,7 +1227,7 @@
     "status": "AGREED",
     "text": "A server update migrates the persistent store forward",
     "file": "docs/spec/admin/README.md",
-    "line": 277
+    "line": 279
   },
   {
     "id": "ADMIN-91",
@@ -1237,7 +1237,7 @@
     "status": "AGREED",
     "text": "Module updates are independent of the server and carry their own",
     "file": "docs/spec/admin/README.md",
-    "line": 281
+    "line": 283
   },
   {
     "id": "ADMIN-92",
@@ -1247,7 +1247,7 @@
     "status": "AGREED",
     "text": "Active playback neither blocks an update nor is stopped by one",
     "file": "docs/spec/admin/README.md",
-    "line": 284
+    "line": 286
   },
   {
     "id": "ADMIN-93",
@@ -1257,7 +1257,7 @@
     "status": "AGREED",
     "text": "The rule above is identical on every host. Only the delivery vehicle",
     "file": "docs/spec/admin/README.md",
-    "line": 289
+    "line": 291
   },
   {
     "id": "DISC-1",
@@ -1597,7 +1597,7 @@
     "status": "AGREED",
     "text": "A **source** is a directory tree the server is told to watch, tagged",
     "file": "docs/spec/library/README.md",
-    "line": 14
+    "line": 15
   },
   {
     "id": "LIB-2",
@@ -1607,7 +1607,7 @@
     "status": "AGREED",
     "text": "A movie source never produces episodes and a show source never produces",
     "file": "docs/spec/library/README.md",
-    "line": 18
+    "line": 19
   },
   {
     "id": "LIB-3",
@@ -1617,7 +1617,7 @@
     "status": "AGREED",
     "text": "A server has zero or more sources, any number of them may point at the",
     "file": "docs/spec/library/README.md",
-    "line": 21
+    "line": 22
   },
   {
     "id": "LIB-4",
@@ -1627,7 +1627,7 @@
     "status": "AGREED",
     "text": "A source is an input, not a category a person browses by. Filtering the",
     "file": "docs/spec/library/README.md",
-    "line": 26
+    "line": 27
   },
   {
     "id": "LIB-5",
@@ -1637,7 +1637,7 @@
     "status": "SHIPPED",
     "text": "A source tree may be assembled from symlinks. A curated folder of links",
     "file": "docs/spec/library/README.md",
-    "line": 29
+    "line": 30
   },
   {
     "id": "LIB-6",
@@ -1647,7 +1647,7 @@
     "status": "SHIPPED",
     "text": "A link the server cannot resolve is reported, never silently skipped,",
     "file": "docs/spec/library/README.md",
-    "line": 33
+    "line": 34
   },
   {
     "id": "LIB-7",
@@ -1657,7 +1657,7 @@
     "status": "AGREED",
     "text": "A source records its mount path, its content kind and its scan schedule.",
     "file": "docs/spec/library/README.md",
-    "line": 37
+    "line": 38
   },
   {
     "id": "LIB-8",
@@ -1667,7 +1667,7 @@
     "status": "AGREED",
     "text": "Nothing about a source is destructive. Removing one drops its titles",
     "file": "docs/spec/library/README.md",
-    "line": 39
+    "line": 40
   },
   {
     "id": "LIB-9",
@@ -1677,7 +1677,7 @@
     "status": "AGREED",
     "text": "Matching is convention-first: a correctly named file matches offline,",
     "file": "docs/spec/library/README.md",
-    "line": 48
+    "line": 49
   },
   {
     "id": "LIB-10",
@@ -1687,7 +1687,7 @@
     "status": "SHIPPED",
     "text": "The `Title (Year)` stem is what is matched. The year is not",
     "file": "docs/spec/library/README.md",
-    "line": 59
+    "line": 60
   },
   {
     "id": "LIB-11",
@@ -1697,7 +1697,7 @@
     "status": "SHIPPED",
     "text": "A trailing tag after ` - `, a resolution, an edition or a source, is",
     "file": "docs/spec/library/README.md",
-    "line": 63
+    "line": 64
   },
   {
     "id": "LIB-12",
@@ -1707,7 +1707,7 @@
     "status": "SHIPPED",
     "text": "A loose file directly under the source root, with no folder, is",
     "file": "docs/spec/library/README.md",
-    "line": 67
+    "line": 68
   },
   {
     "id": "LIB-13",
@@ -1717,7 +1717,7 @@
     "status": "SHIPPED",
     "text": "A season folder is what makes the folder above it the show. With one",
     "file": "docs/spec/library/README.md",
-    "line": 79
+    "line": 80
   },
   {
     "id": "LIB-14",
@@ -1727,7 +1727,7 @@
     "status": "SHIPPED",
     "text": "Without a season folder the folder proves nothing, because a flat pool",
     "file": "docs/spec/library/README.md",
-    "line": 83
+    "line": 84
   },
   {
     "id": "LIB-15",
@@ -1737,7 +1737,7 @@
     "status": "SHIPPED",
     "text": "An episode whose filename is only its marker (`S01E01.mkv`) takes the",
     "file": "docs/spec/library/README.md",
-    "line": 86
+    "line": 87
   },
   {
     "id": "LIB-16",
@@ -1747,7 +1747,7 @@
     "status": "SHIPPED",
     "text": "The show folder name and the `SxxEyy` marker are load-bearing; the",
     "file": "docs/spec/library/README.md",
-    "line": 90
+    "line": 91
   },
   {
     "id": "LIB-17",
@@ -1757,7 +1757,7 @@
     "status": "SHIPPED",
     "text": "`Specials` is accepted as an alias for `Season 00`.",
     "file": "docs/spec/library/README.md",
-    "line": 93
+    "line": 94
   },
   {
     "id": "LIB-18",
@@ -1767,7 +1767,7 @@
     "status": "SHIPPED",
     "text": "A multi-episode file is named with a range (`S01E01-E02`) and matched",
     "file": "docs/spec/library/README.md",
-    "line": 95
+    "line": 96
   },
   {
     "id": "LIB-19",
@@ -1777,7 +1777,7 @@
     "status": "AGREED",
     "text": "A show folder MAY carry a `(Year)` for disambiguation",
     "file": "docs/spec/library/README.md",
-    "line": 98
+    "line": 99
   },
   {
     "id": "LIB-20",
@@ -1787,7 +1787,7 @@
     "status": "SHIPPED",
     "text": "Case is ignored, and separators may be spaces, dots or underscores.",
     "file": "docs/spec/library/README.md",
-    "line": 101
+    "line": 102
   },
   {
     "id": "LIB-21",
@@ -1797,7 +1797,7 @@
     "status": "SHIPPED",
     "text": "Only recognised video containers are considered files to match.",
     "file": "docs/spec/library/README.md",
-    "line": 103
+    "line": 104
   },
   {
     "id": "LIB-22",
@@ -1807,7 +1807,7 @@
     "status": "AGREED",
     "text": "The scheme is a convention rather than configuration, so a library is",
     "file": "docs/spec/library/README.md",
-    "line": 107
+    "line": 108
   },
   {
     "id": "LIB-23",
@@ -1817,7 +1817,7 @@
     "status": "SHIPPED",
     "text": "An **initial scan** runs when a source is added: the whole tree is",
     "file": "docs/spec/library/README.md",
-    "line": 116
+    "line": 117
   },
   {
     "id": "LIB-24",
@@ -1827,7 +1827,7 @@
     "status": "AGREED",
     "text": "An **incremental rescan** keeps the catalogue true to disk afterwards.",
     "file": "docs/spec/library/README.md",
-    "line": 121
+    "line": 122
   },
   {
     "id": "LIB-25",
@@ -1837,7 +1837,7 @@
     "status": "AGREED",
     "text": "An incremental rescan only reconsiders what changed, meaning new paths,",
     "file": "docs/spec/library/README.md",
-    "line": 127
+    "line": 128
   },
   {
     "id": "LIB-26",
@@ -1847,7 +1847,7 @@
     "status": "AGREED",
     "text": "Scanning is safe to run at any time, including while files are being",
     "file": "docs/spec/library/README.md",
-    "line": 131
+    "line": 132
   },
   {
     "id": "LIB-27",
@@ -1857,7 +1857,7 @@
     "status": "AGREED",
     "text": "A file is matched only once it looks **settled**, its size and",
     "file": "docs/spec/library/README.md",
-    "line": 134
+    "line": 135
   },
   {
     "id": "LIB-28",
@@ -1867,7 +1867,7 @@
     "status": "SHIPPED",
     "text": "Scanning **reads only**. It never writes, moves, renames or deletes",
     "file": "docs/spec/library/README.md",
-    "line": 139
+    "line": 140
   },
   {
     "id": "LIB-29",
@@ -1877,7 +1877,7 @@
     "status": "AGREED",
     "text": "KROMA never demands exclusive access to a library and never blocks the",
     "file": "docs/spec/library/README.md",
-    "line": 142
+    "line": 143
   },
   {
     "id": "LIB-30",
@@ -1887,7 +1887,7 @@
     "status": "AGREED",
     "text": "Matching resolves a settled file to an identity: a convention parse",
     "file": "docs/spec/library/README.md",
-    "line": 157
+    "line": 158
   },
   {
     "id": "LIB-31",
@@ -1897,7 +1897,7 @@
     "status": "AGREED",
     "text": "A file that parses to no confident identity, whether from an",
     "file": "docs/spec/library/README.md",
-    "line": 163
+    "line": 164
   },
   {
     "id": "LIB-32",
@@ -1907,7 +1907,7 @@
     "status": "AGREED",
     "text": "Unmatched items appear in a browsable **Unmatched** view in the library",
     "file": "docs/spec/library/README.md",
-    "line": 168
+    "line": 169
   },
   {
     "id": "LIB-33",
@@ -1917,7 +1917,7 @@
     "status": "AGREED",
     "text": "**Manual match.** A person searches the provider, picks the correct",
     "file": "docs/spec/library/README.md",
-    "line": 172
+    "line": 173
   },
   {
     "id": "LIB-34",
@@ -1927,7 +1927,7 @@
     "status": "AGREED",
     "text": "**Rename on disk.** A name fixed to the convention above matches",
     "file": "docs/spec/library/README.md",
-    "line": 176
+    "line": 177
   },
   {
     "id": "LIB-35",
@@ -1937,7 +1937,7 @@
     "status": "AGREED",
     "text": "A file that could be more than one identity, a title shared by a remake",
     "file": "docs/spec/library/README.md",
-    "line": 182
+    "line": 183
   },
   {
     "id": "LIB-36",
@@ -1947,7 +1947,7 @@
     "status": "AGREED",
     "text": "One unplaceable file never stalls a source. The catalogue is always the",
     "file": "docs/spec/library/README.md",
-    "line": 188
+    "line": 189
   },
   {
     "id": "LIB-37",
@@ -1957,7 +1957,7 @@
     "status": "AGREED",
     "text": "Every field and image a provider returns is written to the server's own",
     "file": "docs/spec/library/README.md",
-    "line": 198
+    "line": 199
   },
   {
     "id": "LIB-38",
@@ -1967,7 +1967,7 @@
     "status": "AGREED",
     "text": "With no internet, everything already matched browses and plays exactly",
     "file": "docs/spec/library/README.md",
-    "line": 203
+    "line": 204
   },
   {
     "id": "LIB-39",
@@ -1977,7 +1977,7 @@
     "status": "AGREED",
     "text": "Offline, a brand-new file that needs a first provider lookup stays",
     "file": "docs/spec/library/README.md",
-    "line": 206
+    "line": 207
   },
   {
     "id": "LIB-40",
@@ -1987,7 +1987,7 @@
     "status": "AGREED",
     "text": "Offline, a forced refresh queues rather than fails.",
     "file": "docs/spec/library/README.md",
-    "line": 210
+    "line": 211
   },
   {
     "id": "LIB-41",
@@ -1997,7 +1997,7 @@
     "status": "SHIPPED",
     "text": "A newly matched item fetches its metadata once.",
     "file": "docs/spec/library/README.md",
-    "line": 219
+    "line": 220
   },
   {
     "id": "LIB-42",
@@ -2007,7 +2007,7 @@
     "status": "AGREED",
     "text": "Running series are re-checked on a slow cadence, so a new episode's air",
     "file": "docs/spec/library/README.md",
-    "line": 221
+    "line": 222
   },
   {
     "id": "LIB-43",
@@ -2017,7 +2017,7 @@
     "status": "AGREED",
     "text": "A \"Refresh metadata\" action on any title, season or whole source",
     "file": "docs/spec/library/README.md",
-    "line": 225
+    "line": 226
   },
   {
     "id": "LIB-44",
@@ -2027,7 +2027,7 @@
     "status": "AGREED",
     "text": "A forced refresh **never** discards a manual match or user-chosen",
     "file": "docs/spec/library/README.md",
-    "line": 229
+    "line": 230
   },
   {
     "id": "LIB-45",
@@ -2037,7 +2037,7 @@
     "status": "AGREED",
     "text": "When a file disappears from a source, its title is **marked absent**:",
     "file": "docs/spec/library/README.md",
-    "line": 251
+    "line": 252
   },
   {
     "id": "LIB-46",
@@ -2047,7 +2047,7 @@
     "status": "AGREED",
     "text": "Content that reappears, because a NAS remounts or a file is moved back",
     "file": "docs/spec/library/README.md",
-    "line": 256
+    "line": 257
   },
   {
     "id": "LIB-47",
@@ -2057,7 +2057,7 @@
     "status": "AGREED",
     "text": "A **move** is therefore not a special case. It is an absent path plus a",
     "file": "docs/spec/library/README.md",
-    "line": 260
+    "line": 261
   },
   {
     "id": "LIB-48",
@@ -2067,7 +2067,7 @@
     "status": "AGREED",
     "text": "A rescan **only ever marks absent**. It never deletes user data.",
     "file": "docs/spec/library/README.md",
-    "line": 264
+    "line": 265
   },
   {
     "id": "LIB-49",
@@ -2077,7 +2077,7 @@
     "status": "AGREED",
     "text": "Permanently deleting a title's history is an explicit, person-initiated",
     "file": "docs/spec/library/README.md",
-    "line": 266
+    "line": 267
   },
   {
     "id": "LIB-50",
@@ -2087,14 +2087,14 @@
     "status": "SHIPPED",
     "text": "Refreshing metadata and re-running identification are two actions, and",
     "file": "docs/spec/library/README.md",
-    "line": 233
+    "line": 234
   },
   {
     "id": "MEDIA-1",
     "domain": "MEDIA",
     "space": "media",
     "number": 1,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "**Title.** The work a person searches for: a film, or one episode",
     "file": "docs/spec/media/README.md",
     "line": 21
@@ -2114,7 +2114,7 @@
     "domain": "MEDIA",
     "space": "media",
     "number": 3,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "**Media file.** One physical file on disk that realises an edition",
     "file": "docs/spec/media/README.md",
     "line": 27
@@ -2154,10 +2154,10 @@
     "domain": "MEDIA",
     "space": "media",
     "number": 7,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "A 1080p file and a 4K file of the same cut are **two media files of",
     "file": "docs/spec/media/README.md",
-    "line": 45
+    "line": 48
   },
   {
     "id": "MEDIA-8",
@@ -2167,7 +2167,7 @@
     "status": "AGREED",
     "text": "KROMA ranks a title's media files and keeps a **preferred** one.",
     "file": "docs/spec/media/README.md",
-    "line": 49
+    "line": 52
   },
   {
     "id": "MEDIA-9",
@@ -2177,7 +2177,7 @@
     "status": "AGREED",
     "text": "The preference is a *default*, not a lock. The model enumerates a",
     "file": "docs/spec/media/README.md",
-    "line": 52
+    "line": 55
   },
   {
     "id": "MEDIA-10",
@@ -2187,77 +2187,77 @@
     "status": "AGREED",
     "text": "Editions are surfaced to the person, because they are different",
     "file": "docs/spec/media/README.md",
-    "line": 56
+    "line": 59
   },
   {
     "id": "MEDIA-11",
     "domain": "MEDIA",
     "space": "media",
     "number": 11,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "First-class means KROMA fully describes the format, preserves it end",
     "file": "docs/spec/media/README.md",
-    "line": 64
+    "line": 67
   },
   {
     "id": "MEDIA-12",
     "domain": "MEDIA",
     "space": "media",
     "number": 12,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "The first-class containers are **MP4**, **MKV** and **WebM**.",
     "file": "docs/spec/media/README.md",
-    "line": 68
+    "line": 71
   },
   {
     "id": "MEDIA-13",
     "domain": "MEDIA",
     "space": "media",
     "number": 13,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "**HEVC / H.265** is the priority codec. 8-bit and 10-bit, SDR and",
     "file": "docs/spec/media/README.md",
-    "line": 72
+    "line": 75
   },
   {
     "id": "MEDIA-14",
     "domain": "MEDIA",
     "space": "media",
     "number": 14,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "**H.264 / AVC** is the universal floor, assumed playable",
     "file": "docs/spec/media/README.md",
-    "line": 74
+    "line": 77
   },
   {
     "id": "MEDIA-15",
     "domain": "MEDIA",
     "space": "media",
     "number": 15,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "**AV1** is first-class media truth whatever the client generation,",
     "file": "docs/spec/media/README.md",
-    "line": 76
+    "line": 79
   },
   {
     "id": "MEDIA-16",
     "domain": "MEDIA",
     "space": "media",
     "number": 16,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "**VP9** is first-class within WebM, chiefly for the browser",
     "file": "docs/spec/media/README.md",
-    "line": 78
+    "line": 81
   },
   {
     "id": "MEDIA-17",
     "domain": "MEDIA",
     "space": "media",
     "number": 17,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "A codec being first-class states how *KROMA* handles it, never that a",
     "file": "docs/spec/media/README.md",
-    "line": 81
+    "line": 84
   },
   {
     "id": "MEDIA-18",
@@ -2267,17 +2267,17 @@
     "status": "AGREED",
     "text": "HDR is preserved end to end or it is not offered. KROMA never",
     "file": "docs/spec/media/README.md",
-    "line": 90
+    "line": 93
   },
   {
     "id": "MEDIA-19",
     "domain": "MEDIA",
     "space": "media",
     "number": 19,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "**Bit depth.** 8-bit and 10-bit are first-class, and 10-bit is",
     "file": "docs/spec/media/README.md",
-    "line": 94
+    "line": 97
   },
   {
     "id": "MEDIA-20",
@@ -2287,7 +2287,7 @@
     "status": "AGREED",
     "text": "KROMA distinguishes **HDR10**, **HDR10+**, **Dolby Vision** and",
     "file": "docs/spec/media/README.md",
-    "line": 96
+    "line": 99
   },
   {
     "id": "MEDIA-21",
@@ -2297,7 +2297,7 @@
     "status": "AGREED",
     "text": "Colour primaries, transfer characteristics and matrix coefficients",
     "file": "docs/spec/media/README.md",
-    "line": 100
+    "line": 103
   },
   {
     "id": "MEDIA-22",
@@ -2307,7 +2307,7 @@
     "status": "AGREED",
     "text": "Where dynamic metadata, HDR10+ or Dolby Vision, cannot be carried",
     "file": "docs/spec/media/README.md",
-    "line": 103
+    "line": 106
   },
   {
     "id": "MEDIA-23",
@@ -2317,7 +2317,7 @@
     "status": "AGREED",
     "text": "The first-class audio codecs are **AAC**, **AC-3** and **E-AC-3**",
     "file": "docs/spec/media/README.md",
-    "line": 111
+    "line": 114
   },
   {
     "id": "MEDIA-24",
@@ -2327,17 +2327,17 @@
     "status": "AGREED",
     "text": "An audio stream's **channel layout**, stereo, 5.1, 7.1 or Atmos",
     "file": "docs/spec/media/README.md",
-    "line": 114
+    "line": 118
   },
   {
     "id": "MEDIA-25",
     "domain": "MEDIA",
     "space": "media",
     "number": 25,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "**Passthrough** is the default for multichannel and lossless audio:",
     "file": "docs/spec/media/README.md",
-    "line": 117
+    "line": 121
   },
   {
     "id": "MEDIA-26",
@@ -2347,17 +2347,17 @@
     "status": "AGREED",
     "text": "**Downmixing** to stereo happens only when the target cannot render",
     "file": "docs/spec/media/README.md",
-    "line": 120
+    "line": 124
   },
   {
     "id": "MEDIA-27",
     "domain": "MEDIA",
     "space": "media",
     "number": 27,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "Multiple audio streams, languages and commentary alike, are all",
     "file": "docs/spec/media/README.md",
-    "line": 124
+    "line": 128
   },
   {
     "id": "MEDIA-28",
@@ -2367,7 +2367,7 @@
     "status": "AGREED",
     "text": "A subtitle stream is either **embedded**, a track inside the media",
     "file": "docs/spec/media/README.md",
-    "line": 132
+    "line": 136
   },
   {
     "id": "MEDIA-29",
@@ -2377,7 +2377,7 @@
     "status": "AGREED",
     "text": "The first-class subtitle formats are **SRT**, **WebVTT** and",
     "file": "docs/spec/media/README.md",
-    "line": 136
+    "line": 140
   },
   {
     "id": "MEDIA-30",
@@ -2387,7 +2387,7 @@
     "status": "AGREED",
     "text": "The **forced** disposition, only the foreign-language lines a",
     "file": "docs/spec/media/README.md",
-    "line": 140
+    "line": 144
   },
   {
     "id": "MEDIA-31",
@@ -2397,17 +2397,17 @@
     "status": "AGREED",
     "text": "**Burning in**, rendering a subtitle permanently into the video, is",
     "file": "docs/spec/media/README.md",
-    "line": 143
+    "line": 147
   },
   {
     "id": "MEDIA-32",
     "domain": "MEDIA",
     "space": "media",
     "number": 32,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "Every title carries a **poster**, a **backdrop**, a **logo** and, per",
     "file": "docs/spec/media/README.md",
-    "line": 153
+    "line": 157
   },
   {
     "id": "MEDIA-33",
@@ -2417,7 +2417,7 @@
     "status": "AGREED",
     "text": "Image sources rank by trust: embedded in the media file, then a",
     "file": "docs/spec/media/README.md",
-    "line": 156
+    "line": 160
   },
   {
     "id": "MEDIA-34",
@@ -2427,7 +2427,7 @@
     "status": "AGREED",
     "text": "KROMA derives a fixed set of sizes per image, a small grid",
     "file": "docs/spec/media/README.md",
-    "line": 159
+    "line": 163
   },
   {
     "id": "MEDIA-35",
@@ -2437,7 +2437,7 @@
     "status": "AGREED",
     "text": "Derived sizes are cached and served without re-deriving, and a",
     "file": "docs/spec/media/README.md",
-    "line": 162
+    "line": 166
   },
   {
     "id": "MEDIA-36",
@@ -2447,17 +2447,17 @@
     "status": "AGREED",
     "text": "Artwork is never a reason a title fails to appear. A title with no",
     "file": "docs/spec/media/README.md",
-    "line": 164
+    "line": 168
   },
   {
     "id": "MEDIA-37",
     "domain": "MEDIA",
     "space": "media",
     "number": 37,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "KROMA learns a file's streams by **probing** it once, when the",
     "file": "docs/spec/media/README.md",
-    "line": 171
+    "line": 175
   },
   {
     "id": "MEDIA-38",
@@ -2467,7 +2467,7 @@
     "status": "AGREED",
     "text": "A probe is the authoritative stream truth until the file's bytes",
     "file": "docs/spec/media/README.md",
-    "line": 175
+    "line": 179
   },
   {
     "id": "MEDIA-39",
@@ -2477,7 +2477,7 @@
     "status": "AGREED",
     "text": "When a direct play fails in a way that implicates the stream",
     "file": "docs/spec/media/README.md",
-    "line": 178
+    "line": 182
   },
   {
     "id": "MEDIA-40",
@@ -2487,7 +2487,7 @@
     "status": "AGREED",
     "text": "Trust is per-file and durable: a corrected probe is written back,",
     "file": "docs/spec/media/README.md",
-    "line": 183
+    "line": 187
   },
   {
     "id": "MEDIA-41",
@@ -2497,7 +2497,7 @@
     "status": "AGREED",
     "text": "A file whose container opens and whose streams enumerate, but which",
     "file": "docs/spec/media/README.md",
-    "line": 190
+    "line": 194
   },
   {
     "id": "MEDIA-42",
@@ -2507,7 +2507,7 @@
     "status": "AGREED",
     "text": "The title **appears** in the library with whatever *is* known. A",
     "file": "docs/spec/media/README.md",
-    "line": 194
+    "line": 198
   },
   {
     "id": "MEDIA-43",
@@ -2517,7 +2517,7 @@
     "status": "AGREED",
     "text": "The unknown stream is marked **undescribed** and carries its raw",
     "file": "docs/spec/media/README.md",
-    "line": 197
+    "line": 201
   },
   {
     "id": "MEDIA-44",
@@ -2527,7 +2527,7 @@
     "status": "AGREED",
     "text": "An undescribed stream is *not direct-playable*, because KROMA will",
     "file": "docs/spec/media/README.md",
-    "line": 199
+    "line": 203
   },
   {
     "id": "MEDIA-45",
@@ -2537,7 +2537,7 @@
     "status": "AGREED",
     "text": "A file that will not open at all, a truncated or corrupt container,",
     "file": "docs/spec/media/README.md",
-    "line": 202
+    "line": 206
   },
   {
     "id": "MEDIA-46",
@@ -2547,7 +2547,7 @@
     "status": "AGREED",
     "text": "Undescribed and unreadable are distinct states. The first is \"we",
     "file": "docs/spec/media/README.md",
-    "line": 205
+    "line": 209
   },
   {
     "id": "MOD-1",
@@ -3057,7 +3057,7 @@
     "status": "SHIPPED",
     "text": "Direct play means the client fetches the original file, byte for byte,",
     "file": "docs/spec/playback/README.md",
-    "line": 18
+    "line": 20
   },
   {
     "id": "PLAY-2",
@@ -3067,7 +3067,7 @@
     "status": "AGREED",
     "text": "The client declares it can demux the **container**",
     "file": "docs/spec/playback/README.md",
-    "line": 24
+    "line": 26
   },
   {
     "id": "PLAY-3",
@@ -3077,7 +3077,7 @@
     "status": "AGREED",
     "text": "The client can decode the **video stream**, meaning codec, profile,",
     "file": "docs/spec/playback/README.md",
-    "line": 26
+    "line": 28
   },
   {
     "id": "PLAY-4",
@@ -3087,7 +3087,7 @@
     "status": "AGREED",
     "text": "Every **audio stream the person might select** is decodable by the",
     "file": "docs/spec/playback/README.md",
-    "line": 28
+    "line": 30
   },
   {
     "id": "PLAY-5",
@@ -3097,7 +3097,7 @@
     "status": "AGREED",
     "text": "The chosen **subtitle**, if any, is either a format the client renders",
     "file": "docs/spec/playback/README.md",
-    "line": 30
+    "line": 32
   },
   {
     "id": "PLAY-6",
@@ -3107,7 +3107,7 @@
     "status": "AGREED",
     "text": "The **link** sustains the file's peak bitrate. On a local network this",
     "file": "docs/spec/playback/README.md",
-    "line": 32
+    "line": 34
   },
   {
     "id": "PLAY-7",
@@ -3117,7 +3117,7 @@
     "status": "AGREED",
     "text": "When a title cannot direct-play, KROMA walks a fixed ladder and stops at",
     "file": "docs/spec/playback/README.md",
-    "line": 43
+    "line": 45
   },
   {
     "id": "PLAY-8",
@@ -3127,7 +3127,7 @@
     "status": "AGREED",
     "text": "Change the least: the video stream is never touched while a cheaper",
     "file": "docs/spec/playback/README.md",
-    "line": 46
+    "line": 48
   },
   {
     "id": "PLAY-9",
@@ -3137,7 +3137,7 @@
     "status": "SHIPPED",
     "text": "Rung 1, **direct play**. The original file, untouched. No compromise.",
     "file": "docs/spec/playback/README.md",
-    "line": 49
+    "line": 51
   },
   {
     "id": "PLAY-10",
@@ -3147,7 +3147,7 @@
     "status": "SHIPPED",
     "text": "Rung 2, **remux**, also called direct stream. The video and audio",
     "file": "docs/spec/playback/README.md",
-    "line": 50
+    "line": 52
   },
   {
     "id": "PLAY-11",
@@ -3157,7 +3157,7 @@
     "status": "SHIPPED",
     "text": "Rung 3, **audio-only fallback**. The video is still copied and one",
     "file": "docs/spec/playback/README.md",
-    "line": 53
+    "line": 55
   },
   {
     "id": "PLAY-12",
@@ -3167,7 +3167,7 @@
     "status": "AGREED",
     "text": "Video is never touched to solve an audio problem.",
     "file": "docs/spec/playback/README.md",
-    "line": 57
+    "line": 59
   },
   {
     "id": "PLAY-13",
@@ -3177,7 +3177,7 @@
     "status": "AGREED",
     "text": "Rung 4, **subtitle burn-in**. Only when a selected subtitle can",
     "file": "docs/spec/playback/README.md",
-    "line": 58
+    "line": 60
   },
   {
     "id": "PLAY-14",
@@ -3187,7 +3187,7 @@
     "status": "SHIPPED",
     "text": "Rung 5, **video transcode**, the last resort. The video stream is",
     "file": "docs/spec/playback/README.md",
-    "line": 62
+    "line": 64
   },
   {
     "id": "PLAY-15",
@@ -3197,7 +3197,7 @@
     "status": "AGREED",
     "text": "KROMA takes the highest rung that satisfies the client and does not",
     "file": "docs/spec/playback/README.md",
-    "line": 67
+    "line": 69
   },
   {
     "id": "PLAY-16",
@@ -3207,7 +3207,7 @@
     "status": "AGREED",
     "text": "Transcode is a tolerated last resort, not a headline feature. KROMA is",
     "file": "docs/spec/playback/README.md",
-    "line": 75
+    "line": 77
   },
   {
     "id": "PLAY-17",
@@ -3217,7 +3217,7 @@
     "status": "AGREED",
     "text": "Transcode is always the lowest rung and is never the default for a",
     "file": "docs/spec/playback/README.md",
-    "line": 79
+    "line": 81
   },
   {
     "id": "PLAY-18",
@@ -3227,7 +3227,7 @@
     "status": "AGREED",
     "text": "An admin may **cap or disable** video transcode per server and per",
     "file": "docs/spec/playback/README.md",
-    "line": 81
+    "line": 83
   },
   {
     "id": "PLAY-19",
@@ -3237,7 +3237,7 @@
     "status": "AGREED",
     "text": "KROMA ships no adaptive multi-bitrate ladder, no quality knobs and no",
     "file": "docs/spec/playback/README.md",
-    "line": 84
+    "line": 86
   },
   {
     "id": "PLAY-20",
@@ -3247,7 +3247,7 @@
     "status": "AGREED",
     "text": "Any rung below direct play is a compromise, and the client always shows",
     "file": "docs/spec/playback/README.md",
-    "line": 92
+    "line": 94
   },
   {
     "id": "PLAY-21",
@@ -3257,17 +3257,17 @@
     "status": "AGREED",
     "text": "**Video transcode** and **subtitle burn-in** are shown as *reduced",
     "file": "docs/spec/playback/README.md",
-    "line": 96
+    "line": 98
   },
   {
     "id": "PLAY-22",
     "domain": "PLAY",
     "space": "playback",
     "number": 22,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "**Audio downmix** and **audio transcode** are shown as *audio",
     "file": "docs/spec/playback/README.md",
-    "line": 99
+    "line": 101
   },
   {
     "id": "PLAY-23",
@@ -3277,17 +3277,17 @@
     "status": "AGREED",
     "text": "**Remux** is shown as *repackaged*. Quality is untouched, so this is",
     "file": "docs/spec/playback/README.md",
-    "line": 101
+    "line": 103
   },
   {
     "id": "PLAY-24",
     "domain": "PLAY",
     "space": "playback",
     "number": 24,
-    "status": "AGREED",
-    "text": "Direct play shows nothing. The absence of a badge *is* the signal",
+    "status": "SHIPPED",
+    "text": "Direct play may announce itself, naming the codec it is playing",
     "file": "docs/spec/playback/README.md",
-    "line": 103
+    "line": 105
   },
   {
     "id": "PLAY-25",
@@ -3297,7 +3297,7 @@
     "status": "AGREED",
     "text": "KROMA never re-encodes video to save bandwidth unless the device",
     "file": "docs/spec/playback/README.md",
-    "line": 106
+    "line": 113
   },
   {
     "id": "PLAY-26",
@@ -3307,7 +3307,7 @@
     "status": "AGREED",
     "text": "KROMA never tone-maps HDR without saying so.",
     "file": "docs/spec/playback/README.md",
-    "line": 109
+    "line": 116
   },
   {
     "id": "PLAY-27",
@@ -3317,7 +3317,7 @@
     "status": "AGREED",
     "text": "KROMA never burns in subtitles the person did not ask to see.",
     "file": "docs/spec/playback/README.md",
-    "line": 111
+    "line": 118
   },
   {
     "id": "PLAY-28",
@@ -3327,7 +3327,7 @@
     "status": "AGREED",
     "text": "When the only playable path is one a person or an admin has disabled,",
     "file": "docs/spec/playback/README.md",
-    "line": 113
+    "line": 120
   },
   {
     "id": "PLAY-29",
@@ -3337,7 +3337,7 @@
     "status": "SHIPPED",
     "text": "Under **direct play and remux**, seeking is instant and exact. The",
     "file": "docs/spec/playback/README.md",
-    "line": 120
+    "line": 127
   },
   {
     "id": "PLAY-30",
@@ -3347,7 +3347,7 @@
     "status": "AGREED",
     "text": "Under **transcode**, the stream is produced live from a play position,",
     "file": "docs/spec/playback/README.md",
-    "line": 123
+    "line": 130
   },
   {
     "id": "PLAY-31",
@@ -3357,7 +3357,7 @@
     "status": "AGREED",
     "text": "KROMA anchors at the requested position rather than pre-producing the",
     "file": "docs/spec/playback/README.md",
-    "line": 126
+    "line": 133
   },
   {
     "id": "PLAY-32",
@@ -3367,7 +3367,7 @@
     "status": "AGREED",
     "text": "Seeking accuracy is never silently coarsened. A transcoded seek lands",
     "file": "docs/spec/playback/README.md",
-    "line": 129
+    "line": 136
   },
   {
     "id": "PLAY-33",
@@ -3377,7 +3377,7 @@
     "status": "SHIPPED",
     "text": "Progress is **per person, per media version**, stored on the server. It",
     "file": "docs/spec/playback/README.md",
-    "line": 136
+    "line": 143
   },
   {
     "id": "PLAY-34",
@@ -3387,7 +3387,7 @@
     "status": "SHIPPED",
     "text": "The playing client reports position on a steady heartbeat while",
     "file": "docs/spec/playback/README.md",
-    "line": 140
+    "line": 147
   },
   {
     "id": "PLAY-35",
@@ -3397,7 +3397,7 @@
     "status": "AGREED",
     "text": "The write is idempotent on the person, the version, the position and",
     "file": "docs/spec/playback/README.md",
-    "line": 144
+    "line": 153
   },
   {
     "id": "PLAY-36",
@@ -3407,17 +3407,17 @@
     "status": "SHIPPED",
     "text": "Reopening a title in progress offers *Resume* from the stored position",
     "file": "docs/spec/playback/README.md",
-    "line": 147
+    "line": 156
   },
   {
     "id": "PLAY-37",
     "domain": "PLAY",
     "space": "playback",
     "number": 37,
-    "status": "AGREED",
-    "text": "A title is **watched** at **90% of runtime or more**, or at reaching a",
+    "status": "SHIPPED",
+    "text": "A title is **watched** at a credits or end marker where the media has",
     "file": "docs/spec/playback/README.md",
-    "line": 151
+    "line": 160
   },
   {
     "id": "PLAY-38",
@@ -3427,7 +3427,7 @@
     "status": "SHIPPED",
     "text": "At the watched threshold, continue-watching drops the title and, for",
     "file": "docs/spec/playback/README.md",
-    "line": 157
+    "line": 169
   },
   {
     "id": "PLAY-39",
@@ -3437,7 +3437,7 @@
     "status": "AGREED",
     "text": "Below the threshold, progress is retained and the title stays in",
     "file": "docs/spec/playback/README.md",
-    "line": 160
+    "line": 172
   },
   {
     "id": "PLAY-40",
@@ -3447,7 +3447,7 @@
     "status": "AGREED",
     "text": "Starting a watched title again resets it to unwatched and clears the",
     "file": "docs/spec/playback/README.md",
-    "line": 163
+    "line": 175
   },
   {
     "id": "PLAY-41",
@@ -3457,7 +3457,7 @@
     "status": "SHIPPED",
     "text": "A device watching offline queues its unsent progress reports and, on",
     "file": "docs/spec/playback/README.md",
-    "line": 166
+    "line": 178
   },
   {
     "id": "PLAY-42",
@@ -3467,7 +3467,7 @@
     "status": "AGREED",
     "text": "When queued reports from two offline sessions land for the same person",
     "file": "docs/spec/playback/README.md",
-    "line": 175
+    "line": 187
   },
   {
     "id": "PLAY-43",
@@ -3477,7 +3477,7 @@
     "status": "AGREED",
     "text": "An explicit **reset to start**, from finishing a title or choosing",
     "file": "docs/spec/playback/README.md",
-    "line": 181
+    "line": 193
   },
   {
     "id": "PLAY-44",
@@ -3487,7 +3487,7 @@
     "status": "AGREED",
     "text": "If either device crossed the watched threshold, the title is watched.",
     "file": "docs/spec/playback/README.md",
-    "line": 185
+    "line": 197
   },
   {
     "id": "PLAY-45",
@@ -3497,7 +3497,7 @@
     "status": "AGREED",
     "text": "One account may play on several clients at once. KROMA enforces no",
     "file": "docs/spec/playback/README.md",
-    "line": 191
+    "line": 203
   },
   {
     "id": "PLAY-46",
@@ -3507,7 +3507,7 @@
     "status": "AGREED",
     "text": "Each playing client is an independent session with its own fallback",
     "file": "docs/spec/playback/README.md",
-    "line": 195
+    "line": 207
   },
   {
     "id": "PLAY-47",
@@ -3517,7 +3517,7 @@
     "status": "AGREED",
     "text": "Sessions interleave into one continue-watching state under the",
     "file": "docs/spec/playback/README.md",
-    "line": 199
+    "line": 211
   },
   {
     "id": "PLAY-48",
@@ -3527,7 +3527,7 @@
     "status": "AGREED",
     "text": "KROMA does not hand off an active session between devices as a",
     "file": "docs/spec/playback/README.md",
-    "line": 202
+    "line": 214
   },
   {
     "id": "PLAY-49",
@@ -3537,7 +3537,7 @@
     "status": "AGREED",
     "text": "When a stream dies mid-playback, whether the network drops, a transcode",
     "file": "docs/spec/playback/README.md",
-    "line": 210
+    "line": 222
   },
   {
     "id": "PLAY-50",
@@ -3547,17 +3547,17 @@
     "status": "AGREED",
     "text": "A **transient** failure, a network drop or a brief server hiccup, is",
     "file": "docs/spec/playback/README.md",
-    "line": 215
+    "line": 227
   },
   {
     "id": "PLAY-51",
     "domain": "PLAY",
     "space": "playback",
     "number": 51,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "A **fatal** failure, a source gone, a transcode that cannot start, or",
     "file": "docs/spec/playback/README.md",
-    "line": 218
+    "line": 230
   },
   {
     "id": "PLAY-52",
@@ -3567,7 +3567,17 @@
     "status": "AGREED",
     "text": "When a television's older decoder cannot play a file a modern phone",
     "file": "docs/spec/playback/README.md",
-    "line": 226
+    "line": 238
+  },
+  {
+    "id": "PLAY-53",
+    "domain": "PLAY",
+    "space": "playback",
+    "number": 53,
+    "status": "AGREED",
+    "text": "A settled seek also reports, so jumping and then losing the client does",
+    "file": "docs/spec/playback/README.md",
+    "line": 150
   },
   {
     "id": "SURF-1",

--- a/docs/spec/surfaces/README.md
+++ b/docs/spec/surfaces/README.md
@@ -124,7 +124,7 @@ mechanism.
 
 ### Direct-play by device generation
 
-Status: **AGREED**
+Status: **SHIPPED** in part; each requirement carries its own.
 
 Whether a file direct-plays is decided per session by [`playback/`](../playback/) against a
 device profile. The *class* of media a surface can decode is a surface fact, and it is the


### PR DESCRIPTION
## What

The last Done-when box on all eight epics is "behaviour that ships in this domain matches what
the spec claims", and the spec was failing it by **understatement**. 248 of 406 requirements
said AGREED, which `docs/spec/README.md` defines as "decided, not built", for a product in beta
with a shipping admin dashboard. A status that under-claims is as wrong as one that over-claims,
and this one was mine: the earlier passes left AGREED wherever I had not checked rather than
wherever I knew.

Audited against the code, requirement by requirement. **SHIPPED: 156 to 222.**

| Space | Before | After | Evidence that moved it |
|---|---|---|---|
| admin | 9/93 | 56/93 | `dashboard-filters.ts` holds ADMIN-8's eight windows in ADMIN-8's order, live default; `useScopeChoice` + `Chart.Tooltip` + `meanOf` are ADMIN-5 to 7; `admin.history.tsx` has its own route, search-param filters, column sort, paging at 50, `useCap('users.manage')` |
| media | 0/46 | 15/46 | `capabilities.ts` probes hevc/hevc10/h264/av1/vp9 against mp4 and webm; `MediaItem` backed by many `MediaFile`; `bit_depth`; `audio_tracks` with a default flag; `infra/probe` |
| playback | 11/52 | 15/53 | `audioReencodedToast`, `cantPlay`/`frameTooLarge` with reasons, the 97% threshold plus the credits marker |
| library | 17/49 | 17/50 | unchanged, plus LIB-50 |
| the rest | | | unchanged |

Every section header that said AGREED while holding a SHIPPED requirement now says otherwise,
24 of them. A script verifies there are none left; `spec:index` cannot catch this class, because
it only validates statuses inside requirement lines.

### Four places the spec claims more than the code does

All left AGREED, which is the accurate label, and each names the gap in the chapter so it is not
invisible again:

- A video stream carries one HDR boolean, not the four variants MEDIA-20 names, and none of the
  colour primaries, transfer characteristics or matrix coefficients MEDIA-21 wants.
- A media file hangs off a title directly and names its edition as a string tag rather than
  belonging to one, so the middle level of MEDIA-6's "strict and total" nesting does not exist.
- Of MEDIA-23's eight first-class audio codecs, four are handled that way (`FMP4_COPY_CODECS` is
  aac, ac3, eac3, plus opus in the capability table). TrueHD, DTS, DTS-HD and FLAC are not.
- An unreadable file is deferred rather than surfaced (`unreadable_brand_new_subject_is_deferred_not_inserted`),
  and MEDIA-45 says it is a visible fault, never an absence.

### Three places the code was right and the spec was not

- **The watched threshold is 97%, not 90%**, and 97% is the better number, so the spec moves. The
  credits marker is the real signal and the percentage is only the fallback for media without
  one, so the fallback should err tight. Marking a long film watched with twenty minutes left
  loses a person's place; failing to mark a finished episode leaves a row they can dismiss.
  Losing progress is the worse failure.
- **Direct play announces itself** (`player.directPlayHevc` and friends), and PLAY-24 said it
  shows nothing. Announcing it is right: playing the file unmodified is the product's whole
  claim, so naming the codec is the product showing its work. The rule that carries weight is
  that a *compromise* is never silent, not that a success always is.
- **A settled seek does not report position**, which PLAY-34 claimed alongside three triggers
  that do exist. Split out as PLAY-53 rather than quietly dropped.

## Closes

Closes the third Done-when box on all eight: #67 #68 #69 #70 #71 #72 #73 #74. With boxes one and
two already met, every epic's own checklist is satisfied and they can close.

What stays open is implementation, not specification, and it now has requirement ids to point at
rather than prose to re-argue: 183 AGREED requirements, each one a thing decided and not built.

## Checks

- [x] `bun run spec:check`: 407 requirements, index and `requirements.json` in step
- [x] No section header contradicts a requirement under it (verified by script, 0 remaining)
- [x] Nothing in `docs/spec/` is DRAFT
- [ ] `bun run lint` / `bun run test` not run: `docs/spec/` only
- [x] One idea

## Risk

A status is a claim, and 66 of them just changed. Each was set from something specific in the
repo, named in the table above and in the chapter where it matters, so a wrong one is arguable
against evidence rather than against a vibe.

The class of error to look for is a requirement I marked SHIPPED because the *control* exists
while a clause inside it does not. I split those where I found them (PLAY-34 and PLAY-53, SURF-30
and SURF-48) and flagged them in prose where splitting would have been worse (MEDIA-20, MEDIA-23).
If a reviewer knows a panel better than its components read, push back on the id.

The residual 183 AGREED are the honest floor, not a verified count of unbuilt things. Some are
probably built in ways a code read does not show, particularly in the admin verbs around sources,
users, jobs and backup, where the surface is large and the spec's claims are about wording and
behaviour rather than about a control's existence.
