### PR TITLE
fix(playback): a live row belongs to the account that opened it

### DIFF
--- a/server/crates/kroma-engine/src/services/playback/registry.rs
+++ b/server/crates/kroma-engine/src/services/playback/registry.rs
@@ -82,6 +82,14 @@ pub struct Session {
     played_ms: i64,
 }
 
+/// What one heartbeat did to the live map.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Beat {
+    Opened,
+    Refreshed,
+    Refused,
+}
+
 // Long enough that in-flight heartbeats can't re-register a terminated session.
 const TERMINATE_GRACE: Duration = Duration::from_secs(60);
 
@@ -116,6 +124,11 @@ impl Registry {
         map.contains_key(session_id)
     }
 
+    /// Opens the session on first sight, then refreshes it. The row belongs to
+    /// the account that opened it: a beat from anyone else is [`Beat::Refused`]
+    /// and writes nothing, under the one write lock the check shares with the
+    /// write, so the viewer the dashboard names cannot be whoever beat last.
+    ///
     /// `item` is only read on first sight, to build the title/streams snapshot.
     pub fn upsert(
         &self,
@@ -125,10 +138,14 @@ impl Registry {
         ip: String,
         network: String,
         item: Option<&MediaItem>,
-    ) -> bool {
+    ) -> Beat {
         let now = Instant::now();
         let mut map = self.inner.write().unwrap();
-        let is_new = !map.contains_key(&ping.session_id);
+        let live = map.get(&ping.session_id);
+        if live.is_some_and(|s| s.user_id != user_id) {
+            return Beat::Refused;
+        }
+        let is_new = live.is_none();
         let entry = map.entry(ping.session_id.clone()).or_insert_with(|| {
             let snap = item.map(snapshot).unwrap_or_default();
             Session {
@@ -183,7 +200,11 @@ impl Registry {
             entry.subtitle = s;
         }
         entry.last_seen = now;
-        is_new
+        if is_new {
+            Beat::Opened
+        } else {
+            Beat::Refreshed
+        }
     }
 
     pub fn contains(&self, session_id: &str) -> bool {
@@ -342,22 +363,28 @@ mod tests {
     #[test]
     fn upsert_creates_then_refreshes() {
         let reg = Registry::default();
-        assert!(reg.upsert(
-            ping("s1", 1000, "playing"),
-            Some("u1".into()),
-            "Alice".into(),
-            "1.2.3.4".into(),
-            "WAN".into(),
-            None
-        ));
-        assert!(!reg.upsert(
-            ping("s1", 5000, "paused"),
-            Some("u1".into()),
-            "Alice".into(),
-            "1.2.3.4".into(),
-            "LAN".into(),
-            None
-        ));
+        assert_eq!(
+            reg.upsert(
+                ping("s1", 1000, "playing"),
+                Some("u1".into()),
+                "Alice".into(),
+                "1.2.3.4".into(),
+                "WAN".into(),
+                None
+            ),
+            Beat::Opened
+        );
+        assert_eq!(
+            reg.upsert(
+                ping("s1", 5000, "paused"),
+                Some("u1".into()),
+                "Alice".into(),
+                "1.2.3.4".into(),
+                "LAN".into(),
+                None
+            ),
+            Beat::Refreshed
+        );
         let list = reg.list();
         assert_eq!(list.len(), 1);
         assert_eq!(list[0].position_ms, 5000);
@@ -706,6 +733,55 @@ mod tests {
         );
         assert!(reg.remove_owned("s1", "u1").is_none());
         assert!(reg.contains("anon"));
+    }
+
+    #[test]
+    fn only_the_viewer_of_a_session_can_refresh_it() {
+        let reg = Registry::new();
+        reg.upsert(
+            ping("s1", 1000, "playing"),
+            Some("u1".into()),
+            "Alice".into(),
+            "10.0.0.1".into(),
+            "LAN".into(),
+            None,
+        );
+        reg.upsert(
+            ping("anon", 0, "playing"),
+            None,
+            "Anon".into(),
+            "10.0.0.2".into(),
+            "LAN".into(),
+            None,
+        );
+
+        let stolen = reg.upsert(
+            ping("s1", 9000, "paused"),
+            Some("u2".into()),
+            "Bob".into(),
+            "8.8.8.8".into(),
+            "WAN".into(),
+            None,
+        );
+        let claimed = reg.upsert(
+            ping("anon", 9000, "paused"),
+            Some("u1".into()),
+            "Alice".into(),
+            "8.8.8.8".into(),
+            "WAN".into(),
+            None,
+        );
+
+        assert_eq!(stolen, Beat::Refused, "another account wrote it");
+        assert_eq!(claimed, Beat::Refused, "a signed-out session was claimed");
+        let live = reg.inner.read().unwrap();
+        let mine = &live["s1"];
+        assert_eq!(mine.username, "Alice");
+        assert_eq!(mine.position_ms, 1000);
+        assert_eq!(mine.state, "playing");
+        assert_eq!(mine.ip, "10.0.0.1");
+        assert_eq!(mine.network, "LAN");
+        assert_eq!(live["anon"].position_ms, 0);
     }
 
     async fn let_the_reaper_sweep() {

--- a/server/src/api/it_playback.rs
+++ b/server/src/api/it_playback.rs
@@ -107,6 +107,86 @@ async fn stop_will_not_end_another_viewers_session() {
 }
 
 #[tokio::test]
+async fn a_heartbeat_will_not_take_over_another_viewers_live_row() {
+    let t = test_app();
+    let item = demo_item_id("The Matrix");
+    let (_id, intruder) = seed_session(
+        &t.state,
+        "intruder@test.dev",
+        "intruder",
+        &[Permission::Playback],
+    );
+
+    let (status, _) = send(
+        &t.app,
+        "POST",
+        "/api/playback/ping",
+        Some(&t.token),
+        Some(json!({
+            "sessionId": "sess-shared",
+            "itemId": item,
+            "positionMs": 1000,
+            "device": "Salon",
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+
+    let (status, _) = send(
+        &t.app,
+        "POST",
+        "/api/playback/ping",
+        Some(&intruder),
+        Some(json!({
+            "sessionId": "sess-shared",
+            "itemId": item,
+            "positionMs": 7_200_000,
+            "state": "paused",
+            "device": "Bureau",
+        })),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::NO_CONTENT);
+    let (_, admin) = get(&t.app, "/api/admin/sessions", Some(&t.token)).await;
+    let sessions = admin["sessions"].as_array().expect("sessions array");
+    assert_eq!(sessions.len(), 1, "the beat opened a second row");
+    assert_eq!(sessions[0]["username"], json!("owner"));
+    assert_eq!(sessions[0]["positionMs"], json!(1000));
+    assert_eq!(sessions[0]["state"], json!("playing"));
+    assert_eq!(sessions[0]["device"], json!("Salon"));
+}
+
+#[tokio::test]
+async fn two_viewers_each_get_their_own_live_row() {
+    let t = test_app();
+    let item = demo_item_id("The Matrix");
+    let (_id, guest) = seed_session(&t.state, "guest@test.dev", "guest", &[Permission::Playback]);
+
+    for (token, session) in [(&t.token, "sess-owner"), (&guest, "sess-guest")] {
+        let (status, _) = send(
+            &t.app,
+            "POST",
+            "/api/playback/ping",
+            Some(token),
+            Some(json!({ "sessionId": session, "itemId": item, "positionMs": 1000 })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NO_CONTENT);
+    }
+
+    let (_, admin) = get(&t.app, "/api/admin/sessions", Some(&t.token)).await;
+    let sessions = admin["sessions"].as_array().expect("sessions array");
+    assert_eq!(sessions.len(), 2);
+    let mut names: Vec<&str> = sessions
+        .iter()
+        .map(|s| s["username"].as_str().expect("username"))
+        .collect();
+    names.sort_unstable();
+    assert_eq!(names, ["guest", "owner"]);
+}
+
+#[tokio::test]
 async fn progress_clamps_negative_positions_to_zero() {
     let t = test_app();
     let item = demo_item_id("Sintel");

--- a/server/src/api/playback.rs
+++ b/server/src/api/playback.rs
@@ -15,7 +15,7 @@ use crate::api::util::{client_ip, query};
 use crate::api::visibility;
 use crate::db;
 use crate::infra::events::ServerEvent;
-use crate::services::playback::{self, Ping};
+use crate::services::playback::{self, Beat, Ping};
 use crate::services::settings;
 use crate::state::SharedState;
 use axum::routing::{get, post, put};
@@ -143,7 +143,7 @@ pub async fn ping(
         }
     }
 
-    let is_new = state.playback.upsert(
+    let beat = state.playback.upsert(
         ping,
         Some(user.id.clone()),
         user.username.clone(),
@@ -151,6 +151,11 @@ pub async fn ping(
         network,
         item.as_ref(),
     );
+    // A session another account owns answers 204, as `/playback/stop` does: the
+    // endpoint must not double as a way to discover which sessions exist.
+    if beat == Beat::Refused {
+        return StatusCode::NO_CONTENT.into_response();
+    }
 
     let uid = user.id.clone();
     let _ = query(&state.db, move |pool| {
@@ -160,7 +165,7 @@ pub async fn ping(
     .await;
 
     let count = state.playback.list().len();
-    state.events.publish(if is_new {
+    state.events.publish(if beat == Beat::Opened {
         ServerEvent::PlaybackStarted { count }
     } else {
         ServerEvent::PlaybackUpdated { count }


### PR DESCRIPTION
## What

The live-session heartbeat keyed the registry map on the session id alone, so any signed-in account could name another viewer's id and write the position, state, mode, network class and IP of their row, and fold the silence since their last beat into the viewing time that row writes to `play_history`. The viewer's name survived, because that field is only set when the row is created, so the dashboard went on naming one person while showing another person's numbers. That is ADMIN-3 as a display of a race.

`Registry::upsert` now returns a `Beat` instead of a bool and compares the live row's account with the beat's under the same write lock it writes through, so a racing beat cannot slip between the check and the write. A row owned by someone else is `Beat::Refused`: no position, no played time, no `last_seen`, no `PlaybackUpdated` on the bus.

The endpoint still answers 204 on a refusal, the way `/playback/stop` answers for a session it will not end, so neither one can be used to discover which session ids are live. A session id is minted client side from a clock and a counter and is documented as needing uniqueness rather than unpredictability, which is exactly why the row could not be defended by its id.

Checked every sibling write in the playback group: `PUT/DELETE /progress/:id`, `PUT/DELETE /watched/:id`, `PUT/DELETE /my-list/:id` are SQL writes keyed on `(user_id, item_id)`, so none of them can land on another account's row, and `/playback/stop` already went through `remove_owned`. The heartbeat was the only gap, so the change stays where the bug was.

No requirement changes status, so the spec is untouched. ADMIN-3 was already SHIPPED and this restores what it promises rather than newly satisfying it. PLAY-33 to PLAY-35 are about a different write and are not involved.

## Closes

Closes #227

## Checks

- [x] `bun run lint` and `bun run test` pass, or I said below which failed and why
- [x] `cargo clippy` and `cargo test` pass, if the server changed
- [x] Follows `CODE_STYLE.md`: no comments narrating the work, exported API only
- [x] One idea. If it grew a second, it was split.

`bun run typecheck`, `bun run test` (10013 passing), `bun run spec:check`, `cargo clippy --workspace --all-targets` and `cargo test --workspace` all pass. Clippy's warnings are the nine already on main (`vectors.rs`, `cast/registry`, `enrich.rs`, `markers/fingerprint.rs`, `requests/*`, `admin/reports.rs`, `card.rs`) and this adds none.

`bun run check` passes on CI. Locally it reported one formatting error on `apps/www/project.inlang/settings.json` and a `biome migrate` notice on `biome.json`, both on files byte-identical to `origin/main` and neither in this diff: an artifact of running biome from a git worktree, not a finding.

## Risk

The blast radius is the admin "Now playing" panel and the `play_history` rows it turns into. What a reviewer should try to break:

- Two accounts, one session id. A's beat must leave B's card alone and must not open a second card, and A's own id must still open A's card beside B's. Both are pinned by `it_playback.rs`.
- One account, two devices, same id. The owner check is on the account, not the device, so those still merge into one row exactly as before. Worth deciding whether that is the behaviour wanted long term.
- A genuine id collision between two accounts is no longer a hijack, but the later client is now absent from the panel for the life of its session rather than stealing the earlier one's row. Answering 409 instead would let it re-mint, at the cost of turning the endpoint into an oracle for live session ids. The quiet 204 is the same trade `/playback/stop` already made.
- The reaper and `/playback/stop`. A refused beat does not touch `last_seen`, so a row nobody legitimately refreshes still ages out after the TTL and still logs its real played time.

Progress and continue-watching writes are untouched, explicitly: no line in `server/src/api/playback/progress.rs`, `watch_state.rs` or `crates/kroma-db/src/playback/` is in this diff, and the resume position, the watched flag and the "Continue watching" rail go through their own `(user_id, item_id)` SQL, not through the live registry.
