### PR TITLE
feat(media): the edition level exists, and a title's files rank within it

### DIFF
--- a/clients/web/src/shared/ui/media-info-modal.tsx
+++ b/clients/web/src/shared/ui/media-info-modal.tsx
@@ -3,8 +3,14 @@
 // subtitle stream ffprobe found. All of this already rides on the item DTO the
 // fiche loaded, so the modal reads from cache and adds no request.
 
-import { ItemId, type MediaFile, MediaFileId, type MediaItem } from '@kromatv/client/media';
-import { useT } from '@kromatv/ui';
+import {
+  type Edition,
+  ItemId,
+  type MediaFile,
+  MediaFileId,
+  type MediaItem,
+} from '@kromatv/client/media';
+import { useFormat, useT } from '@kromatv/ui';
 import { Box, Dialog, IconButton, Row, Spinner, Text } from '@kromatv/ui/kit';
 import { useQuery } from '@tanstack/react-query';
 import { createCallable } from 'react-call';
@@ -52,14 +58,58 @@ export const MediaInfoModal = createCallable<{ id: string; title: string }, void
               {t('mediaInfo.noFile')}
             </Text>
           ) : null}
-          {files.map((f, i) => (
-            <FileCard key={f.id} file={f} index={i} multi={files.length > 1} />
-          ))}
+          <FileCards item={item} files={files} />
         </Dialog.Panel>
       </Dialog.Root>
     );
   },
 );
+
+// One cut's cards under its own heading. A title with a single cut has nothing to
+// separate, so the headings only appear once there are two.
+function FileCards({ item, files }: Readonly<{ item?: MediaItem; files: MediaFile[] }>) {
+  const groups = item ? editionGroups(item, files) : [];
+  if (groups.length < 2) {
+    return files.map((file, index) => (
+      <FileCard key={file.id} file={file} index={index} multi={files.length > 1} />
+    ));
+  }
+  return groups.map(({ edition, files: cards }) => (
+    <Box key={edition.id} gap={10} mb={20}>
+      <EditionHeading edition={edition} />
+      {cards.map(({ file, index }) => (
+        <FileCard key={file.id} file={file} index={index} multi />
+      ))}
+    </Box>
+  ));
+}
+
+function EditionHeading({ edition }: Readonly<{ edition: Edition }>) {
+  const t = useT();
+  const fmt = useFormat();
+  return (
+    <Row align="baseline" gap={8}>
+      <Text variant="overline" color="accent">
+        {edition.name ?? t('mediaInfo.editionUnnamed')}
+      </Text>
+      {edition.durationMs != null ? (
+        <Text variant="meta" color="white/35">
+          {fmt.duration(edition.durationMs)}
+        </Text>
+      ) : null}
+    </Row>
+  );
+}
+
+function editionGroups(item: MediaItem, files: MediaFile[]) {
+  const numbered = files.map((file, index) => ({ file, index }));
+  return (item.editions ?? [])
+    .map((edition) => ({
+      edition,
+      files: numbered.filter(({ file }) => file.editionId === edition.id),
+    }))
+    .filter(({ files: cards }) => cards.length > 0);
+}
 
 // A synthetic single-file result from the top-level fields, for legacy rows
 // that predate the per-file list.
@@ -79,6 +129,7 @@ function filesOf(item: MediaItem): MediaFile[] {
       edition: null,
       probed: item.video != null,
       unreadable: null,
+      editionId: null,
     },
   ];
 }

--- a/docs/spec/INDEX.md
+++ b/docs/spec/INDEX.md
@@ -231,13 +231,13 @@
 ## MEDIA - [media](media/)
 
 - **MEDIA-1** (SHIPPED) - **Title.** The work a person searches for: a film, or one episode
-- **MEDIA-2** (AGREED) - **Edition.** A named cut of a title: theatrical, director's,
+- **MEDIA-2** (SHIPPED) - **Edition.** A named cut of a title: theatrical, director's,
 - **MEDIA-3** (SHIPPED) - **Media file.** One physical file on disk that realises an edition
 - **MEDIA-4** (AGREED) - **Stream.** One track inside a media file, exactly one of video,
 - **MEDIA-5** (AGREED) - **Stream properties.** The describable facts about a stream: codec,
-- **MEDIA-6** (AGREED) - The nesting is strict and total: every stream belongs to exactly one
+- **MEDIA-6** (SHIPPED) - The nesting is strict and total: every stream belongs to exactly one
 - **MEDIA-7** (SHIPPED) - A 1080p file and a 4K file of the same cut are **two media files of
-- **MEDIA-8** (AGREED) - KROMA ranks a title's media files and keeps a **preferred** one.
+- **MEDIA-8** (SHIPPED) - KROMA ranks a title's media files and keeps a **preferred** one.
 - **MEDIA-9** (AGREED) - The preference is a *default*, not a lock. The model enumerates a
 - **MEDIA-10** (AGREED) - Editions are surfaced to the person, because they are different
 - **MEDIA-11** (SHIPPED) - First-class means KROMA fully describes the format, preserves it end

--- a/docs/spec/media/README.md
+++ b/docs/spec/media/README.md
@@ -1,7 +1,7 @@
 # Media
 
-Status: **AGREED**, with the codec and stream truth **SHIPPED**. The model's edition level is
-decided and not built. Per-section and per-requirement status is called out where it differs.
+Status: **SHIPPED** in part, with the model and the stream truth **SHIPPED**. Per-section and
+per-requirement status is called out where it differs.
 
 What a title *is* once KROMA knows about it: the technical truth about its streams. That
 truth is the input to every playback decision. If a file direct-plays, it is because its
@@ -21,7 +21,7 @@ Five nouns, nested, each the child of the one before:
 - **MEDIA-1** (SHIPPED) - **Title.** The work a person searches for: a film, or one episode
   of a series. It is the unit [`library/`](../library/) matches to metadata, and it carries
   no bytes.
-- **MEDIA-2** (AGREED) - **Edition.** A named cut of a title: theatrical, director's,
+- **MEDIA-2** (SHIPPED) - **Edition.** A named cut of a title: theatrical, director's,
   extended, remastered. Different runtimes, different content. A title with one cut has one
   unnamed edition.
 - **MEDIA-3** (SHIPPED) - **Media file.** One physical file on disk that realises an edition
@@ -34,12 +34,15 @@ Five nouns, nested, each the child of the one before:
   resolution, bit depth, channel layout, language, disposition. These are what a client is
   matched against.
 
-**MEDIA-6** (AGREED) - The nesting is strict and total: every stream belongs to exactly one
+**MEDIA-6** (SHIPPED) - The nesting is strict and total: every stream belongs to exactly one
 media file, every media file to exactly one edition, every edition to exactly one title.
 Nothing floats.
 
-Today a media file hangs off a title directly and names its edition as a tag rather than
-belonging to one, so the middle level of this nesting is the part still AGREED.
+An edition is **derived** from the cut a file's name carries rather than stored beside it. That
+is what makes the nesting total: the mapping from file to edition is a function, so there is no
+state to drift and no file that can end up in none. A title whose files name only quality tiers
+has exactly one unnamed edition holding all of them, and renaming a file on disk moves it,
+because the name is where the cut was always declared.
 
 ## Versions of one title
 
@@ -49,7 +52,7 @@ Status: **SHIPPED** in part; each requirement carries its own.. This resolves th
 one edition**. They are never modelled as separate titles, and the library never shows a
 duplicate. A person picks a title and a cut; the fidelity is chosen for them.
 
