### PR TITLE
fix(modules): the host settings callback stops handing a sidecar the core's credentials

### DIFF
--- a/docs/module-plugin-model.md
+++ b/docs/module-plugin-model.md
@@ -237,10 +237,20 @@ under `ports/` and should not have been.
 
 ## What the host offers a module
 
-Shipped and generic: settings read/write, its own SQLite file plus a declared and
-authorizer-enforced slice of the core database, event publish, notifications,
-session lookup and permission checks, i18n with the module's own catalogue first,
-admin routes reverse-proxied under `/api/module/<id>/*`, a frontend remote.
+Shipped and generic: settings read/write (the core's own credentials excepted,
+see below), its own SQLite file plus a declared and authorizer-enforced slice of
+the core database, event publish, notifications, session lookup and permission
+checks, i18n with the module's own catalogue first, admin routes reverse-proxied
+under `/api/module/<id>/*`, a frontend remote.
+
+**The settings callback is not a way into the operator's credentials.** The keys
+only the core consumes (mail, LLM, the push private material) and the registry
+list the Store installs from are withheld on both directions of
+`/_host/setting{,s}`: a read answers the caller's own default, a patch naming one
+is refused. The core decides which keys those are, beside the defaults that
+declare them; the supervisor only asks, so it still knows nothing about what any
+module is for. A credential whose consumer IS a sidecar stays readable, because
+the callback is how it reaches the process that uses it.
 
 Four gaps stand between that and "a module can do whatever we want":
 

--- a/docs/modules-as-kmod.md
+++ b/docs/modules-as-kmod.md
@@ -44,9 +44,11 @@ it, supervises it, and reverse-proxies its HTTP.**
   module declared under `storage.adopt` out of the core database and into the
   module's own file -- the core does it, because the module no longer holds the
   rights to. `proxy_to` reverse-proxies a request to a module process.
-  `host_router::<HostCtx>(token)` serves `/api/_host/*` (setting / settings /
-  events / job / enabled / session / ...), token-authed, resolved against the
-  core's real state.
+  `host_router::<HostCtx>(token, core_only)` serves `/api/_host/*` (setting /
+  settings / events / job / enabled / session / ...), token-authed, resolved
+  against the core's real state. `core_only` is the core's own predicate over
+  settings keys: the ones it answers for itself are read back as the caller's
+  default and refused on write.
 - **Core integration**: `main.rs` builds the supervisor and `spawn_enabled`s
   installed modules at boot; `api/mod.rs` mounts the callback API and a
   `/api/module/<id>/*` reverse proxy.

--- a/docs/spec/INDEX.md
+++ b/docs/spec/INDEX.md
@@ -3,7 +3,7 @@
 
 # Requirement index
 
-409 requirements across the spec. The machine-readable source is [`requirements.json`](requirements.json).
+410 requirements across the spec. The machine-readable source is [`requirements.json`](requirements.json).
 
 ## ACCT - [accounts](accounts/)
 
@@ -329,6 +329,7 @@
 - **MOD-48** (AGREED) - The Store names the registry every module came from, on the listing and
 - **MOD-49** (AGREED) - Installing from a registry the operator added is gated once, per
 - **MOD-50** (AGREED) - A module that has disappeared from every configured registry is flagged
+- **MOD-51** (SHIPPED) - It may not read or write the server's own credentials. The settings
 
 ## PLAY - [playback](playback/)
 

--- a/docs/spec/modules/README.md
+++ b/docs/spec/modules/README.md
@@ -54,6 +54,11 @@ What a module may **not** do:
 - **MOD-8** (SHIPPED) - It may not assume it is present. Because any module is uninstallable,
   core never depends on one, so a feature that needs a module is absent, not broken, when the
   module is gone.
+- **MOD-51** (SHIPPED) - It may not read or write the server's own credentials. The settings
+  callback withholds every key only the server consumes, meaning the mail, LLM and push
+  credentials plus the registry list modules are installed from: a read answers the module's
+  own default and a write naming one is refused. A credential whose consumer *is* a module
+  stays reachable, because that callback is how it reaches the process that uses it.
 
 **MOD-9** (SHIPPED) - A module *may* depend on another module, hard or optional, and that
 dependency is declared, resolved and enforced rather than discovered at runtime.

--- a/docs/spec/requirements.json
+++ b/docs/spec/requirements.json
@@ -2657,7 +2657,7 @@
     "status": "SHIPPED",
     "text": "A module *may* depend on another module, hard or optional, and that",
     "file": "docs/spec/modules/README.md",
