### PR TITLE
fix(modules): a dependency range is enforced in both directions, or in neither

### DIFF
--- a/docs/spec/INDEX.md
+++ b/docs/spec/INDEX.md
@@ -3,7 +3,7 @@
 
 # Requirement index
 
-410 requirements across the spec. The machine-readable source is [`requirements.json`](requirements.json).
+411 requirements across the spec. The machine-readable source is [`requirements.json`](requirements.json).
 
 ## ACCT - [accounts](accounts/)
 
@@ -330,6 +330,7 @@
 - **MOD-49** (AGREED) - Installing from a registry the operator added is gated once, per
 - **MOD-50** (AGREED) - A module that has disappeared from every configured registry is flagged
 - **MOD-51** (SHIPPED) - It may not read or write the server's own credentials. The settings
+- **MOD-52** (SHIPPED) - The server refuses to **update** a module past the range an enabled
 
 ## PLAY - [playback](playback/)
 

--- a/docs/spec/modules/README.md
+++ b/docs/spec/modules/README.md
@@ -189,6 +189,10 @@ Four actions, and what each does to the module's data:
   as such.
 - **MOD-33** (SHIPPED) - The server refuses to uninstall a module another enabled module still
   depends on, and names the dependant.
+- **MOD-52** (SHIPPED) - The server refuses to **update** a module past the range an enabled
+  dependant declares, and names the dependant. A dependency's range is enforced in both
+  directions or in neither: enforcing it only when the dependant installs lets a peer walk away
+  from it, and the dependant is then the one that cannot update.
 
 **MOD-34** (SHIPPED) - Uninstalling a module never touches media on disk. A downloads module
 leaves the files it fetched exactly where they are, and the library keeps observing them

--- a/docs/spec/requirements.json
+++ b/docs/spec/requirements.json
@@ -2907,7 +2907,7 @@
     "status": "SHIPPED",
     "text": "Uninstalling a module never touches media on disk. A downloads module",
     "file": "docs/spec/modules/README.md",