-- **MEDIA-8** (AGREED) - KROMA ranks a title's media files and keeps a **preferred** one.
+- **MEDIA-8** (SHIPPED) - KROMA ranks a title's media files and keeps a **preferred** one.
   Rank order: resolution, then HDR over SDR, then bit depth, then audio channel count, then
   bitrate. The preferred file is the default source for a play request.
 - **MEDIA-9** (AGREED) - The preference is a *default*, not a lock. The model enumerates a
@@ -58,7 +61,10 @@ duplicate. A person picks a title and a cut; the fidelity is chosen for them.
   Which file a client actually receives is [`playback/`](../playback/)'s decision.
 - **MEDIA-10** (AGREED) - Editions are surfaced to the person, because they are different
   content; fidelity variants are not, because they are the same content at different quality.
-  A person chooses a cut, never a resolution.
+  A person chooses a cut, never a resolution. Editions are enumerated on the wire and shown
+  where a person looks at a title's files, and no surface ever offers a resolution. **Choosing
+  a cut is the part not built**: `/stream` takes a file id but `/hls` does not, so a picker
+  would play the chosen cut unmodified and the default cut whenever a transcode is needed.
 
 ## Containers and codecs
 

--- a/docs/spec/requirements.json
+++ b/docs/spec/requirements.json
@@ -2124,7 +2124,7 @@
     "domain": "MEDIA",
     "space": "media",
     "number": 2,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "**Edition.** A named cut of a title: theatrical, director's,",
     "file": "docs/spec/media/README.md",
     "line": 24
@@ -2164,7 +2164,7 @@
     "domain": "MEDIA",
     "space": "media",
     "number": 6,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "The nesting is strict and total: every stream belongs to exactly one",
     "file": "docs/spec/media/README.md",
     "line": 37
@@ -2177,17 +2177,17 @@
     "status": "SHIPPED",
     "text": "A 1080p file and a 4K file of the same cut are **two media files of",
     "file": "docs/spec/media/README.md",