-    "line": 58
+    "line": 63
   },
   {
     "id": "MOD-10",
@@ -2667,7 +2667,7 @@
     "status": "SHIPPED",
     "text": "A module ships as a single `.kmod` file: a manifest, the native",
     "file": "docs/spec/modules/README.md",
-    "line": 65
+    "line": 70
   },
   {
     "id": "MOD-11",
@@ -2677,7 +2677,7 @@
     "status": "SHIPPED",
     "text": "**Identity and version.** The reverse-DNS id and a hand-set version.",
     "file": "docs/spec/modules/README.md",
-    "line": 71
+    "line": 76
   },
   {
     "id": "MOD-12",
@@ -2687,7 +2687,7 @@
     "status": "SHIPPED",
     "text": "The release process refuses to publish changed bytes under an",
     "file": "docs/spec/modules/README.md",
-    "line": 73
+    "line": 78
   },
   {
     "id": "MOD-13",
@@ -2697,7 +2697,7 @@
     "status": "SHIPPED",
     "text": "**`minServer`, the compatibility floor.** The minimum server version",
     "file": "docs/spec/modules/README.md",
-    "line": 76
+    "line": 81
   },
   {
     "id": "MOD-14",
@@ -2707,7 +2707,7 @@
     "status": "SHIPPED",
     "text": "**Dependencies.** Hard ones that must be installed alongside it, and",
     "file": "docs/spec/modules/README.md",
-    "line": 78
+    "line": 83
   },
   {
     "id": "MOD-15",
@@ -2717,7 +2717,7 @@
     "status": "SHIPPED",
     "text": "**Target.** Which platform the backend was built for. A library-only",
     "file": "docs/spec/modules/README.md",
-    "line": 80
+    "line": 85
   },
   {
     "id": "MOD-16",
@@ -2727,7 +2727,7 @@
     "status": "SHIPPED",
     "text": "The server checks the bytes it downloads against a published SHA-256",
     "file": "docs/spec/modules/README.md",
-    "line": 84
+    "line": 89
   },
   {
     "id": "MOD-17",
@@ -2737,7 +2737,7 @@
     "status": "SHIPPED",
     "text": "Integrity is not safety: a matching checksum proves the bytes are the",
     "file": "docs/spec/modules/README.md",
-    "line": 87
+    "line": 92
   },
   {
     "id": "MOD-18",
@@ -2747,7 +2747,7 @@
     "status": "SHIPPED",
     "text": "**From the Store**, by id. The server resolves hard dependencies",
     "file": "docs/spec/modules/README.md",
-    "line": 97
+    "line": 102
   },
   {
     "id": "MOD-19",
@@ -2757,7 +2757,7 @@
     "status": "SHIPPED",
     "text": "**By upload**, handing the server a `.kmod` by hand: same unpack,",
     "file": "docs/spec/modules/README.md",
-    "line": 101
+    "line": 106
   },
   {
     "id": "MOD-20",
@@ -2767,7 +2767,7 @@
     "status": "SHIPPED",
     "text": "Both are admin actions on the [`admin/`](../admin/) surface.",
     "file": "docs/spec/modules/README.md",
-    "line": 105
+    "line": 110
   },
   {
     "id": "MOD-21",
@@ -2777,7 +2777,7 @@
     "status": "SHIPPED",
     "text": "The Store (Admin → Modules) is the in-app browser over the configured",
     "file": "docs/spec/modules/README.md",
-    "line": 111
+    "line": 116
   },
   {
     "id": "MOD-22",
@@ -2787,7 +2787,7 @@
     "status": "SHIPPED",
     "text": "The official registry is pinned first and cannot be removed; operators",
     "file": "docs/spec/modules/README.md",
-    "line": 114
+    "line": 119
   },
   {
     "id": "MOD-23",
@@ -2797,7 +2797,7 @@
     "status": "SHIPPED",
     "text": "For each module the Store shows **this server's verdict**, not just the",
     "file": "docs/spec/modules/README.md",
-    "line": 117
+    "line": 122
   },
   {
     "id": "MOD-24",
@@ -2807,7 +2807,7 @@
     "status": "AGREED",
     "text": "**First-party is trusted by default.** The official registry is",
     "file": "docs/spec/modules/README.md",
-    "line": 135
+    "line": 140
   },
   {
     "id": "MOD-25",
@@ -2817,7 +2817,7 @@
     "status": "AGREED",
     "text": "**A third-party registry is an explicit operator opt-in.** Adding one",
     "file": "docs/spec/modules/README.md",
-    "line": 137
+    "line": 142
   },
   {
     "id": "MOD-26",
@@ -2827,7 +2827,7 @@
     "status": "AGREED",
     "text": "The operator is told, in plain terms, that a module is a native binary",
     "file": "docs/spec/modules/README.md",
-    "line": 139
+    "line": 144
   },
   {
     "id": "MOD-27",
@@ -2837,7 +2837,7 @@
     "status": "AGREED",
     "text": "**Checksums guarantee integrity, never safety**, and the server says so",
     "file": "docs/spec/modules/README.md",
-    "line": 142
+    "line": 147
   },
   {
     "id": "MOD-28",
@@ -2847,7 +2847,7 @@
     "status": "SHIPPED",
     "text": "**Enable.** The server spawns the sidecar and the module's routes,",
     "file": "docs/spec/modules/README.md",
-    "line": 171
+    "line": 176
   },
   {
     "id": "MOD-29",
@@ -2857,7 +2857,7 @@
     "status": "SHIPPED",
     "text": "**Disable.** The sidecar is stopped, the module stops running, and",
     "file": "docs/spec/modules/README.md",
-    "line": 174
+    "line": 179
   },
   {
     "id": "MOD-30",
@@ -2867,7 +2867,7 @@
     "status": "SHIPPED",
     "text": "**Update.** A newer version replaces the bundle and the sidecar is",
     "file": "docs/spec/modules/README.md",
-    "line": 177
+    "line": 182
   },
   {
     "id": "MOD-31",
@@ -2877,7 +2877,7 @@
     "status": "SHIPPED",
     "text": "`minServer` is re-checked on update, so an update that outgrows the",
     "file": "docs/spec/modules/README.md",
-    "line": 180
+    "line": 185
   },
   {
     "id": "MOD-32",
@@ -2887,7 +2887,7 @@
     "status": "SHIPPED",
     "text": "**Uninstall.** The module is removed entirely. It is the one",
     "file": "docs/spec/modules/README.md",
-    "line": 182
+    "line": 187
   },
   {
     "id": "MOD-33",
@@ -2897,7 +2897,7 @@
     "status": "SHIPPED",
     "text": "The server refuses to uninstall a module another enabled module still",
     "file": "docs/spec/modules/README.md",
-    "line": 185
+    "line": 190
   },
   {
     "id": "MOD-34",
@@ -2907,7 +2907,7 @@
     "status": "SHIPPED",
     "text": "Uninstalling a module never touches media on disk. A downloads module",
     "file": "docs/spec/modules/README.md",
-    "line": 188
+    "line": 193
   },
   {
     "id": "MOD-35",
@@ -2917,7 +2917,7 @@
     "status": "SHIPPED",
     "text": "**A crashed module cannot take down the server.** The sidecar is a",
     "file": "docs/spec/modules/README.md",
-    "line": 198
+    "line": 203
   },
   {
     "id": "MOD-36",
@@ -2927,7 +2927,7 @@
     "status": "SHIPPED",
     "text": "**An incompatible module never runs by accident.** `minServer` is",
     "file": "docs/spec/modules/README.md",
-    "line": 201
+    "line": 206
   },
   {
     "id": "MOD-37",
@@ -2937,7 +2937,7 @@
     "status": "SHIPPED",
     "text": "**Failure is visible, not silent.** A module that will not start or",
     "file": "docs/spec/modules/README.md",
-    "line": 204
+    "line": 209
   },
   {
     "id": "MOD-38",
@@ -2947,7 +2947,7 @@
     "status": "SHIPPED",
     "text": "The server is forward-compatible with older modules. A module declares",
     "file": "docs/spec/modules/README.md",
-    "line": 212
+    "line": 217
   },
   {
     "id": "MOD-39",
@@ -2957,7 +2957,7 @@
     "status": "SHIPPED",
     "text": "A module installed today keeps working as the server is updated,",
     "file": "docs/spec/modules/README.md",
-    "line": 215
+    "line": 220
   },
   {
     "id": "MOD-40",
@@ -2967,7 +2967,7 @@
     "status": "SHIPPED",
     "text": "A *newer* module may raise its `minServer`, and the Store says so",
     "file": "docs/spec/modules/README.md",
-    "line": 218
+    "line": 223
   },
   {
     "id": "MOD-41",
@@ -2977,7 +2977,7 @@
     "status": "SHIPPED",
     "text": "A module **may** ship UI, and the position is deliberate: a module's",
     "file": "docs/spec/modules/README.md",
-    "line": 226
+    "line": 231
   },
   {
     "id": "MOD-42",
@@ -2987,7 +2987,7 @@
     "status": "AGREED",
     "text": "A module renders **its own admin surface**: configuration, status and",
     "file": "docs/spec/modules/README.md",
-    "line": 230
+    "line": 235
   },
   {
     "id": "MOD-43",
@@ -2997,7 +2997,7 @@
     "status": "SHIPPED",
     "text": "A module's UI is served through the same reverse proxy as its backend",
     "file": "docs/spec/modules/README.md",
-    "line": 233
+    "line": 238
   },
   {
     "id": "MOD-44",
@@ -3007,7 +3007,7 @@
     "status": "AGREED",
     "text": "**The compatibility gate is the early warning.** As the server moves",
     "file": "docs/spec/modules/README.md",
-    "line": 247
+    "line": 252
   },
   {
     "id": "MOD-45",
@@ -3017,7 +3017,7 @@
     "status": "AGREED",
     "text": "**Data is retained.** An incompatible or abandoned module is not",
     "file": "docs/spec/modules/README.md",
-    "line": 251
+    "line": 256
   },
   {
     "id": "MOD-46",
@@ -3027,7 +3027,7 @@
     "status": "AGREED",
     "text": "**The signal is honest.** The person is told the module has not kept",
     "file": "docs/spec/modules/README.md",
-    "line": 254
+    "line": 259
   },
   {
     "id": "MOD-47",
@@ -3037,7 +3037,7 @@
     "status": "SHIPPED",
     "text": "Every capability below could have been core and is a module instead,",
     "file": "docs/spec/modules/README.md",
-    "line": 274
+    "line": 279
   },
   {
     "id": "MOD-48",
@@ -3047,7 +3047,7 @@
     "status": "AGREED",
     "text": "The Store names the registry every module came from, on the listing and",
     "file": "docs/spec/modules/README.md",
-    "line": 145
+    "line": 150
   },
   {
     "id": "MOD-49",
@@ -3057,7 +3057,7 @@
     "status": "AGREED",
     "text": "Installing from a registry the operator added is gated once, per",
     "file": "docs/spec/modules/README.md",
-    "line": 148
+    "line": 153
   },
   {
     "id": "MOD-50",
@@ -3067,7 +3067,17 @@
     "status": "AGREED",
     "text": "A module that has disappeared from every configured registry is flagged",
     "file": "docs/spec/modules/README.md",
-    "line": 259
+    "line": 264
+  },
+  {
+    "id": "MOD-51",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 51,
+    "status": "SHIPPED",
+    "text": "It may not read or write the server's own credentials. The settings",
+    "file": "docs/spec/modules/README.md",
+    "line": 57
   },
   {
     "id": "PLAY-1",

--- a/modules/README.md
+++ b/modules/README.md
@@ -276,6 +276,15 @@ A module calls back into the core over the token-authed `/api/_host/*` API for
 settings, events, jobs and session lookup (`AuthUser` resolves through the
 host, so authenticating a caller costs no database).
 
+The settings callback reads and writes the operator's preferences, **not the
+core's own credentials**. The mail password, the LLM API key, the Web Push / APNs
+/ FCM private material and the registry list the Store installs from are the
+core's alone: a read answers the default you asked with, and a patch naming one
+is refused whole with a `403`. A credential a module is the thing that uses (the
+WireGuard config the bridge brings up, the tunnel token the connector runs on)
+stays readable and writable. For a vendor credential the operator configured, ask
+`GET /_host/secret?name=` by name.
+
 - **`dependencies`** is a hard dependency, as a `{ "<id>": "<range>" }` map.
   The backend enforces it, and the Store installs missing ones automatically.
 - **`optionalDependencies`** is ordered first when present, not required.

--- a/server/crates/kroma-engine/src/services/settings/keys.rs
+++ b/server/crates/kroma-engine/src/services/settings/keys.rs
@@ -1,0 +1,226 @@
+//! The built-in settings keys: every default value, and which of them the core
+//! keeps to itself.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::OnceLock;
+
+use serde_json::{json, Value};
+
+#[cfg(test)]
+mod tests;
+
+/// Whether `key` is the core's alone: a credential only the core consumes, or the
+/// registry list that decides where installable native code comes from. The
+/// module host callback neither reads nor writes one, so a sidecar that asks for
+/// it gets the default it asked with.
+pub fn core_only(key: &str) -> bool {
+    static CORE_ONLY: OnceLock<BTreeSet<&'static str>> = OnceLock::new();
+    CORE_ONLY
+        .get_or_init(|| {
+            declared()
+                .reach
+                .into_iter()
+                .filter(|(_, reach)| *reach == Reach::CoreOnly)
+                .map(|(key, _)| key)
+                .collect()
+        })
+        .contains(key)
+}
+
+pub(super) fn defaults() -> BTreeMap<String, Value> {
+    declared().values
+}
+
+#[derive(PartialEq, Eq)]
+enum Reach {
+    CoreOnly,
+    Sidecar,
+}
+
+struct Declared {
+    values: BTreeMap<String, Value>,
+    reach: BTreeMap<&'static str, Reach>,
+}
+
+impl Declared {
+    fn new() -> Self {
+        Declared {
+            values: BTreeMap::new(),
+            reach: BTreeMap::new(),
+        }
+    }
+
+    fn insert(&mut self, key: String, value: Value) {
+        self.values.insert(key, value);
+    }
+
+    fn core_only(&mut self, key: &'static str, value: Value) {
+        self.reach.insert(key, Reach::CoreOnly);
+        self.values.insert(key.to_string(), value);
+    }
+
+    fn sidecar_credential(&mut self, key: &'static str, value: Value) {
+        self.reach.insert(key, Reach::Sidecar);
+        self.values.insert(key.to_string(), value);
+    }
+}
+
+fn declared() -> Declared {
+    let mut m = Declared::new();
+    m.insert("serverName".into(), json!("KROMA"));
+    // One key for the whole blob: `{ "<id>": { "enabled": bool, "config": {..} } }`
+    // (module ids are not known at compile time, so they can't be allow-listed).
+    m.insert("moduleStates".into(), json!({}));
+    // Empty = the built-in catalog (modules.json on this repo's GitHub Releases).
+    // This is the OFFICIAL slot: it stays pinned first and wins on an id clash.
+    m.core_only("moduleRegistryUrl", json!(""));
+    // Operator-added registries beyond the official one, as
+    // `[{ "name": str, "url": str, "enabled": bool }]`. Validated on read (see
+    // api/admin/store/registries.rs): the list is operator input pointing at
+    // third-party catalogs of native code.
+    m.core_only("moduleRegistries", json!([]));
+    m.insert("uiLanguage".into(), json!("Français"));
+    // Empty → the env-configured `KROMA_TMDB_LANGUAGE` (default "en-US").
+    m.insert("tmdbLanguage".into(), json!(super::TMDB_LANGUAGE_AUTO));
+    m.insert("timezone".into(), json!("Europe/Zurich (UTC+1)"));
+    m.insert("autoUpdate".into(), json!(true));
+    m.insert("updateChannel".into(), json!("Stable"));
+    // Periodic re-scan cadence, the only path that catches NAS/SMB edits (they
+    // emit no FS events). `-1` = `KROMA_WATCH_INTERVAL` or 300s, `0` = FS events only.
+    m.insert("watchAutoScan".into(), json!(true));
+    m.insert("watchIntervalSecs".into(), json!(-1));
+    // On, and an operator turns it off in Admin -> General -> Privacy. What it
+    // sends, and why this is legitimate interest rather than consent, is
+    // docs/anonymous-stats-gdpr.md. The two below are the detail blocks the base
+    // switch carries, each droppable on its own and each silent without it.
+    m.insert("anonStats".into(), json!(true));
+    m.insert("anonStatsUsage".into(), json!(true));
+    m.insert("anonStatsStatistics".into(), json!(true));
+    m.insert("showRecentHome".into(), json!(true));
+    // Security: exposes the account roster on the login screen. Off by default so
+    // knowing the server URL does not reveal who has an account; when off,
+    // `GET /api/users` returns an empty list.
+    m.insert("publicUserList".into(), json!(false));
+    m.insert("themeSongs".into(), json!(false));
+    // off | chapters (free, from embedded chapters) | fingerprint (heavy audio job).
+    m.insert("introDetection".into(), json!("chapters"));
+    m.insert("theme".into(), json!("Sombre (Kroma)"));
+    m.insert("dateFormat".into(), json!("JJ/MM/AAAA"));
+    m.insert("moduleAutoUpdate".into(), json!(true));
+    m.insert("remoteAccess".into(), json!(false));
+    m.insert("remoteUrl".into(), json!(""));
+    // Cloudflare Tunnel token for the `cloudflared` child the remote-access
+    // sidecar supervises. Never returned to clients.
+    m.sidecar_credential("remoteAccessToken", json!(""));
+    m.insert("upLimit".into(), json!("Illimité"));
+    m.insert("https".into(), json!("Préférées"));
+    // Self-signed HTTPS listener: browsers only expose Web Crypto (passkeys) on a
+    // secure origin. Applied at boot, so a change needs a restart; `KROMA_HTTPS` /
+    // `KROMA_HTTPS_PORT` override the stored values. See src/tls.rs.
+    m.insert("httpsEnabled".into(), json!(false));
+    m.insert("httpsPort".into(), json!("4443"));
+    m.insert("httpsRedirect".into(), json!(false));
+    m.insert("ipv6".into(), json!(false));
+    m.insert("localDiscovery".into(), json!(true));
+    m.insert(
+        "localNetworks".into(),
+        json!("192.168.0.0/16, 10.0.0.0/8, 172.16.0.0/12"),
+    );
+    m.insert("hwAccel".into(), json!(false));
+    m.insert("hwDevice".into(), json!("Auto"));
+    m.insert("hevcEncode".into(), json!(false));
+    m.insert("transcoderSpeed".into(), json!("Automatique"));
+    m.insert("bgQuality".into(), json!("Préférer la vitesse"));
+    m.insert("maxConcurrent".into(), json!("8"));
+    // Concurrent CPU-heavy background ffmpeg passes; "0" = auto (cores - 1).
+    m.insert("mediaConcurrency".into(), json!("0"));
+    m.insert("pipelinePaused".into(), json!(false));
+    m.insert("deleteAfter".into(), json!(true));
+    m.insert("cacheLimit".into(), json!("80 Go"));
+    m.insert("transcodeCacheLimit".into(), json!("20 Go"));
+    // Scheduler timezone offset in minutes from UTC (60 = UTC+1, -300 = UTC-5).
+    m.insert("jobsUtcOffset".into(), json!(0));
+    // Keyword lists are comma-separated, matched as whole tokens against release names.
+    m.insert("acqEnabled".into(), json!(false));
+    m.insert("acqAutoApprove".into(), json!(false));
+    m.insert("acqDeleteAfterImport".into(), json!(false));
+    m.insert("acqReplaceOnUpgrade".into(), json!(true));
+    m.insert("acqResolution".into(), json!("1080p"));
+    m.insert("acqPreferHevc".into(), json!(true));
+    m.insert("acqMinSeeders".into(), json!(2));
+    m.insert("acqMaxSizeGbMovie".into(), json!(15));
+    m.insert("acqMaxSizeGbEpisode".into(), json!(3));
+    m.insert("acqRequiredKeywords".into(), json!(""));
+    m.insert(
+        "acqForbiddenKeywords".into(),
+        json!("cam, hdcam, ts, telesync, telecine, screener, dvdscr, workprint"),
+    );
+    // Embedded torrent engine knobs (0 = ephemeral port / unlimited rate).
+    m.insert("rqbitPort".into(), json!(0));
+    m.insert("rqbitDownKbps".into(), json!(0));
+    m.insert("rqbitUpKbps".into(), json!(0));
+    // How many downloads may hold an engine slot at once (0 = no cap); the rest
+    // wait in the queue.
+    m.insert("torrentMaxActive".into(), json!(0));
+    // The WireGuard tunnel the bridge sidecar brings up. Never returned in a
+    // settings view.
+    m.sidecar_credential("vpnWgConfig", json!(""));
+    m.insert("vpnLocalPort".into(), json!(25345));
+    m.insert("vpnKillSwitch".into(), json!(false));
+    m.insert("vpnCheckUrl".into(), json!("https://api.ipify.org"));
+    // Library new downloads land in, by name; "Auto" = first of the matching kind.
+    m.insert("acqMovieLibrary".into(), json!("Auto"));
+    m.insert("acqSeriesLibrary".into(), json!("Auto"));
+    // Sonarr/Radarr-style tokens; see kroma_torrent::organize::naming.
+    m.insert("namingMovieFolder".into(), json!("{Title} ({Year})"));
+    m.insert(
+        "namingMovieFile".into(),
+        json!("{Title} ({Year}) {Quality Full}"),
+    );
+    m.insert("namingSeriesFolder".into(), json!("{Title} ({Year})"));
+    m.insert("namingSeasonFolder".into(), json!("Season {season:00}"));
+    m.insert(
+        "namingEpisodeFile".into(),
+        json!("{Title} - S{season:00}E{episode:00} - {Episode Title} {Quality Full}"),
+    );
+    // MUST stay registered: `set_patch` silently drops unknown keys, so without
+    // this line `save_naming` answers `{"ok": true}` and throws the value away.
+    m.insert("namingCase".into(), json!("default"));
+    // openai = any OpenAI-compatible server (Ollama, llama.cpp, LM Studio, …);
+    // anthropic = Claude.
+    m.insert("llmEnabled".into(), json!(true));
+    m.insert("llmProvider".into(), json!("openai"));
+    m.insert("llmBaseUrl".into(), json!(""));
+    m.insert("llmModel".into(), json!(""));
+    m.core_only("llmApiKey", json!(""));
+    m.insert("llmTemperature".into(), json!(0.7));
+    m.insert("llmMaxTokens".into(), json!(900));
+    m.insert("llmReasoning".into(), json!(false));
+    // Seeded from the flat `llm*` keys above on first read when empty.
+    m.insert("llmProviders".into(), json!([]));
+    m.insert("llmDefaultProvider".into(), json!(""));
+    m.insert("libraries".into(), json!(null));
+    // ISO-8601 `items.added_at` the digest has reported up to. Empty = never run:
+    // the first pass adopts the current library as its baseline and stays silent.
+    m.insert("notifications.digest.since".into(), json!(""));
+    // Web Push (RFC 8292) VAPID identity, minted on the first subscription and
+    // then left alone: rotating it invalidates every subscribed browser.
+    m.insert("notifications.vapid.publicKey".into(), json!(""));
+    m.core_only("notifications.vapid.privateKey", json!(""));
+    // Apple/Google only accept keys they issued to whoever PUBLISHES the app, so
+    // these normally arrive with the build (`KROMA_APNS_*` /
+    // `KROMA_FCM_SERVICE_ACCOUNT`); the rows are the fallback for a fork shipping
+    // its own app. Empty = that platform's push stays off.
+    m.core_only("notifications.apns.keyP8", json!(""));
+    m.core_only("notifications.apns.keyId", json!(""));
+    m.core_only("notifications.apns.teamId", json!(""));
+    m.core_only("notifications.fcm.serviceAccount", json!(""));
+    // Operator SMTP for credential-reset email.
+    m.insert("smtpEnabled".into(), json!(false));
+    m.insert("smtpHost".into(), json!(""));
+    m.insert("smtpPort".into(), json!(587));
+    m.insert("smtpUsername".into(), json!(""));
+    m.insert("smtpFrom".into(), json!(""));
+    m.core_only("smtpPassword", json!(""));
+    m
+}

--- a/server/crates/kroma-engine/src/services/settings/keys/tests.rs
+++ b/server/crates/kroma-engine/src/services/settings/keys/tests.rs
@@ -1,0 +1,100 @@
+use super::*;
+
+const CREDENTIAL_WORDS: [&str; 4] = ["password", "token", "secret", "credential"];
+const CREDENTIAL_COMPOUNDS: [&str; 4] = ["apikey", "privatekey", "serviceaccount", "keyp8"];
+
+fn words(key: &str) -> Vec<String> {
+    let mut spaced = String::new();
+    for c in key.chars() {
+        if c.is_ascii_uppercase() {
+            spaced.push(' ');
+            spaced.push(c.to_ascii_lowercase());
+        } else if c.is_ascii_alphanumeric() {
+            spaced.push(c);
+        } else {
+            spaced.push(' ');
+        }
+    }
+    spaced.split_whitespace().map(str::to_string).collect()
+}
+
+fn reads_like_a_credential(key: &str) -> bool {
+    let words = words(key);
+    let joined = words.concat();
+    words.iter().any(|w| CREDENTIAL_WORDS.contains(&w.as_str()))
+        || CREDENTIAL_COMPOUNDS.iter().any(|c| joined.contains(c))
+}
+
+#[test]
+fn a_key_that_reads_like_a_credential_declares_who_may_reach_it() {
+    let declared = declared();
+
+    let undeclared: Vec<&String> = declared
+        .values
+        .keys()
+        .filter(|key| reads_like_a_credential(key))
+        .filter(|key| !declared.reach.contains_key(key.as_str()))
+        .collect();
+
+    assert!(
+        undeclared.is_empty(),
+        "a credential is the core's alone unless a sidecar configures it; \
+         declare these with core_only() or sidecar_credential(): {undeclared:?}"
+    );
+}
+
+#[test]
+fn the_word_sweep_reads_a_credential_without_flagging_a_count_of_tokens() {
+    assert!(reads_like_a_credential("smtpPassword"));
+    assert!(reads_like_a_credential("remoteAccessToken"));
+    assert!(reads_like_a_credential("llmApiKey"));
+    assert!(reads_like_a_credential("notifications.apns.keyP8"));
+    assert!(reads_like_a_credential("notifications.fcm.serviceAccount"));
+
+    assert!(!reads_like_a_credential("llmMaxTokens"));
+    assert!(!reads_like_a_credential("acqForbiddenKeywords"));
+    assert!(!reads_like_a_credential("notifications.vapid.publicKey"));
+}
+
+#[test]
+fn the_mail_llm_push_and_registry_keys_are_the_cores_alone() {
+    for key in [
+        "smtpPassword",
+        "llmApiKey",
+        "notifications.vapid.privateKey",
+        "notifications.apns.keyP8",
+        "notifications.apns.keyId",
+        "notifications.apns.teamId",
+        "notifications.fcm.serviceAccount",
+        "moduleRegistries",
+        "moduleRegistryUrl",
+    ] {
+        assert!(core_only(key), "{key} must be the core's alone");
+    }
+}
+
+#[test]
+fn a_credential_the_sidecar_that_uses_it_configures_stays_reachable() {
+    assert!(!core_only("vpnWgConfig"));
+    assert!(!core_only("remoteAccessToken"));
+}
+
+#[test]
+fn an_ordinary_preference_and_an_unknown_key_are_not_withheld() {
+    assert!(!core_only("acqEnabled"));
+    assert!(!core_only("namingEpisodeFile"));
+    assert!(!core_only("notifications.vapid.publicKey"));
+    assert!(!core_only("smtpHost"));
+    assert!(!core_only("neverDeclared"));
+}
+
+#[test]
+fn defaults_carry_known_keys() {
+    let d = defaults();
+    assert_eq!(d.get("serverName"), Some(&json!("KROMA")));
+    assert_eq!(d.get("moduleStates"), Some(&json!({})));
+    assert_eq!(d.get("watchIntervalSecs"), Some(&json!(-1)));
+    assert_eq!(d.get("llmTemperature"), Some(&json!(0.7)));
+    assert_eq!(d.get("smtpPassword"), Some(&json!("")));
+    assert!(!d.contains_key("nonexistentKey"));
+}

--- a/server/crates/kroma-engine/src/services/settings/mod.rs
+++ b/server/crates/kroma-engine/src/services/settings/mod.rs
@@ -13,19 +13,22 @@
 //! enforce; those are marked `applied: false` in the schema so the UI can be
 //! honest about it.
 //!
-//! Split into the [`store`] (map + persistence + defaults), the typed functional
-//! [`accessors`] (+ library defs), and the admin view-model [`schema`].
+//! Split into the declared [`keys`] (defaults + which of them the core keeps to
+//! itself), the [`store`] (map + persistence), the typed functional [`accessors`]
+//! (+ library defs), and the admin view-model [`schema`].
 
 /// The dropdown value that means "no explicit choice": the fallback language
 /// defers to the server's own default.
 pub const TMDB_LANGUAGE_AUTO: &str = "Auto";
 
 mod accessors;
+mod keys;
 mod llm;
 mod schema;
 mod store;
 
 pub use accessors::*;
+pub use keys::core_only;
 pub use llm::*;
 pub use schema::*;
 pub use store::*;

--- a/server/crates/kroma-engine/src/services/settings/store.rs
+++ b/server/crates/kroma-engine/src/services/settings/store.rs
@@ -1,12 +1,14 @@
-//! The settings store: in-memory key/value map, typed accessors, persist-on-patch
-//! writes, and the built-in defaults.
+//! The settings store: in-memory key/value map, typed accessors and
+//! persist-on-patch writes, over the keys [`super::keys`] declares.
 
 use std::collections::BTreeMap;
 use std::sync::{Arc, RwLock};
 
-use serde_json::{json, Value};
+use serde_json::Value;
 
 use crate::db::Pool;
+
+use super::keys::defaults;
 
 /// Shared, cheap-to-clone handle to the live settings map.
 #[derive(Clone)]
@@ -116,184 +118,15 @@ impl Settings {
     }
 }
 
