### PR TITLE
feat(accounts): media bytes carry a credential, and a dropped session reaches none of them

### DIFF
--- a/docs/spec/INDEX.md
+++ b/docs/spec/INDEX.md
@@ -27,7 +27,7 @@
 - **ACCT-18** (AGREED) - The owner is the founding admin, the owner may grant admin to another
 - **ACCT-19** (SHIPPED) - A **user** uses the server: browses and plays what they are permitted
 - **ACCT-20** (SHIPPED) - **Library visibility is per user.** An admin decides which libraries a
-- **ACCT-21** (AGREED) - Visibility gates browsing, search and playback alike. A title a user
+- **ACCT-21** (SHIPPED) - Visibility gates browsing, search and playback alike. A title a user
 - **ACCT-22** (SHIPPED) - Installing a module is an **admin** right, because it runs new
 - **ACCT-23** (AGREED) - The matrix below is the whole of what each role may do. A user's power
 - **ACCT-24** (SHIPPED) - **Per-user**: watch state, meaning resume points, watched flags and
@@ -41,7 +41,7 @@
 - **ACCT-32** (AGREED) - Bytes already downloaded for offline viewing sit in local storage the
 - **ACCT-33** (AGREED) - The guarantee is that a revoked device gains nothing new and loses its
 - **ACCT-34** (SHIPPED) - A title outside a person's grant is absent from browse, search, every
-- **ACCT-35** (AGREED) - Every request for media bytes carries a credential the grant can be
+- **ACCT-35** (SHIPPED) - Every request for media bytes carries a credential the grant can be
 
 ## ADMIN - [admin](admin/)
 

--- a/docs/spec/accounts/README.md
+++ b/docs/spec/accounts/README.md
@@ -120,23 +120,38 @@ existing server reads as: narrowing is something an admin does, never something 
 does for them. A library nobody has been granted therefore stays visible to the unrestricted
 accounts and invisible to the narrowed ones.
 
-**ACCT-21** (AGREED) - Visibility gates browsing, search and playback alike. A title a user
+**ACCT-21** (SHIPPED) - Visibility gates browsing, search and playback alike. A title a user
 cannot see is a title they cannot play, resume or find.
 
-That full rule is not true yet, and the two requirements below are the halves it breaks into.
-The catalogue half ships; the bytes do not, so ACCT-21 stays agreed until ACCT-35 lands rather
-than shipping with a caveat only this paragraph carries.
+The rule holds in two halves, and both of them ship: the catalogue below, and the bytes behind
+it.
 
 **ACCT-34** (SHIPPED) - A title outside a person's grant is absent from browse, search, every
 home row and their watch state, and is refused by its id on every endpoint that presents a
 session. An unknown id and an ungranted one refuse identically, so probing cannot tell a title
 that is hidden from one that was never scanned.
 
-**ACCT-35** (AGREED) - Every request for media bytes carries a credential the grant can be
-enforced against. Today those routes are reachable with no session at all, because a `<video>`
-element cannot attach a bearer, so they enforce the grant on a request that presents one and
-nothing on a request that presents none. A person who knows an id and drops their session
-reaches the bytes, which is why ACCT-21 is not shipped.
+**ACCT-35** (SHIPPED) - Every request for media bytes carries a credential the grant can be
+enforced against, and one carrying none is refused before the id is read. A `<video>` element,
+hls.js, a television's own player and the mpv a desktop shell hands a URL to can none of them
+send a header, so the credential rides in the URL: a **media ticket**, handed over beside every
+session token and naming the signed-in device it belongs to. The server reads the account off
+the ticket and the grant out of the database, so narrowing a grant bites on the next request
+rather than when the ticket lapses, and revoking the device stops every ticket it left behind.
+
+A ticket is scoped to an account rather than to one title, so a URL that escapes reaches
+whatever that account may see until the ticket runs out. Twelve hours is that limit: longer
+than a feature film and shorter than a day, which is what a credential written into an access
+log and a browser history can be trusted with. The cost is that a title left paused longer than
+that needs its source rebuilt, which a reload does. Scoping each ticket to one title instead
+would buy a narrower leak for a round trip before every playback URL, and those URLs are built
+in one synchronous step by six players that are handed nothing but a string.
+
+One thing is deliberately left open, named here so this requirement is not read as covering it:
+a title's **artwork** stays reachable by id (`/items/<id>/poster`, `/items/<id>/card`,
+`/images/<hash>`), because the sign-in screen's slideshow and a television's launcher cards are
+drawn before there is any account to hold. Someone who already has an id learns a hidden
+title's name and cover that way. They reach none of its bytes.
 
 **ACCT-22** (SHIPPED) - Installing a module is an **admin** right, because it runs new
 out-of-process code on the server ([`modules/`](../modules/)). A plain user may use whatever

--- a/docs/spec/accounts/README.md
+++ b/docs/spec/accounts/README.md
@@ -147,11 +147,19 @@ that needs its source rebuilt, which a reload does. Scoping each ticket to one t
 would buy a narrower leak for a round trip before every playback URL, and those URLs are built
 in one synchronous step by six players that are handed nothing but a string.
 
-One thing is deliberately left open, named here so this requirement is not read as covering it:
+One thing is deliberately left open, and it is the bytes this requirement covers that bound it:
 a title's **artwork** stays reachable by id (`/items/<id>/poster`, `/items/<id>/card`,
 `/images/<hash>`), because the sign-in screen's slideshow and a television's launcher cards are
 drawn before there is any account to hold. Someone who already has an id learns a hidden
 title's name and cover that way. They reach none of its bytes.
+
+That is a real edge on **ACCT-20**, which says a narrowed account cannot discover the rest: for
+an id already in hand, artwork confirms the title exists and shows its cover. The id is the
+gated half, and ACCT-34 closed every path that hands one out, so the leak needs an id carried in
+from outside the product. This is how artwork has always been served and nothing here changed
+it; it is written down so neither ACCT-20 nor ACCT-21 has to be read charitably to be true.
+Closing it means a credential on the art routes too, which costs the sign-in slideshow and the
+launcher cards, and that trade has not been made.
 
 **ACCT-22** (SHIPPED) - Installing a module is an **admin** right, because it runs new
 out-of-process code on the server ([`modules/`](../modules/)). A plain user may use whatever

--- a/docs/spec/requirements.json
+++ b/docs/spec/requirements.json
@@ -204,7 +204,7 @@
     "domain": "ACCT",
     "space": "accounts",
     "number": 21,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "Visibility gates browsing, search and playback alike. A title a user",
     "file": "docs/spec/accounts/README.md",
     "line": 123
@@ -217,7 +217,7 @@
     "status": "SHIPPED",
     "text": "Installing a module is an **admin** right, because it runs new",
     "file": "docs/spec/accounts/README.md",