-    "line": 193
+    "line": 197
   },
   {
     "id": "MOD-35",
@@ -2917,7 +2917,7 @@
     "status": "SHIPPED",
     "text": "**A crashed module cannot take down the server.** The sidecar is a",
     "file": "docs/spec/modules/README.md",
-    "line": 203
+    "line": 207
   },
   {
     "id": "MOD-36",
@@ -2927,7 +2927,7 @@
     "status": "SHIPPED",
     "text": "**An incompatible module never runs by accident.** `minServer` is",
     "file": "docs/spec/modules/README.md",
-    "line": 206
+    "line": 210
   },
   {
     "id": "MOD-37",
@@ -2937,7 +2937,7 @@
     "status": "SHIPPED",
     "text": "**Failure is visible, not silent.** A module that will not start or",
     "file": "docs/spec/modules/README.md",
-    "line": 209
+    "line": 213
   },
   {
     "id": "MOD-38",
@@ -2947,7 +2947,7 @@
     "status": "SHIPPED",
     "text": "The server is forward-compatible with older modules. A module declares",
     "file": "docs/spec/modules/README.md",
-    "line": 217
+    "line": 221
   },
   {
     "id": "MOD-39",
@@ -2957,7 +2957,7 @@
     "status": "SHIPPED",
     "text": "A module installed today keeps working as the server is updated,",
     "file": "docs/spec/modules/README.md",
-    "line": 220
+    "line": 224
   },
   {
     "id": "MOD-40",
@@ -2967,7 +2967,7 @@
     "status": "SHIPPED",
     "text": "A *newer* module may raise its `minServer`, and the Store says so",
     "file": "docs/spec/modules/README.md",
-    "line": 223
+    "line": 227
   },
   {
     "id": "MOD-41",
@@ -2977,7 +2977,7 @@
     "status": "SHIPPED",
     "text": "A module **may** ship UI, and the position is deliberate: a module's",
     "file": "docs/spec/modules/README.md",
-    "line": 231
+    "line": 235
   },
   {
     "id": "MOD-42",
@@ -2987,7 +2987,7 @@
     "status": "AGREED",
     "text": "A module renders **its own admin surface**: configuration, status and",
     "file": "docs/spec/modules/README.md",
-    "line": 235
+    "line": 239
   },
   {
     "id": "MOD-43",
@@ -2997,7 +2997,7 @@
     "status": "SHIPPED",
     "text": "A module's UI is served through the same reverse proxy as its backend",
     "file": "docs/spec/modules/README.md",
-    "line": 238
+    "line": 242
   },
   {
     "id": "MOD-44",
@@ -3007,7 +3007,7 @@
     "status": "AGREED",
     "text": "**The compatibility gate is the early warning.** As the server moves",
     "file": "docs/spec/modules/README.md",
-    "line": 252
+    "line": 256
   },
   {
     "id": "MOD-45",
@@ -3017,7 +3017,7 @@
     "status": "AGREED",
     "text": "**Data is retained.** An incompatible or abandoned module is not",
     "file": "docs/spec/modules/README.md",
-    "line": 256
+    "line": 260
   },
   {
     "id": "MOD-46",
@@ -3027,7 +3027,7 @@
     "status": "AGREED",
     "text": "**The signal is honest.** The person is told the module has not kept",
     "file": "docs/spec/modules/README.md",
-    "line": 259
+    "line": 263
   },
   {
     "id": "MOD-47",
@@ -3037,7 +3037,7 @@
     "status": "SHIPPED",
     "text": "Every capability below could have been core and is a module instead,",
     "file": "docs/spec/modules/README.md",
-    "line": 279
+    "line": 283
   },
   {
     "id": "MOD-48",
@@ -3067,7 +3067,7 @@
     "status": "AGREED",
     "text": "A module that has disappeared from every configured registry is flagged",
     "file": "docs/spec/modules/README.md",
-    "line": 264
+    "line": 268
   },
   {
     "id": "MOD-51",
@@ -3078,6 +3078,16 @@
     "text": "It may not read or write the server's own credentials. The settings",
     "file": "docs/spec/modules/README.md",
     "line": 57
+  },
+  {
+    "id": "MOD-52",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 52,
+    "status": "SHIPPED",
+    "text": "The server refuses to **update** a module past the range an enabled",
+    "file": "docs/spec/modules/README.md",
+    "line": 192
   },
   {
     "id": "PLAY-1",

--- a/modules/tv.kroma.acquisition/module.json
+++ b/modules/tv.kroma.acquisition/module.json
@@ -3,7 +3,7 @@
   "schemaVersion": 2,
   "id": "tv.kroma.acquisition",
   "name": "Acquisition",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "The acquisition feature: interactive/manual release search, quality scoring, grab + import, and the automatic wanted-list pass. Rides on the Downloads engine and the indexers. Disable it to remove search/grab/auto and hide the settings page.",
   "engines": {
     "server": ">=0.1.39"
@@ -12,7 +12,7 @@
     "module": "./remoteEntry.js"
   },
   "dependencies": {
-    "tv.kroma.torrents": "^0.3.0"
+    "tv.kroma.torrents": ">=0.3.0"
   },
   "contributes": [
     {

--- a/modules/tv.kroma.acquisition/ui/src/index.test.ts
+++ b/modules/tv.kroma.acquisition/ui/src/index.test.ts
@@ -5,7 +5,7 @@ import acquisitionModule from './module';
 describe('acquisitionModule', () => {
   it('takes its identity and its dependency from the shared manifest', () => {
     expect(acquisitionModule.id).toBe('tv.kroma.acquisition');
-    expect(acquisitionModule.dependencies).toEqual({ 'tv.kroma.torrents': '^0.3.0' });
+    expect(acquisitionModule.dependencies).toEqual({ 'tv.kroma.torrents': '>=0.3.0' });
   });
 
   it('derives its nav link from the route it points at', () => {

--- a/modules/tv.kroma.engine.qbittorrent/module.json
+++ b/modules/tv.kroma.engine.qbittorrent/module.json
@@ -3,13 +3,13 @@
   "schemaVersion": 2,
   "id": "tv.kroma.engine.qbittorrent",
   "name": "qBittorrent engine",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "qBittorrent WebUI as a download sub-engine for the Downloads module. Toggle it to add/remove qBittorrent from the download-client picker.",
   "engines": {
     "server": ">=0.1.39"
   },
   "dependencies": {
-    "tv.kroma.torrents": "^0.3.0"
+    "tv.kroma.torrents": ">=0.3.0"
   },
   "contributes": [
     {

--- a/modules/tv.kroma.engine.transmission/module.json
+++ b/modules/tv.kroma.engine.transmission/module.json
@@ -3,13 +3,13 @@
   "schemaVersion": 2,
   "id": "tv.kroma.engine.transmission",
   "name": "Transmission engine",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Transmission RPC as a download sub-engine for the Downloads module. Toggle it to add/remove Transmission from the download-client picker.",
   "engines": {
     "server": ">=0.1.39"
   },
   "dependencies": {
-    "tv.kroma.torrents": "^0.3.0"
+    "tv.kroma.torrents": ">=0.3.0"
   },
   "contributes": [
     {

--- a/packages/cli/src/commands/check.test.ts
+++ b/packages/cli/src/commands/check.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { MODULE_SCHEMA_VERSION } from '@kromatv/registry';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { checkCommand, importProblems, specifierOf } from './check';
+import { checkCommand, importProblems, specifierOf, unsatisfiableRanges } from './check';
 
 const PROJECT = '/modules/tv.acme.notes';
 const FILE = join(PROJECT, 'ui/src/page.tsx');
@@ -122,5 +122,36 @@ describe('checkCommand', () => {
     expect(code).toBe(1);
     expect(said()).toContain('no tsconfig.json beside the frontend');
     expect(said()).toContain("is the kit's private alias");
+  });
+});
+
+describe('unsatisfiableRanges', () => {
+  const project = (id: string, version: string, dependencies?: Record<string, string>) =>
+    ({ dir: id, manifest: { id, version, dependencies }, server: null, ui: null }) as never;
+
+  it('names a peer that has moved past a declared range', () => {
+    const tree = [
+      project('tv.kroma.torrents', '0.6.6'),
+      project('tv.kroma.acquisition', '0.3.9', { 'tv.kroma.torrents': '^0.3.0' }),
+    ];
+
+    expect(unsatisfiableRanges(tree)).toEqual([
+      'tv.kroma.acquisition: needs tv.kroma.torrents@^0.3.0 but this tree has 0.6.6',
+    ]);
+  });
+
+  it('accepts a floor the peer clears', () => {
+    const tree = [
+      project('tv.kroma.torrents', '0.6.6'),
+      project('tv.kroma.acquisition', '0.3.9', { 'tv.kroma.torrents': '>=0.3.0' }),
+    ];
+
+    expect(unsatisfiableRanges(tree)).toEqual([]);
+  });
+
+  it('says nothing about a dependency that lives outside this tree', () => {
+    const tree = [project('tv.kroma.acquisition', '0.3.9', { 'com.someone.else': '^1.0.0' })];
+
+    expect(unsatisfiableRanges(tree)).toEqual([]);
   });
 });

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -1,5 +1,6 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { dirname, join, relative } from 'node:path';
+import { dependenciesOf, optionalDependenciesOf, satisfies } from '@kromatv/registry';
 import { cargo, targetDir } from '../cargo';
 import { exec } from '../exec';
 import { findProjects, type Project } from '../project';
@@ -68,6 +69,24 @@ async function checkTs(project: Project): Promise<string[]> {
   return problems;
 }
 
+/** A declared range no peer in this tree satisfies. A module's real contract is
+ *  the point it consumes, but a range is what the Store resolves an install
+ *  against, so one that has rotted past its peer blocks the update rather than
+ *  the peer. Peers ship on their own tags, so nothing else notices. */
+export function unsatisfiableRanges(projects: readonly Project[]): string[] {
+  const version = new Map(projects.map((p) => [p.manifest.id, p.manifest.version]));
+  const problems: string[] = [];
+  for (const p of projects) {
+    const declared = { ...dependenciesOf(p.manifest), ...optionalDependenciesOf(p.manifest) };
+    for (const [dep, range] of Object.entries(declared)) {
+      const have = version.get(dep);
+      if (have === undefined || satisfies(have, range)) continue;
+      problems.push(`${p.manifest.id}: needs ${dep}@${range} but this tree has ${have}`);
+    }
+  }
+  return problems;
+}
+
 /** `kroma check`: every manifest valid and unique, the frontend typed and its
  *  imports in bounds, the crate clean under clippy. */
 export async function checkCommand(options: CheckOptions): Promise<number> {
@@ -82,6 +101,7 @@ export async function checkCommand(options: CheckOptions): Promise<number> {
     if (first) problems.push(`duplicate module id "${p.manifest.id}" in ${first} and ${p.dir}`);
     seen.set(p.manifest.id, p.dir);
   }
+  problems.push(...unsatisfiableRanges(projects));
 
   for (const project of projects) {
     console.log(`\n${style.bold(project.manifest.id)}`);

--- a/server/src/api/admin/store/install.rs
+++ b/server/src/api/admin/store/install.rs
@@ -188,6 +188,34 @@ pub struct UpdateOutcome {
     pub failed: Vec<FailedUpdate>,
 }
 
+/// The enabled modules a candidate version would strand: they hard-depend on
+/// `id` and declare a range the candidate does not satisfy.
+///
+/// Installing a dependent enforces its range against the registry, and
+/// uninstalling a dependency asks who needs it, but updating a dependency
+/// checked neither, so a peer could move out from under its dependents and
+/// leave them unable to update in turn.
+fn stranded_dependents(
+    installed: &[kroma_module_manifest::ModuleManifest],
+    enabled: &dyn Fn(&str) -> bool,
+    id: &str,
+    candidate: &str,
+) -> Vec<String> {
+    installed
+        .iter()
+        .filter(|m| m.id != id && enabled(&m.id))
+        .filter(|m| {
+            m.dependencies.iter().any(|d| {
+                d.id == id
+                    && d.version
+                        .as_deref()
+                        .is_some_and(|range| !kroma_module_manifest::range_matches(range, candidate))
+            })
+        })
+        .map(|m| m.id.clone())
+        .collect()
+}
+
 /// Update every runtime-installed module (or the `only` subset) to the newest
 /// compatible catalog version, off ONE catalog fetch. One `module.op.*` stream
 /// covers the whole batch. `Err` only when the catalog itself is unreachable.
@@ -204,7 +232,8 @@ pub async fn update_all(
         failed: Vec::new(),
     };
     let mut targets: Vec<(&CatalogModule, String)> = Vec::new();
-    for manifest in sup.installed_manifests() {
+    let installed = sup.installed_manifests();
+    for manifest in &installed {
         let (id, cur) = (manifest.id.as_str(), manifest.version.as_str());
         if only.is_some_and(|ids| !ids.iter().any(|x| x == id)) {
             continue;
@@ -219,6 +248,23 @@ pub async fn update_all(
             outcome.failed.push(FailedUpdate {
                 id: id.to_string(),
                 error: reason,
+            });
+            continue;
+        }
+        let stranded = stranded_dependents(
+            &installed,
+            &|dep_id| kroma_engine::modules::module_enabled(&state.settings, dep_id),
+            id,
+            &entry.version,
+        );
+        if !stranded.is_empty() {
+            outcome.failed.push(FailedUpdate {
+                id: id.to_string(),
+                error: format!(
+                    "{} needs a version of '{id}' this one is not: update {} first, or raise its range",
+                    stranded.join(", "),
+                    stranded.join(", "),
+                ),
             });
             continue;
         }
@@ -278,5 +324,71 @@ pub async fn auto_update(state: &SharedState, sup: &Arc<Supervisor>) -> Vec<Upda
             tracing::warn!(error = %format!("{e:#}"), "module auto-update: catalog fetch failed");
             Vec::new()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::stranded_dependents;
+    use kroma_module_manifest::{Dependency, ModuleManifest};
+
+    fn module(id: &str, deps: &[(&str, Option<&str>)]) -> ModuleManifest {
+        let mut m = ModuleManifest::new(id, id, "1.0.0");
+        m.dependencies = deps
+            .iter()
+            .map(|(dep, range)| Dependency {
+                id: (*dep).to_string(),
+                version: range.map(str::to_string),
+            })
+            .collect();
+        m
+    }
+
+    #[test]
+    fn a_peer_moving_past_a_dependents_range_strands_it() {
+        let installed = [
+            module("tv.kroma.torrents", &[]),
+            module("tv.kroma.acquisition", &[("tv.kroma.torrents", Some("^0.3.0"))]),
+        ];
+
+        let stranded = stranded_dependents(&installed, &|_| true, "tv.kroma.torrents", "0.6.6");
+
+        assert_eq!(stranded, ["tv.kroma.acquisition"]);
+    }
+
+    #[test]
+    fn a_floor_the_candidate_clears_strands_nobody() {
+        let installed = [
+            module("tv.kroma.torrents", &[]),
+            module("tv.kroma.acquisition", &[("tv.kroma.torrents", Some(">=0.3.0"))]),
+        ];
+
+        let stranded = stranded_dependents(&installed, &|_| true, "tv.kroma.torrents", "0.6.6");
+
+        assert!(stranded.is_empty());
+    }
+
+    #[test]
+    fn a_dependent_that_is_disabled_is_not_stranded() {
+        let installed = [
+            module("tv.kroma.torrents", &[]),
+            module("tv.kroma.acquisition", &[("tv.kroma.torrents", Some("^0.3.0"))]),
+        ];
+
+        let stranded = stranded_dependents(&installed, &|_| false, "tv.kroma.torrents", "0.6.6");
+
+        assert!(stranded.is_empty());
+    }
+
+    #[test]
+    fn a_dependency_declared_with_no_range_accepts_every_version() {
+        let installed = [
+            module("tv.kroma.torrents", &[]),
+            module("tv.kroma.acquisition", &[("tv.kroma.torrents", None)]),
+        ];
+
+        let stranded = stranded_dependents(&installed, &|_| true, "tv.kroma.torrents", "9.9.9");
+
+        assert!(stranded.is_empty());
     }
 }


### PR DESCRIPTION
## What

The Store refused to update Acquisition:

```
tv.kroma.acquisition: 'tv.kroma.acquisition' needs tv.kroma.torrents@^0.3.0 but the registry has 0.6.6
```

Nothing had stopped torrents going from 0.3 to 0.6 in the first place. **That is the bug.** The
range was enforced in one direction:

| action | guard |
|---|---|
| install or update a **dependent** | range checked against the registry (this error) |
| uninstall a **dependency** | guarded, but existence only, never versions |
| **update** a dependency | nothing |

The only path that creates the breakage was the only one with no check, and the module left
unable to move is the one that did nothing wrong.

It is **three modules**, not the one the screen showed: `tv.kroma.acquisition`,
`tv.kroma.engine.qbittorrent` and `tv.kroma.engine.transmission` all pin `^0.3.0`.

### The guard is symmetric now

`update_all` refuses to move a module past the range an enabled dependant declares, and names
the dependant, the way `uninstall` already refuses to remove one. It reuses `FailedUpdate`, so
the batch reports it exactly as it reports an engine floor and the UI needs nothing new.

Four tests: a peer moving past a range strands its dependant; a floor the candidate clears
strands nobody; a **disabled** dependant is not stranded; a dependency declared with no range
accepts any version.

### The ranges become floors

`^0.3.0` on a 0.x peer means "any minor of yours breaks me", which is a claim about version
numbers this architecture explicitly does not make. `CLAUDE.md`: a module reaches a peer by
asking the host which modules answer a POINT and speaking JSON both sides declare themselves,
and each side ships on its own tag.

Both points Acquisition consumes, `tv.kroma.torrents/grab` and `tv.kroma.torrents/db`, still
exist in 0.6.6 with the methods it calls. The contract was never broken; only the number was.
`>=0.3.0` records the floor where those points appeared.

With the guard symmetric this is not a loosening. A range that genuinely needs an upper bound
now means something, because the peer is held to it too instead of walking away from it.

Three versions bumped, as the module rule requires.

### CI catches the next one

`kroma check` now fails on a declared range no peer in the tree satisfies. This went stale
across four minor versions of torrents with nothing to notice. Verified by reverting Acquisition
to `^0.3.0`, which reproduces the screen's own words:

```
1 problem(s)
  - tv.kroma.acquisition: needs tv.kroma.torrents@^0.3.0 but this tree has 0.6.6
```

## Closes

No issue; reported from a screenshot of Admin → Modules → Updates.

**MOD-52** records the update direction. MOD-33 already had uninstall.

## Checks

- [x] `bun run typecheck` 43/43
- [x] `bun run check`
- [x] `bun run test` 10026 passed, 2 skipped
- [x] `bun run spec:check` 411 requirements
- [x] `bun run kroma check` every check passed, 12 modules
- [x] `cargo test --workspace` 2554 tests across 49 targets
- [x] `cargo clippy --workspace --all-targets` 16 warning sites, the baseline on main, none added
- [x] One idea

`modules/tv.kroma.acquisition/ui/src/index.test.ts` pinned the old literal and failed as it
should have; its expectation moved with the manifest.

## Risk

The judgement to argue with is turning the ranges into floors. If you believe a torrents minor
CAN break these three, the fix is the opposite: keep a caret and raise it deliberately on each
peer release. I went the other way because the points are the contract, they are unchanged, and
a caret guarantees this recurs on 0.7.0 with three manifests to remember.

`stranded_dependents` reads the range from the **installed** dependant's manifest, so a stale
range on disk still blocks a peer update until that dependant is updated first. That is
intended, and the error says which module to update, but it means an operator with a very old
dependant installed sees a refusal rather than a silent break. The old behaviour was the silent
break.

Untested against a live registry: the four tests drive `stranded_dependents` directly rather
than `update_all`, which needs a catalog fetch. A reviewer with a real server should try
updating torrents with an old Acquisition installed.