-fn defaults() -> BTreeMap<String, Value> {
-    let mut m = BTreeMap::new();
-    m.insert("serverName".into(), json!("KROMA"));
-    // One key for the whole blob: `{ "<id>": { "enabled": bool, "config": {..} } }`
-    // (module ids are not known at compile time, so they can't be allow-listed).
-    m.insert("moduleStates".into(), json!({}));
-    // Empty = the built-in catalog (modules.json on this repo's GitHub Releases).
-    // This is the OFFICIAL slot: it stays pinned first and wins on an id clash.
-    m.insert("moduleRegistryUrl".into(), json!(""));
-    // Operator-added registries beyond the official one, as
-    // `[{ "name": str, "url": str, "enabled": bool }]`. Validated on read (see
-    // api/admin/store/registries.rs): the list is operator input pointing at
-    // third-party catalogs of native code.
-    m.insert("moduleRegistries".into(), json!([]));
-    m.insert("uiLanguage".into(), json!("Français"));
-    // Empty → the env-configured `KROMA_TMDB_LANGUAGE` (default "en-US").
-    m.insert("tmdbLanguage".into(), json!(super::TMDB_LANGUAGE_AUTO));
-    m.insert("timezone".into(), json!("Europe/Zurich (UTC+1)"));
-    m.insert("autoUpdate".into(), json!(true));
-    m.insert("updateChannel".into(), json!("Stable"));
-    // Periodic re-scan cadence, the only path that catches NAS/SMB edits (they
-    // emit no FS events). `-1` = `KROMA_WATCH_INTERVAL` or 300s, `0` = FS events only.
-    m.insert("watchAutoScan".into(), json!(true));
-    m.insert("watchIntervalSecs".into(), json!(-1));
-    // On, and an operator turns it off in Admin -> General -> Privacy. What it
-    // sends, and why this is legitimate interest rather than consent, is
-    // docs/anonymous-stats-gdpr.md. The two below are the detail blocks the base
-    // switch carries, each droppable on its own and each silent without it.
-    m.insert("anonStats".into(), json!(true));
-    m.insert("anonStatsUsage".into(), json!(true));
-    m.insert("anonStatsStatistics".into(), json!(true));
-    m.insert("showRecentHome".into(), json!(true));
-    // Security: exposes the account roster on the login screen. Off by default so
-    // knowing the server URL does not reveal who has an account; when off,
-    // `GET /api/users` returns an empty list.
-    m.insert("publicUserList".into(), json!(false));
-    m.insert("themeSongs".into(), json!(false));
-    // off | chapters (free, from embedded chapters) | fingerprint (heavy audio job).
-    m.insert("introDetection".into(), json!("chapters"));
-    m.insert("theme".into(), json!("Sombre (Kroma)"));
-    m.insert("dateFormat".into(), json!("JJ/MM/AAAA"));
-    m.insert("moduleAutoUpdate".into(), json!(true));
-    m.insert("remoteAccess".into(), json!(false));
-    m.insert("remoteUrl".into(), json!(""));
-    // Cloudflare Tunnel token for the supervised `cloudflared` child
-    // (services::remote). A secret: never returned to clients.
-    m.insert("remoteAccessToken".into(), json!(""));
-    m.insert("upLimit".into(), json!("Illimité"));
-    m.insert("https".into(), json!("Préférées"));
-    // Self-signed HTTPS listener: browsers only expose Web Crypto (passkeys) on a
-    // secure origin. Applied at boot, so a change needs a restart; `KROMA_HTTPS` /
-    // `KROMA_HTTPS_PORT` override the stored values. See src/tls.rs.
-    m.insert("httpsEnabled".into(), json!(false));
-    m.insert("httpsPort".into(), json!("4443"));
-    m.insert("httpsRedirect".into(), json!(false));
-    m.insert("ipv6".into(), json!(false));
-    m.insert("localDiscovery".into(), json!(true));
-    m.insert(
-        "localNetworks".into(),
-        json!("192.168.0.0/16, 10.0.0.0/8, 172.16.0.0/12"),
-    );
-    m.insert("hwAccel".into(), json!(false));
-    m.insert("hwDevice".into(), json!("Auto"));
-    m.insert("hevcEncode".into(), json!(false));
-    m.insert("transcoderSpeed".into(), json!("Automatique"));
-    m.insert("bgQuality".into(), json!("Préférer la vitesse"));
-    m.insert("maxConcurrent".into(), json!("8"));
-    // Concurrent CPU-heavy background ffmpeg passes; "0" = auto (cores - 1).
-    m.insert("mediaConcurrency".into(), json!("0"));
-    m.insert("pipelinePaused".into(), json!(false));
-    m.insert("deleteAfter".into(), json!(true));
-    m.insert("cacheLimit".into(), json!("80 Go"));
-    m.insert("transcodeCacheLimit".into(), json!("20 Go"));
-    // Scheduler timezone offset in minutes from UTC (60 = UTC+1, -300 = UTC-5).
-    m.insert("jobsUtcOffset".into(), json!(0));
-    // Keyword lists are comma-separated, matched as whole tokens against release names.
-    m.insert("acqEnabled".into(), json!(false));
-    m.insert("acqAutoApprove".into(), json!(false));
-    m.insert("acqDeleteAfterImport".into(), json!(false));
-    m.insert("acqReplaceOnUpgrade".into(), json!(true));
-    m.insert("acqResolution".into(), json!("1080p"));
-    m.insert("acqPreferHevc".into(), json!(true));
-    m.insert("acqMinSeeders".into(), json!(2));
-    m.insert("acqMaxSizeGbMovie".into(), json!(15));
-    m.insert("acqMaxSizeGbEpisode".into(), json!(3));
-    m.insert("acqRequiredKeywords".into(), json!(""));
-    m.insert(
-        "acqForbiddenKeywords".into(),
-        json!("cam, hdcam, ts, telesync, telecine, screener, dvdscr, workprint"),
-    );
-    // Embedded torrent engine knobs (0 = ephemeral port / unlimited rate).
-    m.insert("rqbitPort".into(), json!(0));
-    m.insert("rqbitDownKbps".into(), json!(0));
-    m.insert("rqbitUpKbps".into(), json!(0));
-    // How many downloads may hold an engine slot at once (0 = no cap); the rest
-    // wait in the queue.
-    m.insert("torrentMaxActive".into(), json!(0));
-    // `vpnWgConfig` is a secret: written via /api/admin/vpn, never returned in a
-    // settings view.
-    m.insert("vpnWgConfig".into(), json!(""));
-    m.insert("vpnLocalPort".into(), json!(25345));
-    m.insert("vpnKillSwitch".into(), json!(false));
-    m.insert("vpnCheckUrl".into(), json!("https://api.ipify.org"));
-    // Library new downloads land in, by name; "Auto" = first of the matching kind.
-    m.insert("acqMovieLibrary".into(), json!("Auto"));
-    m.insert("acqSeriesLibrary".into(), json!("Auto"));
-    // Sonarr/Radarr-style tokens; see kroma_torrent::organize::naming.
-    m.insert("namingMovieFolder".into(), json!("{Title} ({Year})"));
-    m.insert(
-        "namingMovieFile".into(),
-        json!("{Title} ({Year}) {Quality Full}"),
-    );
-    m.insert("namingSeriesFolder".into(), json!("{Title} ({Year})"));
-    m.insert("namingSeasonFolder".into(), json!("Season {season:00}"));
-    m.insert(
-        "namingEpisodeFile".into(),
-        json!("{Title} - S{season:00}E{episode:00} - {Episode Title} {Quality Full}"),
-    );
-    // MUST stay registered: `set_patch` silently drops unknown keys, so without
-    // this line `save_naming` answers `{"ok": true}` and throws the value away.
-    m.insert("namingCase".into(), json!("default"));
-    // openai = any OpenAI-compatible server (Ollama, llama.cpp, LM Studio, …);
-    // anthropic = Claude.
-    m.insert("llmEnabled".into(), json!(true));
-    m.insert("llmProvider".into(), json!("openai"));
-    m.insert("llmBaseUrl".into(), json!(""));
-    m.insert("llmModel".into(), json!(""));
-    m.insert("llmApiKey".into(), json!(""));
-    m.insert("llmTemperature".into(), json!(0.7));
-    m.insert("llmMaxTokens".into(), json!(900));
-    m.insert("llmReasoning".into(), json!(false));
-    // Seeded from the flat `llm*` keys above on first read when empty.
-    m.insert("llmProviders".into(), json!([]));
-    m.insert("llmDefaultProvider".into(), json!(""));
-    m.insert("libraries".into(), json!(null));
-    // ISO-8601 `items.added_at` the digest has reported up to. Empty = never run:
-    // the first pass adopts the current library as its baseline and stays silent.
-    m.insert("notifications.digest.since".into(), json!(""));
-    // Web Push (RFC 8292) VAPID identity, minted on the first subscription and
-    // then left alone: rotating it invalidates every subscribed browser.
-    m.insert("notifications.vapid.publicKey".into(), json!(""));
-    m.insert("notifications.vapid.privateKey".into(), json!(""));
-    // Apple/Google only accept keys they issued to whoever PUBLISHES the app, so
-    // these normally arrive with the build (`KROMA_APNS_*` /
-    // `KROMA_FCM_SERVICE_ACCOUNT`); the rows are the fallback for a fork shipping
-    // its own app. Empty = that platform's push stays off.
-    m.insert("notifications.apns.keyP8".into(), json!(""));
-    m.insert("notifications.apns.keyId".into(), json!(""));
-    m.insert("notifications.apns.teamId".into(), json!(""));
-    m.insert("notifications.fcm.serviceAccount".into(), json!(""));
-    // Operator SMTP for credential-reset email. The password is a secret: never
-    // returned in a settings view.
-    m.insert("smtpEnabled".into(), json!(false));
-    m.insert("smtpHost".into(), json!(""));
-    m.insert("smtpPort".into(), json!(587));
-    m.insert("smtpUsername".into(), json!(""));
-    m.insert("smtpFrom".into(), json!(""));
-    m.insert("smtpPassword".into(), json!(""));
-    m
-}
-
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
+
     use super::*;
     use crate::db::testing::TempPool;
 
     fn test_pool() -> TempPool {
         crate::db::testing::temp_pool("settings-store")
-    }
-
-    #[test]
-    fn defaults_carry_known_keys() {
-        let d = defaults();
-        assert_eq!(d.get("serverName"), Some(&json!("KROMA")));
-        assert_eq!(d.get("moduleStates"), Some(&json!({})));
-        assert_eq!(d.get("watchIntervalSecs"), Some(&json!(-1)));
-        assert_eq!(d.get("llmTemperature"), Some(&json!(0.7)));
-        assert!(!d.contains_key("nonexistentKey"));
     }
 
     #[test]

