### PR TITLE
fix(modules): a settings key reaches a module only where a declaration says so

### DIFF
--- a/docs/module-plugin-model.md
+++ b/docs/module-plugin-model.md
@@ -243,14 +243,24 @@ the core database, event publish, notifications, session lookup and permission
 checks, i18n with the module's own catalogue first, admin routes reverse-proxied
 under `/api/module/<id>/*`, a frontend remote.
 
-**The settings callback is not a way into the operator's credentials.** The keys
-only the core consumes (mail, LLM, the push private material) and the registry
-list the Store installs from are withheld on both directions of
-`/_host/setting{,s}`: a read answers the caller's own default, a patch naming one
-is refused. The core decides which keys those are, beside the defaults that
-declare them; the supervisor only asks, so it still knows nothing about what any
-module is for. A credential whose consumer IS a sidecar stays readable, because
-the callback is how it reaches the process that uses it.
+**The settings callback is not a way into the operator's credentials.** A key is
+reachable on `/_host/setting{,s}` only when the core declared that a module may
+reach it, beside the key's default. Anything else is withheld on both directions:
+a read answers the caller's own default, a patch naming one is refused. So the
+keys only the core consumes (mail, LLM, the push private material, the ticket
+signing key) and the registry list the Store installs from are withheld because
+they say so, and an identity the server mints for itself is withheld because
+nothing hands it out. The core owns that decision; the supervisor only asks, so
+it still knows nothing about what any module is for. A credential whose consumer
+IS a sidecar stays readable, because the callback is how it reaches the process
+that uses it.
+
+Withholding by default is what makes this survive the next key. The guard used to
+be a deny-list plus a test that swept key NAMES for `password`, `token`, `secret`
+and `credential`, and `mediaTicketKey` carries none of those words: it shipped
+readable until review caught it. The name sweep is still there, now checking that
+a credential-shaped name is never declared reachable, but it is the second net
+rather than the only one.
 
 Four gaps stand between that and "a module can do whatever we want":
 

--- a/docs/modules-as-kmod.md
+++ b/docs/modules-as-kmod.md
@@ -44,11 +44,11 @@ it, supervises it, and reverse-proxies its HTTP.**
   module declared under `storage.adopt` out of the core database and into the
   module's own file -- the core does it, because the module no longer holds the
   rights to. `proxy_to` reverse-proxies a request to a module process.