-    "line": 141
+    "line": 156
   },
   {
     "id": "ACCT-23",
@@ -227,7 +227,7 @@
     "status": "AGREED",
     "text": "The matrix below is the whole of what each role may do. A user's power",
     "file": "docs/spec/accounts/README.md",
-    "line": 150
+    "line": 165
   },
   {
     "id": "ACCT-24",
@@ -237,7 +237,7 @@
     "status": "SHIPPED",
     "text": "**Per-user**: watch state, meaning resume points, watched flags and",
     "file": "docs/spec/accounts/README.md",
-    "line": 177
+    "line": 192
   },
   {
     "id": "ACCT-25",
@@ -247,7 +247,7 @@
     "status": "SHIPPED",
     "text": "**Per-server**: the libraries and their contents, metadata and",
     "file": "docs/spec/accounts/README.md",
-    "line": 182
+    "line": 197
   },
   {
     "id": "ACCT-26",
@@ -257,7 +257,7 @@
     "status": "SHIPPED",
     "text": "Watch state is per user and never per device: resume a film on the",
     "file": "docs/spec/accounts/README.md",
-    "line": 186
+    "line": 201
   },
   {
     "id": "ACCT-27",
@@ -267,7 +267,7 @@
     "status": "SHIPPED",
     "text": "Deletion destroys the account's credentials, all of its sessions and",
     "file": "docs/spec/accounts/README.md",
-    "line": 196
+    "line": 211
   },
   {
     "id": "ACCT-28",
@@ -277,7 +277,7 @@
     "status": "SHIPPED",
     "text": "Everything per-server survives. Libraries, media, metadata and",
     "file": "docs/spec/accounts/README.md",
-    "line": 200
+    "line": 215
   },
   {
     "id": "ACCT-29",
@@ -287,7 +287,7 @@
     "status": "AGREED",
     "text": "The owner account cannot be deleted while it is the only admin.",
     "file": "docs/spec/accounts/README.md",
-    "line": 204
+    "line": 219
   },
   {
     "id": "ACCT-30",
@@ -297,7 +297,7 @@
     "status": "AGREED",
     "text": "A user may request deletion of their own account, which revokes their",
     "file": "docs/spec/accounts/README.md",
-    "line": 208
+    "line": 223
   },
   {
     "id": "ACCT-31",
@@ -307,7 +307,7 @@
     "status": "SHIPPED",
     "text": "Revocation stops a session doing anything new. It cannot fetch, refresh",
     "file": "docs/spec/accounts/README.md",
-    "line": 217
+    "line": 232
   },
   {
     "id": "ACCT-32",
@@ -317,7 +317,7 @@
     "status": "AGREED",
     "text": "Bytes already downloaded for offline viewing sit in local storage the",
     "file": "docs/spec/accounts/README.md",
-    "line": 220
+    "line": 235
   },
   {
     "id": "ACCT-33",
@@ -327,7 +327,7 @@
     "status": "AGREED",
     "text": "The guarantee is that a revoked device gains nothing new and loses its",
     "file": "docs/spec/accounts/README.md",
-    "line": 224
+    "line": 239
   },
   {
     "id": "ACCT-34",
@@ -337,17 +337,17 @@
     "status": "SHIPPED",
     "text": "A title outside a person's grant is absent from browse, search, every",
     "file": "docs/spec/accounts/README.md",
-    "line": 130
+    "line": 129
   },
   {
     "id": "ACCT-35",
     "domain": "ACCT",
     "space": "accounts",
     "number": 35,
-    "status": "AGREED",
+    "status": "SHIPPED",
     "text": "Every request for media bytes carries a credential the grant can be",
     "file": "docs/spec/accounts/README.md",
-    "line": 135
+    "line": 134
   },
   {
     "id": "ADMIN-1",

--- a/docs/spec/requirements.json
+++ b/docs/spec/requirements.json
@@ -217,7 +217,7 @@
     "status": "SHIPPED",
     "text": "Installing a module is an **admin** right, because it runs new",
     "file": "docs/spec/accounts/README.md",
-    "line": 156
+    "line": 164
   },
   {
     "id": "ACCT-23",
@@ -227,7 +227,7 @@
     "status": "AGREED",
     "text": "The matrix below is the whole of what each role may do. A user's power",
     "file": "docs/spec/accounts/README.md",
-    "line": 165
+    "line": 173
   },
   {
     "id": "ACCT-24",
@@ -237,7 +237,7 @@
     "status": "SHIPPED",
     "text": "**Per-user**: watch state, meaning resume points, watched flags and",
     "file": "docs/spec/accounts/README.md",
-    "line": 192
+    "line": 200
   },
   {
     "id": "ACCT-25",
@@ -247,7 +247,7 @@
     "status": "SHIPPED",
     "text": "**Per-server**: the libraries and their contents, metadata and",
     "file": "docs/spec/accounts/README.md",
-    "line": 197
+    "line": 205
   },
   {
     "id": "ACCT-26",
@@ -257,7 +257,7 @@
     "status": "SHIPPED",
     "text": "Watch state is per user and never per device: resume a film on the",
     "file": "docs/spec/accounts/README.md",
-    "line": 201
+    "line": 209
   },
   {
     "id": "ACCT-27",
@@ -267,7 +267,7 @@
     "status": "SHIPPED",
     "text": "Deletion destroys the account's credentials, all of its sessions and",
     "file": "docs/spec/accounts/README.md",
-    "line": 211
+    "line": 219
   },
   {
     "id": "ACCT-28",
@@ -277,7 +277,7 @@
     "status": "SHIPPED",
     "text": "Everything per-server survives. Libraries, media, metadata and",
     "file": "docs/spec/accounts/README.md",
-    "line": 215
+    "line": 223
   },
   {
     "id": "ACCT-29",
@@ -287,7 +287,7 @@
     "status": "AGREED",
     "text": "The owner account cannot be deleted while it is the only admin.",
     "file": "docs/spec/accounts/README.md",
-    "line": 219
+    "line": 227
   },
   {
     "id": "ACCT-30",
@@ -297,7 +297,7 @@
     "status": "AGREED",
     "text": "A user may request deletion of their own account, which revokes their",
     "file": "docs/spec/accounts/README.md",
-    "line": 223
+    "line": 231
   },
   {
     "id": "ACCT-31",
@@ -307,7 +307,7 @@
     "status": "SHIPPED",
     "text": "Revocation stops a session doing anything new. It cannot fetch, refresh",
     "file": "docs/spec/accounts/README.md",
-    "line": 232
+    "line": 240
   },
   {
     "id": "ACCT-32",
@@ -317,7 +317,7 @@
     "status": "AGREED",
     "text": "Bytes already downloaded for offline viewing sit in local storage the",
     "file": "docs/spec/accounts/README.md",
-    "line": 235
+    "line": 243
   },
   {
     "id": "ACCT-33",
@@ -327,7 +327,7 @@
     "status": "AGREED",
     "text": "The guarantee is that a revoked device gains nothing new and loses its",
     "file": "docs/spec/accounts/README.md",
-    "line": 239
+    "line": 247
   },
   {
     "id": "ACCT-34",

--- a/packages/client/src/api/accounts/client.ts
+++ b/packages/client/src/api/accounts/client.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { RequestContext } from '../../core/client';
+import { adoptMediaTicket } from '../../core/http';
 import type { InviteToken, SessionId } from './ids';
 import { passkeysApi } from './passkeys';
 import { quickConnectApi } from './quick-connect';
@@ -31,24 +32,33 @@ export default function accountsApi(ctx: RequestContext) {
      * `inviteToken` is required registration is invite-only. Does NOT set the
      * token; the caller persists it, then calls `setAuthToken`. */
     register: (email: string, username: string, password: string, inviteToken?: InviteToken) =>
-      ctx.post('/auth/register', AuthResult, {
-        auth: 'public',
-        body: { email, username, password, inviteToken },
-      }),
+      adoptMediaTicket(
+        ctx,
+        ctx.post('/auth/register', AuthResult, {
+          auth: 'public',
+          body: { email, username, password, inviteToken },
+        }),
+      ),
 
     /** Log in with email-or-username + password. */
     login: (identifier: string, password: string) =>
-      ctx.post('/auth/login', AuthResult, {
-        auth: 'public',
-        body: { email: identifier, password },
-      }),
+      adoptMediaTicket(
+        ctx,
+        ctx.post('/auth/login', AuthResult, {
+          auth: 'public',
+          body: { email: identifier, password },
+        }),
+      ),
 
     /** Exchange the long-lived access token for a short-lived session token. Pass
      * `pin` when switching into a PIN-locked profile (required on the first
      * exchange; silent refreshes omit it). Throws `KromaApiError` 401 when the PIN
      * is needed or the access token is invalid/expired. */
     exchangeToken: (accessToken: string, pin?: string) =>
-      ctx.post('/auth/token', SessionResult, { auth: 'public', body: { accessToken, pin } }),
+      adoptMediaTicket(
+        ctx,
+        ctx.post('/auth/token', SessionResult, { auth: 'public', body: { accessToken, pin } }),
+      ),
 
     /** Re-lock an access token (clear its PIN-verified flag) so the next exchange
      * re-prompts for the PIN. Called when returning to the profile picker. */
@@ -57,7 +67,10 @@ export default function accountsApi(ctx: RequestContext) {
 
     /** Invalidate the current session server-side and revoke the device's access
      * token, a full disconnect. */
-    logout: (accessToken?: string) => ctx.post('/auth/logout', { body: { accessToken } }),
+    logout: async (accessToken?: string) => {
+      ctx.setMediaTicket(undefined);
+      await ctx.post('/auth/logout', { body: { accessToken } });
+    },
 
     /** The currently-authenticated user (requires a token). */
     me: () => ctx.get('/auth/me', Me),

--- a/packages/client/src/api/accounts/passkeys.ts
+++ b/packages/client/src/api/accounts/passkeys.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { RequestContext } from '../../core/http';
+import { adoptMediaTicket, type RequestContext } from '../../core/http';
 import { CeremonyId, type PasskeyId } from './ids';
 import { AuthResult, PasskeyInfo } from './schemas';
 
@@ -41,6 +41,6 @@ export function passkeysApi(ctx: RequestContext) {
     /** Finish passwordless sign-in with the browser's assertion, giving the same
      * `{ token, accessToken, user }` as a password login. Public. */
     authFinish: (body: { ceremonyId: CeremonyId; credential: WebAuthnCredential }) =>
-      ctx.post('/auth/passkeys/authenticate/finish', AuthResult, { body }),
+      adoptMediaTicket(ctx, ctx.post('/auth/passkeys/authenticate/finish', AuthResult, { body })),
   };
 }

--- a/packages/client/src/api/accounts/quick-connect.ts
+++ b/packages/client/src/api/accounts/quick-connect.ts
@@ -1,4 +1,4 @@
-import { KromaApiError, type RequestContext } from '../../core/http';
+import { adoptMediaTicket, KromaApiError, type RequestContext } from '../../core/http';
 import { PairingStatus, QuickConnectInit } from './schemas';
 
 const PAIRING_SECRET_HEADER = 'x-kroma-pairing-secret';
@@ -7,13 +7,19 @@ function poller(ctx: RequestContext) {
   let legacy = false;
   return async (secret: string): Promise<PairingStatus> => {
     const withQuery = () =>
-      ctx.get('/auth/quickconnect/poll', PairingStatus, { auth: 'public', query: { secret } });
+      adoptMediaTicket(
+        ctx,
+        ctx.get('/auth/quickconnect/poll', PairingStatus, { auth: 'public', query: { secret } }),
+      );
     if (legacy) return withQuery();
     try {
-      return await ctx.get('/auth/quickconnect/poll', PairingStatus, {
-        auth: 'public',
-        headers: { [PAIRING_SECRET_HEADER]: secret },
-      });
+      return await adoptMediaTicket(
+        ctx,
+        ctx.get('/auth/quickconnect/poll', PairingStatus, {
+          auth: 'public',
+          headers: { [PAIRING_SECRET_HEADER]: secret },
+        }),
+      );
     } catch (e) {
       if (!(e instanceof KromaApiError) || e.status !== 400) throw e;
       const status = await withQuery();

--- a/packages/client/src/api/accounts/schemas.ts
+++ b/packages/client/src/api/accounts/schemas.ts
@@ -52,15 +52,18 @@ export const AuthConfig = z.object({
 });
 export type AuthConfig = z.infer<typeof AuthConfig>;
 
-/** `{ token, accessToken, user }` from register/login. */
+/** `{ token, accessToken, mediaTicket, user }` from register/login.
+ * `mediaTicket` is what the media byte routes take in a URL, for the players
+ * that cannot send a header; absent from a server too old to mint one. */
 export const AuthResult = z.object({
   token: z.string(),
   accessToken: z.string(),
+  mediaTicket: z.string().optional(),
   user: User,
 });
 export type AuthResult = z.infer<typeof AuthResult>;
 
-/** `{ token, user }` from `/auth/token` (session refresh/exchange). */
+/** `{ token, mediaTicket, user }` from `/auth/token` (session refresh/exchange). */
 export const SessionResult = AuthResult.omit({ accessToken: true });
 export type SessionResult = z.infer<typeof SessionResult>;
 

--- a/packages/client/src/api/handoff/client.ts
+++ b/packages/client/src/api/handoff/client.ts
@@ -1,4 +1,5 @@
 import type { RequestContext } from '../../core/client';
+import { adoptMediaTicket } from '../../core/http';
 import { PairingStatus } from '../accounts';
 import type { HandoffHandle } from './ids';
 import {
@@ -28,7 +29,10 @@ export default function handoffApi(ctx: RequestContext) {
      * is not a read (it refreshes the beacon and consumes the grant), and a URL
      * is written into every access log the request passes through. */
     poll: (secret: string) =>
-      ctx.post('/handoff/poll', PairingStatus, { auth: 'public', body: { secret } }),
+      adoptMediaTicket(
+        ctx,
+        ctx.post('/handoff/poll', PairingStatus, { auth: 'public', body: { secret } }),
+      ),
 
     /** The TVs waiting on this device's own network. Empty off it: the same
      * answer as "none waiting", which is all a caller may learn. (Bearer.) */

--- a/packages/client/src/api/media/artwork.test.ts
+++ b/packages/client/src/api/media/artwork.test.ts
@@ -36,6 +36,52 @@ describe('artwork resolution setting', () => {
   });
 });
 
+describe('a media-byte path the server composed itself', () => {
+  const SIGNED_IN_USER = {
+    id: 'u1',
+    email: 'a@b.c',
+    username: 'alice',
+    permissions: ['playback'],
+    createdAt: '2026-01-01T00:00:00Z',
+    hasPin: false,
+  };
+
+  async function ticketed() {
+    const { client: signedIn } = recordingClient(() => ({
+      json: { token: 'tok', mediaTicket: 'dev.999.sig', user: SIGNED_IN_USER },
+    }));
+    await signedIn.accounts.exchangeToken('access-token');
+    return signedIn.media.artwork;
+  }
+
+  it('gains the media ticket, keeping the query the server already wrote', async () => {
+    const art = await ticketed();
+
+    expect(art.resolve('/api/items/i1/storyboard.img?v=k')).toBe(
+      'http://kroma.test/api/items/i1/storyboard.img?v=k&t=dev.999.sig',
+    );
+    expect(art.resolve('/api/items/i1/subtitles/dl/d1.vtt')).toBe(
+      'http://kroma.test/api/items/i1/subtitles/dl/d1.vtt?t=dev.999.sig',
+    );
+  });
+
+  it('does not put the ticket on art, which is not library bytes', async () => {
+    const art = await ticketed();
+
+    expect(art.resolve('/api/images/p.webp', 480)).toBe(
+      'http://kroma.test/api/images/p.webp?w=480',
+    );
+    expect(art.resolve('/api/themes/1234.mp3')).toBe('http://kroma.test/api/themes/1234.mp3');
+    expect(art.resolve('https://image.tmdb.org/b.jpg')).toBe('https://image.tmdb.org/b.jpg');
+  });
+
+  it('is left ticketless before a sign-in has handed one over', () => {
+    expect(artwork.resolve('/api/items/i1/storyboard.img?v=k')).toBe(
+      'http://kroma.test/api/items/i1/storyboard.img?v=k',
+    );
+  });
+});
+
 describe('artworkWidth', () => {
   it('snaps to the ladder, so neighbouring cell widths share one URL', () => {
     expect(artworkWidth(203)).toBe(artworkWidth(219));

--- a/packages/client/src/api/media/artwork.ts
+++ b/packages/client/src/api/media/artwork.ts
@@ -4,6 +4,14 @@ import type { Metadata } from './credits';
 import type { ItemId, ShowId } from './ids';
 import type { MediaItem, Show } from './schemas';
 
+// A storyboard sheet and a generated subtitle are composed by the server and
+// handed over as relative paths, so they reach a player through here rather than
+// through a builder, and still need the credential it cannot send as a header.
+const isItemBytes = (url: string) => url.startsWith('/api/items/');
+
+const withParam = (url: string, name: string, value: string) =>
+  `${url}${url.includes('?') ? '&' : '?'}${name}=${value}`;
+
 /** Artwork URLs: resolving stored art against the server, at the size it is drawn. */
 export function artworkApi(ctx: RequestContext) {
   /** Resolve a metadata image URL against the server origin, at the size it will
@@ -14,9 +22,10 @@ export function artworkApi(ctx: RequestContext) {
   const resolve = (url?: string | null, width?: number): string | null => {
     if (!url) return null;
     if (/^https?:\/\//.test(url)) return url;
-    const join = url.includes('?') ? '&' : '?';
-    const sized = width ? `${url}${join}w=${artworkWidth(width)}` : url;
-    return `${ctx.baseUrl}${sized}`;
+    let path = width ? withParam(url, 'w', String(artworkWidth(width))) : url;
+    const held = ctx.mediaTicket();
+    if (held && isItemBytes(url)) path = withParam(path, 't', held);
+    return `${ctx.baseUrl}${path}`;
   };
 
   /** Generated SVG poster URL for a movie/episode. */

--- a/packages/client/src/api/media/client.test.ts
+++ b/packages/client/src/api/media/client.test.ts
@@ -117,6 +117,56 @@ describe('the URL builders, which make no request', () => {
   });
 });
 
+const SIGNED_IN_USER = {
+  id: 'u1',
+  email: 'a@b.c',
+  username: 'alice',
+  permissions: ['playback'],
+  createdAt: '2026-01-01T00:00:00Z',
+  hasPin: false,
+};
+
+/** A client that has signed in and so holds the media ticket its byte URLs carry. */
+async function ticketedClient(ticket = 'dev.999.sig') {
+  const { client } = recordingClient(() => ({
+    json: { token: 'tok', mediaTicket: ticket, user: SIGNED_IN_USER },
+  }));
+  await client.accounts.exchangeToken('access-token');
+  return client;
+}
+
+describe('the URLs a player fetches for itself', () => {
+  it('carries the account media ticket, because the element cannot send a header', async () => {
+    const client = await ticketedClient();
+
+    expect(client.media.streamUrl(item)).toBe(
+      'http://kroma.test/api/items/i1/stream?t=dev.999.sig',
+    );
+    expect(client.media.subtitleUrl(item, 2)).toBe(
+      'http://kroma.test/api/items/i1/subtitles/2.vtt?t=dev.999.sig',
+    );
+    expect(client.media.storyboardUrl(item)).toBe(
+      'http://kroma.test/api/items/i1/storyboard?t=dev.999.sig',
+    );
+    expect(client.media.hlsMasterUrl(item, false, 0, 0, { copyCodecs: ['aac'] })).toBe(
+      'http://kroma.test/api/items/i1/hls/copy/0/0/index.m3u8?copy=aac&t=dev.999.sig',
+    );
+  });
+
+  it('leaves the download alone: a plain fetch sends the bearer as a header', async () => {
+    const client = await ticketedClient();
+
+    expect(client.media.downloadUrl(item)).toBe('http://kroma.test/api/items/i1/download');
+  });
+
+  it('drops the ticket from every URL once the session is cleared', async () => {
+    const client = await ticketedClient();
+    client.setAuthToken(undefined);
+
+    expect(client.media.streamUrl(item)).toBe('http://kroma.test/api/items/i1/stream');
+  });
+});
+
 const SPLASH = {
   kind: 'movie',
   title: 'Dune',

--- a/packages/client/src/api/media/client.ts
+++ b/packages/client/src/api/media/client.ts
@@ -47,6 +47,8 @@ export function streamQuery({ copyCodecs, videoCodecs, maxFrame }: HlsMasterDecl
 const forMode = (mode: string, declaration: HlsMasterDeclaration) =>
   mode === 'copy' ? declaration : { ...declaration, copyCodecs: undefined };
 
+const ticket = (ctx: RequestContext): Query => ({ t: ctx.mediaTicket() });
+
 /** The catalogue: what the library holds, and the URLs that play it. */
 export default function mediaApi(ctx: RequestContext) {
   const artwork = artworkApi(ctx);
@@ -136,8 +138,10 @@ export default function mediaApi(ctx: RequestContext) {
     /** URL of the server's recent log lines (text/plain). */
     logsUrl: (tail = 200) => ctx.url('/logs', { query: { tail } }),
 
-    /** Direct-play stream URL for a `<video>` src. Range requests are served. */
-    streamUrl: (id: ItemId) => ctx.url('/items/:id/stream', { params: { id } }),
+    /** Direct-play stream URL for a `<video>` src. Range requests are served.
+     * Carries the account's media ticket, because the element fetching it cannot
+     * send a header. */
+    streamUrl: (id: ItemId) => ctx.url('/items/:id/stream', { params: { id }, query: ticket(ctx) }),
 
     /** One-file offline download: video stream-copied, every audio track copied
      * or AAC-transcoded server-side. `copyCodecs`/`videoCodecs` must distinguish
@@ -169,17 +173,18 @@ export default function mediaApi(ctx: RequestContext) {
           anchor: Math.max(0, Math.round(startSec)),
           audio: Math.max(0, Math.round(audio)),
         },
-        query: streamQuery(forMode(mode, declaration)),
+        query: { ...streamQuery(forMode(mode, declaration)), ...ticket(ctx) },
       });
     },
 
     /** WebVTT URL for the n-th embedded subtitle track. The server extracts text
      * subtitles on demand. */
     subtitleUrl: (id: ItemId, index: number) =>
-      ctx.url('/items/:id/subtitles/:index.vtt', { params: { id, index } }),
+      ctx.url('/items/:id/subtitles/:index.vtt', { params: { id, index }, query: ticket(ctx) }),
 
     /** Manifest endpoint for an item's storyboard. */
-    storyboardUrl: (id: ItemId) => ctx.url('/items/:id/storyboard', { params: { id } }),
+    storyboardUrl: (id: ItemId) =>
+      ctx.url('/items/:id/storyboard', { params: { id }, query: ticket(ctx) }),
 
     /** The storyboard manifest. The server generates the sheet lazily, so this
      * answers `'pending'` (HTTP 202) while it is being built and `null` when the

--- a/packages/client/src/core/http/adopt-media-ticket.test.ts
+++ b/packages/client/src/core/http/adopt-media-ticket.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { adoptMediaTicket } from './adopt-media-ticket';
+import type { RequestContext } from './request-context';
+
+function transport() {
+  let held: string | undefined;
+  const ctx = {
+    mediaTicket: () => held,
+    setMediaTicket: (ticket: string | undefined) => {
+      held = ticket;
+    },
+  } as RequestContext;
+  return { ctx, ticket: () => held };
+}
+
+describe('adopting the media ticket a sign-in answered with', () => {
+  it('hands the transport the ticket and the answer back untouched', async () => {
+    const { ctx, ticket } = transport();
+    const answer = { token: 'tok', mediaTicket: 'dev.999.sig' };
+
+    await expect(adoptMediaTicket(ctx, Promise.resolve(answer))).resolves.toBe(answer);
+
+    expect(ticket()).toBe('dev.999.sig');
+  });
+
+  it('leaves the held ticket alone when the answer carries none', async () => {
+    const { ctx, ticket } = transport();
+    ctx.setMediaTicket('dev.999.sig');
+
+    await adoptMediaTicket(ctx, Promise.resolve({ status: 'pending' }));
+    await adoptMediaTicket(ctx, Promise.resolve({ token: 'tok' }));
+    await adoptMediaTicket(ctx, Promise.resolve({ mediaTicket: '' }));
+
+    expect(ticket()).toBe('dev.999.sig');
+  });
+
+  it('adopts the one a pairing poll hands over once the device is authorized', async () => {
+    const { ctx, ticket } = transport();
+
+    await adoptMediaTicket(
+      ctx,
+      Promise.resolve({ status: 'authorized', token: 'tok', mediaTicket: 'dev.1.sig' }),
+    );
+
+    expect(ticket()).toBe('dev.1.sig');
+  });
+
+  it('lets a rejected sign-in through rather than swallowing it', async () => {
+    const { ctx, ticket } = transport();
+
+    await expect(adoptMediaTicket(ctx, Promise.reject(new Error('401')))).rejects.toThrow('401');
+
+    expect(ticket()).toBeUndefined();
+  });
+});

--- a/packages/client/src/core/http/adopt-media-ticket.ts
+++ b/packages/client/src/core/http/adopt-media-ticket.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+import type { RequestContext } from './request-context';
+
+const Ticketed = z.object({ mediaTicket: z.string().min(1) });
+
+/** Hand the transport the media ticket a sign-in answered with, so the URLs a
+ * player fetches for itself carry it, and pass the answer through untouched. An
+ * answer with no ticket in it leaves the held one alone: a poll that is still
+ * pending and a server too old to mint one are both silence, not a revocation. */
+export async function adoptMediaTicket<T>(ctx: RequestContext, signIn: Promise<T>): Promise<T> {
+  const answer = await signIn;
+  const ticketed = z.safeParse(Ticketed, answer);
+  if (ticketed.success) ctx.setMediaTicket(ticketed.data.mediaTicket);
+  return answer;
+}

--- a/packages/client/src/core/http/index.ts
+++ b/packages/client/src/core/http/index.ts
@@ -1,3 +1,4 @@
+export * from './adopt-media-ticket';
 export * from './api-error';
 export * from './path';
 export * from './preconnect';

--- a/packages/client/src/core/http/request-context.test.ts
+++ b/packages/client/src/core/http/request-context.test.ts
@@ -44,12 +44,17 @@ function transport(
     } as unknown as Response;
   }) as typeof globalThis.fetch;
 
+  let ticket: string | undefined;
   const ctx = createRequestContext({
     baseUrl: 'http://kroma.test',
     fetchFn,
     token: () => 'tok',
     locale: () => 'fr',
     refresh: async () => undefined,
+    mediaTicket: () => ticket,
+    setMediaTicket: (next) => {
+      ticket = next;
+    },
     ...config,
   });
   return { ctx, calls };
@@ -234,6 +239,8 @@ describe('an abort signal', () => {
       token: () => undefined,
       locale: () => undefined,
       refresh: async () => undefined,
+      mediaTicket: () => undefined,
+      setMediaTicket: () => undefined,
     });
 
     await ctx.get('/items/:id', Item, { params: { id: 'i1' }, signal: controller.signal });
@@ -258,6 +265,8 @@ describe('concurrency policy', () => {
       token: () => undefined,
       locale: () => undefined,
       refresh: async () => undefined,
+      mediaTicket: () => undefined,
+      setMediaTicket: () => undefined,
     });
     return { ctx, aborted, calls: () => calls };
   }

--- a/packages/client/src/core/http/request-context.ts
+++ b/packages/client/src/core/http/request-context.ts
@@ -67,6 +67,13 @@ export interface RequestContext {
   /** The absolute URL, for what fetches itself: a `<video>` src, an `<img>`, the
    * native downloader, a link the user opens. */
   url<const P extends string>(path: P, ...args: PathArgs<P>): string;
+  /** The credential the media byte routes take in a URL, for the players that
+   * cannot send a header. Undefined until a sign-in has handed one over, and
+   * against a server too old to mint one. */
+  mediaTicket(): string | undefined;
+  /** Adopt the ticket a sign-in answered with, or clear it with `undefined`. The
+   * accounts domain calls this; nothing else does. */
+  setMediaTicket(ticket: string | undefined): void;
   get: Verb;
   post: Verb;
   put: Verb;
@@ -100,6 +107,8 @@ export interface TransportConfig {
   locale(): string | undefined;
   /** Mint a fresh bearer after a 401, or resolve undefined to give up. */
   refresh(): Promise<string | undefined>;
+  mediaTicket(): string | undefined;
+  setMediaTicket(ticket: string | undefined): void;
   /** Aborts every request this context makes unless the call named its own.
    * A query adapter builds one context per fetch and hands it the runner's
    * signal, so an endpoint needs no signal parameter of its own. */
@@ -212,6 +221,8 @@ export function createRequestContext(config: TransportConfig): RequestContext {
   return {
     baseUrl,
     url: (template, ...args) => `${baseUrl}/api${resolve(template, args[0])}`,
+    mediaTicket: config.mediaTicket,
+    setMediaTicket: config.setMediaTicket,
     get: ((path: string, ...rest: unknown[]) => {
       const { response, options } = split(rest);
       const target = resolve(path, options);

--- a/packages/client/src/kroma-client.ts
+++ b/packages/client/src/kroma-client.ts
@@ -34,9 +34,10 @@ export interface ClientControls {
    * carries it as a subprotocol. */
   readonly sessionToken: string | undefined;
   /** For requests that bypass the transport because the platform owns the
-   * socket (the native downloader behind `media.downloadUrl`); media-element
-   * URLs need nothing, since those routes are public because a `<video>` cannot
-   * send a header. */
+   * socket (the native downloader behind `media.downloadUrl`). A media-element
+   * URL needs nothing here: `media.streamUrl` and its siblings carry the
+   * account's media ticket in the URL instead, because a `<video>` cannot send
+   * a header. */
   authHeaders(): Record<string, string>;
 }
 
@@ -57,10 +58,12 @@ export function kromaClientParts(options: KromaClientOptions): {
   const base = options.fetch ?? globalThis.fetch.bind(globalThis);
   let authToken = options.authToken;
   let locale = options.locale;
+  let mediaTicket: string | undefined;
   let refreshHandler: (() => Promise<string | undefined>) | undefined;
 
   const setAuthToken = (token?: string): void => {
     authToken = token;
+    if (!token) mediaTicket = undefined;
     setSessionToken(token);
   };
 
@@ -76,6 +79,10 @@ export function kromaClientParts(options: KromaClientOptions): {
     token: () => authToken,
     locale: () => locale,
     refresh: refreshSession,
+    mediaTicket: () => mediaTicket,
+    setMediaTicket: (ticket) => {
+      mediaTicket = ticket;
+    },
   };
   preconnect(baseUrl);
 

--- a/server/crates/kroma-db/src/accounts/access_tokens.rs
+++ b/server/crates/kroma-db/src/accounts/access_tokens.rs
@@ -133,6 +133,32 @@ pub fn access_token_user(pool: &Pool, token: &str) -> Result<Option<(User, bool)
     }
 }
 
+/// The user behind a live device credential named by its non-secret
+/// `short_hash(token)` id, the form a credential carried in a URL can spell.
+/// `None` once the device is revoked, its credential has lapsed, or the account
+/// is gone, so a URL-borne ticket stops working the moment the device does.
+///
+/// Tokens are only reversible by hashing, so the live rows are scanned; there is
+/// one per signed-in device on the server.
+pub fn access_token_user_by_id(pool: &Pool, id: &str) -> Result<Option<User>> {
+    let conn = pool.get()?;
+    let now = time::OffsetDateTime::now_utc().unix_timestamp();
+    let mut stmt = conn.prepare(
+        "SELECT u.id,u.email,u.username,u.avatar_url,u.created_at,u.permissions,u.language,(u.pin_hash IS NOT NULL),u.audio_language,u.subtitle_language,u.libraries,a.token \
+         FROM access_tokens a JOIN users u ON u.id = a.user_id WHERE a.expires_at > ?1",
+    )?;
+    let rows = stmt.query_map(params![now], |r| {
+        Ok((row_to_user(r)?, r.get::<_, String>(11)?))
+    })?;
+    for row in rows {
+        let (user, token) = row?;
+        if kroma_primitives::short_hash(&token) == id {
+            return Ok(Some(user));
+        }
+    }
+    Ok(None)
+}
+
 /// Stamp a device credential as seen now, re-labelling it with whatever the
 /// caller sent this time; an absent header keeps the stored label rather than
 /// blanking it.
@@ -245,6 +271,29 @@ mod tests {
 
         delete_access_token(&p, "at1").unwrap();
         assert!(access_token_user(&p, "at1").unwrap().is_none());
+    }
+
+    #[test]
+    fn a_device_id_resolves_to_its_account_until_the_device_is_revoked() {
+        let p = pool();
+        let alice = mk_user(&p, "a@b.c", "alice");
+        create_access_token(&p, "at-alice", &alice.id, FUTURE, true, &ua("iPhone")).unwrap();
+        create_access_token(&p, "lapsed", &alice.id, 1, true, &ua("Tizen")).unwrap();
+        let id = kroma_primitives::short_hash("at-alice");
+
+        let found = access_token_user_by_id(&p, &id).unwrap();
+
+        assert_eq!(found.map(|u| u.id), Some(alice.id.clone()));
+        assert!(access_token_user_by_id(&p, "deadbeefdeadbeef")
+            .unwrap()
+            .is_none());
+        assert!(
+            access_token_user_by_id(&p, &kroma_primitives::short_hash("lapsed"))
+                .unwrap()
+                .is_none()
+        );
+        delete_access_token(&p, "at-alice").unwrap();
+        assert!(access_token_user_by_id(&p, &id).unwrap().is_none());
     }
 
     #[test]

--- a/server/crates/kroma-engine/src/services/auth.rs
+++ b/server/crates/kroma-engine/src/services/auth.rs
@@ -22,7 +22,7 @@ pub const SESSION_TTL_SECS: i64 = 3600;
 pub const ACCESS_TTL_SECS: i64 = 90 * 24 * 3600;
 
 // HMAC-SHA256 (RFC 2104) over `msg` keyed by `key`.
-fn hmac_sha256(key: &[u8], msg: &[u8]) -> [u8; 32] {
+pub(crate) fn hmac_sha256(key: &[u8], msg: &[u8]) -> [u8; 32] {
     let mut k = [0u8; SHA256_BLOCK];
     if key.len() > SHA256_BLOCK {
         let mut h = Sha256::new();

--- a/server/crates/kroma-engine/src/services/media_ticket.rs
+++ b/server/crates/kroma-engine/src/services/media_ticket.rs
@@ -17,19 +17,23 @@ use super::settings::Settings;
 /// same day.
 pub const TTL_SECS: i64 = 12 * 3600;
 
-const KEY_SETTING: &str = "mediaTicketKey";
+/// Where the signing key is persisted. Declared `core_only` in
+/// [`super::settings::keys`], which is what keeps the module host callback from
+/// handing it to a sidecar: anyone holding it forges a ticket for any device.
+pub const SIGNING_KEY_SETTING: &str = "mediaTicketKey";
+
 const SIG_HEX_LEN: usize = 32;
 
 /// The per-install signing key, minted on first use and persisted with the
-/// settings. Never served: it is stored through [`Settings::set_internal`], so no
-/// admin response and no settings patch can read or write it.
+/// settings. It reaches no response: it sits in no admin settings group, and the
+/// module host callback withholds it.
 pub fn signing_key(settings: &Settings, pool: &Pool) -> String {
-    let existing = settings.get_str(KEY_SETTING, "");
+    let existing = settings.get_str(SIGNING_KEY_SETTING, "");
     if !existing.trim().is_empty() {
         return existing;
     }
     let key = super::auth::random_token();
-    settings.set_internal(pool, KEY_SETTING, json!(key.clone()));
+    settings.set_internal(pool, SIGNING_KEY_SETTING, json!(key.clone()));
     key
 }
 

--- a/server/crates/kroma-engine/src/services/media_ticket.rs
+++ b/server/crates/kroma-engine/src/services/media_ticket.rs
@@ -1,0 +1,172 @@
+//! The credential a media byte request carries in its URL, for the players that
+//! cannot send a header: a `<video>` element, hls.js, AVPlay, mpv.
+//!
+//! A ticket names the device it was minted for and expires on its own. It is not
+//! a bearer: it proves which signed-in device asked, and the library grant is
+//! still read from the database on every request, so narrowing a grant takes
+//! effect at once.
+
+use serde_json::json;
+
+use crate::db::Pool;
+
+use super::settings::Settings;
+
+/// Long enough to outlast a feature film answered from one `<video src>`, short
+/// enough that a URL copied out of a log or a browser history stops working the
+/// same day.
+pub const TTL_SECS: i64 = 12 * 3600;
+
+const KEY_SETTING: &str = "mediaTicketKey";
+const SIG_HEX_LEN: usize = 32;
+
+/// The per-install signing key, minted on first use and persisted with the
+/// settings. Never served: it is stored through [`Settings::set_internal`], so no
+/// admin response and no settings patch can read or write it.
+pub fn signing_key(settings: &Settings, pool: &Pool) -> String {
+    let existing = settings.get_str(KEY_SETTING, "");
+    if !existing.trim().is_empty() {
+        return existing;
+    }
+    let key = super::auth::random_token();
+    settings.set_internal(pool, KEY_SETTING, json!(key.clone()));
+    key
+}
+
+/// A ticket for the device behind `access_token`, valid for [`TTL_SECS`]. Handed
+/// out beside every session token, so a client holds one the moment it holds a
+/// session.
+pub fn for_access_token(key: &str, access_token: &str) -> String {
+    let now = time::OffsetDateTime::now_utc().unix_timestamp();
+    mint(key, &kroma_primitives::short_hash(access_token), now)
+}
+
+/// A ticket for `device_id` (the non-secret `short_hash` of a device's access
+/// token) valid for [`TTL_SECS`] from `now`.
+pub fn mint(key: &str, device_id: &str, now: i64) -> String {
+    let expires_at = now + TTL_SECS;
+    let claim = format!("{device_id}.{expires_at}");
+    let signature = sign(key, &claim);
+    format!("{claim}.{signature}")
+}
+
+/// The device a live, correctly signed `ticket` was minted for, or `None` for one
+/// that is malformed, forged or past its expiry.
+pub fn device_of(key: &str, ticket: &str, now: i64) -> Option<String> {
+    let (claim, signature) = ticket.rsplit_once('.')?;
+    let (device_id, expires_at) = claim.split_once('.')?;
+    if device_id.is_empty() || !device_id.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return None;
+    }
+    if !equal_in_constant_time(signature, &sign(key, claim)) {
+        return None;
+    }
+    if expires_at.parse::<i64>().ok()? <= now {
+        return None;
+    }
+    Some(device_id.to_string())
+}
+
+fn sign(key: &str, claim: &str) -> String {
+    let mac = super::auth::hmac_sha256(key.as_bytes(), claim.as_bytes());
+    hex::encode(mac)[..SIG_HEX_LEN].to_string()
+}
+
+// A signature compared byte by byte leaks how much of a forgery was right, which
+// is enough to recover the rest one request at a time.
+fn equal_in_constant_time(a: &str, b: &str) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.bytes()
+        .zip(b.bytes())
+        .fold(0u8, |acc, (x, y)| acc | (x ^ y))
+        == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const KEY: &str = "0123456789abcdef0123456789abcdef";
+    const DEVICE: &str = "a1b2c3d4e5f60718";
+    const NOW: i64 = 1_700_000_000;
+
+    #[test]
+    fn a_freshly_minted_ticket_names_the_device_it_was_minted_for() {
+        let ticket = mint(KEY, DEVICE, NOW);
+
+        assert_eq!(device_of(KEY, &ticket, NOW).as_deref(), Some(DEVICE));
+    }
+
+    #[test]
+    fn a_ticket_for_an_access_token_names_the_device_that_token_is() {
+        let ticket = for_access_token(KEY, "an-access-token");
+        let now = time::OffsetDateTime::now_utc().unix_timestamp();
+
+        assert_eq!(
+            device_of(KEY, &ticket, now).as_deref(),
+            Some(kroma_primitives::short_hash("an-access-token").as_str())
+        );
+    }
+
+    #[test]
+    fn a_ticket_outlives_a_feature_film_and_not_the_day() {
+        let ticket = mint(KEY, DEVICE, NOW);
+
+        assert!(device_of(KEY, &ticket, NOW + 3 * 3600).is_some());
+        assert!(device_of(KEY, &ticket, NOW + TTL_SECS - 1).is_some());
+        assert!(device_of(KEY, &ticket, NOW + TTL_SECS).is_none());
+    }
+
+    #[test]
+    fn a_ticket_signed_by_another_install_is_refused() {
+        let ticket = mint("a-different-key", DEVICE, NOW);
+
+        assert!(device_of(KEY, &ticket, NOW).is_none());
+    }
+
+    #[test]
+    fn neither_half_of_a_ticket_can_be_edited_without_breaking_it() {
+        let ticket = mint(KEY, DEVICE, NOW);
+        let (claim, signature) = ticket.rsplit_once('.').expect("a signed ticket");
+        let (_device, expires_at) = claim.split_once('.').expect("a device and an expiry");
+
+        let other_device = format!("ffffffffffffffff.{expires_at}.{signature}");
+        let later = format!("{DEVICE}.{}.{signature}", NOW + 10 * TTL_SECS);
+
+        assert!(device_of(KEY, &other_device, NOW).is_none());
+        assert!(device_of(KEY, &later, NOW).is_none());
+    }
+
+    #[test]
+    fn nothing_shaped_unlike_a_ticket_resolves_to_a_device() {
+        for malformed in [
+            "",
+            ".",
+            "..",
+            "no-dots",
+            &format!(
+                "{DEVICE}.notanumber.{}",
+                sign(KEY, &format!("{DEVICE}.notanumber"))
+            ),
+            &format!("nothex.{NOW}.{}", sign(KEY, &format!("nothex.{NOW}"))),
+            &format!(".{NOW}.{}", sign(KEY, &format!(".{NOW}"))),
+        ] {
+            assert!(
+                device_of(KEY, malformed, NOW).is_none(),
+                "{malformed:?} should not resolve"
+            );
+        }
+    }
+
+    #[test]
+    fn a_signature_of_the_wrong_length_is_refused_before_it_is_compared() {
+        let ticket = mint(KEY, DEVICE, NOW);
+        let truncated = &ticket[..ticket.len() - 1];
+
+        assert!(device_of(KEY, truncated, NOW).is_none());
+        assert!(!equal_in_constant_time("abc", "ab"));
+        assert!(equal_in_constant_time("abc", "abc"));
+    }
+}

--- a/server/crates/kroma-engine/src/services/mod.rs
+++ b/server/crates/kroma-engine/src/services/mod.rs
@@ -14,6 +14,7 @@ pub mod library_missing;
 pub mod llm;
 pub mod loginguard;
 pub mod markers;
+pub mod media_ticket;
 pub mod notify;
 pub mod pairing;
 pub mod pipeline;

--- a/server/crates/kroma-engine/src/services/settings/keys.rs
+++ b/server/crates/kroma-engine/src/services/settings/keys.rs
@@ -215,6 +215,10 @@ fn declared() -> Declared {
     m.core_only("notifications.apns.keyId", json!(""));
     m.core_only("notifications.apns.teamId", json!(""));
     m.core_only("notifications.fcm.serviceAccount", json!(""));
+    // Signs the media tickets the byte routes accept in a URL (ACCT-35). Minted on
+    // first boot, and the core's alone: a sidecar holding it forges a ticket for
+    // any device and reads any library.
+    m.core_only("mediaTicketKey", json!(""));
     // Operator SMTP for credential-reset email.
     m.insert("smtpEnabled".into(), json!(false));
     m.insert("smtpHost".into(), json!(""));

--- a/server/crates/kroma-engine/src/services/settings/keys/tests.rs
+++ b/server/crates/kroma-engine/src/services/settings/keys/tests.rs
@@ -73,6 +73,17 @@ fn the_mail_llm_push_and_registry_keys_are_the_cores_alone() {
     }
 }
 
+// The word sweep above cannot reach this one: "mediaTicketKey" carries no
+// password, token, secret or credential word, so only a named case keeps it
+// declared.
+#[test]
+fn the_key_that_signs_a_media_ticket_is_the_cores_alone() {
+    let key = crate::services::media_ticket::SIGNING_KEY_SETTING;
+
+    assert!(core_only(key), "{key} forges a ticket for any device");
+    assert!(!reads_like_a_credential(key), "the sweep would cover it");
+}
+
 #[test]
 fn a_credential_the_sidecar_that_uses_it_configures_stays_reachable() {
     assert!(!core_only("vpnWgConfig"));

--- a/server/crates/kroma-engine/src/services/settings/store.rs
+++ b/server/crates/kroma-engine/src/services/settings/store.rs
@@ -75,8 +75,9 @@ impl Settings {
     ///
     /// [`Self::set_patch`] takes its keys from an HTTP body, so it writes only
     /// what `defaults` declares. Identity the server mints for itself is not a
-    /// preference and must not be settable by a caller, so it is stored through
-    /// here and stays out of `defaults` on purpose.
+    /// preference, so it is written through here and cannot be lost to a missing
+    /// declaration. A minted value that must also be withheld from a sidecar
+    /// still declares its reach in [`super::keys`]; writing it here does not.
     pub fn set_internal(&self, pool: &Pool, key: &str, value: Value) {
         let _ = crate::db::settings_set(pool, key, &value);
         self.inner.write().unwrap().insert(key.to_string(), value);

--- a/server/crates/kroma-engine/src/state.rs
+++ b/server/crates/kroma-engine/src/state.rs
@@ -70,6 +70,8 @@ pub struct AppState {
     pub jobs: Arc<JobManager>,
     pub subtitle_gen: Arc<GenRegistry>,
     pub instance_id: String,
+    // Signs the media tickets the byte routes accept in a URL. Never served.
+    pub media_ticket_key: String,
     // Semaphore for offline-download remuxes; a full gate returns `503`
     // rather than queueing, since a permit is held for the whole transfer.
     pub downloads: Arc<tokio::sync::Semaphore>,
@@ -129,6 +131,7 @@ impl AppState {
         // Mint (or read back) this install's stable identity before anything can
         // serve `/api/health`.
         let instance_id = crate::services::settings::ensure_instance_id(&settings, &db);
+        let media_ticket_key = crate::services::media_ticket::signing_key(&settings, &db);
         // Minted here rather than on the statistics job's first run: the settings
         // page shows it and an operator quotes it to have their row erased, so it
         // has to exist from the moment the feature is on rather than an hour later.
@@ -195,6 +198,7 @@ impl AppState {
             jobs: Arc::new(jobs),
             subtitle_gen: Arc::new(GenRegistry::default()),
             instance_id,
+            media_ticket_key,
             downloads,
             me: weak.clone(),
             contributions,

--- a/server/src/api/accounts/quick_connect.rs
+++ b/server/src/api/accounts/quick_connect.rs
@@ -120,7 +120,10 @@ pub async fn quick_poll(
         .map(str::to_string)
         .or(q.secret)
         .unwrap_or_default();
-    let status = crate::api::dto::PairingPoll::from(state.quickconnect.poll(&secret));
+    let status = crate::api::dto::PairingPoll::of(
+        state.quickconnect.poll(&secret),
+        &state.media_ticket_key,
+    );
     // A code that lapsed after it was approved still has rows behind it.
     drop_orphans(&state, state.quickconnect.take_orphans()).await;
     Json(status).into_response()

--- a/server/src/api/accounts/session.rs
+++ b/server/src/api/accounts/session.rs
@@ -137,7 +137,12 @@ pub async fn exchange_token(
     {
         return resp;
     }
-    Json(crate::api::dto::SessionResult { token, user }).into_response()
+    Json(crate::api::dto::SessionResult {
+        media_ticket: crate::services::media_ticket::for_access_token(&state.media_ticket_key, &access),
+        token,
+        user,
+    })
+    .into_response()
 }
 
 async fn enforce_pin_gate(
@@ -284,6 +289,7 @@ pub(crate) async fn issue_tokens(
     })
     .await;
     Json(crate::api::dto::AuthResult {
+        media_ticket: crate::services::media_ticket::for_access_token(&state.media_ticket_key, &access),
         token,
         access_token: access,
         user,

--- a/server/src/api/dto.rs
+++ b/server/src/api/dto.rs
@@ -29,22 +29,28 @@ pub struct Health {
     pub shows: usize,
 }
 
-/// `{ token, accessToken, user }` returned by register/login. `token` is the
-/// short-lived session bearer; `accessToken` is the long-lived device credential
-/// the client stores and later exchanges (see `/auth/token`).
+/// `{ token, accessToken, mediaTicket, user }` returned by register/login.
+/// `token` is the short-lived session bearer; `accessToken` is the long-lived
+/// device credential the client stores and later exchanges (see `/auth/token`);
+/// `mediaTicket` is what the byte routes take in a URL, for the players that
+/// cannot send a header.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AuthResult {
     pub token: String,
     pub access_token: String,
+    pub media_ticket: String,
     pub user: User,
 }
 
-/// `{ token, user }` from `/auth/token` a fresh session minted from an access
-/// token (the access token itself is unchanged, so it isn't echoed back).
+/// `{ token, mediaTicket, user }` from `/auth/token` a fresh session minted from
+/// an access token (the access token itself is unchanged, so it isn't echoed
+/// back).
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SessionResult {
     pub token: String,
+    pub media_ticket: String,
     pub user: User,
 }
 
@@ -148,18 +154,25 @@ pub enum PairingPoll {
     Authorized {
         token: String,
         access_token: String,
+        media_ticket: String,
         user: Box<User>,
     },
 }
 
-impl From<PollState> for PairingPoll {
-    fn from(state: PollState) -> Self {
-        match state {
+impl PairingPoll {
+    /// The answer a waiting device gets, carrying a media ticket for the device
+    /// this grant belongs to once there is a grant to collect.
+    pub fn of(poll: PollState, signing_key: &str) -> Self {
+        match poll {
             PollState::Authorized {
                 token,
                 access_token,
                 user,
             } => Self::Authorized {
+                media_ticket: crate::services::media_ticket::for_access_token(
+                    signing_key,
+                    &access_token,
+                ),
                 token,
                 access_token,
                 user,

--- a/server/src/api/extract.rs
+++ b/server/src/api/extract.rs
@@ -7,7 +7,7 @@ use axum::http::StatusCode;
 use axum::response::Response;
 use kroma_module_host::json_error;
 
-pub use kroma_module_host::{bearer_from_headers, AuthUser, OptionalAuthUser};
+pub use kroma_module_host::{bearer_from_headers, AuthUser};
 
 /// The token a request authenticated with, for the handlers that must name the
 /// caller's own session rather than merely its user - revoking every *other*

--- a/server/src/api/handoff.rs
+++ b/server/src/api/handoff.rs
@@ -225,7 +225,8 @@ pub async fn leave(State(state): State<SharedState>, Json(body): Json<SecretBody
 /// past (`TraceLayer`'s span records the uri, and every reverse proxy logs it by
 /// default), which is not where a credential redeeming a 90-day token belongs.
 pub async fn poll(State(state): State<SharedState>, Json(body): Json<SecretBody>) -> Response {
-    let status = super::dto::PairingPoll::from(state.handoff.poll(&body.secret));
+    let status =
+        super::dto::PairingPoll::of(state.handoff.poll(&body.secret), &state.media_ticket_key);
     sweep(&state, []).await;
     Json(status).into_response()
 }

--- a/server/src/api/it_host_settings.rs
+++ b/server/src/api/it_host_settings.rs
@@ -49,6 +49,43 @@ async fn a_stored_operator_credential_never_reaches_a_sidecar() {
 }
 
 #[tokio::test]
+async fn the_key_that_signs_a_media_ticket_never_reaches_a_sidecar() {
+    let t = test_app();
+    let minted = t.state.media_ticket_key.clone();
+    let key = crate::services::media_ticket::SIGNING_KEY_SETTING;
+
+    let uri = format!("/api/_host/setting?key={key}&kind=str&default=");
+    let (status, body) = get(&t.app, &uri, Some(HOST_TOKEN)).await;
+
+    assert!(!minted.is_empty(), "the key is minted at boot");
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, json!({ "value": "" }));
+    assert!(
+        !body.to_string().contains(&minted),
+        "a sidecar holding it forges a ticket for any device"
+    );
+}
+
+#[tokio::test]
+async fn a_sidecar_cannot_put_a_signing_key_of_its_own_choosing_in_place() {
+    let t = test_app();
+    let minted = t.state.media_ticket_key.clone();
+    let key = crate::services::media_ticket::SIGNING_KEY_SETTING;
+
+    let (status, _) = send(
+        &t.app,
+        "POST",
+        "/api/_host/settings",
+        Some(HOST_TOKEN),
+        Some(json!({ "patch": { key: "a-key-the-module-knows" } })),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(t.state.settings.get_str(key, ""), minted);
+}
+
+#[tokio::test]
 async fn the_settings_a_module_runs_on_still_come_back_stored() {
     let t = test_app();
     t.state.settings.set_patch(

--- a/server/src/api/it_media_ticket.rs
+++ b/server/src/api/it_media_ticket.rs
@@ -1,0 +1,299 @@
+use axum::http::header::{CONTENT_LENGTH, CONTENT_RANGE};
+use axum::http::StatusCode;
+
+use crate::api::test_support::{
+    demo_item_id, demo_library_ids, grant_libraries, media_ticket_for, raw, seed_playable_item,
+    seed_session, test_app, TestApp,
+};
+use crate::model::Permission;
+use crate::services::media_ticket;
+
+const FILM: &[u8] = b"0123456789abcdefghijklmnopqrstuvwxyz";
+
+struct Household {
+    app: TestApp,
+    viewer: String,
+    ticket: String,
+    episode: String,
+}
+
+fn household_where_the_viewer_only_sees_films() -> Household {
+    let app = test_app();
+    let (viewer_id, viewer) = seed_session(
+        &app.state,
+        "viewer@test.dev",
+        "viewer",
+        &[Permission::Playback],
+    );
+    let (movies_lib, _shows_lib) = demo_library_ids();
+    grant_libraries(&app.state, &viewer_id, &[movies_lib]);
+    let ticket = media_ticket_for(&app.state, &viewer);
+
+    Household {
+        app,
+        viewer,
+        ticket,
+        episode: demo_item_id("Islands"),
+    }
+}
+
+fn byte_routes(item: &str) -> Vec<String> {
+    vec![
+        format!("/api/items/{item}/stream"),
+        format!("/api/items/{item}/hls/copy/0/0/index.m3u8"),
+        format!("/api/items/{item}/hls/copy/0/0/init.mp4"),
+        format!("/api/items/{item}/storyboard"),
+        format!("/api/items/{item}/storyboard.img"),
+        format!("/api/items/{item}/subtitles/0"),
+        format!("/api/items/{item}/subtitles/dl/anything.vtt"),
+    ]
+}
+
+fn ticketed(uri: &str, ticket: &str) -> String {
+    let join = if uri.contains('?') { '&' } else { '?' };
+    format!("{uri}{join}t={ticket}")
+}
+
+fn device_of(h: &Household) -> String {
+    crate::db::session_device_id(&h.app.state.db, &h.viewer)
+        .expect("read the session's device")
+        .expect("a session minted from an access token")
+}
+
+#[tokio::test]
+async fn a_request_for_bytes_that_carries_no_credential_at_all_is_refused() {
+    let h = household_where_the_viewer_only_sees_films();
+    let granted = seed_playable_item(&h.app.state, "Granted", FILM);
+
+    for uri in byte_routes(&granted) {
+        let (status, _headers, _) = raw(&h.app.app, "GET", &uri, None, None, &[]).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED, "{uri} should refuse");
+    }
+}
+
+#[tokio::test]
+async fn a_ticket_reaches_the_bytes_of_a_title_its_account_was_granted() {
+    let h = household_where_the_viewer_only_sees_films();
+    let granted = seed_playable_item(&h.app.state, "Granted", FILM);
+
+    let (status, headers, _) = raw(
+        &h.app.app,
+        "GET",
+        &ticketed(&format!("/api/items/{granted}/stream"), &h.ticket),
+        None,
+        None,
+        &[],
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(headers[CONTENT_LENGTH], FILM.len().to_string());
+}
+
+#[tokio::test]
+async fn a_ticket_does_not_reach_a_title_outside_its_accounts_grant() {
+    let h = household_where_the_viewer_only_sees_films();
+
+    for uri in byte_routes(&h.episode) {
+        let (status, _headers, _) = raw(
+            &h.app.app,
+            "GET",
+            &ticketed(&uri, &h.ticket),
+            None,
+            None,
+            &[],
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND, "{uri} should refuse");
+    }
+}
+
+#[tokio::test]
+async fn each_accounts_ticket_carries_that_accounts_grant_and_no_other() {
+    let t = test_app();
+    let (films_id, films_viewer) = seed_session(&t.state, "films@test.dev", "films", &[]);
+    let (series_id, series_viewer) = seed_session(&t.state, "series@test.dev", "series", &[]);
+    let (movies_lib, shows_lib) = demo_library_ids();
+    grant_libraries(&t.state, &films_id, &[movies_lib]);
+    grant_libraries(&t.state, &series_id, &[shows_lib]);
+    let episode = demo_item_id("Islands");
+    let film = seed_playable_item(&t.state, "Granted", FILM);
+
+    let films_ticket = media_ticket_for(&t.state, &films_viewer);
+    let series_ticket = media_ticket_for(&t.state, &series_viewer);
+    let film_uri = format!("/api/items/{film}/stream");
+    let episode_uri = format!("/api/items/{episode}/storyboard");
+
+    let (own, _, _) = raw(
+        &t.app,
+        "GET",
+        &ticketed(&film_uri, &films_ticket),
+        None,
+        None,
+        &[],
+    )
+    .await;
+    let (borrowed, _, _) = raw(
+        &t.app,
+        "GET",
+        &ticketed(&film_uri, &series_ticket),
+        None,
+        None,
+        &[],
+    )
+    .await;
+    let (theirs, _, _) = raw(
+        &t.app,
+        "GET",
+        &ticketed(&episode_uri, &films_ticket),
+        None,
+        None,
+        &[],
+    )
+    .await;
+
+    assert_eq!(own, StatusCode::OK);
+    assert_eq!(borrowed, StatusCode::NOT_FOUND);
+    assert_eq!(theirs, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn a_ticket_that_has_run_out_is_refused() {
+    let h = household_where_the_viewer_only_sees_films();
+    let granted = seed_playable_item(&h.app.state, "Granted", FILM);
+    let long_ago = time::OffsetDateTime::now_utc().unix_timestamp() - media_ticket::TTL_SECS - 1;
+    let lapsed = media_ticket::mint(&h.app.state.media_ticket_key, &device_of(&h), long_ago);
+
+    let uri = ticketed(&format!("/api/items/{granted}/stream"), &lapsed);
+    let (status, _headers, _) = raw(&h.app.app, "GET", &uri, None, None, &[]).await;
+
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn a_ticket_this_install_never_signed_is_refused() {
+    let h = household_where_the_viewer_only_sees_films();
+    let granted = seed_playable_item(&h.app.state, "Granted", FILM);
+    let device = device_of(&h);
+    let now = time::OffsetDateTime::now_utc().unix_timestamp();
+
+    for ticket in [
+        media_ticket::mint("a-key-this-install-never-held", &device, now),
+        format!("{device}.9999999999.0123456789abcdef0123456789abcdef"),
+        "nonsense".to_string(),
+    ] {
+        let uri = ticketed(&format!("/api/items/{granted}/stream"), &ticket);
+        let (status, _headers, _) = raw(&h.app.app, "GET", &uri, None, None, &[]).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED, "{ticket} should refuse");
+    }
+}
+
+#[tokio::test]
+async fn a_ticket_a_revoked_device_left_behind_stops_working() {
+    let h = household_where_the_viewer_only_sees_films();
+    let granted = seed_playable_item(&h.app.state, "Granted", FILM);
+    let uri = ticketed(&format!("/api/items/{granted}/stream"), &h.ticket);
+    let (before, _headers, _) = raw(&h.app.app, "GET", &uri, None, None, &[]).await;
+
+    let viewer_id = crate::db::session_user(&h.app.state.db, &h.viewer)
+        .expect("read the session")
+        .expect("a live session")
+        .id;
+    let revoked =
+        crate::db::delete_access_token_by_id(&h.app.state.db, &viewer_id, &device_of(&h)).unwrap();
+    let (after, _headers, _) = raw(&h.app.app, "GET", &uri, None, None, &[]).await;
+
+    assert_eq!(before, StatusCode::OK);
+    assert!(revoked);
+    assert_eq!(after, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn a_range_request_partway_through_a_film_is_answered_for_the_same_ticket() {
+    let h = household_where_the_viewer_only_sees_films();
+    let granted = seed_playable_item(&h.app.state, "Granted", FILM);
+    let uri = ticketed(&format!("/api/items/{granted}/stream"), &h.ticket);
+
+    let (first, first_headers, _) = raw(
+        &h.app.app,
+        "GET",
+        &uri,
+        None,
+        None,
+        &[("range", "bytes=0-7")],
+    )
+    .await;
+    let (later, later_headers, _) = raw(
+        &h.app.app,
+        "GET",
+        &uri,
+        None,
+        None,
+        &[("range", "bytes=20-27")],
+    )
+    .await;
+
+    assert_eq!(first, StatusCode::PARTIAL_CONTENT);
+    assert_eq!(later, StatusCode::PARTIAL_CONTENT);
+    assert_eq!(first_headers[CONTENT_RANGE], "bytes 0-7/36");
+    assert_eq!(later_headers[CONTENT_RANGE], "bytes 20-27/36");
+}
+
+#[tokio::test]
+async fn a_session_bearer_still_answers_for_the_bytes_it_may_see() {
+    let h = household_where_the_viewer_only_sees_films();
+    let granted = seed_playable_item(&h.app.state, "Granted", FILM);
+
+    let (status, _headers, _) = raw(
+        &h.app.app,
+        "GET",
+        &format!("/api/items/{granted}/stream"),
+        Some(&h.viewer),
+        None,
+        &[],
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn a_bearer_that_is_no_longer_a_session_is_refused_rather_than_read_as_anonymous() {
+    let h = household_where_the_viewer_only_sees_films();
+    let granted = seed_playable_item(&h.app.state, "Granted", FILM);
+
+    let (status, _headers, _) = raw(
+        &h.app.app,
+        "GET",
+        &ticketed(&format!("/api/items/{granted}/stream"), &h.ticket),
+        Some("not-a-session"),
+        None,
+        &[],
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn every_signed_in_device_is_handed_a_ticket_with_its_session() {
+    let t = test_app();
+    let access = crate::api::test_support::seed_access_token(&t.state, &t.user_id, true);
+
+    let (status, body) = crate::api::test_support::send(
+        &t.app,
+        "POST",
+        "/api/auth/token",
+        None,
+        Some(serde_json::json!({ "accessToken": access })),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    let ticket = body["mediaTicket"].as_str().expect("a media ticket");
+    let now = time::OffsetDateTime::now_utc().unix_timestamp();
+    assert_eq!(
+        media_ticket::device_of(&t.state.media_ticket_key, ticket, now),
+        Some(crate::services::scan::short_hash(&access))
+    );
+}

--- a/server/src/api/media_ticket.rs
+++ b/server/src/api/media_ticket.rs
@@ -1,0 +1,98 @@
+//! Who may read an item's bytes. The byte routes are reached by players that
+//! cannot send a header, so they take a session bearer OR a media ticket in the
+//! query string, and nothing else (ACCT-35).
+
+use axum::extract::{FromRequestParts, Query};
+use axum::http::request::Parts;
+use axum::http::StatusCode;
+use axum::response::Response;
+use serde::Deserialize;
+
+use crate::api::error::json_error;
+use crate::api::extract::bearer_from_headers;
+use crate::api::util::query;
+use crate::db;
+use crate::model::User;
+use crate::services::media_ticket;
+use crate::state::SharedState;
+
+/// The query parameter a ticket travels in, kept short because an HLS playlist
+/// repeats it on every segment URI.
+pub const PARAM: &str = "t";
+
+const MAX_TICKET_LEN: usize = 256;
+
+/// The ticket a media URL carries. Flattened into the byte routes' own query
+/// structs so one `Query` extraction reads both.
+#[derive(Debug, Default, Deserialize)]
+pub struct TicketQuery {
+    #[serde(default)]
+    pub t: Option<String>,
+}
+
+impl TicketQuery {
+    /// The ticket, once it is short enough to be one.
+    pub fn ticket(&self) -> Option<&str> {
+        self.t
+            .as_deref()
+            .map(str::trim)
+            .filter(|t| !t.is_empty() && t.len() <= MAX_TICKET_LEN)
+    }
+}
+
+/// The account a media byte request may be answered for. Resolved from the
+/// session bearer when there is one, otherwise from the ticket in the URL. The
+/// library grant is NOT checked here: a handler still holds the caller to it, so
+/// one answer covers an unknown id and an ungranted one alike.
+pub struct MediaViewer(pub User);
+
+impl FromRequestParts<SharedState> for MediaViewer {
+    type Rejection = Response;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &SharedState,
+    ) -> Result<Self, Self::Rejection> {
+        if let Some(token) = bearer_from_headers(&parts.headers) {
+            let user = query(&state.db, move |pool| db::session_user(&pool, &token)).await?;
+            return user.map(MediaViewer).ok_or_else(refused);
+        }
+        let presented = Query::<TicketQuery>::from_request_parts(parts, state)
+            .await
+            .map_err(|_| refused())?;
+        let ticket = presented.ticket().ok_or_else(refused)?.to_string();
+        let now = time::OffsetDateTime::now_utc().unix_timestamp();
+        let device =
+            media_ticket::device_of(&state.media_ticket_key, &ticket, now).ok_or_else(refused)?;
+        let user = query(&state.db, move |pool| {
+            db::access_token_user_by_id(&pool, &device)
+        })
+        .await?;
+        user.map(MediaViewer).ok_or_else(refused)
+    }
+}
+
+fn refused() -> Response {
+    json_error(StatusCode::UNAUTHORIZED, "media credential required")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn presented(t: &str) -> TicketQuery {
+        TicketQuery { t: Some(t.into()) }
+    }
+
+    #[test]
+    fn a_ticket_is_what_survives_the_bounds() {
+        assert_eq!(presented("abc").ticket(), Some("abc"));
+        assert_eq!(presented("  abc  ").ticket(), Some("abc"));
+        assert!(TicketQuery::default().ticket().is_none());
+        assert!(presented("").ticket().is_none());
+        assert!(presented("   ").ticket().is_none());
+        assert!(presented(&"x".repeat(MAX_TICKET_LEN + 1))
+            .ticket()
+            .is_none());
+    }
+}

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -23,6 +23,7 @@ mod host_jobs;
 mod images;
 mod invites;
 mod media;
+pub mod media_ticket;
 mod metadata;
 mod modules;
 mod notifications;
@@ -81,6 +82,8 @@ mod it_invites;
 mod it_library_visibility;
 #[cfg(test)]
 mod it_media;
+#[cfg(test)]
+mod it_media_ticket;
 #[cfg(test)]
 mod it_notification_images;
 #[cfg(test)]
@@ -175,8 +178,9 @@ pub fn router(
 ) -> Router {
     // Public endpoints reachable before (or without) a session: the auth
     // handshake + roster + invites, uploaded avatars/art, liveness, and the media
-    // byte streams (a `<video>`/hls element can't attach a bearer these carry no
-    // catalogue listing and stay open under the LAN trust model).
+    // byte streams. The byte routes sit outside this middleware because a
+    // `<video>`/hls element can't attach a bearer, and carry their own credential
+    // in the URL instead (see `media_ticket`); they are not open.
     let public = Router::new()
         .merge(accounts::routes())
         .merge(passkeys::routes())
@@ -194,9 +198,9 @@ pub fn router(
 
     // Content endpoints require a valid session: the catalogue listing + detail,
     // search, people, metadata, discovery/requests, home rows and per-user
-    // playback. Knowing the URL no longer lists the library. `themes` +
-    // downloaded-subtitle bytes are served publicly above they're fetched by an
-    // <audio> element / plain fetch that can't attach a bearer.
+    // playback. Knowing the URL no longer lists the library. `themes` is served
+    // publicly above: an <audio> element can't attach a bearer and a theme song
+    // is not library bytes.
     let content = Router::new()
         .merge(media::routes())
         .merge(stream::protected_routes())

--- a/server/src/api/online_subs.rs
+++ b/server/src/api/online_subs.rs
@@ -12,7 +12,9 @@ use axum::Json;
 use serde::Serialize;
 
 use crate::api::error::json_error;
+use crate::api::media_ticket::MediaViewer;
 use crate::api::util::query;
+use crate::api::visibility;
 use crate::boot::transcriber::TranscriberClient;
 use crate::db;
 use crate::services::settings;
@@ -42,9 +44,9 @@ pub fn routes() -> Router<SharedState> {
         )
 }
 
-/// Public: serve a generated/downloaded subtitle's WebVTT bytes. The player
-/// fetches this URL as a plain `fetch()` (and can't attach a bearer), so like
-/// the embedded-subtitle + stream byte routes it stays outside the session gate.
+/// Outside the session middleware because the player fetches this URL itself and
+/// cannot attach a bearer; gated instead by the media credential, like the other
+/// byte routes (ACCT-35).
 pub fn public_routes() -> Router<SharedState> {
     Router::new().route("/items/{id}/subtitles/dl/{dl}", get(file))
 }
@@ -148,8 +150,12 @@ pub async fn delete_downloaded(
 /// `GET /api/items/:id/subtitles/dl/:dl.vtt` → serve a cached generated WebVTT.
 pub async fn file(
     State(state): State<SharedState>,
-    Path((_id, dl)): Path<(String, String)>,
+    MediaViewer(viewer): MediaViewer,
+    Path((id, dl)): Path<(String, String)>,
 ) -> Response {
+    if let Err(resp) = visibility::gate_item(&state, &viewer, &id).await {
+        return resp;
+    }
     let dl_id = dl.trim_end_matches(".vtt").to_string();
     let sub = match query(&state.db, move |pool| {
         let conn = pool.get()?;

--- a/server/src/api/stream.rs
+++ b/server/src/api/stream.rs
@@ -10,7 +10,7 @@ use axum::response::Response;
 use serde::Deserialize;
 
 use crate::api::error::json_error;
-use crate::api::extract::OptionalAuthUser;
+use crate::api::media_ticket::MediaViewer;
 use crate::api::util::client_ip;
 use crate::api::visibility;
 use crate::infra::stream::stream_or_demo_error;
@@ -24,6 +24,7 @@ use axum::Router;
 
 mod download;
 mod hls;
+mod hls_playlist;
 
 use download::download_item;
 use hls::{hls_file, hls_master};
@@ -39,9 +40,10 @@ fn byte_sink(
 }
 
 /// Direct-play streaming, HLS remux, storyboard previews and subtitle tracks.
-/// Unauthenticated: a `<video>` / hls.js element can't attach a bearer to the
-/// URLs it fetches, so these stay open under the LAN trust model. A request that
-/// does carry a session is still held to that account's library grant (ACCT-21).
+/// Outside the session middleware because a `<video>` / hls.js element can't
+/// attach a bearer to the URLs it fetches, and gated instead by
+/// [`MediaViewer`]: every request names an account, and that account's library
+/// grant decides what it may read (ACCT-35).
 pub fn routes() -> Router<SharedState> {
     Router::new()
         .route("/items/{id}/stream", get(stream_item))
@@ -73,13 +75,13 @@ pub struct StreamQuery {
 /// original file. Without `?file`, the item's default/best file is served.
 pub async fn stream_item(
     State(state): State<SharedState>,
-    OptionalAuthUser(caller): OptionalAuthUser,
+    MediaViewer(viewer): MediaViewer,
     Path(id): Path<String>,
     Query(q): Query<StreamQuery>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
 ) -> Result<Response, Response> {
-    let item = load_item(&state, caller.as_ref(), id)
+    let item = load_item(&state, &viewer, id)
         .await
         .ok_or_else(visibility::out_of_scope)?;
     let abs_path = pick_file_path(&item, q.file.as_deref());
@@ -96,18 +98,18 @@ fn pick_file_path(item: &MediaItem, file_id: Option<&str>) -> Option<String> {
     item.abs_path.clone()
 }
 
-async fn load_item(state: &SharedState, caller: Option<&User>, id: String) -> Option<MediaItem> {
-    visibility::item_in_scope(state, caller, id).await
+pub(super) async fn load_item(state: &SharedState, viewer: &User, id: String) -> Option<MediaItem> {
+    visibility::item_in_scope(state, Some(viewer), id).await
 }
 
 /// `GET /api/items/:id/storyboard` → the sprite-sheet manifest mapping a cursor
 /// time to a tile. 202 `{"status":"pending"}` while generating (the client polls).
 pub async fn storyboard(
     State(state): State<SharedState>,
-    OptionalAuthUser(caller): OptionalAuthUser,
+    MediaViewer(viewer): MediaViewer,
     Path(id): Path<String>,
 ) -> Response {
-    let Some(item) = load_item(&state, caller.as_ref(), id).await else {
+    let Some(item) = load_item(&state, &viewer, id).await else {
         return visibility::out_of_scope();
     };
     use crate::infra::storyboard::Status;
@@ -124,10 +126,10 @@ pub async fn storyboard(
 /// generated. Cached immutably; the manifest's `?v=<key>` busts it.
 pub async fn storyboard_image(
     State(state): State<SharedState>,
-    OptionalAuthUser(caller): OptionalAuthUser,
+    MediaViewer(viewer): MediaViewer,
     Path(id): Path<String>,
 ) -> Response {
-    let Some(item) = load_item(&state, caller.as_ref(), id).await else {
+    let Some(item) = load_item(&state, &viewer, id).await else {
         return visibility::out_of_scope();
     };
     match state.storyboard.sheet(&item).await {
@@ -154,7 +156,7 @@ fn json_no_store(status: StatusCode, body: Vec<u8>) -> Response {
 /// image subtitles (PGS/VobSub) can't convert and return 404.
 pub async fn subtitles(
     State(state): State<SharedState>,
-    OptionalAuthUser(caller): OptionalAuthUser,
+    MediaViewer(viewer): MediaViewer,
     Path((id, track)): Path<(String, String)>,
 ) -> Response {
     let index: usize = match track.trim_end_matches(".vtt").parse() {
@@ -162,7 +164,7 @@ pub async fn subtitles(
         Err(_) => return json_error(StatusCode::BAD_REQUEST, "invalid subtitle index"),
     };
 
-    let Some(item) = load_item(&state, caller.as_ref(), id).await else {
+    let Some(item) = load_item(&state, &viewer, id).await else {
         return visibility::out_of_scope();
     };
     let Some(abs) = item.abs_path.clone() else {

--- a/server/src/api/stream/hls.rs
+++ b/server/src/api/stream/hls.rs
@@ -9,14 +9,14 @@ use axum::response::{IntoResponse, Redirect, Response};
 use serde::Deserialize;
 
 use crate::api::error::json_error;
-use crate::api::extract::OptionalAuthUser;
+use crate::api::media_ticket::{self, MediaViewer, TicketQuery};
 use crate::api::visibility;
 use crate::infra::hls::StreamMode;
 use crate::infra::metrics::ByteSink;
 use crate::infra::stream::metered_body;
 use crate::state::SharedState;
 
-use super::{byte_sink, load_item};
+use super::{byte_sink, hls_playlist, load_item};
 
 /// `?copy=` names the audio codecs the client can decode or pass through, so the
 /// server can refuse to stream-copy one the device would play silent; `?video=`
@@ -31,6 +31,8 @@ pub struct HlsQuery {
     /// it never probed one, and the source's own size stands.
     pub maxw: Option<u32>,
     pub maxh: Option<u32>,
+    #[serde(flatten)]
+    pub ticket: TicketQuery,
 }
 
 /// `GET /api/items/:id/hls/:mode/:anchor/:audio/index.m3u8` (mode = an audio
@@ -41,7 +43,7 @@ pub struct HlsQuery {
 /// URLs, so switching language means reloading with a different `audio`.
 pub async fn hls_master(
     State(state): State<SharedState>,
-    OptionalAuthUser(caller): OptionalAuthUser,
+    MediaViewer(viewer): MediaViewer,
     Path((id, mode, anchor, audio)): Path<(String, String, u64, u32)>,
     Query(q): Query<HlsQuery>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
@@ -50,7 +52,7 @@ pub async fn hls_master(
     let Some(mode) = StreamMode::parse(&mode) else {
         return json_error(StatusCode::BAD_REQUEST, "bad mode");
     };
-    let Some(item) = load_item(&state, caller.as_ref(), id).await else {
+    let Some(item) = load_item(&state, &viewer, id).await else {
         return visibility::out_of_scope();
     };
     // Redirected rather than served here: the effective mode owns the session and
@@ -70,8 +72,14 @@ pub async fn hls_master(
         )
         .for_client_frame(source_frame, q.maxw.zip(q.maxh));
     if effective != mode {
-        return Redirect::temporary(&hls_master_path(&item.id, effective, anchor, audio))
-            .into_response();
+        return Redirect::temporary(&hls_master_path(
+            &item.id,
+            effective,
+            anchor,
+            audio,
+            q.ticket.ticket(),
+        ))
+        .into_response();
     }
     let Some(abs) = item.abs_path.clone() else {
         return json_error(StatusCode::NOT_FOUND, "no media file for item");
@@ -96,6 +104,10 @@ pub async fn hls_master(
         // `X-Hls-Start` is the real start (the keyframe at-or-before the anchor, where
         // `-noaccurate_seek` begins); the client needs it to align clock and subtitles.
         Some((body, start)) => {
+            let body = match q.ticket.ticket() {
+                Some(ticket) => hls_playlist::ticketed(&body, ticket),
+                None => body,
+            };
             let mut resp = playlist_response(body, byte_sink(&state, &headers, &addr));
             if let Ok(v) = header::HeaderValue::from_str(&format!("{start:.3}")) {
                 resp.headers_mut().insert("X-Hls-Start", v);
@@ -126,7 +138,7 @@ pub async fn hls_master(
 /// segment is polled for until ffmpeg flushes it.
 pub async fn hls_file(
     State(state): State<SharedState>,
-    OptionalAuthUser(caller): OptionalAuthUser,
+    MediaViewer(viewer): MediaViewer,
     Path((id, mode, anchor, audio, file)): Path<(String, String, u64, u32, String)>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
@@ -134,10 +146,8 @@ pub async fn hls_file(
     let Some(mode) = StreamMode::parse(&mode) else {
         return json_error(StatusCode::BAD_REQUEST, "bad mode");
     };
-    if let Some(user) = caller.as_ref() {
-        if let Err(resp) = visibility::gate_item(&state, user, &id).await {
-            return resp;
-        }
+    if let Err(resp) = visibility::gate_item(&state, &viewer, &id).await {
+        return resp;
     }
     let immutable = !file.ends_with(".m3u8");
     match state.hls.file(&id, mode, anchor, audio, &file).await {
@@ -176,10 +186,20 @@ pub async fn hls_file(
 }
 
 // Item ids are hex `short_hash`es (optionally joined by a colon), so they need no
-// escaping to sit in a path segment.
-fn hls_master_path(id: &str, mode: StreamMode, anchor: u64, audio: u32) -> String {
+// escaping to sit in a path segment. The ticket is carried across because a
+// redirect drops the query and the player would arrive with no credential.
+fn hls_master_path(
+    id: &str,
+    mode: StreamMode,
+    anchor: u64,
+    audio: u32,
+    ticket: Option<&str>,
+) -> String {
+    let credential = ticket
+        .map(|t| format!("?{}={t}", media_ticket::PARAM))
+        .unwrap_or_default();
     format!(
-        "/api/items/{id}/hls/{}/{anchor}/{audio}/index.m3u8",
+        "/api/items/{id}/hls/{}/{anchor}/{audio}/index.m3u8{credential}",
         mode.token()
     )
 }
@@ -195,77 +215,4 @@ fn playlist_response(body: String, sink: ByteSink) -> Response {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::infra::hls::{AudioMode, VideoMode};
-
-    fn mode(video: VideoMode, audio: AudioMode) -> StreamMode {
-        StreamMode::new(video, audio)
-    }
-
-    #[test]
-    fn redirect_path_swaps_only_the_mode_segment() {
-        assert_eq!(
-            hls_master_path("abc123", mode(VideoMode::Copy, AudioMode::Aac), 30, 1),
-            "/api/items/abc123/hls/aac/30/1/index.m3u8"
-        );
-        assert_eq!(
-            hls_master_path("tv:s1e2", mode(VideoMode::Copy, AudioMode::Aac), 0, 0),
-            "/api/items/tv:s1e2/hls/aac/0/0/index.m3u8"
-        );
-        assert_eq!(
-            hls_master_path("abc123", mode(VideoMode::H264, AudioMode::AacNight), 30, 1),
-            "/api/items/abc123/hls/h264-aac-night/30/1/index.m3u8"
-        );
-    }
-
-    #[test]
-    fn parse_mode_variants() {
-        assert_eq!(
-            StreamMode::parse("copy"),
-            Some(mode(VideoMode::Copy, AudioMode::Copy))
-        );
-        assert_eq!(
-            StreamMode::parse("aac"),
-            Some(mode(VideoMode::Copy, AudioMode::Aac))
-        );
-        assert_eq!(
-            StreamMode::parse("aac-standard"),
-            Some(mode(VideoMode::Copy, AudioMode::AacStandard))
-        );
-        assert_eq!(
-            StreamMode::parse("aac-night"),
-            Some(mode(VideoMode::Copy, AudioMode::AacNight))
-        );
-        assert_eq!(
-            StreamMode::parse("h264-copy"),
-            Some(mode(VideoMode::H264, AudioMode::Copy))
-        );
-        assert_eq!(
-            StreamMode::parse("h264-aac-standard"),
-            Some(mode(VideoMode::H264, AudioMode::AacStandard))
-        );
-        assert_eq!(StreamMode::parse("bogus"), None);
-    }
-
-    // A redirect drops the query, so re-resolving the mode it names must be a
-    // no-op or the master would bounce forever.
-    #[test]
-    fn the_redirect_target_resolves_to_itself() {
-        let asked = mode(VideoMode::Copy, AudioMode::Copy);
-        let effective = asked
-            .for_client_audio(Some("dts"), Some("aac"))
-            .for_client_video(Some("hevc"), Some("h264"));
-        assert_eq!(effective, mode(VideoMode::H264, AudioMode::Aac));
-        assert_eq!(
-            hls_master_path("abc123", effective, 30, 1),
-            "/api/items/abc123/hls/h264-aac/30/1/index.m3u8"
-        );
-        assert_eq!(
-            effective
-                .for_client_audio(Some("dts"), None)
-                .for_client_video(Some("hevc"), None),
-            effective
-        );
-    }
-}
+mod tests;

--- a/server/src/api/stream/hls/tests.rs
+++ b/server/src/api/stream/hls/tests.rs
@@ -1,0 +1,92 @@
+use super::*;
+use crate::infra::hls::{AudioMode, VideoMode};
+
+fn mode(video: VideoMode, audio: AudioMode) -> StreamMode {
+    StreamMode::new(video, audio)
+}
+
+#[test]
+fn redirect_path_swaps_only_the_mode_segment() {
+    assert_eq!(
+        hls_master_path("abc123", mode(VideoMode::Copy, AudioMode::Aac), 30, 1, None),
+        "/api/items/abc123/hls/aac/30/1/index.m3u8"
+    );
+    assert_eq!(
+        hls_master_path("tv:s1e2", mode(VideoMode::Copy, AudioMode::Aac), 0, 0, None),
+        "/api/items/tv:s1e2/hls/aac/0/0/index.m3u8"
+    );
+    assert_eq!(
+        hls_master_path(
+            "abc123",
+            mode(VideoMode::H264, AudioMode::AacNight),
+            30,
+            1,
+            None
+        ),
+        "/api/items/abc123/hls/h264-aac-night/30/1/index.m3u8"
+    );
+}
+
+#[test]
+fn a_redirect_carries_the_credential_the_player_arrived_with() {
+    assert_eq!(
+        hls_master_path(
+            "abc123",
+            mode(VideoMode::H264, AudioMode::Aac),
+            0,
+            0,
+            Some("dev.999.sig")
+        ),
+        "/api/items/abc123/hls/h264-aac/0/0/index.m3u8?t=dev.999.sig"
+    );
+}
+
+#[test]
+fn parse_mode_variants() {
+    assert_eq!(
+        StreamMode::parse("copy"),
+        Some(mode(VideoMode::Copy, AudioMode::Copy))
+    );
+    assert_eq!(
+        StreamMode::parse("aac"),
+        Some(mode(VideoMode::Copy, AudioMode::Aac))
+    );
+    assert_eq!(
+        StreamMode::parse("aac-standard"),
+        Some(mode(VideoMode::Copy, AudioMode::AacStandard))
+    );
+    assert_eq!(
+        StreamMode::parse("aac-night"),
+        Some(mode(VideoMode::Copy, AudioMode::AacNight))
+    );
+    assert_eq!(
+        StreamMode::parse("h264-copy"),
+        Some(mode(VideoMode::H264, AudioMode::Copy))
+    );
+    assert_eq!(
+        StreamMode::parse("h264-aac-standard"),
+        Some(mode(VideoMode::H264, AudioMode::AacStandard))
+    );
+    assert_eq!(StreamMode::parse("bogus"), None);
+}
+
+// A redirect drops the query, so re-resolving the mode it names must be a
+// no-op or the master would bounce forever.
+#[test]
+fn the_redirect_target_resolves_to_itself() {
+    let asked = mode(VideoMode::Copy, AudioMode::Copy);
+    let effective = asked
+        .for_client_audio(Some("dts"), Some("aac"))
+        .for_client_video(Some("hevc"), Some("h264"));
+    assert_eq!(effective, mode(VideoMode::H264, AudioMode::Aac));
+    assert_eq!(
+        hls_master_path("abc123", effective, 30, 1, None),
+        "/api/items/abc123/hls/h264-aac/30/1/index.m3u8"
+    );
+    assert_eq!(
+        effective
+            .for_client_audio(Some("dts"), None)
+            .for_client_video(Some("hevc"), None),
+        effective
+    );
+}

--- a/server/src/api/stream/hls_playlist.rs
+++ b/server/src/api/stream/hls_playlist.rs
@@ -1,0 +1,86 @@
+//! Writing the media credential into the playlist text.
+//!
+//! hls.js, AVPlay, Safari and mpv all resolve a playlist's URIs against the
+//! playlist's own URL and carry none of its query, so a ticket on the master
+//! reaches no segment unless the body the player reads carries it too.
+
+use crate::api::media_ticket;
+
+/// The same playlist with `ticket` on every URI the player will fetch for itself.
+pub fn ticketed(playlist: &str, ticket: &str) -> String {
+    let credential = format!("?{}={ticket}", media_ticket::PARAM);
+    let mut out =
+        String::with_capacity(playlist.len() + playlist.lines().count() * credential.len());
+    for line in playlist.lines() {
+        match line.starts_with('#') {
+            true => out.push_str(&ticketed_attribute(line, &credential)),
+            false if line.is_empty() => out.push_str(line),
+            false => {
+                out.push_str(line);
+                out.push_str(&credential);
+            }
+        }
+        out.push('\n');
+    }
+    out
+}
+
+// `#EXT-X-MAP:URI="init.mp4"` points at the initialisation segment, which the
+// player fetches like any other child.
+fn ticketed_attribute(tag: &str, credential: &str) -> String {
+    const URI: &str = "URI=\"";
+    let Some(start) = tag.find(URI).map(|i| i + URI.len()) else {
+        return tag.to_string();
+    };
+    let Some(end) = tag[start..].find('"').map(|i| start + i) else {
+        return tag.to_string();
+    };
+    format!("{}{credential}{}", &tag[..end], &tag[end..])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_uri_a_player_will_fetch_leaves_the_playlist_ticketed() {
+        let playlist = concat!(
+            "#EXTM3U\n",
+            "#EXT-X-TARGETDURATION:4\n",
+            "#EXT-X-MAP:URI=\"init.mp4\"\n",
+            "#EXTINF:4.000000,\n",
+            "seg00001.m4s\n",
+            "#EXTINF:4.000000,\n",
+            "seg00002.m4s\n",
+        );
+
+        let stamped = ticketed(playlist, "dev.999.sig");
+
+        assert_eq!(
+            stamped,
+            concat!(
+                "#EXTM3U\n",
+                "#EXT-X-TARGETDURATION:4\n",
+                "#EXT-X-MAP:URI=\"init.mp4?t=dev.999.sig\"\n",
+                "#EXTINF:4.000000,\n",
+                "seg00001.m4s?t=dev.999.sig\n",
+                "#EXTINF:4.000000,\n",
+                "seg00002.m4s?t=dev.999.sig\n",
+            )
+        );
+    }
+
+    #[test]
+    fn a_tag_with_no_uri_and_a_blank_line_are_left_alone() {
+        let stamped = ticketed("#EXT-X-ENDLIST\n\n#EXT-X-MAP:BYTERANGE=0\n", "tkt");
+
+        assert_eq!(stamped, "#EXT-X-ENDLIST\n\n#EXT-X-MAP:BYTERANGE=0\n");
+    }
+
+    #[test]
+    fn an_unterminated_uri_attribute_is_handed_back_rather_than_mangled() {
+        let stamped = ticketed("#EXT-X-MAP:URI=\"init.mp4\n", "tkt");
+
+        assert_eq!(stamped, "#EXT-X-MAP:URI=\"init.mp4\n");
+    }
+}

--- a/server/src/api/test_support.rs
+++ b/server/src/api/test_support.rs
@@ -207,6 +207,56 @@ pub fn seed_session_pw(
     (user.id, token)
 }
 
+/// A title backed by real bytes on disk, alongside the demo catalogue, so the
+/// byte routes can answer something a demo entry cannot. Returns its item id.
+pub fn seed_playable_item(state: &SharedState, title: &str, bytes: &[u8]) -> String {
+    let data = crate::services::demo::demo_data();
+    let mut item = data
+        .items
+        .iter()
+        .find(|i| i.show_id.is_none())
+        .cloned()
+        .expect("a demo movie to stand in for");
+    let path = state.config.data_dir.join(format!("{title}.mp4"));
+    std::fs::write(&path, bytes).expect("write media file");
+    let abs = path.to_string_lossy().into_owned();
+
+    item.id = crate::services::scan::short_hash(&abs);
+    item.title = title.to_string();
+    item.abs_path = Some(abs.clone());
+    let mut file = item.files[0].clone();
+    file.id = crate::services::scan::short_hash(&format!("{abs}|file"));
+    file.abs_path = Some(abs);
+    file.size = Some(bytes.len() as u64);
+    item.default_file_id = Some(file.id.clone());
+    item.files = vec![file];
+
+    let mut items = data.items.clone();
+    items.push(item.clone());
+    db::sync_all(
+        &state.db,
+        &data.libraries,
+        &data.shows,
+        &items,
+        &data.mtimes,
+    )
+    .expect("seed a playable item");
+    item.id
+}
+
+/// The media ticket a session's device would be handed, for driving the byte
+/// routes the way a `<video>` element does.
+pub fn media_ticket_for(state: &SharedState, session_token: &str) -> String {
+    let device = db::session_device_id(&state.db, session_token)
+        .expect("read session device")
+        .expect("a session minted from an access token");
+    crate::services::media_ticket::mint(
+        &state.media_ticket_key,
+        &device,
+        time::OffsetDateTime::now_utc().unix_timestamp(),
+    )
+}
+
 /// Mint a bare access token (no session) with the given `pin_verified` flag,
 /// so a test can drive `POST /auth/token` through the PIN gate.
 pub fn seed_access_token(state: &SharedState, user_id: &str, pin_verified: bool) -> String {


### PR DESCRIPTION
## What

The media byte routes sat in the public router on purpose: a `<video>` element, hls.js, Tizen's AVPlay and the mpv the desktop shell hands a URL to can none of them attach a bearer. #221 gated the catalogue, so those routes enforced the library grant on a request that presented a session and **nothing** on a request that presented none. Someone who had once seen an item id reached bytes they were never granted.

The credential now rides in the URL, which is the only place those players can carry one: a **media ticket**, shaped `<device>.<expiry>.<hmac>` and signed with a key this install mints on first boot and keeps out of every response (`Settings::set_internal`, the same door `instanceId` uses, so no settings patch and no admin response can read or write it). Verification resolves the device to its access-token row, then reads the grant from the database, so narrowing a grant bites on the next request rather than when the ticket lapses, and revoking a device stops every ticket it left behind. A request with neither a session nor a ticket is refused before the id is looked at, so probing learns nothing a `404` would not already tell it.

It is minted beside every session token (`/auth/login`, `/auth/register`, `/auth/token`, the passkey finish, both pairing polls), so a client holds one the moment it holds a session and no URL builder has to become async. On the client, nothing outside `packages/client` changes: every media URL was already built in `api/media/client.ts`, and the transport holds the ticket per client instance rather than as a module global.

**What I rejected, and why.**

- **A short-lived per-item token**, which is the usual answer and what the issue suggests. It needs an authenticated round trip before every playback URL, and those URLs are built in one synchronous step by six player engines that are handed nothing but a string (`BaseTvEngine.sourceUrl`, `attachDirectPlay`, `mpvEngine.load`, AVPlay, the mobile engine, the web engine). Making that async ripples into `<video src>`, `<track src>`, the storyboard poll, the mpv hand-off and Tizen. So the scope is the account rather than the title, and the leak is bounded by lifetime instead: **twelve hours**, which outlasts a feature film and not the day. A ticket never widens its account's reach, only carries it.
- **Keeping the routes open on a LAN address** and asking for the credential only off it. It is a smaller change, but the person the issue actually names, a household member who already saw an id, is *on* the LAN. That would have closed the smaller half while calling ACCT-35 done, and it would have written "a LAN neighbour is trusted with every library" into the product. Off-LAN-only gating is still strictly weaker than what landed, so nothing is lost by not taking it.
- **Putting the session bearer in the query string.** No new endpoint, no new state, and the transport already holds it. Rejected: it is a full account capability with a one-hour life, so it both dies mid-film and turns every access log and browser history into a credential store.
- **A cookie.** A `<video>` sends one, but the TV shells and the desktop shell are a different origin from the server, and mpv and AVPlay share no cookie jar with the app.

## Closes

Closes #222

## Checks

- [x] `bun run lint` and `bun run test` pass, or I said below which failed and why (`bun run check` clean, 10016 vitest tests pass, `bun run typecheck` clean, `bun run spec:check` up to date)
- [x] `cargo clippy` and `cargo test` pass, if the server changed (`--workspace --all-targets`; the same 16 warning sites as `main`, none of them in this diff)
- [x] Follows `CODE_STYLE.md` - no comments narrating the work, exported API only
- [x] One idea. If it grew a second, it was split.

## Risk

**Routes now gated** (session bearer **or** media ticket, nothing else):

| route | reached by |
| --- | --- |
| `/items/{id}/stream` | `<video src>`, mpv, AVPlay, the mobile raw download |
| `/items/{id}/hls/{mode}/{anchor}/{audio}/index.m3u8` | hls.js, Shaka, Safari native, mpv, AVPlay, and the bare `fetch` that reads `X-Hls-Start` |
| `/items/{id}/hls/{mode}/{anchor}/{audio}/{file}` | the player itself, resolving the playlist |
| `/items/{id}/storyboard` | the scrubber's manifest poll |
| `/items/{id}/storyboard.img` | `<img src>` / the mobile sidecar download |
| `/items/{id}/subtitles/{track}` | `<track src>` / a plain fetch |
| `/items/{id}/subtitles/dl/{dl}` | the generated-subtitle fetch (not named in the issue; same family, same gate) |

**Left public on purpose**, and now written into the spec chapter rather than implied: `/items/{id}/poster`, `/shows/{id}/poster`, `/items/{id}/card` and `/images/{hash}`. The sign-in screen's slideshow (`/splash`, deliberately public) and a television's launcher and Top Shelf cards are drawn by elements with no account behind them. Someone holding an id learns a hidden title's name and cover that way; they reach none of its bytes. `/items/{id}/download` stays bearer-only: it is a plain fetch that can send a header, and keeping a credential out of its URL is worth more than route-shape consistency.

**What a reviewer should try to break:**

- **HLS children.** hls.js, Safari, AVPlay and mpv all resolve a playlist's URIs against the playlist and carry none of its query, so `hls_playlist::ticketed` writes the ticket onto every segment line and into the `#EXT-X-MAP:URI` attribute. Start a remux on a real file and check that the segments 200 rather than 401. Then force the mode redirect (`?maxw=1920&maxh=1920` on a 4K title) and check the `Location` still carries `?t=`: a redirect drops the query, and without that the player arrives with no credential.
- **Two-hour watch.** The same `<video src>` is re-requested with new `Range` headers for the life of the film, so the ticket has to outlive the session it was minted from (one hour) without becoming permanent. Twelve hours is the bound; a title left **paused longer than twelve hours** now needs its source rebuilt, which a reload does. Before this PR it kept working. That is the one behaviour regression, and it is the price of the URL-borne credential.
- **Every shell's first playback after a cold boot.** The ticket arrives with the session, so the window where a client has a bearer and no ticket should not exist. Worth confirming on Tizen and webOS, where the session comes from a Quick Connect or handoff poll rather than a password login: both polls adopt it.
- **mpv.** `clients/desktop/src-tauri/src/mpv/launch.rs` passes no `--http-header-fields`, so the URL is mpv's only channel. Check a direct-play file and an anchored master, including `reanchor` after a seek.
- **Offline downloads.** `/download` still takes the bearer from `client.authHeaders()`; the sidecars (subtitle, storyboard sprite) are header-less fetches that now depend on the ticket being in the URL they were handed.
- **Revocation.** Revoke a device from Appareils while it is streaming: the next segment should 401, because the access-token row the ticket names is gone.
- **A narrowed grant mid-stream.** An admin removing a library while a ticket for it is live: the grant is re-read per request, so the next segment should 404.