--- a/server/crates/kroma-module-supervisor/src/host_api.rs
+++ b/server/crates/kroma-module-supervisor/src/host_api.rs
@@ -8,20 +8,25 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::middleware::from_fn_with_state;
 use axum::routing::{get, post};
-use axum::{Json, Router};
+use axum::{Extension, Json, Router};
 use kroma_module_host::host_token::{require_host_token, HostToken};
 use kroma_module_host::{Event, HostCtx};
 use serde_json::{json, Value};
 
+mod settings;
+
+pub use settings::CoreOnlySettings;
+
 /// The `/_host/*` callback router modules call back into (mount under `/api`),
-/// guarded by the shared `token`.
-pub fn host_router<S>(token: String) -> Router<S>
+/// guarded by the shared `token`. `core_only` decides which settings keys the
+/// callback withholds.
+pub fn host_router<S>(token: String, core_only: CoreOnlySettings) -> Router<S>
 where
     S: HostCtx + Clone + Send + Sync + 'static,
 {
     Router::new()
-        .route("/_host/setting", get(get_setting::<S>))
-        .route("/_host/settings", post(set_settings::<S>))
+        .route("/_host/setting", get(settings::get_setting::<S>))
+        .route("/_host/settings", post(settings::set_settings::<S>))
         .route("/_host/events", post(publish_event::<S>))
         .route("/_host/events_to", post(publish_event_to::<S>))
         .route("/_host/notify", post(notify::<S>))
@@ -42,6 +47,7 @@ where
         // answers with whoever serves it. No module id crosses this wire.
         .route("/_host/contributions", get(contributions::<S>))
         .route_layer(from_fn_with_state(HostToken(token), require_host_token))
+        .layer(Extension(core_only))
 }
 
 #[derive(serde::Deserialize)]