-  `host_router::<HostCtx>(token, core_only)` serves `/api/_host/*` (setting /
+  `host_router::<HostCtx>(token, withheld)` serves `/api/_host/*` (setting /
   settings / events / job / enabled / session / ...), token-authed, resolved
-  against the core's real state. `core_only` is the core's own predicate over
-  settings keys: the ones it answers for itself are read back as the caller's
-  default and refused on write.
+  against the core's real state. `withheld` is the core's own predicate over
+  settings keys: one it answers for itself is read back as the caller's default
+  and refused on write, and a key no declaration hands out is withheld too.
 - **Core integration**: `main.rs` builds the supervisor and `spawn_enabled`s
   installed modules at boot; `api/mod.rs` mounts the callback API and a
   `/api/module/<id>/*` reverse proxy.

--- a/docs/spec/INDEX.md
+++ b/docs/spec/INDEX.md
@@ -329,7 +329,7 @@
 - **MOD-48** (AGREED) - The Store names the registry every module came from, on the listing and
 - **MOD-49** (AGREED) - Installing from a registry the operator added is gated once, per
 - **MOD-50** (AGREED) - A module that has disappeared from every configured registry is flagged
-- **MOD-51** (SHIPPED) - It may not read or write the server's own credentials. The settings
+- **MOD-51** (SHIPPED) - It may not read or write the server's own credentials. A settings key
 - **MOD-52** (SHIPPED) - The server refuses to **update** a module past the range an enabled
 
 ## PLAY - [playback](playback/)

--- a/docs/spec/modules/README.md
+++ b/docs/spec/modules/README.md
@@ -54,11 +54,13 @@ What a module may **not** do:
 - **MOD-8** (SHIPPED) - It may not assume it is present. Because any module is uninstallable,
   core never depends on one, so a feature that needs a module is absent, not broken, when the
   module is gone.
-- **MOD-51** (SHIPPED) - It may not read or write the server's own credentials. The settings
-  callback withholds every key only the server consumes, meaning the mail, LLM and push
-  credentials plus the registry list modules are installed from: a read answers the module's
-  own default and a write naming one is refused. A credential whose consumer *is* a module
-  stays reachable, because that callback is how it reaches the process that uses it.
+- **MOD-51** (SHIPPED) - It may not read or write the server's own credentials. A settings key
+  reaches a module only where the server declared that one may have it, so the mail, LLM and
+  push credentials, the key that signs a media ticket and the registry list modules are
+  installed from are all withheld, and so is any key the server keeps for itself without saying
+  who reads it: a read answers the module's own default and a write naming one is refused. A
+  credential whose consumer *is* a module stays reachable, because that callback is how it
+  reaches the process that uses it.
 
 **MOD-9** (SHIPPED) - A module *may* depend on another module, hard or optional, and that
 dependency is declared, resolved and enforced rather than discovered at runtime.

--- a/docs/spec/requirements.json
+++ b/docs/spec/requirements.json
@@ -2657,7 +2657,7 @@
     "status": "SHIPPED",
     "text": "A module *may* depend on another module, hard or optional, and that",
     "file": "docs/spec/modules/README.md",
-    "line": 63
+    "line": 65
   },
   {
     "id": "MOD-10",
@@ -2667,7 +2667,7 @@
     "status": "SHIPPED",
     "text": "A module ships as a single `.kmod` file: a manifest, the native",
     "file": "docs/spec/modules/README.md",
-    "line": 70
+    "line": 72
   },
   {
     "id": "MOD-11",
@@ -2677,7 +2677,7 @@
     "status": "SHIPPED",
     "text": "**Identity and version.** The reverse-DNS id and a hand-set version.",
     "file": "docs/spec/modules/README.md",
-    "line": 76
+    "line": 78
   },
   {
     "id": "MOD-12",
@@ -2687,7 +2687,7 @@
     "status": "SHIPPED",
     "text": "The release process refuses to publish changed bytes under an",
     "file": "docs/spec/modules/README.md",
-    "line": 78
+    "line": 80
   },
   {
     "id": "MOD-13",
@@ -2697,7 +2697,7 @@
     "status": "SHIPPED",
     "text": "**`minServer`, the compatibility floor.** The minimum server version",
     "file": "docs/spec/modules/README.md",
-    "line": 81
+    "line": 83
   },
   {
     "id": "MOD-14",
@@ -2707,7 +2707,7 @@
     "status": "SHIPPED",
     "text": "**Dependencies.** Hard ones that must be installed alongside it, and",
     "file": "docs/spec/modules/README.md",
-    "line": 83
+    "line": 85
   },
   {
     "id": "MOD-15",
@@ -2717,7 +2717,7 @@
     "status": "SHIPPED",
     "text": "**Target.** Which platform the backend was built for. A library-only",
     "file": "docs/spec/modules/README.md",
-    "line": 85
+    "line": 87
   },
   {
     "id": "MOD-16",
@@ -2727,7 +2727,7 @@
     "status": "SHIPPED",
     "text": "The server checks the bytes it downloads against a published SHA-256",
     "file": "docs/spec/modules/README.md",
-    "line": 89
+    "line": 91
   },
   {
     "id": "MOD-17",
@@ -2737,7 +2737,7 @@
     "status": "SHIPPED",
     "text": "Integrity is not safety: a matching checksum proves the bytes are the",
     "file": "docs/spec/modules/README.md",
-    "line": 92
+    "line": 94
   },
   {
     "id": "MOD-18",
@@ -2747,7 +2747,7 @@
     "status": "SHIPPED",
     "text": "**From the Store**, by id. The server resolves hard dependencies",
     "file": "docs/spec/modules/README.md",
-    "line": 102
+    "line": 104
   },
   {
     "id": "MOD-19",
@@ -2757,7 +2757,7 @@
     "status": "SHIPPED",
     "text": "**By upload**, handing the server a `.kmod` by hand: same unpack,",
     "file": "docs/spec/modules/README.md",
-    "line": 106
+    "line": 108
   },
   {
     "id": "MOD-20",
@@ -2767,7 +2767,7 @@
     "status": "SHIPPED",
     "text": "Both are admin actions on the [`admin/`](../admin/) surface.",
     "file": "docs/spec/modules/README.md",
-    "line": 110
+    "line": 112
   },
   {
     "id": "MOD-21",
@@ -2777,7 +2777,7 @@
     "status": "SHIPPED",
     "text": "The Store (Admin → Modules) is the in-app browser over the configured",
     "file": "docs/spec/modules/README.md",
-    "line": 116
+    "line": 118
   },
   {
     "id": "MOD-22",
@@ -2787,7 +2787,7 @@
     "status": "SHIPPED",
     "text": "The official registry is pinned first and cannot be removed; operators",
     "file": "docs/spec/modules/README.md",
-    "line": 119
+    "line": 121
   },
   {
     "id": "MOD-23",
@@ -2797,7 +2797,7 @@
     "status": "SHIPPED",
     "text": "For each module the Store shows **this server's verdict**, not just the",
     "file": "docs/spec/modules/README.md",
-    "line": 122
+    "line": 124
   },
   {
     "id": "MOD-24",
@@ -2807,7 +2807,7 @@
     "status": "AGREED",
     "text": "**First-party is trusted by default.** The official registry is",
     "file": "docs/spec/modules/README.md",
-    "line": 140
+    "line": 142
   },
   {
     "id": "MOD-25",
@@ -2817,7 +2817,7 @@
     "status": "AGREED",
     "text": "**A third-party registry is an explicit operator opt-in.** Adding one",
     "file": "docs/spec/modules/README.md",
-    "line": 142
+    "line": 144
   },
   {
     "id": "MOD-26",
@@ -2827,7 +2827,7 @@
     "status": "AGREED",
     "text": "The operator is told, in plain terms, that a module is a native binary",
     "file": "docs/spec/modules/README.md",
-    "line": 144
+    "line": 146
   },
   {
     "id": "MOD-27",
@@ -2837,7 +2837,7 @@
     "status": "AGREED",
     "text": "**Checksums guarantee integrity, never safety**, and the server says so",
     "file": "docs/spec/modules/README.md",
-    "line": 147
+    "line": 149
   },
   {
     "id": "MOD-28",
@@ -2847,7 +2847,7 @@
     "status": "SHIPPED",
     "text": "**Enable.** The server spawns the sidecar and the module's routes,",
     "file": "docs/spec/modules/README.md",
-    "line": 176
+    "line": 178
   },
   {
     "id": "MOD-29",
@@ -2857,7 +2857,7 @@
     "status": "SHIPPED",
     "text": "**Disable.** The sidecar is stopped, the module stops running, and",
     "file": "docs/spec/modules/README.md",
-    "line": 179
+    "line": 181
   },
   {
     "id": "MOD-30",
@@ -2867,7 +2867,7 @@
     "status": "SHIPPED",
     "text": "**Update.** A newer version replaces the bundle and the sidecar is",
     "file": "docs/spec/modules/README.md",
-    "line": 182
+    "line": 184
   },
   {
     "id": "MOD-31",
@@ -2877,7 +2877,7 @@
     "status": "SHIPPED",
     "text": "`minServer` is re-checked on update, so an update that outgrows the",
     "file": "docs/spec/modules/README.md",
-    "line": 185
+    "line": 187
   },
   {
     "id": "MOD-32",
@@ -2887,7 +2887,7 @@
     "status": "SHIPPED",
     "text": "**Uninstall.** The module is removed entirely. It is the one",
     "file": "docs/spec/modules/README.md",
-    "line": 187
+    "line": 189
   },
   {
     "id": "MOD-33",
@@ -2897,7 +2897,7 @@
     "status": "SHIPPED",
     "text": "The server refuses to uninstall a module another enabled module still",
     "file": "docs/spec/modules/README.md",
-    "line": 190
+    "line": 192
   },
   {
     "id": "MOD-34",
@@ -2907,7 +2907,7 @@
     "status": "SHIPPED",
     "text": "Uninstalling a module never touches media on disk. A downloads module",
     "file": "docs/spec/modules/README.md",
-    "line": 197
+    "line": 199
   },
   {
     "id": "MOD-35",
@@ -2917,7 +2917,7 @@
     "status": "SHIPPED",
     "text": "**A crashed module cannot take down the server.** The sidecar is a",
     "file": "docs/spec/modules/README.md",
-    "line": 207
+    "line": 209
   },
   {
     "id": "MOD-36",
@@ -2927,7 +2927,7 @@
     "status": "SHIPPED",
     "text": "**An incompatible module never runs by accident.** `minServer` is",
     "file": "docs/spec/modules/README.md",
-    "line": 210
+    "line": 212
   },
   {
     "id": "MOD-37",
@@ -2937,7 +2937,7 @@
     "status": "SHIPPED",
     "text": "**Failure is visible, not silent.** A module that will not start or",
     "file": "docs/spec/modules/README.md",
-    "line": 213
+    "line": 215
   },
   {
     "id": "MOD-38",
@@ -2947,7 +2947,7 @@
     "status": "SHIPPED",
     "text": "The server is forward-compatible with older modules. A module declares",
     "file": "docs/spec/modules/README.md",
-    "line": 221
+    "line": 223
   },
   {
     "id": "MOD-39",
@@ -2957,7 +2957,7 @@
     "status": "SHIPPED",
     "text": "A module installed today keeps working as the server is updated,",
     "file": "docs/spec/modules/README.md",
-    "line": 224
+    "line": 226
   },
   {
     "id": "MOD-40",
@@ -2967,7 +2967,7 @@
     "status": "SHIPPED",
     "text": "A *newer* module may raise its `minServer`, and the Store says so",
     "file": "docs/spec/modules/README.md",
-    "line": 227
+    "line": 229
   },
   {
     "id": "MOD-41",
@@ -2977,7 +2977,7 @@
     "status": "SHIPPED",
     "text": "A module **may** ship UI, and the position is deliberate: a module's",
     "file": "docs/spec/modules/README.md",
-    "line": 235
+    "line": 237
   },
   {
     "id": "MOD-42",
@@ -2987,7 +2987,7 @@
     "status": "AGREED",
     "text": "A module renders **its own admin surface**: configuration, status and",
     "file": "docs/spec/modules/README.md",
-    "line": 239
+    "line": 241
   },
   {
     "id": "MOD-43",
@@ -2997,7 +2997,7 @@
     "status": "SHIPPED",
     "text": "A module's UI is served through the same reverse proxy as its backend",
     "file": "docs/spec/modules/README.md",
-    "line": 242
+    "line": 244
   },
   {
     "id": "MOD-44",
@@ -3007,7 +3007,7 @@
     "status": "AGREED",
     "text": "**The compatibility gate is the early warning.** As the server moves",
     "file": "docs/spec/modules/README.md",
-    "line": 256
+    "line": 258
   },
   {
     "id": "MOD-45",
@@ -3017,7 +3017,7 @@
     "status": "AGREED",
     "text": "**Data is retained.** An incompatible or abandoned module is not",
     "file": "docs/spec/modules/README.md",
-    "line": 260
+    "line": 262
   },
   {
     "id": "MOD-46",
@@ -3027,7 +3027,7 @@
     "status": "AGREED",
     "text": "**The signal is honest.** The person is told the module has not kept",
     "file": "docs/spec/modules/README.md",
-    "line": 263
+    "line": 265
   },
   {
     "id": "MOD-47",
@@ -3037,7 +3037,7 @@
     "status": "SHIPPED",
     "text": "Every capability below could have been core and is a module instead,",
     "file": "docs/spec/modules/README.md",
-    "line": 283
+    "line": 285
   },
   {
     "id": "MOD-48",
@@ -3047,7 +3047,7 @@
     "status": "AGREED",
     "text": "The Store names the registry every module came from, on the listing and",
     "file": "docs/spec/modules/README.md",
-    "line": 150
+    "line": 152
   },
   {
     "id": "MOD-49",
@@ -3057,7 +3057,7 @@
     "status": "AGREED",
     "text": "Installing from a registry the operator added is gated once, per",
     "file": "docs/spec/modules/README.md",
-    "line": 153
+    "line": 155
   },
   {
     "id": "MOD-50",
@@ -3067,7 +3067,7 @@
     "status": "AGREED",
     "text": "A module that has disappeared from every configured registry is flagged",
     "file": "docs/spec/modules/README.md",
-    "line": 268
+    "line": 270
   },
   {
     "id": "MOD-51",
@@ -3075,7 +3075,7 @@
     "space": "modules",
     "number": 51,
     "status": "SHIPPED",
-    "text": "It may not read or write the server's own credentials. The settings",
+    "text": "It may not read or write the server's own credentials. A settings key",
     "file": "docs/spec/modules/README.md",
     "line": 57
   },