-    "line": 48
+    "line": 51
   },
   {
     "id": "MEDIA-8",
     "domain": "MEDIA",
     "space": "media",
     "number": 8,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "KROMA ranks a title's media files and keeps a **preferred** one.",
     "file": "docs/spec/media/README.md",
-    "line": 52
+    "line": 55
   },
   {
     "id": "MEDIA-9",
@@ -2197,7 +2197,7 @@
     "status": "AGREED",
     "text": "The preference is a *default*, not a lock. The model enumerates a",
     "file": "docs/spec/media/README.md",
-    "line": 55
+    "line": 58
   },
   {
     "id": "MEDIA-10",
@@ -2207,7 +2207,7 @@
     "status": "AGREED",
     "text": "Editions are surfaced to the person, because they are different",
     "file": "docs/spec/media/README.md",
-    "line": 59
+    "line": 62
   },
   {
     "id": "MEDIA-11",
@@ -2217,7 +2217,7 @@
     "status": "SHIPPED",
     "text": "First-class means KROMA fully describes the format, preserves it end",
     "file": "docs/spec/media/README.md",
-    "line": 67
+    "line": 73
   },
   {
     "id": "MEDIA-12",
@@ -2227,7 +2227,7 @@
     "status": "SHIPPED",
     "text": "The first-class containers are **MP4**, **MKV** and **WebM**.",
     "file": "docs/spec/media/README.md",
-    "line": 71
+    "line": 77
   },
   {
     "id": "MEDIA-13",
@@ -2237,7 +2237,7 @@
     "status": "SHIPPED",
     "text": "**HEVC / H.265** is the priority codec. 8-bit and 10-bit, SDR and",
     "file": "docs/spec/media/README.md",
-    "line": 75
+    "line": 81
   },
   {
     "id": "MEDIA-14",
@@ -2247,7 +2247,7 @@
     "status": "SHIPPED",
     "text": "**H.264 / AVC** is the universal floor, assumed playable",
     "file": "docs/spec/media/README.md",
-    "line": 77
+    "line": 83
   },
   {
     "id": "MEDIA-15",
@@ -2257,7 +2257,7 @@
     "status": "SHIPPED",
     "text": "**AV1** is first-class media truth whatever the client generation,",
     "file": "docs/spec/media/README.md",
-    "line": 79
+    "line": 85
   },
   {
     "id": "MEDIA-16",
@@ -2267,7 +2267,7 @@
     "status": "SHIPPED",
     "text": "**VP9** is first-class within WebM, chiefly for the browser",
     "file": "docs/spec/media/README.md",
-    "line": 81
+    "line": 87
   },
   {
     "id": "MEDIA-17",
@@ -2277,7 +2277,7 @@
     "status": "SHIPPED",
     "text": "A codec being first-class states how *KROMA* handles it, never that a",
     "file": "docs/spec/media/README.md",
-    "line": 84
+    "line": 90
   },
   {
     "id": "MEDIA-18",
@@ -2287,7 +2287,7 @@
     "status": "AGREED",
     "text": "HDR is preserved end to end or it is not offered. KROMA never",
     "file": "docs/spec/media/README.md",
-    "line": 93
+    "line": 99
   },
   {
     "id": "MEDIA-19",
@@ -2297,7 +2297,7 @@
     "status": "SHIPPED",
     "text": "**Bit depth.** 8-bit and 10-bit are first-class, and 10-bit is",
     "file": "docs/spec/media/README.md",
-    "line": 103
+    "line": 109
   },
   {
     "id": "MEDIA-20",
@@ -2307,7 +2307,7 @@
     "status": "AGREED",
     "text": "KROMA distinguishes **HDR10**, **HDR10+**, **Dolby Vision** and",
     "file": "docs/spec/media/README.md",
-    "line": 105
+    "line": 111
   },
   {
     "id": "MEDIA-21",
@@ -2317,7 +2317,7 @@
     "status": "SHIPPED",
     "text": "Colour primaries, transfer characteristics and matrix coefficients",
     "file": "docs/spec/media/README.md",
-    "line": 111
+    "line": 117
   },
   {
     "id": "MEDIA-22",
@@ -2327,7 +2327,7 @@
     "status": "AGREED",
     "text": "Where dynamic metadata, HDR10+ or Dolby Vision, cannot be carried",
     "file": "docs/spec/media/README.md",
-    "line": 114
+    "line": 120
   },
   {
     "id": "MEDIA-23",
@@ -2337,7 +2337,7 @@
     "status": "AGREED",
     "text": "The first-class audio codecs are **AAC**, **AC-3** and **E-AC-3**",
     "file": "docs/spec/media/README.md",
-    "line": 122
+    "line": 128
   },
   {
     "id": "MEDIA-24",
@@ -2347,7 +2347,7 @@
     "status": "AGREED",
     "text": "An audio stream's **channel layout**, stereo, 5.1, 7.1 or Atmos",
     "file": "docs/spec/media/README.md",
-    "line": 126
+    "line": 132
   },
   {
     "id": "MEDIA-25",
@@ -2357,7 +2357,7 @@
     "status": "SHIPPED",
     "text": "**Passthrough** is the default for multichannel and lossless audio:",
     "file": "docs/spec/media/README.md",
-    "line": 129
+    "line": 135
   },
   {
     "id": "MEDIA-26",
@@ -2367,7 +2367,7 @@
     "status": "AGREED",
     "text": "**Downmixing** to stereo happens only when the target cannot render",
     "file": "docs/spec/media/README.md",
-    "line": 132
+    "line": 138
   },
   {
     "id": "MEDIA-27",
@@ -2377,7 +2377,7 @@
     "status": "SHIPPED",
     "text": "Multiple audio streams, languages and commentary alike, are all",
     "file": "docs/spec/media/README.md",
-    "line": 136
+    "line": 142
   },
   {
     "id": "MEDIA-28",
@@ -2387,7 +2387,7 @@
     "status": "AGREED",
     "text": "A subtitle stream is either **embedded**, a track inside the media",
     "file": "docs/spec/media/README.md",
-    "line": 144
+    "line": 150
   },
   {
     "id": "MEDIA-29",
@@ -2397,7 +2397,7 @@
     "status": "AGREED",
     "text": "The first-class subtitle formats are **SRT**, **WebVTT** and",
     "file": "docs/spec/media/README.md",
-    "line": 148
+    "line": 154
   },
   {
     "id": "MEDIA-30",
@@ -2407,7 +2407,7 @@
     "status": "AGREED",
     "text": "The **forced** disposition, only the foreign-language lines a",
     "file": "docs/spec/media/README.md",
-    "line": 152
+    "line": 158
   },
   {
     "id": "MEDIA-31",
@@ -2417,7 +2417,7 @@
     "status": "AGREED",
     "text": "**Burning in**, rendering a subtitle permanently into the video, is",
     "file": "docs/spec/media/README.md",
-    "line": 155
+    "line": 161
   },
   {
     "id": "MEDIA-32",
@@ -2427,7 +2427,7 @@
     "status": "SHIPPED",
     "text": "Every title carries a **poster**, a **backdrop**, a **logo** and, per",
     "file": "docs/spec/media/README.md",
-    "line": 165
+    "line": 171
   },
   {
     "id": "MEDIA-33",
@@ -2437,7 +2437,7 @@
     "status": "AGREED",
     "text": "Image sources rank by trust: embedded in the media file, then a",
     "file": "docs/spec/media/README.md",
-    "line": 168
+    "line": 174
   },
   {
     "id": "MEDIA-34",
@@ -2447,7 +2447,7 @@
     "status": "AGREED",
     "text": "KROMA derives a fixed set of sizes per image, a small grid",
     "file": "docs/spec/media/README.md",
-    "line": 171
+    "line": 177
   },
   {
     "id": "MEDIA-35",
@@ -2457,7 +2457,7 @@
     "status": "AGREED",
     "text": "Derived sizes are cached and served without re-deriving, and a",
     "file": "docs/spec/media/README.md",
-    "line": 174
+    "line": 180
   },
   {
     "id": "MEDIA-36",
@@ -2467,7 +2467,7 @@
     "status": "AGREED",
     "text": "Artwork is never a reason a title fails to appear. A title with no",
     "file": "docs/spec/media/README.md",
-    "line": 176
+    "line": 182
   },
   {
     "id": "MEDIA-37",
@@ -2477,7 +2477,7 @@
     "status": "SHIPPED",
     "text": "KROMA learns a file's streams by **probing** it once, when the",
     "file": "docs/spec/media/README.md",
-    "line": 183
+    "line": 189
   },
   {
     "id": "MEDIA-38",
@@ -2487,7 +2487,7 @@
     "status": "AGREED",
     "text": "A probe is the authoritative stream truth until the file's bytes",
     "file": "docs/spec/media/README.md",
-    "line": 193
+    "line": 199
   },
   {
     "id": "MEDIA-39",
@@ -2497,7 +2497,7 @@
     "status": "AGREED",
     "text": "When a direct play fails in a way that implicates the stream",
     "file": "docs/spec/media/README.md",
-    "line": 196
+    "line": 202
   },
   {
     "id": "MEDIA-40",
@@ -2507,7 +2507,7 @@
     "status": "AGREED",
     "text": "Trust is per-file and durable: a corrected probe is written back,",
     "file": "docs/spec/media/README.md",
-    "line": 201
+    "line": 207
   },
   {
     "id": "MEDIA-41",
@@ -2517,7 +2517,7 @@
     "status": "AGREED",
     "text": "A file whose container opens and whose streams enumerate, but which",
     "file": "docs/spec/media/README.md",
-    "line": 215
+    "line": 221
   },
   {
     "id": "MEDIA-42",
@@ -2527,7 +2527,7 @@
     "status": "AGREED",
     "text": "The title **appears** in the library with whatever *is* known. A",
     "file": "docs/spec/media/README.md",
-    "line": 219
+    "line": 225
   },
   {
     "id": "MEDIA-43",
@@ -2537,7 +2537,7 @@
     "status": "AGREED",
     "text": "The unknown stream is marked **undescribed** and carries its raw",
     "file": "docs/spec/media/README.md",
-    "line": 222
+    "line": 228
   },
   {
     "id": "MEDIA-44",
@@ -2547,7 +2547,7 @@
     "status": "SHIPPED",
     "text": "An undescribed stream is *not direct-playable*, because KROMA will",
     "file": "docs/spec/media/README.md",
-    "line": 224
+    "line": 230
   },
   {
     "id": "MEDIA-45",
@@ -2557,7 +2557,7 @@
     "status": "SHIPPED",
     "text": "A file that will not open at all, a truncated or corrupt container,",
     "file": "docs/spec/media/README.md",
-    "line": 227
+    "line": 233
   },
   {
     "id": "MEDIA-46",
@@ -2567,7 +2567,7 @@
     "status": "AGREED",
     "text": "Undescribed and unreadable are distinct states. The first is \"we",
     "file": "docs/spec/media/README.md",
-    "line": 230
+    "line": 236
   },
   {
     "id": "MOD-1",

--- a/packages/client/src/api/media/ids.ts
+++ b/packages/client/src/api/media/ids.ts
@@ -14,5 +14,8 @@ export type SubjectId = ItemId | ShowId;
 export const MediaFileId = brandedId('MediaFileId');
 export type MediaFileId = z.infer<typeof MediaFileId>;
 
+export const EditionId = brandedId('EditionId');
+export type EditionId = z.infer<typeof EditionId>;
+
 export const LibraryId = brandedId('LibraryId');
 export type LibraryId = z.infer<typeof LibraryId>;

--- a/packages/client/src/api/media/schemas.ts
+++ b/packages/client/src/api/media/schemas.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { CastMember, Metadata } from './credits';
 import { ItemId, LibraryId, MediaFileId, ShowId } from './ids';
-import { AudioAnalysis, Marker, MediaFile, Tracks, VideoTrack } from './tracks';
+import { AudioAnalysis, Edition, Marker, MediaFile, Tracks, VideoTrack } from './tracks';
 
 export const MediaKind = z.enum(['movie', 'episode', 'video']);
 export type MediaKind = z.infer<typeof MediaKind>;
@@ -48,6 +48,10 @@ const CatalogEntry = z.object({
   metadata: Metadata.nullish(),
 });
 
+/** `files` arrives ranked best-first, so `files[0]` is the preferred file of the
+ * preferred edition and `defaultFileId` names it. `editions` lists the cuts those
+ * files realise, the preferred one first; every file names exactly one of them in
+ * `editionId`. */
 export const MediaItem = CatalogEntry.extend(Tracks.shape).extend({
   id: ItemId,
   kind: MediaKind,
@@ -58,6 +62,7 @@ export const MediaItem = CatalogEntry.extend(Tracks.shape).extend({
   episodeEnd: z.number().nullable(),
   episodeTitle: z.string().nullable(),
   files: z.array(MediaFile),
+  editions: z.array(Edition).default([]),
   defaultFileId: MediaFileId.nullish(),
   markers: z.array(Marker).nullish(),
   audioAnalysis: AudioAnalysis.nullish(),

--- a/packages/client/src/api/media/tracks.ts
+++ b/packages/client/src/api/media/tracks.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { MediaFileId } from './ids';
+import { EditionId, MediaFileId } from './ids';
 
 /** The HDR system a stream carries. Each has its own client support, so a device
  * that renders HDR10 and one that also renders Dolby Vision are not the same
@@ -82,8 +82,19 @@ export const MediaFile = Tracks.extend({
   edition: z.string().nullish(),
   probed: z.boolean(),
   unreadable: z.string().nullish(),
+  editionId: EditionId.nullish(),
 });
 export type MediaFile = z.infer<typeof MediaFile>;
+
+/** One named cut of a title: its own runtime, its own content. Two files of one
+ * cut at different fidelities are two media files of THIS, never two editions.
+ * `name` is absent for the one unnamed edition a single-cut title has. */
+export const Edition = z.object({
+  id: EditionId,
+  name: z.string().nullish(),
+  durationMs: z.number().nullish(),
+});
+export type Edition = z.infer<typeof Edition>;
 
 export const MarkerKind = z.enum(['intro', 'credits']);
 export type MarkerKind = z.infer<typeof MarkerKind>;

--- a/packages/core/src/locales/en/mediaInfo.json
+++ b/packages/core/src/locales/en/mediaInfo.json
@@ -5,6 +5,7 @@
   "mediaInfo.container": "Container",
   "mediaInfo.default": "Default",
   "mediaInfo.duration": "Duration",
+  "mediaInfo.editionUnnamed": "Standard edition",
   "mediaInfo.noFile": "No file for this element.",
   "mediaInfo.noSubs": "None",
   "mediaInfo.size": "Size",

--- a/packages/core/src/locales/fr/mediaInfo.json
+++ b/packages/core/src/locales/fr/mediaInfo.json
@@ -5,6 +5,7 @@
   "mediaInfo.container": "Conteneur",
   "mediaInfo.default": "Défaut",
   "mediaInfo.duration": "Durée",
+  "mediaInfo.editionUnnamed": "Version standard",
   "mediaInfo.noFile": "Aucun fichier pour cet élément.",
   "mediaInfo.noSubs": "Aucun",
   "mediaInfo.size": "Taille",

--- a/server/crates/kroma-db/src/hydrate/editions.rs
+++ b/server/crates/kroma-db/src/hydrate/editions.rs
@@ -1,0 +1,176 @@
+//! Grouping an item's files into the editions they realise, and ranking them.
+
+use kroma_domain::{by_preference, edition_cut, edition_id, Edition, MediaFile, MediaItem};
+
+/// Rank `files` best-first by MEDIA-8, stamp each with the edition it belongs to,
+/// and list those editions on the item with the one holding the preferred file
+/// first. Every file lands in exactly one edition and every edition has at least
+/// one file, so the title to edition to media file nesting is total.
+pub(super) fn apply_editions(item: &mut MediaItem, mut files: Vec<MediaFile>) -> Vec<MediaFile> {
+    files.sort_by(by_preference);
+    for file in files.iter_mut() {
+        file.edition_id = Some(edition_id(&item.id, file.edition.as_deref()));
+    }
+    item.editions = editions_of(&files);
+    files
+}
+
+// First sighting wins, and the files arrive preferred-first, so the edition of the
+// preferred file leads and each edition's runtime is its own preferred file's.
+fn editions_of(files: &[MediaFile]) -> Vec<Edition> {
+    let mut editions: Vec<Edition> = Vec::new();
+    for file in files {
+        let Some(id) = file.edition_id.as_deref() else {
+            continue;
+        };
+        if editions.iter().any(|e| e.id == id) {
+            continue;
+        }
+        editions.push(Edition {
+            id: id.to_string(),
+            name: edition_cut(file.edition.as_deref()).map(str::to_owned),
+            duration_ms: file.duration_ms,
+        });
+    }
+    editions
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kroma_domain::{Kind, VideoStream};
+
+    fn item() -> MediaItem {
+        MediaItem {
+            id: "m1".into(),
+            title: "Blade Runner".into(),
+            kind: Kind::Movie,
+            year: None,
+            duration_ms: None,
+            container: String::new(),
+            video: None,
+            audio: None,
+            audio_tracks: Vec::new(),
+            subtitles: Vec::new(),
+            library: "lib".into(),
+            show_id: None,
+            show_title: None,
+            season: None,
+            episode: None,
+            episode_end: None,
+            episode_title: None,
+            rel_path: None,
+            added_at: "t".into(),
+            metadata: None,
+            abs_path: None,
+            files: Vec::new(),
+            editions: Vec::new(),
+            default_file_id: None,
+            markers: Vec::new(),
+            audio_analysis: None,
+        }
+    }
+
+    fn file(id: &str, edition: Option<&str>, width: u32, duration_ms: u64) -> MediaFile {
+        MediaFile {
+            id: id.into(),
+            rel_path: None,
+            container: "mkv".into(),
+            duration_ms: Some(duration_ms),
+            video: Some(VideoStream {
+                codec: "hevc".into(),
+                width: Some(width),
+                height: None,
+                hdr: false,
+                bit_depth: Some(8),
+                hdr_format: None,
+                dolby_vision_profile: None,
+                color: None,
+            }),
+            audio: None,
+            audio_tracks: Vec::new(),
+            subtitles: Vec::new(),
+            size: None,
+            edition: edition.map(str::to_owned),
+            probed: true,
+            unreadable: None,
+            edition_id: None,
+            abs_path: None,
+        }
+    }
+
+    #[test]
+    fn two_fidelities_of_one_cut_are_one_edition_with_two_files() {
+        let mut item = item();
+
+        let files = apply_editions(
+            &mut item,
+            vec![
+                file("hd", Some("Theatrical"), 1920, 7_000_000),
+                file("uhd", Some("Theatrical"), 3840, 7_000_000),
+            ],
+        );
+
+        assert_eq!(item.editions.len(), 1);
+        assert_eq!(item.editions[0].name.as_deref(), Some("Theatrical"));
+        assert_eq!(files[0].id, "uhd", "the preferred file leads");
+        assert_eq!(files[0].edition_id, files[1].edition_id);
+    }
+
+    #[test]
+    fn two_cuts_are_two_editions_each_carrying_its_own_runtime() {
+        let mut item = item();
+
+        apply_editions(
+            &mut item,
+            vec![
+                file("theatrical", Some("Theatrical"), 1920, 7_000_000),
+                file("extended", Some("Extended"), 3840, 9_000_000),
+            ],
+        );
+
+        assert_eq!(item.editions.len(), 2);
+        assert_eq!(
+            item.editions[0].name.as_deref(),
+            Some("Extended"),
+            "the edition holding the preferred file leads"
+        );
+        assert_eq!(item.editions[0].duration_ms, Some(9_000_000));
+        assert_eq!(item.editions[1].duration_ms, Some(7_000_000));
+    }
+
+    #[test]
+    fn a_title_whose_files_name_no_cut_still_has_one_unnamed_edition() {
+        let mut item = item();
+
+        let files = apply_editions(
+            &mut item,
+            vec![
+                file("a", None, 1920, 7_000_000),
+                file("b", Some("4K"), 3840, 7_000_000),
+            ],
+        );
+
+        assert_eq!(item.editions.len(), 1, "a quality tier is not a cut");
+        assert!(item.editions[0].name.is_none());
+        assert_eq!(files[0].edition_id, files[1].edition_id);
+    }
+
+    #[test]
+    fn a_file_names_its_edition_under_the_key_a_client_reads() {
+        let mut item = item();
+
+        let files = apply_editions(&mut item, vec![file("a", Some("Extended"), 1920, 1)]);
+
+        let json = serde_json::to_string(&files[0]).unwrap();
+        assert!(json.contains(r#""editionId":"m1:extended""#), "{json}");
+    }
+
+    #[test]
+    fn an_item_with_no_files_lists_no_editions() {
+        let mut item = item();
+
+        assert!(apply_editions(&mut item, Vec::new()).is_empty());
+        assert!(item.editions.is_empty());
+    }
+}

--- a/server/crates/kroma-db/src/hydrate/mod.rs
+++ b/server/crates/kroma-db/src/hydrate/mod.rs
@@ -1,5 +1,6 @@
 //! Hydrating items: their files, markers and audio analysis.
 
+mod editions;
 mod representative;
 
 use rusqlite::{params, Connection};
@@ -9,10 +10,9 @@ use kroma_domain::{Kind, MediaFile, MediaItem};
 use self::representative::apply_files;
 use crate::{audio_analysis, markers, row_to_file, row_to_item, FILE_COLS, IN_CHUNK, ITEM_COLS};
 
-// The one order every file read uses: a broken file last, then probed before
-// unprobed, then widest first.
-const FILE_ORDER: &str = "ORDER BY (unreadable IS NULL) DESC, (probed=1) DESC, \
-     v_width DESC NULLS LAST, id";
+// Only so the rows arrive in a fixed order: the rank a client sees is MEDIA-8's,
+// applied in Rust, because bitrate is a division SQL does not hold a column for.
+const FILE_ORDER: &str = "ORDER BY id";
 
 fn files_for_item(conn: &Connection, item_id: &str) -> rusqlite::Result<Vec<MediaFile>> {
     let mut stmt = conn.prepare(&format!(

--- a/server/crates/kroma-db/src/hydrate/representative.rs
+++ b/server/crates/kroma-db/src/hydrate/representative.rs
@@ -3,9 +3,10 @@
 
 use kroma_domain::{MediaFile, MediaItem};
 
-// Mirror the representative file into the item's top-level fields (the shared
-// tail of [`attach_files`] / [`attach_files_batch`]).
+// Rank and group the files, then mirror the representative one into the item's
+// top-level fields (the shared tail of [`attach_files`] / [`attach_files_batch`]).
 pub(super) fn apply_files(item: &mut MediaItem, files: Vec<MediaFile>) {
+    let files = super::editions::apply_editions(item, files);
     // Representative = the first probed file that opened, else the first file.
     let rep = files
         .iter()
@@ -65,6 +66,7 @@ mod apply_files_tests {
             edition: None,
             probed,
             unreadable: None,
+            edition_id: None,
             abs_path: Some(abs.into()),
         }
     }
@@ -94,6 +96,7 @@ mod apply_files_tests {
             metadata: None,
             abs_path: None,
             files: Vec::new(),
+            editions: Vec::new(),
             default_file_id: None,
             markers: Vec::new(),
             audio_analysis: None,

--- a/server/crates/kroma-db/src/ingest/probe_result.rs
+++ b/server/crates/kroma-db/src/ingest/probe_result.rs
@@ -72,7 +72,7 @@ fn recompute_item_representative(conn: &Connection, item_id: &str) -> Result<()>
     let best: Option<(String, String, Option<String>, Option<i64>)> = conn
         .query_row(
             "SELECT abs_path, container, rel_path, duration_ms FROM files \
-             WHERE item_id = ?1 AND probed = 1 \
+             WHERE item_id = ?1 AND probed = 1 AND unreadable IS NULL \
              ORDER BY v_width DESC NULLS LAST, id LIMIT 1",
             params![item_id],
             |r| {

--- a/server/crates/kroma-db/src/ingest/test_support.rs
+++ b/server/crates/kroma-db/src/ingest/test_support.rs
@@ -45,6 +45,7 @@ pub(super) fn file(id: &str, abs: &str, probed: bool) -> MediaFile {
         edition: None,
         probed,
         unreadable: None,
+        edition_id: None,
         abs_path: Some(abs.into()),
     }
 }
@@ -73,6 +74,7 @@ pub(super) fn movie(id: &str, title: &str, library: &str, files: Vec<MediaFile>)
         metadata: None,
         abs_path: None,
         files,
+        editions: Vec::new(),
         default_file_id: None,
         markers: Vec::new(),
         audio_analysis: None,

--- a/server/crates/kroma-db/src/localize/test_support.rs
+++ b/server/crates/kroma-db/src/localize/test_support.rs
@@ -61,6 +61,7 @@ pub(super) fn item(id: &str, kind: Kind) -> MediaItem {
         metadata: Some(meta("Original")),
         abs_path: None,
         files: Vec::new(),
+        editions: Vec::new(),
         default_file_id: None,
         markers: Vec::new(),
         audio_analysis: None,

--- a/server/crates/kroma-db/src/rows.rs
+++ b/server/crates/kroma-db/src/rows.rs
@@ -116,6 +116,7 @@ pub(crate) fn row_to_file(r: &Row) -> rusqlite::Result<MediaFile> {
         subtitles,
         abs_path: r.get(16)?,
         unreadable: r.get(18)?,
+        edition_id: None,
     })
 }
 
@@ -152,6 +153,7 @@ pub(crate) fn row_to_item(r: &Row) -> rusqlite::Result<MediaItem> {
         added_at: r.get(24)?,
         metadata,
         files: Vec::new(),
+        editions: Vec::new(),
         default_file_id: None,
         markers: Vec::new(),
         audio_analysis: None,

--- a/server/crates/kroma-domain/src/media/edition.rs
+++ b/server/crates/kroma-domain/src/media/edition.rs
@@ -1,5 +1,10 @@
-//! Edition labels: which filename tokens name a cut of a title, and which
-//! only name a quality tier.
+//! The edition level of the model: which filename tokens name a cut of a title,
+//! which only name a quality tier, and the edition a media file therefore
+//! belongs to.
+
+use serde::{Deserialize, Serialize};
+
+use crate::slug::slugify;
 
 // (needle, label) cut/edition labels first, then source/quality.
 const EDITION_TABLE: &[(&str, &str)] = &[
@@ -52,4 +57,99 @@ pub fn edition_cut(edition: Option<&str>) -> Option<&'static str> {
         .iter()
         .copied()
         .find(|cut| cut.eq_ignore_ascii_case(edition))
+}
+
+const UNNAMED_EDITION: &str = "default";
+
+/// One named cut of a title: its own runtime, its own content. Two files of one
+/// cut at different fidelities are two media files of THIS, never two editions
+/// and never two titles. A title whose files name no cut has exactly one unnamed
+/// edition, so the title to edition to media file nesting is total.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Edition {
+    pub id: String,
+    /// `None` is the unnamed edition a title with a single cut has.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(
+        rename = "durationMs",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub duration_ms: Option<u64>,
+}
+
+/// The edition a file belongs to, derived from the cut its name carries. Stable
+/// per (title, cut), so a theatrical 1080p and a theatrical 4K share it while an
+/// extended cut of the same title does not. Scoped by the item id, because two
+/// titles both having a theatrical cut are not the same edition.
+pub fn edition_id(item_id: &str, edition: Option<&str>) -> String {
+    match edition_cut(edition) {
+        Some(cut) => format!("{item_id}:{}", slugify(cut)),
+        None => format!("{item_id}:{UNNAMED_EDITION}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn two_fidelities_of_one_cut_land_in_one_edition_and_two_cuts_do_not() {
+        let theatrical_hd = edition_id("m1", Some("Theatrical"));
+        let theatrical_4k = edition_id("m1", Some("Theatrical"));
+        let extended = edition_id("m1", Some("Extended"));
+
+        assert_eq!(theatrical_hd, theatrical_4k);
+        assert_ne!(theatrical_hd, extended);
+    }
+
+    #[test]
+    fn a_tag_that_only_names_a_quality_tier_belongs_to_the_unnamed_edition() {
+        let unnamed = edition_id("m1", None);
+
+        assert_eq!(edition_id("m1", Some("4K")), unnamed);
+        assert_eq!(edition_id("m1", Some("1080p")), unnamed);
+        assert_eq!(edition_id("m1", Some("Remux")), unnamed);
+        assert_eq!(unnamed, "m1:default");
+    }
+
+    #[test]
+    fn the_same_cut_of_two_titles_is_two_editions() {
+        assert_ne!(
+            edition_id("m1", Some("Extended")),
+            edition_id("m2", Some("Extended"))
+        );
+    }
+
+    #[test]
+    fn an_edition_travels_under_the_keys_a_client_reads() {
+        let named = Edition {
+            id: "m1:extended".into(),
+            name: Some("Extended".into()),
+            duration_ms: Some(9_000_000),
+        };
+        let unnamed = Edition {
+            id: "m1:default".into(),
+            name: None,
+            duration_ms: None,
+        };
+
+        assert_eq!(
+            serde_json::to_string(&named).unwrap(),
+            r#"{"id":"m1:extended","name":"Extended","durationMs":9000000}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&unnamed).unwrap(),
+            r#"{"id":"m1:default"}"#
+        );
+    }
+
+    #[test]
+    fn a_cut_with_punctuation_in_its_name_still_makes_one_id() {
+        assert_eq!(
+            edition_id("m1", Some("Director's Cut")),
+            "m1:director-s-cut"
+        );
+    }
 }

--- a/server/crates/kroma-domain/src/media/mod.rs
+++ b/server/crates/kroma-domain/src/media/mod.rs
@@ -1,13 +1,16 @@
 //! The media catalog's entities: kinds, files, items, shows and seasons.
-//! A track's own description is in [`streams`], edition labels in [`edition`].
+//! A track's own description is in [`streams`], the edition level in [`edition`],
+//! and which of a title's files is preferred in [`preference`].
 //!
 //! The JSON shape here is a public contract web/TV clients depend on it, so
 //! field names and casing must not drift.
 
 mod edition;
+mod preference;
 mod streams;
 
 pub use edition::*;
+pub use preference::*;
 pub use streams::*;
 
 use serde::{Deserialize, Serialize};
@@ -48,6 +51,10 @@ pub struct MediaFile {
     // ffprobe's own reason the container would not open.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unreadable: Option<String>,
+    // Which of the owning item's editions this file realises. Filled by the read
+    // path, which knows the item; a scan does not yet.
+    #[serde(rename = "editionId", default, skip_serializing_if = "Option::is_none")]
+    pub edition_id: Option<String>,
     #[serde(skip)]
     pub abs_path: Option<String>,
 }
@@ -57,7 +64,7 @@ pub struct MediaFile {
 ///
 /// An item can be backed by multiple physical [`MediaFile`]s; the top-level
 /// `video`/`audio`/`duration_ms`/`container`/`subtitles`/`abs_path` fields
-/// mirror the highest-resolution probed file, for clients that read
+/// mirror the preferred one ([`by_preference`]), for clients that read
 /// `item.video.codec` directly.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MediaItem {
@@ -95,8 +102,14 @@ pub struct MediaItem {
     // Mirrors the representative file's path so `/stream` keeps working.
     #[serde(skip)]
     pub abs_path: Option<String>,
+    // Best-first: MEDIA-8's rank, so `files[0]` is the preferred file of the
+    // preferred edition.
     #[serde(default)]
     pub files: Vec<MediaFile>,
+    // The cuts this title has, the one holding the preferred file first. Every
+    // entry exists because a file named it, and every file names exactly one.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub editions: Vec<Edition>,
     // Id of the representative file `/stream` serves and whose stream info
     // populates the top-level fields above. `None` until a file exists.
     #[serde(

--- a/server/crates/kroma-domain/src/media/preference.rs
+++ b/server/crates/kroma-domain/src/media/preference.rs
@@ -1,0 +1,159 @@
+//! Which of a title's media files is preferred, and the order the rest follow in.
+
+use std::cmp::Ordering;
+
+use super::MediaFile;
+
+/// MEDIA-8's rank, best first: resolution, then HDR over SDR, then bit depth,
+/// then audio channel count, then bitrate, with the file id settling a tie so the
+/// order never depends on how the rows came back. Standing comes before all of
+/// it, because a file's stream columns describe what it claims and not whether it
+/// opens.
+pub fn by_preference(a: &MediaFile, b: &MediaFile) -> Ordering {
+    preference(b)
+        .cmp(&preference(a))
+        .then_with(|| a.id.cmp(&b.id))
+}
+
+// How far a file is from playable, which no stream column says. A file ffprobe
+// refused is below one nothing has looked at yet: the first is known broken, the
+// second is only undescribed.
+fn standing(file: &MediaFile) -> u8 {
+    match (file.unreadable.is_some(), file.probed) {
+        (true, _) => 0,
+        (false, false) => 1,
+        (false, true) => 2,
+    }
+}
+
+type Preference = (u8, u32, bool, u32, u32, u64);
+
+fn preference(file: &MediaFile) -> Preference {
+    let video = file.video.as_ref();
+    (
+        standing(file),
+        video.and_then(|v| v.width).unwrap_or(0),
+        video.is_some_and(|v| v.hdr),
+        video.and_then(|v| v.bit_depth).unwrap_or(0),
+        file.audio.as_ref().and_then(|a| a.channels).unwrap_or(0),
+        bitrate_bps(file),
+    )
+}
+
+fn bitrate_bps(file: &MediaFile) -> u64 {
+    match (file.size, file.duration_ms) {
+        (Some(size), Some(ms)) if ms > 0 => size.saturating_mul(8_000) / ms,
+        _ => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{AudioStream, VideoStream};
+    use super::*;
+
+    fn file(id: &str) -> MediaFile {
+        MediaFile {
+            id: id.into(),
+            rel_path: None,
+            container: "mkv".into(),
+            duration_ms: Some(7_200_000),
+            video: Some(VideoStream {
+                codec: "hevc".into(),
+                width: Some(1920),
+                height: Some(1080),
+                hdr: false,
+                bit_depth: Some(8),
+                hdr_format: None,
+                dolby_vision_profile: None,
+                color: None,
+            }),
+            audio: Some(AudioStream {
+                index: 0,
+                codec: "eac3".into(),
+                channels: Some(2),
+                language: None,
+                title: None,
+                default: true,
+            }),
+            audio_tracks: Vec::new(),
+            subtitles: Vec::new(),
+            size: Some(1_000_000_000),
+            edition: None,
+            probed: true,
+            unreadable: None,
+            edition_id: None,
+            abs_path: None,
+        }
+    }
+
+    fn ranked(mut files: Vec<MediaFile>) -> Vec<String> {
+        files.sort_by(by_preference);
+        files.into_iter().map(|f| f.id).collect()
+    }
+
+    fn preferred(better: MediaFile, worse: MediaFile) -> String {
+        let ids = ranked(vec![worse, better]);
+        ids[0].clone()
+    }
+
+    #[test]
+    fn resolution_outranks_everything_under_it() {
+        let mut uhd = file("uhd");
+        uhd.video.as_mut().unwrap().width = Some(3840);
+        let mut hd = file("hd");
+        hd.video.as_mut().unwrap().hdr = true;
+        hd.video.as_mut().unwrap().bit_depth = Some(10);
+        hd.audio.as_mut().unwrap().channels = Some(8);
+
+        assert_eq!(preferred(uhd, hd), "uhd");
+    }
+
+    #[test]
+    fn at_one_resolution_hdr_then_bit_depth_then_channels_then_bitrate_decide() {
+        let mut hdr = file("hdr");
+        hdr.video.as_mut().unwrap().hdr = true;
+        assert_eq!(preferred(hdr, file("sdr")), "hdr");
+
+        let mut ten_bit = file("ten-bit");
+        ten_bit.video.as_mut().unwrap().bit_depth = Some(10);
+        assert_eq!(preferred(ten_bit, file("eight-bit")), "ten-bit");
+
+        let mut surround = file("surround");
+        surround.audio.as_mut().unwrap().channels = Some(6);
+        assert_eq!(preferred(surround, file("stereo")), "surround");
+
+        let mut fat = file("fat");
+        fat.size = Some(20_000_000_000);
+        assert_eq!(preferred(fat, file("thin")), "fat");
+    }
+
+    #[test]
+    fn a_file_that_will_not_open_sinks_below_one_nothing_has_probed_yet() {
+        let mut broken = file("broken");
+        broken.unreadable = Some("moov atom not found".into());
+        broken.video.as_mut().unwrap().width = Some(3840);
+        let mut unprobed = file("unprobed");
+        unprobed.probed = false;
+        unprobed.video = None;
+
+        assert_eq!(
+            ranked(vec![broken, unprobed, file("good")]),
+            ["good", "unprobed", "broken"]
+        );
+    }
+
+    #[test]
+    fn two_files_that_compare_equal_order_by_id_rather_than_by_arrival() {
+        assert_eq!(ranked(vec![file("b"), file("a")]), ["a", "b"]);
+        assert_eq!(ranked(vec![file("a"), file("b")]), ["a", "b"]);
+    }
+
+    #[test]
+    fn a_file_with_no_duration_is_ranked_without_guessing_a_bitrate() {
+        let mut no_duration = file("no-duration");
+        no_duration.duration_ms = None;
+
+        assert_eq!(preferred(file("known"), no_duration), "known");
+    }
+}

--- a/server/crates/kroma-engine/src/services/cast/registry/test_support.rs
+++ b/server/crates/kroma-engine/src/services/cast/registry/test_support.rs
@@ -26,6 +26,7 @@ pub(super) fn item(id: &str) -> MediaItem {
         metadata: None,
         abs_path: None,
         files: Vec::new(),
+        editions: Vec::new(),
         default_file_id: None,
         markers: Vec::new(),
         audio_analysis: None,

--- a/server/crates/kroma-engine/src/services/demo/mod.rs
+++ b/server/crates/kroma-engine/src/services/demo/mod.rs
@@ -29,6 +29,7 @@ fn demo_file(item: &MediaItem) -> MediaFile {
         edition: None,
         probed: true,
         unreadable: None,
+        edition_id: None,
         // No real path on disk; a synthetic URI satisfies the DB's NOT NULL
         // UNIQUE `abs_path` column. Can't be streamed, matching demo behaviour.
         abs_path: Some(format!("demo://{fid}")),
@@ -287,6 +288,7 @@ fn movie(
         metadata: None,
         abs_path: None,
         files: Vec::new(),
+        editions: Vec::new(),
         default_file_id: None,
         markers: Vec::new(),
         audio_analysis: None,
@@ -333,6 +335,7 @@ fn episode(
         metadata: None,
         abs_path: None,
         files: Vec::new(),
+        editions: Vec::new(),
         default_file_id: None,
         markers: Vec::new(),
         audio_analysis: None,

--- a/server/crates/kroma-engine/src/services/enrich.rs
+++ b/server/crates/kroma-engine/src/services/enrich.rs
@@ -855,6 +855,7 @@ mod tests {
             }),
             abs_path: None,
             files: Vec::new(),
+            editions: Vec::new(),
             default_file_id: None,
             markers: Vec::new(),
             audio_analysis: None,

--- a/server/crates/kroma-engine/src/services/pipeline/stages/markers.rs
+++ b/server/crates/kroma-engine/src/services/pipeline/stages/markers.rs
@@ -117,6 +117,7 @@ mod tests {
             metadata: None,
             abs_path: abs_path.map(str::to_string),
             files: Vec::new(),
+            editions: Vec::new(),
             default_file_id: None,
             markers: Vec::new(),
             audio_analysis: None,

--- a/server/crates/kroma-engine/src/services/playback/registry.rs
+++ b/server/crates/kroma-engine/src/services/playback/registry.rs
@@ -527,6 +527,7 @@ mod tests {
             metadata: None,
             abs_path: None,
             files: Vec::new(),
+            editions: Vec::new(),
             default_file_id: None,
             markers: Vec::new(),
             audio_analysis: None,

--- a/server/crates/kroma-engine/src/services/playback/snapshot.rs
+++ b/server/crates/kroma-engine/src/services/playback/snapshot.rs
@@ -145,6 +145,7 @@ mod tests {
             metadata: None,
             abs_path: None,
             files: Vec::new(),
+            editions: Vec::new(),
             default_file_id: None,
             markers: Vec::new(),
             audio_analysis: None,
@@ -267,6 +268,7 @@ mod tests {
             edition: None,
             probed: true,
             unreadable: None,
+            edition_id: None,
             abs_path: None,
         }];
         it.default_file_id = Some("f1".into());

--- a/server/crates/kroma-engine/src/services/scan/walk.rs
+++ b/server/crates/kroma-engine/src/services/scan/walk.rs
@@ -119,6 +119,7 @@ pub(super) fn scan_root(
             edition,
             probed: false,
             unreadable: None,
+            edition_id: None,
             abs_path: Some(abs.to_string_lossy().to_string()),
         };
         index_parsed(
@@ -236,6 +237,7 @@ fn index_parsed(
                 metadata: None,
                 abs_path: None,
                 files: Vec::new(),
+                editions: Vec::new(),
                 default_file_id: None,
                 markers: Vec::new(),
                 audio_analysis: None,
@@ -301,6 +303,7 @@ fn index_parsed(
                 metadata: None,
                 abs_path: None,
                 files: Vec::new(),
+                editions: Vec::new(),
                 default_file_id: None,
                 markers: Vec::new(),
                 audio_analysis: None,

--- a/server/crates/kroma-engine/src/services/search/tests.rs
+++ b/server/crates/kroma-engine/src/services/search/tests.rs
@@ -58,6 +58,7 @@ fn movie(id: &str, title: &str, m: Option<Metadata>) -> MediaItem {
         metadata: m,
         abs_path: None,
         files: Vec::new(),
+        editions: Vec::new(),
         default_file_id: None,
         markers: Vec::new(),
         audio_analysis: None,

--- a/server/crates/kroma-engine/src/services/sections/curate.rs
+++ b/server/crates/kroma-engine/src/services/sections/curate.rs
@@ -580,6 +580,7 @@ mod tests {
             metadata: m,
             abs_path: None,
             files: Vec::new(),
+            editions: Vec::new(),
             default_file_id: None,
             markers: Vec::new(),
             audio_analysis: None,

--- a/server/crates/kroma-engine/src/services/sections/featured/fixtures.rs
+++ b/server/crates/kroma-engine/src/services/sections/featured/fixtures.rs
@@ -72,6 +72,7 @@ pub(super) fn movie(
             metadata: m,
             abs_path: None,
             files: Vec::new(),
+            editions: Vec::new(),
             default_file_id: None,
             markers: Vec::new(),
             audio_analysis: None,


### PR DESCRIPTION
> Stacked on #220. Its base is `fix/media-probe-truth`, so review that one first;
> the ranking here uses the `hdr` and `unreadable` it lands.

## What

`MediaFile.edition` was a tag, so the middle level of MEDIA-6's nesting did not
exist. A media file hung off a title directly, nothing said which files were the
same cut, and the ranking being `ORDER BY v_width DESC` meant a theatrical 1080p
and an extended 4K sat in one pool with the extended 4K handed back as the default
source for a title whose person had asked for neither.

**An edition is derived, not stored.** `edition_id(item_id, edition)` maps a file
to the cut its name carries, or to the title's one unnamed edition when it carries
only a quality tier. That is what makes the nesting total: the mapping is a
function, so there is no column to drift out of step with the tag it was derived
from and no file that can end up in no edition. It also means every library that
exists already has editions, with no migration and no rescan, which a stored
column could not give. A file renamed on disk moves edition, because the name is
where the cut was always declared.

`MediaItem.editions` lists them with the one holding the preferred file first, and
every file names its own in `editionId`. An Edition carries its runtime, because
MEDIA-2 says a cut has its own and that is its preferred file's.

MEDIA-8's rank order is now the rank order: resolution, then HDR over SDR, then
bit depth, then audio channel count, then bitrate. It lives in `kroma-domain` as
one comparator rather than in SQL, because bitrate is size over duration and there
is no column for it; the file read's `ORDER BY` drops to `id`, whose only job now
is that rows arrive in a fixed order. Standing comes before all five: a file
ffprobe refused ranks below one nothing has probed yet, because the first is known
broken and the second is only undescribed.

Media details groups its file cards by cut once a title has two, each under its
name and runtime. A title with one cut renders exactly as it did.

### Requirement statuses

| | Before | After |
|---|---|---|
| MEDIA-2 | AGREED | **SHIPPED** |
| MEDIA-6 | AGREED | **SHIPPED** |
| MEDIA-8 | AGREED | **SHIPPED** |
| MEDIA-7 | SHIPPED | SHIPPED, now true by construction rather than by accident |
| MEDIA-10 | AGREED | AGREED, built half named in the chapter |
| MEDIA-9 | AGREED | AGREED, untouched |

MEDIA-10 stays AGREED because the half that matters to a person is not built.
Editions are enumerated on the wire and shown where a person looks at a title's
files, and no surface has ever offered a resolution, but **choosing** a cut needs
`/api/items/:id/hls/...` to take a file id the way `/stream` already does. Without
it a picker would play the chosen cut unmodified and the default cut whenever a
transcode is needed, which is a wrong-content bug rather than a missing feature.
That is its own issue and its own PR.

### What I declined to do

- **A stored `edition_id` column**, which is what the issue's "schema" implies.
  See the judgement under Risk: it would be a denormalised copy of a derived
  value, and deriving it is what makes "no rescan" free rather than a backfill.
- **A cut picker on any surface**, for the `/hls` reason above. MEDIA-10 says so
  in the chapter rather than being quietly claimed.
- **Translating edition names.** `EDITION_CUTS` holds English labels
  (`Director's Cut`, `Extended`, `IMAX`) and the heading shows them verbatim, as
  the existing per-file chip already does. Only the unnamed edition's label is a
  translation key (`mediaInfo.editionUnnamed`). Turning the seven cut labels into
  keys is a content change, not this one.
- **Edition-aware replacement in `tv.kroma.acquisition`.** `same_cut_singletons`
  already compares cuts through `edition_cut`, so it was right before this and is
  right after it. Rewriting it to take an `editionId` would change the only code
  path in the product that deletes a user's media, which does not belong in the
  same PR as a model change.
- **Editions on `Show`.** A show is an aggregate of episodes and an episode is a
  title; editions of a series as a whole are not a thing MEDIA-2 describes.

## Closes

Closes #211

## Checks

- [x] `bun run lint` and `bun run test` pass, or I said below which failed and why
- [x] `cargo clippy` and `cargo test` pass, if the server changed
- [x] Follows `CODE_STYLE.md` — no comments narrating the work, exported API only
- [x] One idea. If it grew a second, it was split.

Run locally on the full stack, all green: `bun run typecheck` (43 workspaces),
`bun run check`, `bun run test` (9996 passed, 2 skipped), `bun run spec:check`,
and from `server/` `cargo clippy --workspace --all-targets` and
`cargo test --workspace`.

One thing rode along that belongs to #220's idea rather than this one:
`recompute_item_representative` gained the `AND unreadable IS NULL` guard that
commit describes but had not actually applied. It is one SQL clause and it is
about which file is preferred, which is this PR's subject, so it is here rather
than in a fourth commit on the base branch.

## Risk

**The judgement to argue with is deriving the edition instead of storing it.**
Storing `edition_id` on `files` would let an operator rename or merge editions
later and would let SQL group by them; deriving it means renaming a file on disk
silently moves it between cuts, and a future "rename this edition" feature has
nowhere to write. I think derived is right today: the cut has exactly one source
of truth (the filename, which is where `detect_edition` has always read it), a
stored copy could disagree with that source, and deriving is what lets every
existing library gain editions without a migration or a rescan. If the answer is
that editions must be editable, the column is the way and this should be rewritten
rather than extended.

The second thing to check is that the ranking change moves `defaultFileId` for
some titles. Resolution still decides first, so a title whose files differ in
width picks the same file it did. A title with two files of the same width now
picks by HDR, then bit depth, then channels, then bitrate, where before the `id`
settled it: that is the MEDIA-8 order and it is an improvement, but it means the
file `/stream` serves can change under a viewer who had a resume position on the
other one. Resume is keyed on the item, not the file, so the position survives; the
stream itself may re-request from the other copy once.

Third, `editions` is a new array on every item in every listing. It is two short
fields per cut and most titles have one, and it is omitted entirely when empty, so
a home row grows by roughly 60 bytes per title. That is small but it is not free
on a television.