@@ -73,38 +79,6 @@ async fn contributions<S: HostCtx>(
     axum::extract::Query(q): axum::extract::Query<PointQuery>,
 ) -> Json<Vec<kroma_module_host::Contribution>> {
     Json(host.contributions(&q.point))
-}
-
-#[derive(serde::Deserialize)]
-struct SettingQuery {
-    key: String,
-    kind: String,
-    default: String,
-}
-
-async fn get_setting<S: HostCtx>(
-    State(host): State<S>,
-    axum::extract::Query(q): axum::extract::Query<SettingQuery>,
-) -> Json<Value> {
-    let value = match q.kind.as_str() {
-        "bool" => json!(host.setting_bool(&q.key, q.default == "true")),
-        "i64" => json!(host.setting_i64(&q.key, q.default.parse().unwrap_or(0))),
-        _ => json!(host.setting_str(&q.key, &q.default)),
-    };
-    Json(json!({ "value": value }))
-}
-
-#[derive(serde::Deserialize)]
-struct SettingsPatch {
-    patch: std::collections::BTreeMap<String, Value>,
-}
-
-async fn set_settings<S: HostCtx>(
-    State(host): State<S>,
-    Json(body): Json<SettingsPatch>,
-) -> StatusCode {
-    host.set_settings(body.patch);
-    StatusCode::NO_CONTENT
 }
 
 #[derive(serde::Deserialize)]