@@ -3087,7 +3087,7 @@
     "status": "SHIPPED",
     "text": "The server refuses to **update** a module past the range an enabled",
     "file": "docs/spec/modules/README.md",
-    "line": 192
+    "line": 194
   },
   {
     "id": "PLAY-1",

--- a/modules/README.md
+++ b/modules/README.md
@@ -277,13 +277,15 @@ settings, events, jobs and session lookup (`AuthUser` resolves through the
 host, so authenticating a caller costs no database).
 
 The settings callback reads and writes the operator's preferences, **not the
-core's own credentials**. The mail password, the LLM API key, the Web Push / APNs
-/ FCM private material and the registry list the Store installs from are the
-core's alone: a read answers the default you asked with, and a patch naming one
-is refused whole with a `403`. A credential a module is the thing that uses (the
-WireGuard config the bridge brings up, the tunnel token the connector runs on)
-stays readable and writable. For a vendor credential the operator configured, ask
-`GET /_host/secret?name=` by name.
+core's own credentials**. A key reaches you only when the core declared that it
+may: the mail password, the LLM API key, the Web Push / APNs / FCM private
+material and the registry list the Store installs from are the core's alone, and
+so is every key no declaration mentions, which is what an identity the server
+minted for itself is. A read answers the default you asked with, and a patch
+naming one is refused whole with a `403`. A credential a module is the thing that
+uses (the WireGuard config the bridge brings up, the tunnel token the connector
+runs on) stays readable and writable. For a vendor credential the operator
+configured, ask `GET /_host/secret?name=` by name.
 
 - **`dependencies`** is a hard dependency, as a `{ "<id>": "<range>" }` map.
   The backend enforces it, and the Store installs missing ones automatically.

--- a/server/crates/kroma-engine/src/services/settings/keys.rs
+++ b/server/crates/kroma-engine/src/services/settings/keys.rs
@@ -1,5 +1,4 @@
-//! The built-in settings keys: every default value, and which of them the core
-//! keeps to itself.
+//! The built-in settings keys: every default value, and who may reach each one.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::OnceLock;
@@ -9,18 +8,21 @@ use serde_json::{json, Value};
 #[cfg(test)]
 mod tests;
 
-/// Whether `key` is the core's alone: a credential only the core consumes, or the
-/// registry list that decides where installable native code comes from. The
-/// module host callback neither reads nor writes one, so a sidecar that asks for
-/// it gets the default it asked with.
-pub fn core_only(key: &str) -> bool {
-    static CORE_ONLY: OnceLock<BTreeSet<&'static str>> = OnceLock::new();
-    CORE_ONLY
+/// Whether the module host callback withholds `key` from every sidecar: a read
+/// answers the default the caller asked with, and a write naming it is refused.
+///
+/// Withheld unless a declaration in this module hands it out, so a key that
+/// reaches the store with no declared reach is withheld rather than served. An
+/// identity the server mints for itself is in that position, and so is the next
+/// key someone adds without thinking about who reads it.
+pub fn withheld_from_modules(key: &str) -> bool {
+    static REACHABLE: OnceLock<BTreeSet<&'static str>> = OnceLock::new();
+    !REACHABLE
         .get_or_init(|| {
             declared()
                 .reach
                 .into_iter()
-                .filter(|(_, reach)| *reach == Reach::CoreOnly)
+                .filter(|(_, reach)| *reach != Reach::CoreOnly)
                 .map(|(key, _)| key)
                 .collect()
         })
@@ -31,10 +33,11 @@ pub(super) fn defaults() -> BTreeMap<String, Value> {
     declared().values
 }
 
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Reach {
     CoreOnly,
     Sidecar,
+    Public,
 }
 
 struct Declared {
@@ -50,27 +53,35 @@ impl Declared {
         }
     }
 
-    fn insert(&mut self, key: String, value: Value) {
-        self.values.insert(key, value);
+    fn public(&mut self, key: &'static str, value: Value) {
+        self.declare(key, Reach::Public, value);
     }
 
     fn core_only(&mut self, key: &'static str, value: Value) {
-        self.reach.insert(key, Reach::CoreOnly);
-        self.values.insert(key.to_string(), value);
+        self.declare(key, Reach::CoreOnly, value);
     }
 
     fn sidecar_credential(&mut self, key: &'static str, value: Value) {
-        self.reach.insert(key, Reach::Sidecar);
+        self.declare(key, Reach::Sidecar, value);
+    }
+
+    fn minted(&mut self, key: &'static str) {
+        self.reach.insert(key, Reach::CoreOnly);
+    }
+
+    fn declare(&mut self, key: &'static str, reach: Reach, value: Value) {
+        self.reach.insert(key, reach);
         self.values.insert(key.to_string(), value);
     }
 }
 
 fn declared() -> Declared {
     let mut m = Declared::new();
-    m.insert("serverName".into(), json!("KROMA"));
+    m.public("serverName", json!("KROMA"));
+    m.minted("instanceId");
     // One key for the whole blob: `{ "<id>": { "enabled": bool, "config": {..} } }`
     // (module ids are not known at compile time, so they can't be allow-listed).
-    m.insert("moduleStates".into(), json!({}));
+    m.public("moduleStates", json!({}));
     // Empty = the built-in catalog (modules.json on this repo's GitHub Releases).
     // This is the OFFICIAL slot: it stays pinned first and wins on an id clash.
     m.core_only("moduleRegistryUrl", json!(""));
@@ -79,133 +90,132 @@ fn declared() -> Declared {
     // api/admin/store/registries.rs): the list is operator input pointing at
     // third-party catalogs of native code.
     m.core_only("moduleRegistries", json!([]));
-    m.insert("uiLanguage".into(), json!("Français"));
+    m.public("uiLanguage", json!("Français"));
     // Empty → the env-configured `KROMA_TMDB_LANGUAGE` (default "en-US").
-    m.insert("tmdbLanguage".into(), json!(super::TMDB_LANGUAGE_AUTO));
-    m.insert("timezone".into(), json!("Europe/Zurich (UTC+1)"));
-    m.insert("autoUpdate".into(), json!(true));
-    m.insert("updateChannel".into(), json!("Stable"));
+    m.public("tmdbLanguage", json!(super::TMDB_LANGUAGE_AUTO));
+    m.public("timezone", json!("Europe/Zurich (UTC+1)"));
+    m.public("autoUpdate", json!(true));
+    m.public("updateChannel", json!("Stable"));
     // Periodic re-scan cadence, the only path that catches NAS/SMB edits (they
     // emit no FS events). `-1` = `KROMA_WATCH_INTERVAL` or 300s, `0` = FS events only.
-    m.insert("watchAutoScan".into(), json!(true));
-    m.insert("watchIntervalSecs".into(), json!(-1));
+    m.public("watchAutoScan", json!(true));
+    m.public("watchIntervalSecs", json!(-1));
     // On, and an operator turns it off in Admin -> General -> Privacy. What it
     // sends, and why this is legitimate interest rather than consent, is
     // docs/anonymous-stats-gdpr.md. The two below are the detail blocks the base
     // switch carries, each droppable on its own and each silent without it.
-    m.insert("anonStats".into(), json!(true));
-    m.insert("anonStatsUsage".into(), json!(true));
-    m.insert("anonStatsStatistics".into(), json!(true));
-    m.insert("showRecentHome".into(), json!(true));
+    m.public("anonStats", json!(true));
+    m.public("anonStatsUsage", json!(true));
+    m.public("anonStatsStatistics", json!(true));
+    m.minted("statsId");
+    m.minted("stats.lastSentAt");
+    m.public("showRecentHome", json!(true));
     // Security: exposes the account roster on the login screen. Off by default so
     // knowing the server URL does not reveal who has an account; when off,
     // `GET /api/users` returns an empty list.
-    m.insert("publicUserList".into(), json!(false));
-    m.insert("themeSongs".into(), json!(false));
+    m.public("publicUserList", json!(false));
+    m.public("themeSongs", json!(false));
     // off | chapters (free, from embedded chapters) | fingerprint (heavy audio job).
-    m.insert("introDetection".into(), json!("chapters"));
-    m.insert("theme".into(), json!("Sombre (Kroma)"));
-    m.insert("dateFormat".into(), json!("JJ/MM/AAAA"));
-    m.insert("moduleAutoUpdate".into(), json!(true));
-    m.insert("remoteAccess".into(), json!(false));
-    m.insert("remoteUrl".into(), json!(""));
+    m.public("introDetection", json!("chapters"));
+    m.public("theme", json!("Sombre (Kroma)"));
+    m.public("dateFormat", json!("JJ/MM/AAAA"));
+    m.public("moduleAutoUpdate", json!(true));
+    m.public("remoteAccess", json!(false));
+    m.public("remoteUrl", json!(""));
     // Cloudflare Tunnel token for the `cloudflared` child the remote-access
     // sidecar supervises. Never returned to clients.
     m.sidecar_credential("remoteAccessToken", json!(""));
-    m.insert("upLimit".into(), json!("Illimité"));
-    m.insert("https".into(), json!("Préférées"));
+    m.public("upLimit", json!("Illimité"));
+    m.public("https", json!("Préférées"));
     // Self-signed HTTPS listener: browsers only expose Web Crypto (passkeys) on a
     // secure origin. Applied at boot, so a change needs a restart; `KROMA_HTTPS` /
     // `KROMA_HTTPS_PORT` override the stored values. See src/tls.rs.
-    m.insert("httpsEnabled".into(), json!(false));
-    m.insert("httpsPort".into(), json!("4443"));
-    m.insert("httpsRedirect".into(), json!(false));
-    m.insert("ipv6".into(), json!(false));
-    m.insert("localDiscovery".into(), json!(true));
-    m.insert(
-        "localNetworks".into(),
+    m.public("httpsEnabled", json!(false));
+    m.public("httpsPort", json!("4443"));
+    m.public("httpsRedirect", json!(false));
+    m.public("ipv6", json!(false));
+    m.public("localDiscovery", json!(true));
+    m.public(
+        "localNetworks",
         json!("192.168.0.0/16, 10.0.0.0/8, 172.16.0.0/12"),
     );
-    m.insert("hwAccel".into(), json!(false));
-    m.insert("hwDevice".into(), json!("Auto"));
-    m.insert("hevcEncode".into(), json!(false));
-    m.insert("transcoderSpeed".into(), json!("Automatique"));
-    m.insert("bgQuality".into(), json!("Préférer la vitesse"));
-    m.insert("maxConcurrent".into(), json!("8"));
+    m.public("hwAccel", json!(false));
+    m.public("hwDevice", json!("Auto"));
+    m.public("hevcEncode", json!(false));
+    m.public("transcoderSpeed", json!("Automatique"));
+    m.public("bgQuality", json!("Préférer la vitesse"));
+    m.public("maxConcurrent", json!("8"));
     // Concurrent CPU-heavy background ffmpeg passes; "0" = auto (cores - 1).
-    m.insert("mediaConcurrency".into(), json!("0"));
-    m.insert("pipelinePaused".into(), json!(false));
-    m.insert("deleteAfter".into(), json!(true));
-    m.insert("cacheLimit".into(), json!("80 Go"));
-    m.insert("transcodeCacheLimit".into(), json!("20 Go"));
+    m.public("mediaConcurrency", json!("0"));
+    m.public("pipelinePaused", json!(false));
+    m.public("deleteAfter", json!(true));
+    m.public("cacheLimit", json!("80 Go"));
+    m.public("transcodeCacheLimit", json!("20 Go"));
     // Scheduler timezone offset in minutes from UTC (60 = UTC+1, -300 = UTC-5).
-    m.insert("jobsUtcOffset".into(), json!(0));
+    m.public("jobsUtcOffset", json!(0));
     // Keyword lists are comma-separated, matched as whole tokens against release names.
-    m.insert("acqEnabled".into(), json!(false));
-    m.insert("acqAutoApprove".into(), json!(false));
-    m.insert("acqDeleteAfterImport".into(), json!(false));
-    m.insert("acqReplaceOnUpgrade".into(), json!(true));
-    m.insert("acqResolution".into(), json!("1080p"));
-    m.insert("acqPreferHevc".into(), json!(true));
-    m.insert("acqMinSeeders".into(), json!(2));
-    m.insert("acqMaxSizeGbMovie".into(), json!(15));
-    m.insert("acqMaxSizeGbEpisode".into(), json!(3));
-    m.insert("acqRequiredKeywords".into(), json!(""));
-    m.insert(
-        "acqForbiddenKeywords".into(),
+    m.public("acqEnabled", json!(false));
+    m.public("acqAutoApprove", json!(false));
+    m.public("acqDeleteAfterImport", json!(false));
+    m.public("acqReplaceOnUpgrade", json!(true));
+    m.public("acqResolution", json!("1080p"));
+    m.public("acqPreferHevc", json!(true));
+    m.public("acqMinSeeders", json!(2));
+    m.public("acqMaxSizeGbMovie", json!(15));
+    m.public("acqMaxSizeGbEpisode", json!(3));
+    m.public("acqRequiredKeywords", json!(""));
+    m.public(
+        "acqForbiddenKeywords",
         json!("cam, hdcam, ts, telesync, telecine, screener, dvdscr, workprint"),
     );
     // Embedded torrent engine knobs (0 = ephemeral port / unlimited rate).
-    m.insert("rqbitPort".into(), json!(0));
-    m.insert("rqbitDownKbps".into(), json!(0));
-    m.insert("rqbitUpKbps".into(), json!(0));
+    m.public("rqbitPort", json!(0));
+    m.public("rqbitDownKbps", json!(0));
+    m.public("rqbitUpKbps", json!(0));
     // How many downloads may hold an engine slot at once (0 = no cap); the rest
     // wait in the queue.
-    m.insert("torrentMaxActive".into(), json!(0));
+    m.public("torrentMaxActive", json!(0));
     // The WireGuard tunnel the bridge sidecar brings up. Never returned in a
     // settings view.
     m.sidecar_credential("vpnWgConfig", json!(""));
-    m.insert("vpnLocalPort".into(), json!(25345));
-    m.insert("vpnKillSwitch".into(), json!(false));
-    m.insert("vpnCheckUrl".into(), json!("https://api.ipify.org"));
+    m.public("vpnLocalPort", json!(25345));
+    m.public("vpnKillSwitch", json!(false));
+    m.public("vpnCheckUrl", json!("https://api.ipify.org"));
     // Library new downloads land in, by name; "Auto" = first of the matching kind.
-    m.insert("acqMovieLibrary".into(), json!("Auto"));
-    m.insert("acqSeriesLibrary".into(), json!("Auto"));
+    m.public("acqMovieLibrary", json!("Auto"));
+    m.public("acqSeriesLibrary", json!("Auto"));
     // Sonarr/Radarr-style tokens; see kroma_torrent::organize::naming.
-    m.insert("namingMovieFolder".into(), json!("{Title} ({Year})"));
-    m.insert(
-        "namingMovieFile".into(),
-        json!("{Title} ({Year}) {Quality Full}"),
-    );
-    m.insert("namingSeriesFolder".into(), json!("{Title} ({Year})"));
-    m.insert("namingSeasonFolder".into(), json!("Season {season:00}"));
-    m.insert(
-        "namingEpisodeFile".into(),
+    m.public("namingMovieFolder", json!("{Title} ({Year})"));
+    m.public("namingMovieFile", json!("{Title} ({Year}) {Quality Full}"));
+    m.public("namingSeriesFolder", json!("{Title} ({Year})"));
+    m.public("namingSeasonFolder", json!("Season {season:00}"));
+    m.public(
+        "namingEpisodeFile",
         json!("{Title} - S{season:00}E{episode:00} - {Episode Title} {Quality Full}"),
     );
     // MUST stay registered: `set_patch` silently drops unknown keys, so without
     // this line `save_naming` answers `{"ok": true}` and throws the value away.
-    m.insert("namingCase".into(), json!("default"));
+    m.public("namingCase", json!("default"));
     // openai = any OpenAI-compatible server (Ollama, llama.cpp, LM Studio, …);
     // anthropic = Claude.
-    m.insert("llmEnabled".into(), json!(true));
-    m.insert("llmProvider".into(), json!("openai"));
-    m.insert("llmBaseUrl".into(), json!(""));
-    m.insert("llmModel".into(), json!(""));
+    m.public("llmEnabled", json!(true));
+    m.public("llmProvider", json!("openai"));
+    m.public("llmBaseUrl", json!(""));
+    m.public("llmModel", json!(""));
     m.core_only("llmApiKey", json!(""));
-    m.insert("llmTemperature".into(), json!(0.7));
-    m.insert("llmMaxTokens".into(), json!(900));
-    m.insert("llmReasoning".into(), json!(false));
+    m.public("llmTemperature", json!(0.7));
+    m.public("llmMaxTokens", json!(900));
+    m.public("llmReasoning", json!(false));
     // Seeded from the flat `llm*` keys above on first read when empty.
-    m.insert("llmProviders".into(), json!([]));
-    m.insert("llmDefaultProvider".into(), json!(""));
-    m.insert("libraries".into(), json!(null));
+    m.public("llmProviders", json!([]));
+    m.public("llmDefaultProvider", json!(""));
+    m.public("libraries", json!(null));
     // ISO-8601 `items.added_at` the digest has reported up to. Empty = never run:
     // the first pass adopts the current library as its baseline and stays silent.
-    m.insert("notifications.digest.since".into(), json!(""));
+    m.public("notifications.digest.since", json!(""));
     // Web Push (RFC 8292) VAPID identity, minted on the first subscription and
     // then left alone: rotating it invalidates every subscribed browser.
-    m.insert("notifications.vapid.publicKey".into(), json!(""));
+    m.public("notifications.vapid.publicKey", json!(""));
     m.core_only("notifications.vapid.privateKey", json!(""));
     // Apple/Google only accept keys they issued to whoever PUBLISHES the app, so
     // these normally arrive with the build (`KROMA_APNS_*` /
@@ -220,11 +230,11 @@ fn declared() -> Declared {
     // any device and reads any library.
     m.core_only("mediaTicketKey", json!(""));
     // Operator SMTP for credential-reset email.
-    m.insert("smtpEnabled".into(), json!(false));
-    m.insert("smtpHost".into(), json!(""));
-    m.insert("smtpPort".into(), json!(587));
-    m.insert("smtpUsername".into(), json!(""));
-    m.insert("smtpFrom".into(), json!(""));
+    m.public("smtpEnabled", json!(false));
+    m.public("smtpHost", json!(""));
+    m.public("smtpPort", json!(587));
+    m.public("smtpUsername", json!(""));
+    m.public("smtpFrom", json!(""));
     m.core_only("smtpPassword", json!(""));
     m
 }

--- a/server/crates/kroma-engine/src/services/settings/keys/tests.rs
+++ b/server/crates/kroma-engine/src/services/settings/keys/tests.rs
@@ -26,20 +26,37 @@ fn reads_like_a_credential(key: &str) -> bool {
 }
 
 #[test]
-fn a_key_that_reads_like_a_credential_declares_who_may_reach_it() {
+fn every_key_that_carries_a_default_declares_who_may_reach_it() {
     let declared = declared();
 
     let undeclared: Vec<&String> = declared
         .values
         .keys()
-        .filter(|key| reads_like_a_credential(key))
         .filter(|key| !declared.reach.contains_key(key.as_str()))
         .collect();
 
     assert!(
         undeclared.is_empty(),
+        "a key reaches the store through one of public(), core_only() and \
+         sidecar_credential(), each of which declares a reach: {undeclared:?}"
+    );
+}
+
+#[test]
+fn a_key_that_reads_like_a_credential_is_never_declared_public() {
+    let declared = declared();
+
+    let served: Vec<&&str> = declared
+        .reach
+        .iter()
+        .filter(|(key, reach)| reads_like_a_credential(key) && **reach == Reach::Public)
+        .map(|(key, _)| key)
+        .collect();
+
+    assert!(
+        served.is_empty(),
         "a credential is the core's alone unless a sidecar configures it; \
-         declare these with core_only() or sidecar_credential(): {undeclared:?}"
+         declare these with core_only() or sidecar_credential(): {served:?}"
     );
 }
 
@@ -69,34 +86,66 @@ fn the_mail_llm_push_and_registry_keys_are_the_cores_alone() {
         "moduleRegistries",
         "moduleRegistryUrl",
     ] {
-        assert!(core_only(key), "{key} must be the core's alone");
+        assert!(withheld_from_modules(key), "{key} must be the core's alone");
     }
 }
 
-// The word sweep above cannot reach this one: "mediaTicketKey" carries no
-// password, token, secret or credential word, so only a named case keeps it
-// declared.
+// The word sweep cannot reach this one: "mediaTicketKey" carries no password,
+// token, secret or credential word, so only a named case says it was thought
+// about rather than caught.
 #[test]
 fn the_key_that_signs_a_media_ticket_is_the_cores_alone() {
     let key = crate::services::media_ticket::SIGNING_KEY_SETTING;
 
-    assert!(core_only(key), "{key} forges a ticket for any device");
+    assert!(
+        withheld_from_modules(key),
+        "{key} forges a ticket for any device"
+    );
     assert!(!reads_like_a_credential(key), "the sweep would cover it");
+    assert_eq!(declared().reach.get(key), Some(&Reach::CoreOnly));
+}
+
+#[test]
+fn the_identities_the_server_mints_for_itself_are_declared_and_withheld() {
+    let declared = declared();
+
+    for key in [
+        "instanceId",
+        crate::services::stats::ID_KEY,
+        crate::services::stats::SENT_KEY,
+    ] {
+        assert_eq!(
+            declared.reach.get(key),
+            Some(&Reach::CoreOnly),
+            "{key} is minted, not configured"
+        );
+        assert!(
+            !declared.values.contains_key(key),
+            "{key} carries no default, so no patch off the wire writes it"
+        );
+        assert!(withheld_from_modules(key), "{key} is no module's business");
+    }
 }
 
 #[test]
 fn a_credential_the_sidecar_that_uses_it_configures_stays_reachable() {
-    assert!(!core_only("vpnWgConfig"));
-    assert!(!core_only("remoteAccessToken"));
+    assert!(!withheld_from_modules("vpnWgConfig"));
+    assert!(!withheld_from_modules("remoteAccessToken"));
 }
 
 #[test]
-fn an_ordinary_preference_and_an_unknown_key_are_not_withheld() {
-    assert!(!core_only("acqEnabled"));
-    assert!(!core_only("namingEpisodeFile"));
-    assert!(!core_only("notifications.vapid.publicKey"));
-    assert!(!core_only("smtpHost"));
-    assert!(!core_only("neverDeclared"));
+fn an_ordinary_preference_is_reachable() {
+    assert!(!withheld_from_modules("acqEnabled"));
+    assert!(!withheld_from_modules("namingEpisodeFile"));
+    assert!(!withheld_from_modules("notifications.vapid.publicKey"));
+    assert!(!withheld_from_modules("smtpHost"));
+}
+
+#[test]
+fn a_key_nothing_declares_is_withheld_whatever_it_is_called() {
+    assert!(withheld_from_modules("neverDeclared"));
+    assert!(withheld_from_modules("aPlausiblePreference"));
+    assert!(withheld_from_modules(""));
 }
 
 #[test]

--- a/server/crates/kroma-engine/src/services/settings/mod.rs
+++ b/server/crates/kroma-engine/src/services/settings/mod.rs
@@ -13,9 +13,9 @@
 //! enforce; those are marked `applied: false` in the schema so the UI can be
 //! honest about it.
 //!
-//! Split into the declared [`keys`] (defaults + which of them the core keeps to
-//! itself), the [`store`] (map + persistence), the typed functional [`accessors`]
-//! (+ library defs), and the admin view-model [`schema`].
+//! Split into the declared [`keys`] (defaults + who may reach each one), the
+//! [`store`] (map + persistence), the typed functional [`accessors`] (+ library
+//! defs), and the admin view-model [`schema`].
 
 /// The dropdown value that means "no explicit choice": the fallback language
 /// defers to the server's own default.
@@ -28,7 +28,7 @@ mod schema;
 mod store;
 
 pub use accessors::*;
-pub use keys::core_only;
+pub use keys::withheld_from_modules;
 pub use llm::*;
 pub use schema::*;
 pub use store::*;

--- a/server/crates/kroma-module-supervisor/src/host_api.rs
+++ b/server/crates/kroma-module-supervisor/src/host_api.rs
@@ -15,12 +15,12 @@ use serde_json::{json, Value};
 
 mod settings;
 
-pub use settings::CoreOnlySettings;
+pub use settings::WithheldSettings;
 
 /// The `/_host/*` callback router modules call back into (mount under `/api`),
-/// guarded by the shared `token`. `core_only` decides which settings keys the
-/// callback withholds.
-pub fn host_router<S>(token: String, core_only: CoreOnlySettings) -> Router<S>
+/// guarded by the shared `token`. `withheld` decides which settings keys the
+/// callback keeps from a module.
+pub fn host_router<S>(token: String, withheld: WithheldSettings) -> Router<S>
 where
     S: HostCtx + Clone + Send + Sync + 'static,
 {
@@ -47,7 +47,7 @@ where
         // answers with whoever serves it. No module id crosses this wire.
         .route("/_host/contributions", get(contributions::<S>))
         .route_layer(from_fn_with_state(HostToken(token), require_host_token))
-        .layer(Extension(core_only))
+        .layer(Extension(withheld))
 }
 
 #[derive(serde::Deserialize)]

--- a/server/crates/kroma-module-supervisor/src/host_api/settings.rs
+++ b/server/crates/kroma-module-supervisor/src/host_api/settings.rs
@@ -7,11 +7,11 @@ use axum::{Extension, Json};
 use kroma_module_host::HostCtx;
 use serde_json::{json, Value};
 
-/// Asks the core whether a settings key is its own. `true` withholds that key, so
+/// Asks the core whether a settings key is withheld from a module. `true` means
 /// no sidecar reads or writes it through the callback: the supervisor carries the
 /// question, the core owns the answer.
 #[derive(Clone, Copy)]
-pub struct CoreOnlySettings(pub fn(&str) -> bool);
+pub struct WithheldSettings(pub fn(&str) -> bool);
 
 #[derive(serde::Deserialize)]
 pub(super) struct SettingQuery {
@@ -35,10 +35,10 @@ fn asked_with(q: &SettingQuery) -> Value {
 
 pub(super) async fn get_setting<S: HostCtx>(
     State(host): State<S>,
-    Extension(CoreOnlySettings(core_only)): Extension<CoreOnlySettings>,
+    Extension(WithheldSettings(withheld)): Extension<WithheldSettings>,
     Query(q): Query<SettingQuery>,
 ) -> Json<Value> {
-    if core_only(&q.key) {
+    if withheld(&q.key) {
         tracing::warn!(key = %q.key, "a module asked for a setting the core keeps to itself");
         return Json(json!({ "value": asked_with(&q) }));
     }
@@ -52,10 +52,10 @@ pub(super) async fn get_setting<S: HostCtx>(
 
 pub(super) async fn set_settings<S: HostCtx>(
     State(host): State<S>,
-    Extension(CoreOnlySettings(core_only)): Extension<CoreOnlySettings>,
+    Extension(WithheldSettings(withheld)): Extension<WithheldSettings>,
     Json(body): Json<SettingsPatch>,
 ) -> StatusCode {
-    if let Some(key) = body.patch.keys().find(|key| core_only(key)) {
+    if let Some(key) = body.patch.keys().find(|key| withheld(key)) {
         tracing::warn!(key = %key, "refusing a module's write to a setting the core keeps to itself");
         return StatusCode::FORBIDDEN;
     }

--- a/server/crates/kroma-module-supervisor/src/lib.rs
+++ b/server/crates/kroma-module-supervisor/src/lib.rs
@@ -19,7 +19,7 @@ mod proxy;
 mod registry;
 mod watch;
 
-pub use host_api::{host_router, CoreOnlySettings};
+pub use host_api::{host_router, WithheldSettings};
 pub use origin::{BinStamp, Origin, Source};
 pub use proxy::proxy_to;
 pub use registry::{sibling_url, verify_sha256, FetchProgress, DESCRIPTOR_PATH, MAX_BUNDLE_BYTES};

--- a/server/crates/kroma-module-supervisor/tests/host_metadata.rs
+++ b/server/crates/kroma-module-supervisor/tests/host_metadata.rs
@@ -2,11 +2,11 @@ use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use kroma_domain::metadata::{EpisodeInfo, MatchCandidate};
 use kroma_module_host::testing::StubHost;
-use kroma_module_supervisor::CoreOnlySettings;
+use kroma_module_supervisor::WithheldSettings;
 use tower::ServiceExt;
 
 const TOKEN: &str = "host-token";
-const NOTHING_WITHHELD: CoreOnlySettings = CoreOnlySettings(|_| false);
+const NOTHING_WITHHELD: WithheldSettings = WithheldSettings(|_| false);
 
 fn dune() -> MatchCandidate {
     MatchCandidate {

--- a/server/crates/kroma-module-supervisor/tests/host_secret.rs
+++ b/server/crates/kroma-module-supervisor/tests/host_secret.rs
@@ -10,11 +10,11 @@
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use kroma_module_host::testing::StubHost;
-use kroma_module_supervisor::CoreOnlySettings;
+use kroma_module_supervisor::WithheldSettings;
 use tower::ServiceExt;
 
 const TOKEN: &str = "host-token";
-const NOTHING_WITHHELD: CoreOnlySettings = CoreOnlySettings(|_| false);
+const NOTHING_WITHHELD: WithheldSettings = WithheldSettings(|_| false);
 
 async fn get(host: StubHost, uri: &str, token: Option<&str>) -> (StatusCode, String) {
     let mut req = Request::builder().method("GET").uri(uri);

--- a/server/crates/kroma-module-supervisor/tests/host_session.rs
+++ b/server/crates/kroma-module-supervisor/tests/host_session.rs
@@ -9,11 +9,11 @@ use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use kroma_domain::User;
 use kroma_module_host::testing::StubHost;
-use kroma_module_supervisor::CoreOnlySettings;
+use kroma_module_supervisor::WithheldSettings;
 use tower::ServiceExt;
 
 const TOKEN: &str = "host-token";
-const NOTHING_WITHHELD: CoreOnlySettings = CoreOnlySettings(|_| false);
+const NOTHING_WITHHELD: WithheldSettings = WithheldSettings(|_| false);
 
 fn ana() -> User {
     User {

--- a/server/crates/kroma-module-supervisor/tests/host_settings.rs
+++ b/server/crates/kroma-module-supervisor/tests/host_settings.rs
@@ -4,15 +4,15 @@
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use kroma_module_host::testing::StubHost;
-use kroma_module_supervisor::CoreOnlySettings;
+use kroma_module_supervisor::WithheldSettings;
 use serde_json::json;
 use tower::ServiceExt;
 
 const TOKEN: &str = "host-token";
-const CORE_ONLY: CoreOnlySettings = CoreOnlySettings(|key| key == "smtpPassword");
+const WITHHELD: WithheldSettings = WithheldSettings(|key| key == "smtpPassword");
 
 async fn send(host: StubHost, req: Request<Body>) -> (StatusCode, String) {
-    let res = kroma_module_supervisor::host_router::<StubHost>(TOKEN.into(), CORE_ONLY)
+    let res = kroma_module_supervisor::host_router::<StubHost>(TOKEN.into(), WITHHELD)
         .with_state(host)
         .oneshot(req)
         .await

--- a/server/src/api/it_host_settings.rs
+++ b/server/src/api/it_host_settings.rs
@@ -176,3 +176,55 @@ async fn a_sidecar_still_saves_the_settings_it_owns() {
     assert_eq!(t.state.settings.get("acqEnabled"), json!(true));
     assert_eq!(t.state.settings.get("vpnWgConfig"), json!("[Interface]"));
 }
+
+#[tokio::test]
+async fn an_identity_the_server_minted_for_itself_never_reaches_a_sidecar() {
+    let t = test_app();
+    let instance = crate::services::settings::ensure_instance_id(&t.state.settings, &t.state.db);
+    let stats = crate::services::settings::stats::ensure_identity(&t.state.settings, &t.state.db);
+
+    let mut answers = Vec::new();
+    for key in ["instanceId", crate::services::stats::ID_KEY] {
+        let uri = format!("/api/_host/setting?key={key}&kind=str&default=");
+        answers.push(get(&t.app, &uri, Some(HOST_TOKEN)).await);
+    }
+
+    assert!(!instance.is_empty() && !stats.is_empty(), "both are minted");
+    for (status, body) in &answers {
+        assert_eq!(*status, StatusCode::OK);
+        assert_eq!(*body, json!({ "value": "" }));
+        assert!(!body.to_string().contains(&instance));
+        assert!(!body.to_string().contains(&stats));
+    }
+}
+
+#[tokio::test]
+async fn a_key_no_declaration_names_is_withheld_in_both_directions() {
+    let t = test_app();
+    t.state
+        .settings
+        .set_internal(&t.state.db, "undeclaredSecret", json!("minted-by-nobody"));
+
+    let (read_status, read) = get(
+        &t.app,
+        "/api/_host/setting?key=undeclaredSecret&kind=str&default=",
+        Some(HOST_TOKEN),
+    )
+    .await;
+    let (write_status, _) = send(
+        &t.app,
+        "POST",
+        "/api/_host/settings",
+        Some(HOST_TOKEN),
+        Some(json!({ "patch": { "undeclaredSecret": "mine now" } })),
+    )
+    .await;
+
+    assert_eq!(read_status, StatusCode::OK);
+    assert_eq!(read, json!({ "value": "" }));
+    assert_eq!(write_status, StatusCode::FORBIDDEN);
+    assert_eq!(
+        t.state.settings.get_str("undeclaredSecret", ""),
+        "minted-by-nobody"
+    );
+}

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -232,7 +232,9 @@ pub fn router(
         .merge(content)
         .merge(kroma_module_supervisor::host_router::<SharedState>(
             supervisor.host_token().to_string(),
-            kroma_module_supervisor::CoreOnlySettings(crate::services::settings::core_only),
+            kroma_module_supervisor::WithheldSettings(
+                crate::services::settings::withheld_from_modules,
+            ),
         ))
         // A sidecar registers its scheduled jobs with the core JobManager here, so
         // they appear in admin Tâches like in-core jobs (same host-token guard).


### PR DESCRIPTION
## What

The host settings callback withheld a key only when `settings/keys.rs` declared it
`core_only()`, so an undeclared key was served to any sidecar holding the host token.
The only thing standing between a new secret and every installed module was a test that
swept key NAMES for `password`, `token`, `secret` and `credential`. `mediaTicketKey`
contains none of those words, so it shipped readable until review caught it on #234.
`instanceId`, `statsId` and `stats.lastSentAt` were in the same position: written through
`Settings::set_internal`, declared nowhere.

This takes the issue's first route and makes the compiler carry it. `Reach` gains
`Public`, `Declared::insert` is deleted, and a key enters the table only through
`public()`, `core_only()` or `sidecar_credential()`. There is no way left to put a
default in the store without recording who may reach it, so the omission #234 hit is
now a compile error rather than a naming gamble.

The callback asks the inverse question. `core_only(key)` becomes
`withheld_from_modules(key)`, true for everything the declarations do not hand out. That
closes the minted keys and every future one at once, whatever it is named. `minted()`
writes the three we have down explicitly, with no default so `set_patch` still drops
them off the wire.

The word sweep stays as the second net with a narrower job: a credential-shaped name may
never be declared `public()`. `mediaTicketKey` keeps its named case, the assertion that
the sweep misses it included, because that is why the case exists.

### What I rejected

The issue's other route was **`set_internal` implies core-only**, via a typed key only
`keys.rs` can construct. Withholding by default already covers every key `set_internal`
writes, and it also covers a key that never went through `set_internal` at all, which the
typed key would not. The typed key would have bought documentation at the cost of moving
`stats::ID_KEY` and `media_ticket::SIGNING_KEY_SETTING` into the table; `minted()` buys
the same documentation for three lines.

### Spec

MOD-51 said the callback "withholds every key only the server consumes", a deny-list.
The boundary is now "a key reaches a module only where the server declared that one may
have it", so MOD-51's text moves with it and stays SHIPPED. `spec:index` regenerated.

## Closes

Closes #235

## Checks

- [x] `bun run typecheck` and `bun run test` pass (10023 passed, 2 skipped)
- [x] `cargo clippy --workspace --all-targets` and `cargo test --workspace` pass; still
      the same 16 pre-existing warning sites, none new
- [x] `bun run spec:check` up to date
- [x] Follows `CODE_STYLE.md`
- [x] One idea: a key cannot reach a module without a declared reach

`bun run check` fails on `apps/www/project.inlang/settings.json` and
`bun run modules:check` on six modules' clippy. Both pre-existing on `main` and
untouched here.

## Risk

A module could read a core settings key that no declaration names, and now gets its own
default instead. For the modules in this repo that is a no-op: every core key they read
is declared, and the two the indexer reads that are not in the table
(`acqIndexersUseVpn`, `acqFlaresolverrUrl`) already answered the module's own default,
because `set_patch` drops a key `defaults()` does not declare and nothing was ever
stored under either name.

A third-party module reading an undeclared key would see the same flip, and a patch
naming one now answers `403` where it used to answer `204` and silently drop the key.
Both are logged with the key name.

Found while reading: `acqIndexersUseVpn` is rendered as an admin row in
`settings/schema.rs` but is absent from `defaults()`, so the console's save throws it
away. That is a different bug and is not fixed here.