--- a/server/crates/kroma-module-supervisor/src/host_api/settings.rs
+++ b/server/crates/kroma-module-supervisor/src/host_api/settings.rs
@@ -1,0 +1,86 @@
+//! The settings half of the callback API: one typed read, one batched write, and
+//! the keys the core answers for itself rather than for a sidecar.
+
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::{Extension, Json};
+use kroma_module_host::HostCtx;
+use serde_json::{json, Value};
+
+/// Asks the core whether a settings key is its own. `true` withholds that key, so
+/// no sidecar reads or writes it through the callback: the supervisor carries the
+/// question, the core owns the answer.
+#[derive(Clone, Copy)]
+pub struct CoreOnlySettings(pub fn(&str) -> bool);
+
+#[derive(serde::Deserialize)]
+pub(super) struct SettingQuery {
+    key: String,
+    kind: String,
+    default: String,
+}
+
+#[derive(serde::Deserialize)]
+pub(super) struct SettingsPatch {
+    patch: std::collections::BTreeMap<String, Value>,
+}
+
+fn asked_with(q: &SettingQuery) -> Value {
+    match q.kind.as_str() {
+        "bool" => json!(q.default == "true"),
+        "i64" => json!(q.default.parse::<i64>().unwrap_or(0)),
+        _ => json!(q.default),
+    }
+}
+
+pub(super) async fn get_setting<S: HostCtx>(
+    State(host): State<S>,
+    Extension(CoreOnlySettings(core_only)): Extension<CoreOnlySettings>,
+    Query(q): Query<SettingQuery>,
+) -> Json<Value> {
+    if core_only(&q.key) {
+        tracing::warn!(key = %q.key, "a module asked for a setting the core keeps to itself");
+        return Json(json!({ "value": asked_with(&q) }));
+    }
+    let value = match q.kind.as_str() {
+        "bool" => json!(host.setting_bool(&q.key, q.default == "true")),
+        "i64" => json!(host.setting_i64(&q.key, q.default.parse().unwrap_or(0))),
+        _ => json!(host.setting_str(&q.key, &q.default)),
+    };
+    Json(json!({ "value": value }))
+}
+
+pub(super) async fn set_settings<S: HostCtx>(
+    State(host): State<S>,
+    Extension(CoreOnlySettings(core_only)): Extension<CoreOnlySettings>,
+    Json(body): Json<SettingsPatch>,
+) -> StatusCode {
+    if let Some(key) = body.patch.keys().find(|key| core_only(key)) {
+        tracing::warn!(key = %key, "refusing a module's write to a setting the core keeps to itself");
+        return StatusCode::FORBIDDEN;
+    }
+    host.set_settings(body.patch);
+    StatusCode::NO_CONTENT
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn query(kind: &str, default: &str) -> SettingQuery {
+        SettingQuery {
+            key: "anything".to_string(),
+            kind: kind.to_string(),
+            default: default.to_string(),
+        }
+    }
+
+    #[test]
+    fn a_withheld_key_answers_in_the_type_the_caller_asked_with() {
+        assert_eq!(asked_with(&query("bool", "true")), json!(true));
+        assert_eq!(asked_with(&query("bool", "nope")), json!(false));
+        assert_eq!(asked_with(&query("i64", "42")), json!(42));
+        assert_eq!(asked_with(&query("i64", "not a number")), json!(0));
+        assert_eq!(asked_with(&query("str", "fallback")), json!("fallback"));
+    }
+}

--- a/server/crates/kroma-module-supervisor/src/lib.rs
+++ b/server/crates/kroma-module-supervisor/src/lib.rs
@@ -19,7 +19,7 @@ mod proxy;
 mod registry;
 mod watch;
 
-pub use host_api::host_router;
+pub use host_api::{host_router, CoreOnlySettings};
 pub use origin::{BinStamp, Origin, Source};
 pub use proxy::proxy_to;
 pub use registry::{sibling_url, verify_sha256, FetchProgress, DESCRIPTOR_PATH, MAX_BUNDLE_BYTES};

--- a/server/crates/kroma-module-supervisor/tests/host_metadata.rs
+++ b/server/crates/kroma-module-supervisor/tests/host_metadata.rs
@@ -2,9 +2,11 @@ use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use kroma_domain::metadata::{EpisodeInfo, MatchCandidate};
 use kroma_module_host::testing::StubHost;
+use kroma_module_supervisor::CoreOnlySettings;
 use tower::ServiceExt;
 
 const TOKEN: &str = "host-token";
+const NOTHING_WITHHELD: CoreOnlySettings = CoreOnlySettings(|_| false);
 
 fn dune() -> MatchCandidate {
     MatchCandidate {
@@ -35,7 +37,7 @@ async fn get(host: StubHost, uri: &str, token: Option<&str>) -> (StatusCode, Str
     if let Some(t) = token {
         req = req.header("authorization", format!("Bearer {t}"));
     }
-    let res = kroma_module_supervisor::host_router::<StubHost>(TOKEN.into())
+    let res = kroma_module_supervisor::host_router::<StubHost>(TOKEN.into(), NOTHING_WITHHELD)
         .with_state(host)
         .oneshot(req.body(Body::empty()).unwrap())
         .await

--- a/server/crates/kroma-module-supervisor/tests/host_secret.rs
+++ b/server/crates/kroma-module-supervisor/tests/host_secret.rs
@@ -10,16 +10,18 @@
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use kroma_module_host::testing::StubHost;
+use kroma_module_supervisor::CoreOnlySettings;
 use tower::ServiceExt;
 
 const TOKEN: &str = "host-token";
+const NOTHING_WITHHELD: CoreOnlySettings = CoreOnlySettings(|_| false);
 
 async fn get(host: StubHost, uri: &str, token: Option<&str>) -> (StatusCode, String) {
     let mut req = Request::builder().method("GET").uri(uri);
     if let Some(t) = token {
         req = req.header("authorization", format!("Bearer {t}"));
     }
-    let res = kroma_module_supervisor::host_router::<StubHost>(TOKEN.into())
+    let res = kroma_module_supervisor::host_router::<StubHost>(TOKEN.into(), NOTHING_WITHHELD)
         .with_state(host)
         .oneshot(req.body(Body::empty()).unwrap())
         .await

--- a/server/crates/kroma-module-supervisor/tests/host_session.rs
+++ b/server/crates/kroma-module-supervisor/tests/host_session.rs
@@ -9,9 +9,11 @@ use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use kroma_domain::User;
 use kroma_module_host::testing::StubHost;
+use kroma_module_supervisor::CoreOnlySettings;
 use tower::ServiceExt;
 
 const TOKEN: &str = "host-token";
+const NOTHING_WITHHELD: CoreOnlySettings = CoreOnlySettings(|_| false);
 
 fn ana() -> User {
     User {
@@ -30,7 +32,8 @@ fn ana() -> User {
 }
 
 fn app(host: StubHost) -> axum::Router {
-    kroma_module_supervisor::host_router::<StubHost>(TOKEN.into()).with_state(host)
+    kroma_module_supervisor::host_router::<StubHost>(TOKEN.into(), NOTHING_WITHHELD)
+        .with_state(host)
 }
 
 async fn post(host: StubHost, token: Option<&str>, body: &str) -> (StatusCode, String) {

--- a/server/crates/kroma-module-supervisor/tests/host_settings.rs
+++ b/server/crates/kroma-module-supervisor/tests/host_settings.rs
@@ -1,0 +1,127 @@
+//! The `/_host/setting` + `/_host/settings` callbacks: what a sidecar may read
+//! and write of the core's settings store.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use kroma_module_host::testing::StubHost;
+use kroma_module_supervisor::CoreOnlySettings;
+use serde_json::json;
+use tower::ServiceExt;
+
+const TOKEN: &str = "host-token";
+const CORE_ONLY: CoreOnlySettings = CoreOnlySettings(|key| key == "smtpPassword");
+
+async fn send(host: StubHost, req: Request<Body>) -> (StatusCode, String) {
+    let res = kroma_module_supervisor::host_router::<StubHost>(TOKEN.into(), CORE_ONLY)
+        .with_state(host)
+        .oneshot(req)
+        .await
+        .unwrap();
+    let status = res.status();
+    let bytes = axum::body::to_bytes(res.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    (status, String::from_utf8(bytes.to_vec()).unwrap())
+}
+
+async fn get(host: StubHost, uri: &str) -> (StatusCode, String) {
+    let req = Request::builder()
+        .method("GET")
+        .uri(uri)
+        .header("authorization", format!("Bearer {TOKEN}"))
+        .body(Body::empty())
+        .unwrap();
+    send(host, req).await
+}
+
+async fn patch(host: StubHost, body: &str) -> (StatusCode, String) {
+    let req = Request::builder()
+        .method("POST")
+        .uri("/_host/settings")
+        .header("authorization", format!("Bearer {TOKEN}"))
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    send(host, req).await
+}
+
+#[tokio::test]
+async fn a_setting_the_core_keeps_to_itself_answers_the_default_the_module_asked_with() {
+    let host = StubHost::new().with_setting("smtpPassword", json!("s3cr3t"));
+
+    let (status, body) = get(host, "/_host/setting?key=smtpPassword&kind=str&default=").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, r#"{"value":""}"#);
+    assert!(!body.contains("s3cr3t"), "the stored credential leaked");
+}
+
+#[tokio::test]
+async fn a_setting_a_module_configures_still_comes_back_stored() {
+    let host = StubHost::new()
+        .with_setting("acqEnabled", json!(true))
+        .with_setting("namingMovieFolder", json!("{Title} ({Year})"));
+
+    let (enabled_status, enabled) = get(
+        host.clone(),
+        "/_host/setting?key=acqEnabled&kind=bool&default=false",
+    )
+    .await;
+    let (folder_status, folder) = get(
+        host,
+        "/_host/setting?key=namingMovieFolder&kind=str&default=x",
+    )
+    .await;
+
+    assert_eq!(enabled_status, StatusCode::OK);
+    assert_eq!(enabled, r#"{"value":true}"#);
+    assert_eq!(folder_status, StatusCode::OK);
+    assert_eq!(folder, r#"{"value":"{Title} ({Year})"}"#);
+}
+
+#[tokio::test]
+async fn a_write_that_names_a_setting_the_core_keeps_to_itself_is_refused_whole() {
+    let host = StubHost::new();
+
+    let (status, _) = patch(
+        host.clone(),
+        r#"{"patch":{"acqEnabled":true,"smtpPassword":"mine now"}}"#,
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert!(
+        host.settings_written().is_empty(),
+        "a refused patch must write none of its keys"
+    );
+}
+
+#[tokio::test]
+async fn a_write_of_the_settings_a_module_owns_goes_through() {
+    let host = StubHost::new();
+
+    let (status, _) = patch(host.clone(), r#"{"patch":{"acqEnabled":true}}"#).await;
+
+    assert_eq!(status, StatusCode::NO_CONTENT);
+    assert_eq!(
+        host.settings_written(),
+        vec![std::collections::BTreeMap::from([(
+            "acqEnabled".to_string(),
+            json!(true)
+        )])]
+    );
+}
+
+#[tokio::test]
+async fn a_caller_with_no_host_token_reads_nothing_at_all() {
+    let host = StubHost::new().with_setting("acqEnabled", json!(true));
+    let req = Request::builder()
+        .method("GET")
+        .uri("/_host/setting?key=acqEnabled&kind=bool&default=false")
+        .body(Body::empty())
+        .unwrap();
+
+    let (status, _) = send(host, req).await;
+
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}

--- a/server/src/api/it_host_settings.rs
+++ b/server/src/api/it_host_settings.rs
@@ -1,0 +1,141 @@
+//! The `/api/_host/*` settings callbacks against the real wiring: which keys a
+//! sidecar holding the host token reads and writes.
+
+use std::collections::BTreeMap;
+
+use axum::http::StatusCode;
+use serde_json::json;
+
+use crate::api::test_support::{get, send, test_app};
+
+const HOST_TOKEN: &str = "test-host-token";
+
+#[tokio::test]
+async fn a_stored_operator_credential_never_reaches_a_sidecar() {
+    let t = test_app();
+    t.state.settings.set_patch(
+        &t.state.db,
+        BTreeMap::from([
+            ("smtpPassword".to_string(), json!("mail-s3cr3t")),
+            ("llmApiKey".to_string(), json!("sk-llm")),
+            (
+                "notifications.vapid.privateKey".to_string(),
+                json!("vapid-private"),
+            ),
+            ("notifications.apns.keyP8".to_string(), json!("apns-p8")),
+            (
+                "notifications.fcm.serviceAccount".to_string(),
+                json!("fcm-account"),
+            ),
+            ("moduleRegistryUrl".to_string(), json!("https://mine.test")),
+        ]),
+    );
+
+    for (key, stored) in [
+        ("smtpPassword", "mail-s3cr3t"),
+        ("llmApiKey", "sk-llm"),
+        ("notifications.vapid.privateKey", "vapid-private"),
+        ("notifications.apns.keyP8", "apns-p8"),
+        ("notifications.fcm.serviceAccount", "fcm-account"),
+        ("moduleRegistryUrl", "https://mine.test"),
+    ] {
+        let uri = format!("/api/_host/setting?key={key}&kind=str&default=");
+        let (status, body) = get(&t.app, &uri, Some(HOST_TOKEN)).await;
+
+        assert_eq!(status, StatusCode::OK, "{key}");
+        assert_eq!(body, json!({ "value": "" }), "{key} leaked");
+        assert!(!body.to_string().contains(stored), "{key} leaked");
+    }
+}
+
+#[tokio::test]
+async fn the_settings_a_module_runs_on_still_come_back_stored() {
+    let t = test_app();
+    t.state.settings.set_patch(
+        &t.state.db,
+        BTreeMap::from([
+            ("acqEnabled".to_string(), json!(true)),
+            ("vpnWgConfig".to_string(), json!("[Interface]")),
+            ("remoteAccessToken".to_string(), json!("tunnel-token")),
+        ]),
+    );
+
+    let (acq_status, acq) = get(
+        &t.app,
+        "/api/_host/setting?key=acqEnabled&kind=bool&default=false",
+        Some(HOST_TOKEN),
+    )
+    .await;
+    let (wg_status, wg) = get(
+        &t.app,
+        "/api/_host/setting?key=vpnWgConfig&kind=str&default=",
+        Some(HOST_TOKEN),
+    )
+    .await;
+    let (tunnel_status, tunnel) = get(
+        &t.app,
+        "/api/_host/setting?key=remoteAccessToken&kind=str&default=",
+        Some(HOST_TOKEN),
+    )
+    .await;
+
+    assert_eq!(acq_status, StatusCode::OK);
+    assert_eq!(acq, json!({ "value": true }));
+    assert_eq!(wg_status, StatusCode::OK);
+    assert_eq!(wg, json!({ "value": "[Interface]" }));
+    assert_eq!(tunnel_status, StatusCode::OK);
+    assert_eq!(tunnel, json!({ "value": "tunnel-token" }));
+}
+
+#[tokio::test]
+async fn a_sidecar_cannot_write_a_credential_or_retarget_the_registries() {
+    let t = test_app();
+
+    let (password, _) = send(
+        &t.app,
+        "POST",
+        "/api/_host/settings",
+        Some(HOST_TOKEN),
+        Some(json!({ "patch": { "smtpPassword": "mine now" } })),
+    )
+    .await;
+    let (registries, _) = send(
+        &t.app,
+        "POST",
+        "/api/_host/settings",
+        Some(HOST_TOKEN),
+        Some(json!({ "patch": {
+            "cacheLimit": "1 Go",
+            "moduleRegistries": [{ "name": "mine", "url": "https://mine.test", "enabled": true }],
+        } })),
+    )
+    .await;
+
+    assert_eq!(password, StatusCode::FORBIDDEN);
+    assert_eq!(registries, StatusCode::FORBIDDEN);
+    assert_eq!(t.state.settings.get("smtpPassword"), json!(""));
+    assert_eq!(t.state.settings.get("moduleRegistries"), json!([]));
+    assert_eq!(
+        t.state.settings.get("cacheLimit"),
+        json!("80 Go"),
+        "a refused patch writes none of its keys"
+    );
+}
+
+#[tokio::test]
+async fn a_sidecar_still_saves_the_settings_it_owns() {
+    let t = test_app();
+
+    let (status, _) = send(
+        &t.app,
+        "POST",
+        "/api/_host/settings",
+        Some(HOST_TOKEN),
+        Some(json!({ "patch": { "acqEnabled": true, "vpnWgConfig": "[Interface]" } })),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::NO_CONTENT);
+    assert_eq!(t.state.settings.get("acqEnabled"), json!(true));
+    assert_eq!(t.state.settings.get("vpnWgConfig"), json!("[Interface]"));
+}

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -70,6 +70,8 @@ mod it_diagnostics;
 #[cfg(test)]
 mod it_handoff;
 #[cfg(test)]
+mod it_host_settings;
+#[cfg(test)]
 mod it_images;
 #[cfg(test)]
 mod it_invites;
@@ -222,6 +224,7 @@ pub fn router(
         .merge(content)
         .merge(kroma_module_supervisor::host_router::<SharedState>(
             supervisor.host_token().to_string(),
+            kroma_module_supervisor::CoreOnlySettings(crate::services::settings::core_only),
         ))
         // A sidecar registers its scheduled jobs with the core JobManager here, so
         // they appear in admin Tâches like in-core jobs (same host-token guard).


### PR DESCRIPTION
## What

`GET /api/_host/setting` forwarded any key straight into the settings store, so
any installed `.kmod` holding the host token could read `smtpPassword`,
`llmApiKey` and the Web Push / APNs / FCM private material, and
`POST /api/_host/settings` could overwrite them or point `moduleRegistries` at a
catalog the operator never chose. Masked admin views, the name-gated
`/_host/secret` and the SQLite grant all say that boundary exists; on this one
route it did not.

The keys now carry the answer themselves. `defaults()` moves out of
`settings/store.rs` into `settings/keys.rs`, and every credential is declared at
its own line: `core_only()` for the ones only the core consumes, and
`sidecar_credential()` for the ones whose consumer is a module. `core_only(key)`
is derived from that table, so there is no second list to keep in step, and a
sweep over every declared key fails when a credential-shaped name (a `password`,
`token`, `secret`, `credential` word, or an `apikey` / `privatekey` /
`serviceaccount` / `keyp8` compound) carries no declaration at all. Adding
`indexerPassword` to `defaults()` fails that test until someone says which side
of the boundary it is on.

The refusal sits at the callback rather than in the `HostCtx` impl, because the
core reads its own push credentials (`notify/push/credentials.rs`) and the digest
watermark through that same trait in-process: filtering there would have broken
VAPID minting. The supervisor asks rather than knows, so it still holds no
settings vocabulary: `host_router` takes `CoreOnlySettings(fn(&str) -> bool)` and
`api/mod.rs`, the composition point, hands it the core's predicate. A withheld
read answers the default the caller asked with; a patch naming a withheld key is
refused whole with a `403` and writes none of its keys.

Withheld: `smtpPassword`, `llmApiKey`, `notifications.vapid.privateKey`,
`notifications.apns.{keyP8,keyId,teamId}`,
`notifications.fcm.serviceAccount`, `moduleRegistries`, `moduleRegistryUrl`.

## Closes

Closes #224

## Checks

- [x] `bun run lint` and `bun run test` pass, or I said below which failed and why
- [x] `cargo clippy` and `cargo test` pass, if the server changed
- [x] Follows `CODE_STYLE.md` - no comments narrating the work, exported API only
- [x] One idea. If it grew a second, it was split.

`bun run typecheck`, `bun run check`, `bun run test` (10013), `bun run spec:check`
and, in `server/`, `cargo clippy --workspace --all-targets` + `cargo test
--workspace` all pass. Clippy still reports the warnings that were on `main`
before this branch (`vectors.rs`, `cast/registry`, `enrich.rs`,
`markers/fingerprint.rs`, `requests/*`, `admin/reports.rs`, `card.rs`,
`home.rs`, `poster.rs`, `accounts/profile.rs`); none is in a file this PR
touches. `docs/spec/INDEX.md` + `requirements.json` are regenerated for the new
MOD-51.

## Risk

**Two keys are deliberately NOT withheld: `vpnWgConfig` and
`remoteAccessToken`.** The WireGuard bridge and the `cloudflared` connector are
sidecars, they read and write those through this callback (`tv.kroma.vpn`,
`tv.kroma.remote`, and `tv.kroma.torrents` reads `vpnWgConfig` to tell whether a
tunnel is configured), and modules release on their own tags, so withholding
them would break installed bundles rather than close a hole. They are marked
`sidecar_credential` so the choice is visible at the declaration and the sweep
does not silently pass. Scoping the callback to the calling module is what
actually fixes those two, and it needs a declaration in `module.json` first:
filed as the follow-up below. Nothing else was left open knowingly; `llmProviders`
holds per-provider API keys but the read callback is typed
(`str`/`bool`/`i64`), so an array never comes back through it, and the write path
now refuses the registry keys that were the other half of the report.

What a reviewer should try to break:

- A module that reads a withheld key and silently gets `""`. `tv.kroma.indexer`
  reads `acqIndexersUseVpn` / `acqFlaresolverrUrl`, acquisition reads the `acq*`
  and naming keys, torrents reads `rqbit*` / `vpn*`: none of those is on the
  list, and `it_host_settings.rs` pins the stored value still coming back for
  `acqEnabled`, `vpnWgConfig` and `remoteAccessToken`.
- The core's own paths that go through `HostCtx`, not the route: push credential
  minting, the digest watermark, and `registry_url()` reading
  `moduleRegistryUrl`. They are unchanged by design, and `cargo test --workspace`
  covers all three.
- The patch refusal is all-or-nothing. A module that batched a withheld key with
  legitimate ones now saves neither. No first-party module does, and a silent
  drop would have been worse.
- `defaults()` moved file. It is a pure move apart from the ten marked lines; a
  key lost in the move would make `set_patch` drop writes silently, which is why
  the settings store suite and the whole API suite were run.
