### PR TITLE
feat(modules): a module reaches the credentials it declared and no others

### DIFF
--- a/docs/module-plugin-model.md
+++ b/docs/module-plugin-model.md
@@ -192,7 +192,7 @@ opinion about any of it.
 
 ```
 POST http://127.0.0.1:<port>/_port/<point>/<method>
-Authorization: Bearer <per-process host token>
+Authorization: Bearer <the fabric host token>
 { ...request json... }
 ->  { "Ok": ...json... } | { "Err": "message" }
 ```
@@ -209,6 +209,11 @@ generic.
 The path carries the point's FULL name, which is the same string the caller
 resolved with (`call_point` builds it), so nothing has to hold a point name and
 an unrelated URL prefix and keep the two in step.
+
+One token, not a module's own, and deliberately: a caller holds it to reach a
+peer, so a token that also NAMED its holder would hand one module another's
+identity. Identity belongs on the hop where it changes the answer, which is the
+module-to-core callback, and that hop has `KROMA_MODULE_TOKEN` instead.
 
 What holds the wire together instead:
 
@@ -250,10 +255,21 @@ a read answers the caller's own default, a patch naming one is refused. So the
 keys only the core consumes (mail, LLM, the push private material, the ticket
 signing key) and the registry list the Store installs from are withheld because
 they say so, and an identity the server mints for itself is withheld because
-nothing hands it out. The core owns that decision; the supervisor only asks, so
-it still knows nothing about what any module is for. A credential whose consumer
-IS a sidecar stays readable, because the callback is how it reaches the process
-that uses it.
+nothing hands it out. A key nothing declares at all is withheld too, and said so
+at `debug` rather than as a warning, because it is a typo or a feature that left
+rather than something an operator has to act on. The core owns that decision; the supervisor only asks, so
+it still knows nothing about what any module is for.
+
+A credential whose consumer IS a sidecar is the third case, and it reaches **the
+sidecar that declared it**. The supervisor spawns every module with its own
+`KROMA_MODULE_TOKEN`, so a callback names its caller, and `settings: { read, write }`
+in that module's manifest says which core keys it uses. The WireGuard config goes
+to the module that brings the tunnel up and to the one that has to know whether
+the tunnel is up, because both named it, and to nothing else installed. A caller
+the core cannot name holds no declaration and reaches none of these, which is what
+a bundle built before the field is: it keeps every ordinary preference and loses
+the credentials. Preferences are not scoped by the declaration yet; reaching one
+a manifest omits logs it, and that log is the migration for when they are.
 
 Withholding by default is what makes this survive the next key. The guard used to
 be a deny-list plus a test that swept key NAMES for `password`, `token`, `secret`

--- a/docs/modules-as-kmod.md
+++ b/docs/modules-as-kmod.md
@@ -44,11 +44,13 @@ it, supervises it, and reverse-proxies its HTTP.**
   module declared under `storage.adopt` out of the core database and into the
   module's own file -- the core does it, because the module no longer holds the
   rights to. `proxy_to` reverse-proxies a request to a module process.
-  `host_router::<HostCtx>(token, withheld)` serves `/api/_host/*` (setting /
-  settings / events / job / enabled / session / ...), token-authed, resolved
-  against the core's real state. `withheld` is the core's own predicate over
-  settings keys: one it answers for itself is read back as the caller's default
-  and refused on write, and a key no declaration hands out is withheld too.
+  `host_router::<HostCtx>(supervisor, reach)` serves `/api/_host/*` (setting /
+  settings / events / job / enabled / session / ...), resolved against the core's
+  real state behind a token the supervisor minted **per module process**, so a
+  callback names its caller. `reach` is the core's own answer for one settings
+  key: its own is read back as the caller's default and refused on write, a key
+  no declaration hands out likewise, and a credential whose consumer is a module
+  goes to the module whose `settings` block named it and no other.
 - **Core integration**: `main.rs` builds the supervisor and `spawn_enabled`s
   installed modules at boot; `api/mod.rs` mounts the callback API and a
   `/api/module/<id>/*` reverse proxy.

--- a/docs/spec/INDEX.md
+++ b/docs/spec/INDEX.md
@@ -3,7 +3,7 @@
 
 # Requirement index
 
-411 requirements across the spec. The machine-readable source is [`requirements.json`](requirements.json).
+412 requirements across the spec. The machine-readable source is [`requirements.json`](requirements.json).
 
 ## ACCT - [accounts](accounts/)
 
@@ -331,6 +331,7 @@
 - **MOD-50** (AGREED) - A module that has disappeared from every configured registry is flagged
 - **MOD-51** (SHIPPED) - It may not read or write the server's own credentials. A settings key
 - **MOD-52** (SHIPPED) - The server refuses to **update** a module past the range an enabled
+- **MOD-53** (SHIPPED) - A credential whose consumer *is* a module reaches the module that
 
 ## PLAY - [playback](playback/)
 

--- a/docs/spec/modules/README.md
+++ b/docs/spec/modules/README.md
@@ -61,6 +61,11 @@ What a module may **not** do:
   who reads it: a read answers the module's own default and a write naming one is refused. A
   credential whose consumer *is* a module stays reachable, because that callback is how it
   reaches the process that uses it.
+- **MOD-53** (SHIPPED) - A credential whose consumer *is* a module reaches the module that
+  declared it and no other. The manifest says which core settings keys the module reads and
+  writes, the callback answers within that declaration, and a refusal is logged. A module whose
+  manifest predates the declaration keeps every ordinary preference and reaches none of these
+  credentials, so the reach an operator was never shown is the one that is refused.
 
 **MOD-9** (SHIPPED) - A module *may* depend on another module, hard or optional, and that
 dependency is declared, resolved and enforced rather than discovered at runtime.

--- a/docs/spec/requirements.json
+++ b/docs/spec/requirements.json
@@ -2657,7 +2657,7 @@
     "status": "SHIPPED",
     "text": "A module *may* depend on another module, hard or optional, and that",
     "file": "docs/spec/modules/README.md",
-    "line": 65
+    "line": 70
   },
   {
     "id": "MOD-10",
@@ -2667,7 +2667,7 @@
     "status": "SHIPPED",
     "text": "A module ships as a single `.kmod` file: a manifest, the native",
     "file": "docs/spec/modules/README.md",
-    "line": 72
+    "line": 77
   },
   {
     "id": "MOD-11",
@@ -2677,7 +2677,7 @@
     "status": "SHIPPED",
     "text": "**Identity and version.** The reverse-DNS id and a hand-set version.",
     "file": "docs/spec/modules/README.md",
-    "line": 78
+    "line": 83
   },
   {
     "id": "MOD-12",
@@ -2687,7 +2687,7 @@
     "status": "SHIPPED",
     "text": "The release process refuses to publish changed bytes under an",
     "file": "docs/spec/modules/README.md",
-    "line": 80
+    "line": 85
   },
   {
     "id": "MOD-13",
@@ -2697,7 +2697,7 @@
     "status": "SHIPPED",
     "text": "**`minServer`, the compatibility floor.** The minimum server version",
     "file": "docs/spec/modules/README.md",
-    "line": 83
+    "line": 88
   },
   {
     "id": "MOD-14",
@@ -2707,7 +2707,7 @@
     "status": "SHIPPED",
     "text": "**Dependencies.** Hard ones that must be installed alongside it, and",
     "file": "docs/spec/modules/README.md",
-    "line": 85
+    "line": 90
   },
   {
     "id": "MOD-15",
@@ -2717,7 +2717,7 @@
     "status": "SHIPPED",
     "text": "**Target.** Which platform the backend was built for. A library-only",
     "file": "docs/spec/modules/README.md",
-    "line": 87
+    "line": 92
   },
   {
     "id": "MOD-16",
@@ -2727,7 +2727,7 @@
     "status": "SHIPPED",
     "text": "The server checks the bytes it downloads against a published SHA-256",
     "file": "docs/spec/modules/README.md",
-    "line": 91
+    "line": 96
   },
   {
     "id": "MOD-17",
@@ -2737,7 +2737,7 @@
     "status": "SHIPPED",
     "text": "Integrity is not safety: a matching checksum proves the bytes are the",
     "file": "docs/spec/modules/README.md",
-    "line": 94
+    "line": 99
   },
   {
     "id": "MOD-18",
@@ -2747,7 +2747,7 @@
     "status": "SHIPPED",
     "text": "**From the Store**, by id. The server resolves hard dependencies",
     "file": "docs/spec/modules/README.md",
-    "line": 104
+    "line": 109
   },
   {
     "id": "MOD-19",
@@ -2757,7 +2757,7 @@
     "status": "SHIPPED",
     "text": "**By upload**, handing the server a `.kmod` by hand: same unpack,",
     "file": "docs/spec/modules/README.md",
-    "line": 108
+    "line": 113
   },
   {
     "id": "MOD-20",
@@ -2767,7 +2767,7 @@
     "status": "SHIPPED",
     "text": "Both are admin actions on the [`admin/`](../admin/) surface.",
     "file": "docs/spec/modules/README.md",
-    "line": 112
+    "line": 117
   },
   {
     "id": "MOD-21",
@@ -2777,7 +2777,7 @@
     "status": "SHIPPED",
     "text": "The Store (Admin → Modules) is the in-app browser over the configured",
     "file": "docs/spec/modules/README.md",
-    "line": 118
+    "line": 123
   },
   {
     "id": "MOD-22",
@@ -2787,7 +2787,7 @@
     "status": "SHIPPED",
     "text": "The official registry is pinned first and cannot be removed; operators",
     "file": "docs/spec/modules/README.md",
-    "line": 121
+    "line": 126
   },
   {
     "id": "MOD-23",
@@ -2797,7 +2797,7 @@
     "status": "SHIPPED",
     "text": "For each module the Store shows **this server's verdict**, not just the",
     "file": "docs/spec/modules/README.md",
-    "line": 124
+    "line": 129
   },
   {
     "id": "MOD-24",
@@ -2807,7 +2807,7 @@
     "status": "AGREED",
     "text": "**First-party is trusted by default.** The official registry is",
     "file": "docs/spec/modules/README.md",
-    "line": 142
+    "line": 147
   },
   {
     "id": "MOD-25",
@@ -2817,7 +2817,7 @@
     "status": "AGREED",
     "text": "**A third-party registry is an explicit operator opt-in.** Adding one",
     "file": "docs/spec/modules/README.md",
-    "line": 144
+    "line": 149
   },
   {
     "id": "MOD-26",
@@ -2827,7 +2827,7 @@
     "status": "AGREED",
     "text": "The operator is told, in plain terms, that a module is a native binary",
     "file": "docs/spec/modules/README.md",
-    "line": 146
+    "line": 151
   },
   {
     "id": "MOD-27",
@@ -2837,7 +2837,7 @@
     "status": "AGREED",
     "text": "**Checksums guarantee integrity, never safety**, and the server says so",
     "file": "docs/spec/modules/README.md",
-    "line": 149
+    "line": 154
   },
   {
     "id": "MOD-28",
@@ -2847,7 +2847,7 @@
     "status": "SHIPPED",
     "text": "**Enable.** The server spawns the sidecar and the module's routes,",
     "file": "docs/spec/modules/README.md",
-    "line": 178
+    "line": 183
   },
   {
     "id": "MOD-29",
@@ -2857,7 +2857,7 @@
     "status": "SHIPPED",
     "text": "**Disable.** The sidecar is stopped, the module stops running, and",
     "file": "docs/spec/modules/README.md",
-    "line": 181
+    "line": 186
   },
   {
     "id": "MOD-30",
@@ -2867,7 +2867,7 @@
     "status": "SHIPPED",
     "text": "**Update.** A newer version replaces the bundle and the sidecar is",
     "file": "docs/spec/modules/README.md",
-    "line": 184
+    "line": 189
   },
   {
     "id": "MOD-31",
@@ -2877,7 +2877,7 @@
     "status": "SHIPPED",
     "text": "`minServer` is re-checked on update, so an update that outgrows the",
     "file": "docs/spec/modules/README.md",
-    "line": 187
+    "line": 192
   },
   {
     "id": "MOD-32",
@@ -2887,7 +2887,7 @@
     "status": "SHIPPED",
     "text": "**Uninstall.** The module is removed entirely. It is the one",
     "file": "docs/spec/modules/README.md",
-    "line": 189
+    "line": 194
   },
   {
     "id": "MOD-33",
@@ -2897,7 +2897,7 @@
     "status": "SHIPPED",
     "text": "The server refuses to uninstall a module another enabled module still",
     "file": "docs/spec/modules/README.md",
-    "line": 192
+    "line": 197
   },
   {
     "id": "MOD-34",
@@ -2907,7 +2907,7 @@
     "status": "SHIPPED",
     "text": "Uninstalling a module never touches media on disk. A downloads module",
     "file": "docs/spec/modules/README.md",
-    "line": 199
+    "line": 204
   },
   {
     "id": "MOD-35",
@@ -2917,7 +2917,7 @@
     "status": "SHIPPED",
     "text": "**A crashed module cannot take down the server.** The sidecar is a",
     "file": "docs/spec/modules/README.md",
-    "line": 209
+    "line": 214
   },
   {
     "id": "MOD-36",
@@ -2927,7 +2927,7 @@
     "status": "SHIPPED",
     "text": "**An incompatible module never runs by accident.** `minServer` is",
     "file": "docs/spec/modules/README.md",
-    "line": 212
+    "line": 217
   },
   {
     "id": "MOD-37",
@@ -2937,7 +2937,7 @@
     "status": "SHIPPED",
     "text": "**Failure is visible, not silent.** A module that will not start or",
     "file": "docs/spec/modules/README.md",
-    "line": 215
+    "line": 220
   },
   {
     "id": "MOD-38",
@@ -2947,7 +2947,7 @@
     "status": "SHIPPED",
     "text": "The server is forward-compatible with older modules. A module declares",
     "file": "docs/spec/modules/README.md",
-    "line": 223
+    "line": 228
   },
   {
     "id": "MOD-39",
@@ -2957,7 +2957,7 @@
     "status": "SHIPPED",
     "text": "A module installed today keeps working as the server is updated,",
     "file": "docs/spec/modules/README.md",
-    "line": 226
+    "line": 231
   },
   {
     "id": "MOD-40",
@@ -2967,7 +2967,7 @@
     "status": "SHIPPED",
     "text": "A *newer* module may raise its `minServer`, and the Store says so",
     "file": "docs/spec/modules/README.md",
-    "line": 229
+    "line": 234
   },
   {
     "id": "MOD-41",
@@ -2977,7 +2977,7 @@
     "status": "SHIPPED",
     "text": "A module **may** ship UI, and the position is deliberate: a module's",
     "file": "docs/spec/modules/README.md",
-    "line": 237
+    "line": 242
   },
   {
     "id": "MOD-42",
@@ -2987,7 +2987,7 @@
     "status": "AGREED",
     "text": "A module renders **its own admin surface**: configuration, status and",
     "file": "docs/spec/modules/README.md",
-    "line": 241
+    "line": 246
   },
   {
     "id": "MOD-43",
@@ -2997,7 +2997,7 @@
     "status": "SHIPPED",
     "text": "A module's UI is served through the same reverse proxy as its backend",
     "file": "docs/spec/modules/README.md",
-    "line": 244
+    "line": 249
   },
   {
     "id": "MOD-44",
@@ -3007,7 +3007,7 @@
     "status": "AGREED",
     "text": "**The compatibility gate is the early warning.** As the server moves",
     "file": "docs/spec/modules/README.md",
-    "line": 258
+    "line": 263
   },
   {
     "id": "MOD-45",
@@ -3017,7 +3017,7 @@
     "status": "AGREED",
     "text": "**Data is retained.** An incompatible or abandoned module is not",
     "file": "docs/spec/modules/README.md",
-    "line": 262
+    "line": 267
   },
   {
     "id": "MOD-46",
@@ -3027,7 +3027,7 @@
     "status": "AGREED",
     "text": "**The signal is honest.** The person is told the module has not kept",
     "file": "docs/spec/modules/README.md",
-    "line": 265
+    "line": 270
   },
   {
     "id": "MOD-47",
@@ -3037,7 +3037,7 @@
     "status": "SHIPPED",
     "text": "Every capability below could have been core and is a module instead,",
     "file": "docs/spec/modules/README.md",
-    "line": 285
+    "line": 290
   },
   {
     "id": "MOD-48",
@@ -3047,7 +3047,7 @@
     "status": "AGREED",
     "text": "The Store names the registry every module came from, on the listing and",
     "file": "docs/spec/modules/README.md",
-    "line": 152
+    "line": 157
   },
   {
     "id": "MOD-49",
@@ -3057,7 +3057,7 @@
     "status": "AGREED",
     "text": "Installing from a registry the operator added is gated once, per",
     "file": "docs/spec/modules/README.md",
-    "line": 155
+    "line": 160
   },
   {
     "id": "MOD-50",
@@ -3067,7 +3067,7 @@
     "status": "AGREED",
     "text": "A module that has disappeared from every configured registry is flagged",
     "file": "docs/spec/modules/README.md",
-    "line": 270
+    "line": 275
   },
   {
     "id": "MOD-51",
@@ -3087,7 +3087,17 @@
     "status": "SHIPPED",
     "text": "The server refuses to **update** a module past the range an enabled",
     "file": "docs/spec/modules/README.md",
-    "line": 194
+    "line": 199
+  },
+  {
+    "id": "MOD-53",
+    "domain": "MOD",
+    "space": "modules",
+    "number": 53,
+    "status": "SHIPPED",
+    "text": "A credential whose consumer *is* a module reaches the module that",
+    "file": "docs/spec/modules/README.md",
+    "line": 64
   },
   {
     "id": "PLAY-1",

--- a/modules/README.md
+++ b/modules/README.md
@@ -282,10 +282,27 @@ may: the mail password, the LLM API key, the Web Push / APNs / FCM private
 material and the registry list the Store installs from are the core's alone, and
 so is every key no declaration mentions, which is what an identity the server
 minted for itself is. A read answers the default you asked with, and a patch
-naming one is refused whole with a `403`. A credential a module is the thing that
-uses (the WireGuard config the bridge brings up, the tunnel token the connector
-runs on) stays readable and writable. For a vendor credential the operator
+naming one is refused whole with a `403`. For a vendor credential the operator
 configured, ask `GET /_host/secret?name=` by name.
+
+A credential a module is the thing that uses (the WireGuard config the bridge
+brings up, the tunnel token the connector runs on) reaches **the module that
+declared it**, because the core knows which module is calling: every sidecar is
+spawned with its own `KROMA_MODULE_TOKEN` and the callback resolves it. Declare
+yours in `module.json`:
+
+```jsonc
+"settings": {
+  "read": ["vpnLocalPort", "vpnWgConfig"],
+  "write": ["vpnLocalPort", "vpnWgConfig"]
+}
+```
+
+A read declaration is not a write declaration, and a bundle that declares nothing
+keeps every ordinary preference and reaches none of these credentials. Ordinary
+preferences are not scoped by the declaration yet, so write down the full truth
+today: reaching a key you did not declare logs a line at `debug` level, which is
+the reach that will be refused when it is.
 
 - **`dependencies`** is a hard dependency, as a `{ "<id>": "<range>" }` map.
   The backend enforces it, and the Store installs missing ones automatically.
@@ -296,6 +313,9 @@ configured, ask `GET /_host/secret?name=` by name.
 - **`engines`** is what the module needs from its host (`{ "server": ">=0.1.4" }`),
   enforced at install **and** at spawn, so a stale bundle fails with a clear
   message instead of proxy errors.
+- **`settings`** is the core settings keys you read and write, as
+  `{ "read": [...], "write": [...] }`. Absent is not empty: a manifest without it
+  predates the field and keeps the reach it had.
 
 ## Storage
 

--- a/modules/tv.kroma.acquisition/module.json
+++ b/modules/tv.kroma.acquisition/module.json
@@ -8,6 +8,28 @@
   "engines": {
     "server": ">=0.1.39"
   },
+  "settings": {
+    "read": [
+      "acqDeleteAfterImport",
+      "acqEnabled",
+      "acqForbiddenKeywords",
+      "acqMaxSizeGbEpisode",
+      "acqMaxSizeGbMovie",
+      "acqMinSeeders",
+      "acqMovieLibrary",
+      "acqPreferHevc",
+      "acqReplaceOnUpgrade",
+      "acqRequiredKeywords",
+      "acqResolution",
+      "acqSeriesLibrary",
+      "namingCase",
+      "namingEpisodeFile",
+      "namingMovieFile",
+      "namingMovieFolder",
+      "namingSeasonFolder",
+      "namingSeriesFolder"
+    ]
+  },
   "feRemote": {
     "module": "./remoteEntry.js"
   },

--- a/modules/tv.kroma.indexer/module.json
+++ b/modules/tv.kroma.indexer/module.json
@@ -3,10 +3,13 @@
   "schemaVersion": 2,
   "id": "tv.kroma.indexer",
   "name": "Indexers",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "Native Cardigann indexer engine: searches trackers from community YAML definitions, no external Torznab aggregator.",
   "engines": {
     "server": ">=0.1.39"
+  },
+  "settings": {
+    "read": ["acqFlaresolverrUrl", "acqIndexersUseVpn"]
   },
   "feRemote": {
     "module": "./remoteEntry.js"

--- a/modules/tv.kroma.mdns/module.json
+++ b/modules/tv.kroma.mdns/module.json
@@ -3,9 +3,12 @@
   "schemaVersion": 2,
   "id": "tv.kroma.mdns",
   "name": "mDNS discovery",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "mDNS / DNS-SD advertising so LAN clients find the server automatically.",
   "engines": {
     "server": ">=0.1.39"
+  },
+  "settings": {
+    "read": ["localDiscovery"]
   }
 }

--- a/modules/tv.kroma.remote/module.json
+++ b/modules/tv.kroma.remote/module.json
@@ -3,10 +3,14 @@
   "schemaVersion": 2,
   "id": "tv.kroma.remote",
   "name": "Remote access",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Public HTTPS access: the share / Quick Connect URL plus an optional managed Cloudflare Tunnel connector. Disable it to hide the page + routes.",
   "engines": {
     "server": ">=0.1.39"
+  },
+  "settings": {
+    "read": ["remoteAccess", "remoteAccessToken", "remoteUrl"],
+    "write": ["remoteAccess", "remoteAccessToken", "remoteUrl"]
   },
   "feRemote": {
     "module": "./remoteEntry.js"

--- a/modules/tv.kroma.torrents/module.json
+++ b/modules/tv.kroma.torrents/module.json
@@ -3,10 +3,38 @@
   "schemaVersion": 2,
   "id": "tv.kroma.torrents",
   "name": "Torrent downloads",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "The embedded librqbit download engine + the downloads queue. Transmission and qBittorrent are their own engine sub-modules that plug into this one.",
   "engines": {
     "server": ">=0.1.39"
+  },
+  "settings": {
+    "read": [
+      "namingCase",
+      "namingEpisodeFile",
+      "namingMovieFile",
+      "namingMovieFolder",
+      "namingSeasonFolder",
+      "namingSeriesFolder",
+      "rqbitDownKbps",
+      "rqbitPort",
+      "rqbitUpKbps",
+      "torrentMaxActive",
+      "vpnCheckUrl",
+      "vpnKillSwitch",
+      "vpnWgConfig"
+    ],
+    "write": [
+      "namingCase",
+      "namingEpisodeFile",
+      "namingMovieFile",
+      "namingMovieFolder",
+      "namingSeasonFolder",
+      "namingSeriesFolder",
+      "rqbitDownKbps",
+      "rqbitUpKbps",
+      "torrentMaxActive"
+    ]
   },
   "feRemote": {
     "module": "./remoteEntry.js"

--- a/modules/tv.kroma.vpn/module.json
+++ b/modules/tv.kroma.vpn/module.json
@@ -3,10 +3,14 @@
   "schemaVersion": 2,
   "id": "tv.kroma.vpn",
   "name": "VPN",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Managed WireGuard bridge (any provider) that torrent traffic routes through, with a live seal test. Disable it to stop the bridge and hide its page + routes.",
   "engines": {
     "server": ">=0.1.39"
+  },
+  "settings": {
+    "read": ["vpnLocalPort", "vpnWgConfig"],
+    "write": ["vpnLocalPort", "vpnWgConfig"]
   },
   "feRemote": {
     "module": "./remoteEntry.js"

--- a/packages/registry/src/manifest/index.ts
+++ b/packages/registry/src/manifest/index.ts
@@ -30,6 +30,7 @@ export {
   Manifest,
   optionalDependenciesOf,
   REVERSE_DNS_ID,
+  SettingsScope,
   Storage,
   speaksCurrentSchema,
 } from './v2.ts';

--- a/packages/registry/src/manifest/v2.test.ts
+++ b/packages/registry/src/manifest/v2.test.ts
@@ -89,6 +89,45 @@ describe('storage', () => {
   });
 });
 
+describe('settings', () => {
+  it('is absent for a module that predates it, which keeps the reach it had', () => {
+    expect(Manifest.parse(base).settings).toBeUndefined();
+  });
+
+  it('reads an empty object as a module that declares and declares nothing', () => {
+    expect(Manifest.parse({ ...base, settings: {} }).settings).toEqual({});
+  });
+
+  it('keeps the read and write lists apart', () => {
+    const parsed = Manifest.parse({
+      ...base,
+      settings: { read: ['vpnWgConfig', 'vpnLocalPort'], write: ['vpnWgConfig'] },
+    });
+    expect(parsed.settings).toEqual({
+      read: ['vpnWgConfig', 'vpnLocalPort'],
+      write: ['vpnWgConfig'],
+    });
+  });
+
+  it('refuses an entry that is not a settings key', () => {
+    const bad = (read: string[]) => () => Manifest.parse({ ...base, settings: { read } });
+    expect(bad(['*'])).toThrow();
+    expect(bad([''])).toThrow();
+    expect(bad(['vpnWgConfig; DROP TABLE users'])).toThrow();
+    expect(bad(['.leading'])).toThrow();
+    // ...and the dotted namespaced keys are fine.
+    expect(
+      Manifest.parse({ ...base, settings: { read: ['notifications.vapid.publicKey'] } }).settings
+        ?.read,
+    ).toEqual(['notifications.vapid.publicKey']);
+  });
+
+  it('is additive: a manifest that predates it still parses', () => {
+    expect(speaksCurrentSchema({ schemaVersion: 2 })).toBe(true);
+    expect(Manifest.parse({ ...base, schemaVersion: 2 }).settings).toBeUndefined();
+  });
+});
+
 describe('the shape a real manifest declares', () => {
   // Every property a manifest may carry. zod STRIPS what it does not declare,
   // so a field missing here is a field the published catalog would lose without
@@ -117,6 +156,7 @@ describe('the shape a real manifest declares', () => {
       core: { read: ['downloads', 'requests'], write: ['downloads'] },
       adopt: ['download_clients'],
     },
+    settings: { read: ['rqbitPort', 'vpnWgConfig'], write: ['rqbitPort'] },
   };
 
   it('keeps every one of them', () => {

--- a/packages/registry/src/manifest/v2.ts
+++ b/packages/registry/src/manifest/v2.ts
@@ -51,6 +51,27 @@ export const CoreScope = z.object({
 });
 export type CoreScope = z.infer<typeof CoreScope>;
 
+// A core settings key: camelCase, or dotted for the namespaced ones
+// (`notifications.vapid.publicKey`). Matched exactly, so the spelling has to be.
+const SettingKey = z.string().regex(/^[A-Za-z][\w]*(?:\.[A-Za-z][\w]*)*$/);
+
+/** The CORE settings keys a module reads and writes. */
+export const SettingsScope = z.object({
+  read: z
+    .array(SettingKey)
+    .nullish()
+    .describe(
+      'Core settings keys this module reads through the host callback. A key the server hands only to the module that consumes it reaches a module that named it here and no other.',
+    ),
+  write: z
+    .array(SettingKey)
+    .nullish()
+    .describe(
+      'Core settings keys this module writes. A read declaration is not a write declaration, and a patch naming a key this list omits is refused whole.',
+    ),
+});
+export type SettingsScope = z.infer<typeof SettingsScope>;
+
 /** A module's databases, and the capability itself. */
 export const Storage = z.object({
   core: CoreScope.nullish().describe(
@@ -140,6 +161,9 @@ export const Manifest = z.object({
     .describe('Admin-configurable settings this module exposes, rendered as a form.'),
   storage: Storage.nullish().describe(
     "This module's databases, and the capability itself: without a storage object the module gets no database and its binary does not link SQLite. Its presence alone grants it its own file at <data>/modules/<id>/module.sqlite, where its migrations run and which it owns outright.",
+  ),
+  settings: SettingsScope.nullish().describe(
+    'The core settings keys this module reads and writes. Absent is not the same as empty: a manifest with no settings object predates the field, so it keeps every ordinary preference and reaches none of the credentials a module has to declare.',
   ),
   feRemote: z
     .object({ module: z.string() })

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1981,6 +1981,7 @@ dependencies = [
  "kroma-domain",
  "kroma-module-host",
  "kroma-module-manifest",
+ "kroma-primitives",
  "kroma-testing",
  "libc",
  "rand 0.10.2",

--- a/server/crates/kroma-engine/src/services/settings/keys.rs
+++ b/server/crates/kroma-engine/src/services/settings/keys.rs
@@ -1,48 +1,36 @@
 //! The built-in settings keys: every default value, and who may reach each one.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::sync::OnceLock;
 
+use kroma_module_host::SettingReach;
 use serde_json::{json, Value};
 
 #[cfg(test)]
 mod tests;
 
-/// Whether the module host callback withholds `key` from every sidecar: a read
-/// answers the default the caller asked with, and a write naming it is refused.
+/// How far `key` reaches out of the core, for the module host callback to apply.
 ///
-/// Withheld unless a declaration in this module hands it out, so a key that
-/// reaches the store with no declared reach is withheld rather than served. An
-/// identity the server mints for itself is in that position, and so is the next
-/// key someone adds without thinking about who reads it.
-pub fn withheld_from_modules(key: &str) -> bool {
-    static REACHABLE: OnceLock<BTreeSet<&'static str>> = OnceLock::new();
-    !REACHABLE
-        .get_or_init(|| {
-            declared()
-                .reach
-                .into_iter()
-                .filter(|(_, reach)| *reach != Reach::CoreOnly)
-                .map(|(key, _)| key)
-                .collect()
-        })
-        .contains(key)
+/// Withheld unless a declaration in this module hands the key out, so a key that
+/// reaches the store with no declared reach is [`SettingReach::Unknown`] rather
+/// than served. An identity the server mints for itself is declared
+/// [`SettingReach::CoreOnly`], and the next key someone adds without thinking
+/// about who reads it is withheld either way.
+pub fn reach_of_setting(key: &str) -> SettingReach {
+    static REACH: OnceLock<BTreeMap<&'static str, SettingReach>> = OnceLock::new();
+    *REACH
+        .get_or_init(|| declared().reach)
+        .get(key)
+        .unwrap_or(&SettingReach::Unknown)
 }
 
 pub(super) fn defaults() -> BTreeMap<String, Value> {
     declared().values
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum Reach {
-    CoreOnly,
-    Sidecar,
-    Public,
-}
-
 struct Declared {
     values: BTreeMap<String, Value>,
-    reach: BTreeMap<&'static str, Reach>,
+    reach: BTreeMap<&'static str, SettingReach>,
 }
 
 impl Declared {
@@ -54,22 +42,22 @@ impl Declared {
     }
 
     fn public(&mut self, key: &'static str, value: Value) {
-        self.declare(key, Reach::Public, value);
+        self.declare(key, SettingReach::Any, value);
     }
 
     fn core_only(&mut self, key: &'static str, value: Value) {
-        self.declare(key, Reach::CoreOnly, value);
+        self.declare(key, SettingReach::CoreOnly, value);
     }
 
     fn sidecar_credential(&mut self, key: &'static str, value: Value) {
-        self.declare(key, Reach::Sidecar, value);
+        self.declare(key, SettingReach::Declared, value);
     }
 
     fn minted(&mut self, key: &'static str) {
-        self.reach.insert(key, Reach::CoreOnly);
+        self.reach.insert(key, SettingReach::CoreOnly);
     }
 
-    fn declare(&mut self, key: &'static str, reach: Reach, value: Value) {
+    fn declare(&mut self, key: &'static str, reach: SettingReach, value: Value) {
         self.reach.insert(key, reach);
         self.values.insert(key.to_string(), value);
     }
@@ -79,9 +67,10 @@ fn declared() -> Declared {
     let mut m = Declared::new();
     m.public("serverName", json!("KROMA"));
     m.minted("instanceId");
-    // One key for the whole blob: `{ "<id>": { "enabled": bool, "config": {..} } }`
-    // (module ids are not known at compile time, so they can't be allow-listed).
-    m.public("moduleStates", json!({}));
+    // One key for the whole blob: `{ "<id>": { "enabled": bool, "config": {..} } }`.
+    // A module reads its own config out of the point call that carries it, never
+    // out of here, so the blob holding every other module's stays the core's.
+    m.core_only("moduleStates", json!({}));
     // Empty = the built-in catalog (modules.json on this repo's GitHub Releases).
     // This is the OFFICIAL slot: it stays pinned first and wins on an id clash.
     m.core_only("moduleRegistryUrl", json!(""));

--- a/server/crates/kroma-engine/src/services/settings/keys/tests.rs
+++ b/server/crates/kroma-engine/src/services/settings/keys/tests.rs
@@ -43,20 +43,20 @@ fn every_key_that_carries_a_default_declares_who_may_reach_it() {
 }
 
 #[test]
-fn a_key_that_reads_like_a_credential_is_never_declared_public() {
+fn a_key_that_reads_like_a_credential_is_never_reachable_by_any_module() {
     let declared = declared();
 
     let served: Vec<&&str> = declared
         .reach
         .iter()
-        .filter(|(key, reach)| reads_like_a_credential(key) && **reach == Reach::Public)
+        .filter(|(key, reach)| reads_like_a_credential(key) && **reach == SettingReach::Any)
         .map(|(key, _)| key)
         .collect();
 
     assert!(
         served.is_empty(),
-        "a credential is the core's alone unless a sidecar configures it; \
-         declare these with core_only() or sidecar_credential(): {served:?}"
+        "a credential is the core's alone unless the module that uses it declared \
+         it; declare these with core_only() or sidecar_credential(): {served:?}"
     );
 }
 
@@ -86,8 +86,18 @@ fn the_mail_llm_push_and_registry_keys_are_the_cores_alone() {
         "moduleRegistries",
         "moduleRegistryUrl",
     ] {
-        assert!(withheld_from_modules(key), "{key} must be the core's alone");
+        assert_eq!(
+            reach_of_setting(key),
+            SettingReach::CoreOnly,
+            "{key} must be the core's alone"
+        );
     }
+}
+
+#[test]
+fn the_blob_holding_every_modules_config_is_the_cores_alone() {
+    assert_eq!(reach_of_setting("moduleStates"), SettingReach::CoreOnly);
+    assert!(defaults().contains_key("moduleStates"));
 }
 
 // The word sweep cannot reach this one: "mediaTicketKey" carries no password,
@@ -97,12 +107,12 @@ fn the_mail_llm_push_and_registry_keys_are_the_cores_alone() {
 fn the_key_that_signs_a_media_ticket_is_the_cores_alone() {
     let key = crate::services::media_ticket::SIGNING_KEY_SETTING;
 
-    assert!(
-        withheld_from_modules(key),
+    assert_eq!(
+        reach_of_setting(key),
+        SettingReach::CoreOnly,
         "{key} forges a ticket for any device"
     );
     assert!(!reads_like_a_credential(key), "the sweep would cover it");
-    assert_eq!(declared().reach.get(key), Some(&Reach::CoreOnly));
 }
 
 #[test]
@@ -116,36 +126,44 @@ fn the_identities_the_server_mints_for_itself_are_declared_and_withheld() {
     ] {
         assert_eq!(
             declared.reach.get(key),
-            Some(&Reach::CoreOnly),
+            Some(&SettingReach::CoreOnly),
             "{key} is minted, not configured"
         );
         assert!(
             !declared.values.contains_key(key),
             "{key} carries no default, so no patch off the wire writes it"
         );
-        assert!(withheld_from_modules(key), "{key} is no module's business");
     }
 }
 
 #[test]
-fn a_credential_the_sidecar_that_uses_it_configures_stays_reachable() {
-    assert!(!withheld_from_modules("vpnWgConfig"));
-    assert!(!withheld_from_modules("remoteAccessToken"));
+fn a_credential_the_sidecar_that_uses_it_configures_wants_a_declaration() {
+    assert_eq!(reach_of_setting("vpnWgConfig"), SettingReach::Declared);
+    assert_eq!(
+        reach_of_setting("remoteAccessToken"),
+        SettingReach::Declared
+    );
 }
 
 #[test]
-fn an_ordinary_preference_is_reachable() {
-    assert!(!withheld_from_modules("acqEnabled"));
-    assert!(!withheld_from_modules("namingEpisodeFile"));
-    assert!(!withheld_from_modules("notifications.vapid.publicKey"));
-    assert!(!withheld_from_modules("smtpHost"));
+fn an_ordinary_preference_reaches_any_module() {
+    for key in [
+        "acqEnabled",
+        "namingEpisodeFile",
+        "notifications.vapid.publicKey",
+        "smtpHost",
+        "vpnLocalPort",
+        "localDiscovery",
+    ] {
+        assert_eq!(reach_of_setting(key), SettingReach::Any, "{key}");
+    }
 }
 
 #[test]
-fn a_key_nothing_declares_is_withheld_whatever_it_is_called() {
-    assert!(withheld_from_modules("neverDeclared"));
-    assert!(withheld_from_modules("aPlausiblePreference"));
-    assert!(withheld_from_modules(""));
+fn a_key_nothing_declares_reaches_no_module_whatever_it_is_called() {
+    for key in ["neverDeclared", "aPlausiblePreference", ""] {
+        assert_eq!(reach_of_setting(key), SettingReach::Unknown, "{key}");
+    }
 }
 
 #[test]

--- a/server/crates/kroma-engine/src/services/settings/mod.rs
+++ b/server/crates/kroma-engine/src/services/settings/mod.rs
@@ -28,7 +28,7 @@ mod schema;
 mod store;
 
 pub use accessors::*;
-pub use keys::withheld_from_modules;
+pub use keys::reach_of_setting;
 pub use llm::*;
 pub use schema::*;
 pub use store::*;

--- a/server/crates/kroma-module-host/src/host_token.rs
+++ b/server/crates/kroma-module-host/src/host_token.rs
@@ -1,9 +1,14 @@
-//! The shared-host-token guard.
+//! The host-token guard.
 //!
-//! Every hop of the module IPC authenticates with the SAME random token the
-//! supervisor mints at boot: the core's `/api/_host/*` callbacks, the core's
-//! `/_host/register-job` endpoint, and a sidecar's `/_job/run/*` + `/_port/*`
-//! routes. It lives in the host seam they all already depend on.
+//! One random token the supervisor mints at boot authenticates the hops where
+//! the caller's identity does not change the answer: the core's
+//! `/_host/register-job` and `/_host/register-events` endpoints, and a sidecar's
+//! `/_job/run/*`, `/_event/*` and `/_port/*` routes. A peer holds it too, which
+//! is why it cannot also name its holder.
+//!
+//! The `/api/_host/*` callbacks are the exception and are guarded by the
+//! supervisor instead, against a token minted per module process, because what a
+//! module may read of the settings store depends on which module is asking.
 
 use axum::extract::{Request, State};
 use axum::http::{HeaderMap, StatusCode};
@@ -34,9 +39,10 @@ pub async fn require_host_token(
     }
 }
 
-// Constant-time, so matching the shared host token never leaks a shared
-// prefix through timing.
-fn ct_eq(a: &[u8], b: &[u8]) -> bool {
+/// Constant-time byte equality, so matching a host token never leaks a shared
+/// prefix through timing. Length is compared first and in the clear, which a
+/// token's length already is.
+pub fn ct_eq(a: &[u8], b: &[u8]) -> bool {
     if a.len() != b.len() {
         return false;
     }

--- a/server/crates/kroma-module-host/src/lib.rs
+++ b/server/crates/kroma-module-host/src/lib.rs
@@ -26,11 +26,13 @@ mod auth;
 mod host_ctx;
 mod module;
 mod port;
+mod setting_reach;
 
 pub use auth::*;
 pub use host_ctx::*;
 pub use module::*;
 pub use port::*;
+pub use setting_reach::*;
 
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};

--- a/server/crates/kroma-module-host/src/setting_reach.rs
+++ b/server/crates/kroma-module-host/src/setting_reach.rs
@@ -1,0 +1,27 @@
+//! How far one settings key reaches out of the core.
+
+/// What the module host callback may do with a settings key. The core declares
+/// it beside the key's default; the supervisor carries the answer and never
+/// decides it.
+///
+/// [`Self::Declared`] is the narrow one: the key is handed to a module because a
+/// module is what consumes it, and to no module that did not say in its manifest
+/// that it reads or writes it. A caller the callback cannot name holds no
+/// declaration, so it reaches none of these.
+///
+/// [`Self::Unknown`] is withheld like [`Self::CoreOnly`] and separate from it only
+/// so the refusal can be logged for what it is: a module asking for the mail
+/// password is worth an operator's attention, one asking for a key the core has
+/// never heard of is a typo or a feature that left.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SettingReach {
+    Unknown,
+    CoreOnly,
+    Declared,
+    Any,
+}
+
+/// Asks the core how far a settings key reaches. The supervisor holds this and
+/// nothing else about what any key means.
+#[derive(Clone, Copy)]
+pub struct SettingReachOf(pub fn(&str) -> SettingReach);

--- a/server/crates/kroma-module-manifest/src/lib.rs
+++ b/server/crates/kroma-module-manifest/src/lib.rs
@@ -20,7 +20,7 @@ pub use kroma_module_macros::embedded_module;
 pub use manifest::MODULE_SCHEMA_VERSION;
 pub use manifest::{
     ConfigField, Contribution, CoreScope, Dependency, FeRemote, ModuleManifest, PointDef, PointReq,
-    Storage, Version,
+    SettingsScope, Storage, Version,
 };
 pub use registry::{ModuleRegistration, Registry, ResolveError};
 

--- a/server/crates/kroma-module-manifest/src/manifest.rs
+++ b/server/crates/kroma-module-manifest/src/manifest.rs
@@ -327,6 +327,36 @@ impl CoreScope {
     }
 }
 
+/// The CORE settings keys a module reads and writes, as the keys themselves.
+///
+/// The core decides which keys a module may reach at all; this narrows that to
+/// the caller. A key the core hands out only to the module that consumes it
+/// reaches a module that named it here and no other, which is the difference
+/// between a credential reaching the tunnel and reaching everything installed.
+///
+/// Additive, so it cost no [`MODULE_SCHEMA_VERSION`] bump, and absent is not the
+/// same as empty: a manifest with no `settings` object predates the field, so it
+/// keeps every ordinary preference and reaches none of the keys that want a
+/// declaration. One that declares reaches exactly what it lists.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SettingsScope {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub read: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub write: Vec<String>,
+}
+
+impl SettingsScope {
+    pub fn reads(&self, key: &str) -> bool {
+        self.read.iter().any(|k| k == key)
+    }
+
+    pub fn writes(&self, key: &str) -> bool {
+        self.write.iter().any(|k| k == key)
+    }
+}
+
 /// The public description of a module.
 ///
 /// This is the serde shape served at `GET /api/modules` and mirrored by the
@@ -372,6 +402,9 @@ pub struct ModuleManifest {
     /// Absent for a module that touches no database, which is most of them.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub storage: Option<Storage>,
+    /// Absent for a module that predates the field, which keeps the reach it had.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub settings: Option<SettingsScope>,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub library: bool,
 }
@@ -399,6 +432,7 @@ impl ModuleManifest {
             config: Vec::new(),
             fe_remote: None,
             storage: None,
+            settings: None,
             library: false,
         }
     }
@@ -453,6 +487,45 @@ mod tests {
         let back: ModuleManifest =
             serde_json::from_value(serde_json::to_value(&scoped).unwrap()).unwrap();
         assert_eq!(back.storage, scoped.storage);
+    }
+
+    #[test]
+    fn a_settings_declaration_is_absent_unless_written_and_round_trips_when_it_is() {
+        let plain: ModuleManifest =
+            serde_json::from_str(r#"{ "id": "a", "name": "A", "version": "1.0.0" }"#).unwrap();
+        assert!(
+            plain.settings.is_none(),
+            "a manifest predating the field keeps the reach it had"
+        );
+        assert!(serde_json::to_value(&plain)
+            .unwrap()
+            .get("settings")
+            .is_none());
+
+        // An empty object is NOT the same as an absent one: it declares, and
+        // declares nothing.
+        let nothing: ModuleManifest = serde_json::from_str(
+            r#"{ "id": "a", "name": "A", "version": "1.0.0", "settings": {} }"#,
+        )
+        .unwrap();
+        assert_eq!(nothing.settings, Some(SettingsScope::default()));
+
+        let scoped: ModuleManifest = serde_json::from_str(
+            r#"{ "id": "a", "name": "A", "version": "1.0.0",
+                 "settings": { "read": ["vpnWgConfig", "vpnLocalPort"],
+                               "write": ["vpnWgConfig"] } }"#,
+        )
+        .unwrap();
+        let settings = scoped.settings.as_ref().unwrap();
+        assert!(settings.reads("vpnWgConfig"));
+        assert!(settings.reads("vpnLocalPort"));
+        assert!(settings.writes("vpnWgConfig"));
+        assert!(!settings.writes("vpnLocalPort"), "a read is not a write");
+        assert!(!settings.reads("remoteAccessToken"));
+
+        let back: ModuleManifest =
+            serde_json::from_value(serde_json::to_value(&scoped).unwrap()).unwrap();
+        assert_eq!(back.settings, scoped.settings);
     }
 
     #[test]

--- a/server/crates/kroma-module-runtime/src/lib.rs
+++ b/server/crates/kroma-module-runtime/src/lib.rs
@@ -24,6 +24,7 @@ struct Env {
     port: u16,
     core_url: String,
     host_token: String,
+    module_token: String,
     // Only read under `storage`: a module that declares none never learns where
     // the core database is, which is the capability said in one more place.
     #[cfg(feature = "storage")]
@@ -39,6 +40,11 @@ impl Env {
             port: get("KROMA_MODULE_PORT")?.parse()?,
             core_url: get("KROMA_CORE_URL")?,
             host_token: get("KROMA_HOST_TOKEN")?,
+            // A host that predates per-module tokens sends none, and the fabric
+            // token still authenticates; it just does not name this module, so
+            // the callback answers it nothing that wants a declaration.
+            module_token: std::env::var("KROMA_MODULE_TOKEN")
+                .or_else(|_| get("KROMA_HOST_TOKEN"))?,
             #[cfg(feature = "storage")]
             db_path: PathBuf::from(get("KROMA_DB_PATH")?),
             data_dir: PathBuf::from(get("KROMA_DATA_DIR")?),
@@ -86,7 +92,7 @@ struct Inner {
     #[cfg(feature = "storage")]
     core: kroma_sqlite::Pool,
     core_url: String,
-    host_token: String,
+    module_token: String,
     services: RwLock<HashMap<TypeId, Arc<dyn Any + Send + Sync>>>,
     // The metadata language, cached: it is one env-derived string, and every
     // caller that renames a file asks for it.
@@ -106,7 +112,7 @@ impl RemoteHost {
                 #[cfg(feature = "storage")]
                 core: kroma_sqlite::init_scoped(&env.db_path, &env.module_id, &env.grant())?,
                 core_url: env.core_url.clone(),
-                host_token: env.host_token.clone(),
+                module_token: env.module_token.clone(),
                 services: RwLock::new(HashMap::new()),
                 language: RwLock::new(None),
             }),
@@ -129,8 +135,10 @@ impl RemoteHost {
     }
 
     fn callback(&self) -> kroma_http::Loopback {
-        kroma_http::Loopback::new()
-            .header("authorization", format!("Bearer {}", self.inner.host_token))
+        kroma_http::Loopback::new().header(
+            "authorization",
+            format!("Bearer {}", self.inner.module_token),
+        )
     }
 
     fn host_url(&self, path: &str) -> String {

--- a/server/crates/kroma-module-supervisor/Cargo.toml
+++ b/server/crates/kroma-module-supervisor/Cargo.toml
@@ -10,6 +10,8 @@ license.workspace = true
 # The host contract the callback endpoints resolve against (any HostCtx state).
 kroma-module-host = { workspace = true }
 kroma-module-manifest = { workspace = true }
+# The per-module host token every callback names its caller with.
+kroma-primitives = { workspace = true }
 # The `User` the session callback answers with.
 kroma-domain = { workspace = true }
 # Moving a module's tables out of the core database, before it is spawned.

--- a/server/crates/kroma-module-supervisor/src/host_api.rs
+++ b/server/crates/kroma-module-supervisor/src/host_api.rs
@@ -2,25 +2,28 @@
 //! settings, events, notifications, jobs and session lookups.
 
 use std::collections::HashMap;
-use std::sync::RwLock;
+use std::sync::{Arc, RwLock};
 
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::middleware::from_fn_with_state;
 use axum::routing::{get, post};
 use axum::{Extension, Json, Router};
-use kroma_module_host::host_token::{require_host_token, HostToken};
-use kroma_module_host::{Event, HostCtx};
+use kroma_module_host::{Event, HostCtx, SettingReachOf};
 use serde_json::{json, Value};
 
+use super::Supervisor;
+
+mod caller;
 mod settings;
 
-pub use settings::WithheldSettings;
+use caller::{resolve_caller, Caller};
 
-/// The `/_host/*` callback router modules call back into (mount under `/api`),
-/// guarded by the shared `token`. `withheld` decides which settings keys the
-/// callback keeps from a module.
-pub fn host_router<S>(token: String, withheld: WithheldSettings) -> Router<S>
+/// The `/_host/*` callback router modules call back into (mount under `/api`).
+/// Every route is behind a token the `supervisor` minted, which is what names the
+/// calling module; `reach` is the core's answer for how far one settings key
+/// reaches out of it.
+pub fn host_router<S>(supervisor: Arc<Supervisor>, reach: SettingReachOf) -> Router<S>
 where
     S: HostCtx + Clone + Send + Sync + 'static,
 {
@@ -46,8 +49,8 @@ where
         // How a module reaches a peer: it asks for a CONTRACT and the core
         // answers with whoever serves it. No module id crosses this wire.
         .route("/_host/contributions", get(contributions::<S>))
-        .route_layer(from_fn_with_state(HostToken(token), require_host_token))
-        .layer(Extension(withheld))
+        .route_layer(from_fn_with_state(supervisor, resolve_caller))
+        .layer(Extension(reach))
 }
 
 #[derive(serde::Deserialize)]

--- a/server/crates/kroma-module-supervisor/src/host_api/caller.rs
+++ b/server/crates/kroma-module-supervisor/src/host_api/caller.rs
@@ -1,0 +1,72 @@
+//! Which module made a callback, resolved from the token it presented, and what
+//! that module declared about the settings it reads.
+
+use std::sync::Arc;
+
+use axum::extract::{Request, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+
+use crate::Supervisor;
+
+/// Who made a callback, and what that caller declared about itself.
+///
+/// `module` is `None` for a caller holding the fabric token rather than one minted
+/// per module process: authenticated, but not named. A bundle built before
+/// per-module tokens existed is in that position, and so is a module presenting
+/// the fabric token on purpose, so an unnamed caller reaches nothing that wants a
+/// declaration.
+#[derive(Clone)]
+pub(super) struct Caller {
+    module: Option<String>,
+    supervisor: Arc<Supervisor>,
+}
+
+impl Caller {
+    pub(super) fn declares_read(&self, key: &str) -> bool {
+        self.declaration().is_some_and(|scope| scope.reads(key))
+    }
+
+    pub(super) fn declares_write(&self, key: &str) -> bool {
+        self.declaration().is_some_and(|scope| scope.writes(key))
+    }
+
+    pub(super) fn declares_nothing(&self) -> bool {
+        self.declaration().is_none()
+    }
+
+    pub(super) fn name(&self) -> &str {
+        self.module.as_deref().unwrap_or("an unnamed caller")
+    }
+
+    fn declaration(&self) -> Option<kroma_module_manifest::SettingsScope> {
+        self.supervisor.settings_scope(self.module.as_deref()?)
+    }
+}
+
+pub(super) async fn resolve_caller(
+    State(supervisor): State<Arc<Supervisor>>,
+    headers: HeaderMap,
+    mut req: Request,
+    next: Next,
+) -> Response {
+    let Some(bearer) = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+    else {
+        return (StatusCode::UNAUTHORIZED, "bad host token").into_response();
+    };
+    let fabric =
+        kroma_module_host::host_token::ct_eq(bearer.as_bytes(), supervisor.host_token().as_bytes());
+    let module = supervisor.module_of_token(bearer);
+    if !fabric && module.is_none() {
+        return (StatusCode::UNAUTHORIZED, "bad host token").into_response();
+    }
+    req.extensions_mut().insert(Caller {
+        module,
+        supervisor: supervisor.clone(),
+    });
+    next.run(req).await
+}

--- a/server/crates/kroma-module-supervisor/src/host_api/settings.rs
+++ b/server/crates/kroma-module-supervisor/src/host_api/settings.rs
@@ -1,17 +1,19 @@
 //! The settings half of the callback API: one typed read, one batched write, and
-//! the keys the core answers for itself rather than for a sidecar.
+//! the two declarations that decide which of the core's keys the caller gets.
 
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::{Extension, Json};
-use kroma_module_host::HostCtx;
+use kroma_module_host::{HostCtx, SettingReach, SettingReachOf};
 use serde_json::{json, Value};
 
-/// Asks the core whether a settings key is withheld from a module. `true` means
-/// no sidecar reads or writes it through the callback: the supervisor carries the
-/// question, the core owns the answer.
-#[derive(Clone, Copy)]
-pub struct WithheldSettings(pub fn(&str) -> bool);
+use super::Caller;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Use {
+    Read,
+    Write,
+}
 
 #[derive(serde::Deserialize)]
 pub(super) struct SettingQuery {
@@ -33,15 +35,61 @@ fn asked_with(q: &SettingQuery) -> Value {
     }
 }
 
+fn declares(caller: &Caller, key: &str, how: Use) -> bool {
+    match how {
+        Use::Read => caller.declares_read(key),
+        Use::Write => caller.declares_write(key),
+    }
+}
+
+fn may_reach(reach: SettingReach, caller: &Caller, key: &str, how: Use) -> bool {
+    match reach {
+        SettingReach::Unknown | SettingReach::CoreOnly => false,
+        SettingReach::Declared => declares(caller, key, how),
+        SettingReach::Any => true,
+    }
+}
+
+fn log_a_refusal(reach: SettingReach, caller: &Caller, key: &str) {
+    if reach == SettingReach::Unknown {
+        tracing::debug!(
+            module = %caller.name(),
+            key = %key,
+            "a module reached for a setting the core does not have",
+        );
+        return;
+    }
+    tracing::warn!(
+        module = %caller.name(),
+        key = %key,
+        "a module reached for a setting it may not have",
+    );
+}
+
+fn log_a_reach_the_declaration_omits(caller: &Caller, key: &str, how: Use) {
+    if caller.declares_nothing() || declares(caller, key, how) {
+        return;
+    }
+    tracing::debug!(
+        module = %caller.name(),
+        key = %key,
+        write = how == Use::Write,
+        "a module reached a setting its manifest does not declare",
+    );
+}
+
 pub(super) async fn get_setting<S: HostCtx>(
     State(host): State<S>,
-    Extension(WithheldSettings(withheld)): Extension<WithheldSettings>,
+    Extension(SettingReachOf(reach)): Extension<SettingReachOf>,
+    Extension(caller): Extension<Caller>,
     Query(q): Query<SettingQuery>,
 ) -> Json<Value> {
-    if withheld(&q.key) {
-        tracing::warn!(key = %q.key, "a module asked for a setting the core keeps to itself");
+    let asked_for = reach(&q.key);
+    if !may_reach(asked_for, &caller, &q.key, Use::Read) {
+        log_a_refusal(asked_for, &caller, &q.key);
         return Json(json!({ "value": asked_with(&q) }));
     }
+    log_a_reach_the_declaration_omits(&caller, &q.key, Use::Read);
     let value = match q.kind.as_str() {
         "bool" => json!(host.setting_bool(&q.key, q.default == "true")),
         "i64" => json!(host.setting_i64(&q.key, q.default.parse().unwrap_or(0))),
@@ -52,12 +100,20 @@ pub(super) async fn get_setting<S: HostCtx>(
 
 pub(super) async fn set_settings<S: HostCtx>(
     State(host): State<S>,
-    Extension(WithheldSettings(withheld)): Extension<WithheldSettings>,
+    Extension(SettingReachOf(reach)): Extension<SettingReachOf>,
+    Extension(caller): Extension<Caller>,
     Json(body): Json<SettingsPatch>,
 ) -> StatusCode {
-    if let Some(key) = body.patch.keys().find(|key| withheld(key)) {
-        tracing::warn!(key = %key, "refusing a module's write to a setting the core keeps to itself");
+    if let Some(key) = body
+        .patch
+        .keys()
+        .find(|key| !may_reach(reach(key), &caller, key, Use::Write))
+    {
+        log_a_refusal(reach(key), &caller, key);
         return StatusCode::FORBIDDEN;
+    }
+    for key in body.patch.keys() {
+        log_a_reach_the_declaration_omits(&caller, key, Use::Write);
     }
     host.set_settings(body.patch);
     StatusCode::NO_CONTENT

--- a/server/crates/kroma-module-supervisor/src/lib.rs
+++ b/server/crates/kroma-module-supervisor/src/lib.rs
@@ -19,7 +19,7 @@ mod proxy;
 mod registry;
 mod watch;
 
-pub use host_api::{host_router, WithheldSettings};
+pub use host_api::host_router;
 pub use origin::{BinStamp, Origin, Source};
 pub use proxy::proxy_to;
 pub use registry::{sibling_url, verify_sha256, FetchProgress, DESCRIPTOR_PATH, MAX_BUNDLE_BYTES};
@@ -52,6 +52,7 @@ pub struct SupervisorConfig {
 pub struct Supervisor {
     cfg: SupervisorConfig,
     procs: RwLock<HashMap<String, Proc>>,
+    module_tokens: RwLock<HashMap<String, String>>,
     manifests_cache: RwLock<Option<Vec<ModuleManifest>>>,
     // Short-TTL catalog cache: the admin flow sweeps EVERY registry from the
     // catalog view, the plan dialog (once per opt-in toggle) and the install
@@ -68,6 +69,7 @@ impl Supervisor {
         Arc::new(Self {
             cfg,
             procs: RwLock::new(HashMap::new()),
+            module_tokens: RwLock::new(HashMap::new()),
             manifests_cache: RwLock::new(None),
             catalog_cache: RwLock::new(HashMap::new()),
             catalog_client: std::sync::OnceLock::new(),
@@ -177,6 +179,47 @@ impl Supervisor {
 
     pub fn host_token(&self) -> &str {
         &self.cfg.host_token
+    }
+
+    /// The token `id`'s process calls back with, minted on first ask and then
+    /// stable for the life of this server. It names its holder, which is what lets
+    /// a callback answer for the module that made it rather than for "a module".
+    ///
+    /// A sidecar's own routes are NOT guarded by this: a peer reaching one holds
+    /// the fabric token from [`Self::host_token`], and handing it this instead
+    /// would hand one module another's identity.
+    pub fn module_token(&self, id: &str) -> String {
+        if let Some(token) = self.module_tokens.read().unwrap().get(id) {
+            return token.clone();
+        }
+        let mut tokens = self.module_tokens.write().unwrap();
+        tokens
+            .entry(id.to_string())
+            .or_insert_with(kroma_primitives::random_token)
+            .clone()
+    }
+
+    /// The module `token` was minted for, or `None` for the fabric token and for
+    /// anything else: a caller the callback cannot name holds no declaration, so it
+    /// reaches nothing that wants one.
+    pub fn module_of_token(&self, token: &str) -> Option<String> {
+        self.module_tokens
+            .read()
+            .unwrap()
+            .iter()
+            .find(|(_, minted)| {
+                kroma_module_host::host_token::ct_eq(minted.as_bytes(), token.as_bytes())
+            })
+            .map(|(id, _)| id.clone())
+    }
+
+    /// What `id` declared under `settings`, or `None` when its manifest predates
+    /// the field, which is a module that keeps the reach it had.
+    pub fn settings_scope(&self, id: &str) -> Option<kroma_module_manifest::SettingsScope> {
+        self.installed_manifests()
+            .into_iter()
+            .find(|m| m.id == id)?
+            .settings
     }
 }
 

--- a/server/crates/kroma-module-supervisor/src/manifests.rs
+++ b/server/crates/kroma-module-supervisor/src/manifests.rs
@@ -155,6 +155,87 @@ mod tests {
     }
 
     #[test]
+    fn a_module_token_names_its_holder_and_nothing_else_does() {
+        let dir = kroma_testing::temp_dir("module-tokens");
+        let sup = Supervisor::new(SupervisorConfig {
+            modules_dir: dir.path().to_path_buf(),
+            core_url: "http://127.0.0.1:0".into(),
+            host_token: "fabric".into(),
+            db_path: dir.path().join("db.sqlite"),
+            data_dir: dir.path().to_path_buf(),
+            reserved_ids: Vec::new(),
+            server_version: "0.1.4".into(),
+            log_line: None,
+        });
+
+        let first = sup.module_token("com.example.one");
+        let second = sup.module_token("com.example.two");
+
+        assert_eq!(
+            first,
+            sup.module_token("com.example.one"),
+            "stable per module"
+        );
+        assert_ne!(first, second);
+        assert_ne!(first, "fabric");
+        assert_eq!(
+            sup.module_of_token(&first),
+            Some("com.example.one".to_string())
+        );
+        assert_eq!(
+            sup.module_of_token("fabric"),
+            None,
+            "the fabric token names no module"
+        );
+        assert_eq!(sup.module_of_token("invented"), None);
+        assert_eq!(sup.module_of_token(""), None);
+    }
+
+    #[test]
+    fn a_modules_settings_declaration_is_what_its_manifest_says() {
+        let dir = kroma_testing::temp_dir("settings-scope");
+        let sup = Supervisor::new(SupervisorConfig {
+            modules_dir: dir.path().to_path_buf(),
+            core_url: "http://127.0.0.1:0".into(),
+            host_token: "fabric".into(),
+            db_path: dir.path().join("db.sqlite"),
+            data_dir: dir.path().to_path_buf(),
+            reserved_ids: Vec::new(),
+            server_version: "0.1.4".into(),
+            log_line: None,
+        });
+        let v = kroma_module_manifest::MODULE_SCHEMA_VERSION;
+        let write = |id: &str, body: &str| {
+            let d = dir.path().join(id);
+            std::fs::create_dir_all(&d).unwrap();
+            std::fs::write(d.join("module.json"), body).unwrap();
+        };
+
+        write(
+            "com.example.declaring",
+            &format!(
+                r#"{{ "schemaVersion": {v}, "id": "com.example.declaring", "name": "D",
+                      "version": "1.0.0",
+                      "settings": {{ "read": ["vpnWgConfig"], "write": ["vpnLocalPort"] }} }}"#
+            ),
+        );
+        write(
+            "com.example.silent",
+            &format!(
+                r#"{{ "schemaVersion": {v}, "id": "com.example.silent", "name": "S",
+                      "version": "1.0.0" }}"#
+            ),
+        );
+
+        let declared = sup.settings_scope("com.example.declaring").unwrap();
+        assert!(declared.reads("vpnWgConfig"));
+        assert!(!declared.writes("vpnWgConfig"));
+        assert!(declared.writes("vpnLocalPort"));
+        assert!(sup.settings_scope("com.example.silent").is_none());
+        assert!(sup.settings_scope("com.example.never-installed").is_none());
+    }
+
+    #[test]
     fn a_modules_grant_comes_off_disk_even_when_the_listing_cache_is_stale() {
         let dir = kroma_testing::temp_dir("grant-stale-cache");
         let sup = Supervisor::new(SupervisorConfig {

--- a/server/crates/kroma-module-supervisor/src/process.rs
+++ b/server/crates/kroma-module-supervisor/src/process.rs
@@ -65,6 +65,9 @@ impl Supervisor {
             .env("KROMA_MODULE_PORT", port.to_string())
             .env("KROMA_CORE_URL", &self.cfg.core_url)
             .env("KROMA_HOST_TOKEN", &self.cfg.host_token)
+            // What a callback names its caller with. A module built before this
+            // existed sends the fabric token above, which names none.
+            .env("KROMA_MODULE_TOKEN", self.module_token(id))
             .env("KROMA_DB_PATH", &self.cfg.db_path)
             .env("KROMA_DATA_DIR", &self.cfg.data_dir)
             // What the module may reach in the CORE database, as its manifest

--- a/server/crates/kroma-module-supervisor/tests/host_metadata.rs
+++ b/server/crates/kroma-module-supervisor/tests/host_metadata.rs
@@ -2,11 +2,11 @@ use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use kroma_domain::metadata::{EpisodeInfo, MatchCandidate};
 use kroma_module_host::testing::StubHost;
-use kroma_module_supervisor::WithheldSettings;
 use tower::ServiceExt;
 
-const TOKEN: &str = "host-token";
-const NOTHING_WITHHELD: WithheldSettings = WithheldSettings(|_| false);
+mod test_support;
+
+use test_support::{Modules, FABRIC, NOTHING_WITHHELD};
 
 fn dune() -> MatchCandidate {
     MatchCandidate {
@@ -37,7 +37,8 @@ async fn get(host: StubHost, uri: &str, token: Option<&str>) -> (StatusCode, Str
     if let Some(t) = token {
         req = req.header("authorization", format!("Bearer {t}"));
     }
-    let res = kroma_module_supervisor::host_router::<StubHost>(TOKEN.into(), NOTHING_WITHHELD)
+    let res = Modules::new("host-metadata")
+        .router::<StubHost>(NOTHING_WITHHELD)
         .with_state(host)
         .oneshot(req.body(Body::empty()).unwrap())
         .await
@@ -56,7 +57,7 @@ async fn a_search_comes_back_as_the_candidates_the_core_ranked() {
     let (status, body) = get(
         host,
         "/_host/metadata-search?q=Dune&kind=movie&year=2021",
-        Some(TOKEN),
+        Some(FABRIC),
     )
     .await;
 
@@ -71,7 +72,7 @@ async fn a_search_comes_back_as_the_candidates_the_core_ranked() {
 async fn a_search_needs_only_the_query_text() {
     let host = StubHost::new().with_metadata_candidates(vec![dune()]);
 
-    let (status, body) = get(host, "/_host/metadata-search?q=Dune", Some(TOKEN)).await;
+    let (status, body) = get(host, "/_host/metadata-search?q=Dune", Some(FABRIC)).await;
 
     assert_eq!(status, StatusCode::OK);
     let found: Vec<MatchCandidate> = serde_json::from_str(&body).expect("candidates came back");
@@ -83,7 +84,7 @@ async fn a_search_with_no_query_text_is_rejected() {
     let (status, _) = get(
         StubHost::new(),
         "/_host/metadata-search?kind=movie",
-        Some(TOKEN),
+        Some(FABRIC),
     )
     .await;
 
@@ -97,7 +98,7 @@ async fn a_season_comes_back_as_the_episodes_the_provider_names() {
     let (status, body) = get(
         host,
         "/_host/metadata-episodes?tmdbId=1399&season=1",
-        Some(TOKEN),
+        Some(FABRIC),
     )
     .await;
 
@@ -115,7 +116,7 @@ async fn a_season_lookup_takes_its_title_id_in_camel_case_only() {
     let (status, _) = get(
         host,
         "/_host/metadata-episodes?tmdb_id=1399&season=1",
-        Some(TOKEN),
+        Some(FABRIC),
     )
     .await;
 

--- a/server/crates/kroma-module-supervisor/tests/host_secret.rs
+++ b/server/crates/kroma-module-supervisor/tests/host_secret.rs
@@ -10,18 +10,19 @@
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use kroma_module_host::testing::StubHost;
-use kroma_module_supervisor::WithheldSettings;
 use tower::ServiceExt;
 
-const TOKEN: &str = "host-token";
-const NOTHING_WITHHELD: WithheldSettings = WithheldSettings(|_| false);
+mod test_support;
+
+use test_support::{Modules, FABRIC, NOTHING_WITHHELD};
 
 async fn get(host: StubHost, uri: &str, token: Option<&str>) -> (StatusCode, String) {
     let mut req = Request::builder().method("GET").uri(uri);
     if let Some(t) = token {
         req = req.header("authorization", format!("Bearer {t}"));
     }
-    let res = kroma_module_supervisor::host_router::<StubHost>(TOKEN.into(), NOTHING_WITHHELD)
+    let res = Modules::new("host-secret")
+        .router::<StubHost>(NOTHING_WITHHELD)
         .with_state(host)
         .oneshot(req.body(Body::empty()).unwrap())
         .await
@@ -37,7 +38,7 @@ async fn get(host: StubHost, uri: &str, token: Option<&str>) -> (StatusCode, Str
 async fn a_configured_secret_comes_back_by_name() {
     let host = StubHost::new().with_tmdb_key("abc123");
 
-    let (status, body) = get(host, "/_host/secret?name=tmdb", Some(TOKEN)).await;
+    let (status, body) = get(host, "/_host/secret?name=tmdb", Some(FABRIC)).await;
 
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body, r#""abc123""#);
@@ -49,7 +50,7 @@ async fn a_configured_secret_comes_back_by_name() {
 async fn a_name_the_host_does_not_know_is_null_and_not_another_secret() {
     let host = StubHost::new().with_tmdb_key("abc123");
 
-    let (status, body) = get(host, "/_host/secret?name=invented", Some(TOKEN)).await;
+    let (status, body) = get(host, "/_host/secret?name=invented", Some(FABRIC)).await;
 
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body, "null");
@@ -57,7 +58,7 @@ async fn a_name_the_host_does_not_know_is_null_and_not_another_secret() {
 
 #[tokio::test]
 async fn a_secret_the_operator_never_set_is_null() {
-    let (status, body) = get(StubHost::new(), "/_host/secret?name=tmdb", Some(TOKEN)).await;
+    let (status, body) = get(StubHost::new(), "/_host/secret?name=tmdb", Some(FABRIC)).await;
 
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body, "null");
@@ -78,7 +79,7 @@ async fn a_caller_with_no_host_token_gets_nothing() {
 
 #[tokio::test]
 async fn asking_with_no_name_at_all_is_rejected() {
-    let (status, _) = get(StubHost::new(), "/_host/secret", Some(TOKEN)).await;
+    let (status, _) = get(StubHost::new(), "/_host/secret", Some(FABRIC)).await;
 
     assert_eq!(status, StatusCode::BAD_REQUEST);
 }
@@ -89,7 +90,7 @@ async fn asking_with_no_name_at_all_is_rejected() {
 async fn the_metadata_language_is_served_beside_it() {
     let host = StubHost::new().with_metadata_language("fr-FR");
 
-    let (status, body) = get(host, "/_host/metadata-language", Some(TOKEN)).await;
+    let (status, body) = get(host, "/_host/metadata-language", Some(FABRIC)).await;
 
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body, r#""fr-FR""#);

--- a/server/crates/kroma-module-supervisor/tests/host_session.rs
+++ b/server/crates/kroma-module-supervisor/tests/host_session.rs
@@ -9,11 +9,11 @@ use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use kroma_domain::User;
 use kroma_module_host::testing::StubHost;
-use kroma_module_supervisor::WithheldSettings;
 use tower::ServiceExt;
 
-const TOKEN: &str = "host-token";
-const NOTHING_WITHHELD: WithheldSettings = WithheldSettings(|_| false);
+mod test_support;
+
+use test_support::{Modules, FABRIC, NOTHING_WITHHELD};
 
 fn ana() -> User {
     User {
@@ -32,7 +32,8 @@ fn ana() -> User {
 }
 
 fn app(host: StubHost) -> axum::Router {
-    kroma_module_supervisor::host_router::<StubHost>(TOKEN.into(), NOTHING_WITHHELD)
+    Modules::new("host-session")
+        .router::<StubHost>(NOTHING_WITHHELD)
         .with_state(host)
 }
 
@@ -61,7 +62,7 @@ async fn a_live_token_comes_back_as_the_whole_account() {
     // The whole `User`, because the sidecar gates on its permissions and
     // localizes for it; a bare id would cost a second round-trip per request.
     let host = StubHost::new().with_session("sess-1", ana());
-    let (status, body) = post(host, Some(TOKEN), r#"{"token":"sess-1"}"#).await;
+    let (status, body) = post(host, Some(FABRIC), r#"{"token":"sess-1"}"#).await;
 
     assert_eq!(status, StatusCode::OK);
     let user: User = serde_json::from_str(&body).expect("a User came back");
@@ -73,7 +74,7 @@ async fn a_live_token_comes_back_as_the_whole_account() {
 async fn an_unknown_token_is_null_rather_than_an_error() {
     // `OptionalAuthUser` never rejects, so "no session" has to be a value.
     let host = StubHost::new().with_session("sess-1", ana());
-    let (status, body) = post(host, Some(TOKEN), r#"{"token":"not-a-session"}"#).await;
+    let (status, body) = post(host, Some(FABRIC), r#"{"token":"not-a-session"}"#).await;
 
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body, "null");

--- a/server/crates/kroma-module-supervisor/tests/host_settings.rs
+++ b/server/crates/kroma-module-supervisor/tests/host_settings.rs
@@ -1,18 +1,41 @@
 //! The `/_host/setting` + `/_host/settings` callbacks: what a sidecar may read
-//! and write of the core's settings store.
+//! and write of the core's settings store, by what the core declared about the key
+//! and what the calling module declared about itself.
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use kroma_module_host::testing::StubHost;
-use kroma_module_supervisor::WithheldSettings;
+use kroma_module_host::{SettingReach, SettingReachOf};
 use serde_json::json;
 use tower::ServiceExt;
 
-const TOKEN: &str = "host-token";
-const WITHHELD: WithheldSettings = WithheldSettings(|key| key == "smtpPassword");
+mod test_support;
 
-async fn send(host: StubHost, req: Request<Body>) -> (StatusCode, String) {
-    let res = kroma_module_supervisor::host_router::<StubHost>(TOKEN.into(), WITHHELD)
+use test_support::{Modules, FABRIC};
+
+const TUNNEL: &str = "tv.kroma.tunnel";
+const NOTES: &str = "tv.kroma.notes";
+
+// `smtpPassword` is the core's own, `vpnWgConfig` goes to the module that declared
+// it, and everything else is an ordinary preference.
+const REACH: SettingReachOf = SettingReachOf(|key| match key {
+    "smtpPassword" => SettingReach::CoreOnly,
+    "vpnWgConfig" => SettingReach::Declared,
+    _ => SettingReach::Any,
+});
+
+fn installed() -> Modules {
+    Modules::new("host-settings")
+        .declaring(
+            TUNNEL,
+            Some(r#"{ "read": ["vpnWgConfig"], "write": ["vpnWgConfig"] }"#),
+        )
+        .declaring(NOTES, Some(r#"{ "read": ["acqEnabled"] }"#))
+}
+
+async fn send(modules: &Modules, host: StubHost, req: Request<Body>) -> (StatusCode, String) {
+    let res = modules
+        .router::<StubHost>(REACH)
         .with_state(host)
         .oneshot(req)
         .await
@@ -24,32 +47,39 @@ async fn send(host: StubHost, req: Request<Body>) -> (StatusCode, String) {
     (status, String::from_utf8(bytes.to_vec()).unwrap())
 }
 
-async fn get(host: StubHost, uri: &str) -> (StatusCode, String) {
+async fn get(modules: &Modules, host: StubHost, token: &str, uri: &str) -> (StatusCode, String) {
     let req = Request::builder()
         .method("GET")
         .uri(uri)
-        .header("authorization", format!("Bearer {TOKEN}"))
+        .header("authorization", format!("Bearer {token}"))
         .body(Body::empty())
         .unwrap();
-    send(host, req).await
+    send(modules, host, req).await
 }
 
-async fn patch(host: StubHost, body: &str) -> (StatusCode, String) {
+async fn patch(modules: &Modules, host: StubHost, token: &str, body: &str) -> (StatusCode, String) {
     let req = Request::builder()
         .method("POST")
         .uri("/_host/settings")
-        .header("authorization", format!("Bearer {TOKEN}"))
+        .header("authorization", format!("Bearer {token}"))
         .header("content-type", "application/json")
         .body(Body::from(body.to_string()))
         .unwrap();
-    send(host, req).await
+    send(modules, host, req).await
 }
 
 #[tokio::test]
 async fn a_setting_the_core_keeps_to_itself_answers_the_default_the_module_asked_with() {
+    let modules = installed();
     let host = StubHost::new().with_setting("smtpPassword", json!("s3cr3t"));
 
-    let (status, body) = get(host, "/_host/setting?key=smtpPassword&kind=str&default=").await;
+    let (status, body) = get(
+        &modules,
+        host,
+        &modules.token(TUNNEL),
+        "/_host/setting?key=smtpPassword&kind=str&default=",
+    )
+    .await;
 
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body, r#"{"value":""}"#);
@@ -58,17 +88,22 @@ async fn a_setting_the_core_keeps_to_itself_answers_the_default_the_module_asked
 
 #[tokio::test]
 async fn a_setting_a_module_configures_still_comes_back_stored() {
+    let modules = installed();
     let host = StubHost::new()
         .with_setting("acqEnabled", json!(true))
         .with_setting("namingMovieFolder", json!("{Title} ({Year})"));
 
     let (enabled_status, enabled) = get(
+        &modules,
         host.clone(),
+        &modules.token(NOTES),
         "/_host/setting?key=acqEnabled&kind=bool&default=false",
     )
     .await;
     let (folder_status, folder) = get(
+        &modules,
         host,
+        &modules.token(NOTES),
         "/_host/setting?key=namingMovieFolder&kind=str&default=x",
     )
     .await;
@@ -80,11 +115,98 @@ async fn a_setting_a_module_configures_still_comes_back_stored() {
 }
 
 #[tokio::test]
+async fn a_credential_goes_to_the_module_that_declared_it() {
+    let modules = installed();
+    let host = StubHost::new().with_setting("vpnWgConfig", json!("[Interface]"));
+
+    let (status, body) = get(
+        &modules,
+        host,
+        &modules.token(TUNNEL),
+        "/_host/setting?key=vpnWgConfig&kind=str&default=",
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, r#"{"value":"[Interface]"}"#);
+}
+
+#[tokio::test]
+async fn a_credential_reaches_no_other_module_whatever_it_asks() {
+    let modules = installed();
+    let host = StubHost::new().with_setting("vpnWgConfig", json!("[Interface]"));
+
+    let (declared_elsewhere, by_notes) = get(
+        &modules,
+        host.clone(),
+        &modules.token(NOTES),
+        "/_host/setting?key=vpnWgConfig&kind=str&default=",
+    )
+    .await;
+    let (unnamed, by_fabric) = get(
+        &modules,
+        host.clone(),
+        FABRIC,
+        "/_host/setting?key=vpnWgConfig&kind=str&default=",
+    )
+    .await;
+    let (not_installed, by_stranger) = get(
+        &modules,
+        host,
+        &modules.token("tv.kroma.never-installed"),
+        "/_host/setting?key=vpnWgConfig&kind=str&default=",
+    )
+    .await;
+
+    for (status, body) in [
+        (declared_elsewhere, by_notes),
+        (unnamed, by_fabric),
+        (not_installed, by_stranger),
+    ] {
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, r#"{"value":""}"#);
+        assert!(!body.contains("[Interface]"), "the tunnel config leaked");
+    }
+}
+
+#[tokio::test]
+async fn a_module_whose_manifest_predates_the_field_keeps_its_preferences_and_loses_the_credential()
+{
+    let modules = Modules::new("host-settings-undeclared").declaring(NOTES, None);
+    let host = StubHost::new()
+        .with_setting("acqEnabled", json!(true))
+        .with_setting("vpnWgConfig", json!("[Interface]"));
+
+    let (pref_status, pref) = get(
+        &modules,
+        host.clone(),
+        &modules.token(NOTES),
+        "/_host/setting?key=acqEnabled&kind=bool&default=false",
+    )
+    .await;
+    let (credential_status, credential) = get(
+        &modules,
+        host,
+        &modules.token(NOTES),
+        "/_host/setting?key=vpnWgConfig&kind=str&default=",
+    )
+    .await;
+
+    assert_eq!(pref_status, StatusCode::OK);
+    assert_eq!(pref, r#"{"value":true}"#);
+    assert_eq!(credential_status, StatusCode::OK);
+    assert_eq!(credential, r#"{"value":""}"#);
+}
+
+#[tokio::test]
 async fn a_write_that_names_a_setting_the_core_keeps_to_itself_is_refused_whole() {
+    let modules = installed();
     let host = StubHost::new();
 
     let (status, _) = patch(
+        &modules,
         host.clone(),
+        &modules.token(TUNNEL),
         r#"{"patch":{"acqEnabled":true,"smtpPassword":"mine now"}}"#,
     )
     .await;
@@ -97,23 +219,48 @@ async fn a_write_that_names_a_setting_the_core_keeps_to_itself_is_refused_whole(
 }
 
 #[tokio::test]
-async fn a_write_of_the_settings_a_module_owns_goes_through() {
+async fn a_write_to_a_credential_a_module_did_not_declare_is_refused() {
+    let modules = installed();
     let host = StubHost::new();
 
-    let (status, _) = patch(host.clone(), r#"{"patch":{"acqEnabled":true}}"#).await;
+    let (status, _) = patch(
+        &modules,
+        host.clone(),
+        &modules.token(NOTES),
+        r#"{"patch":{"vpnWgConfig":"[Interface] mine"}}"#,
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert!(host.settings_written().is_empty());
+}
+
+#[tokio::test]
+async fn a_write_of_the_settings_a_module_owns_goes_through() {
+    let modules = installed();
+    let host = StubHost::new();
+
+    let (status, _) = patch(
+        &modules,
+        host.clone(),
+        &modules.token(TUNNEL),
+        r#"{"patch":{"acqEnabled":true,"vpnWgConfig":"[Interface]"}}"#,
+    )
+    .await;
 
     assert_eq!(status, StatusCode::NO_CONTENT);
     assert_eq!(
         host.settings_written(),
-        vec![std::collections::BTreeMap::from([(
-            "acqEnabled".to_string(),
-            json!(true)
-        )])]
+        vec![std::collections::BTreeMap::from([
+            ("acqEnabled".to_string(), json!(true)),
+            ("vpnWgConfig".to_string(), json!("[Interface]")),
+        ])]
     );
 }
 
 #[tokio::test]
 async fn a_caller_with_no_host_token_reads_nothing_at_all() {
+    let modules = installed();
     let host = StubHost::new().with_setting("acqEnabled", json!(true));
     let req = Request::builder()
         .method("GET")
@@ -121,7 +268,23 @@ async fn a_caller_with_no_host_token_reads_nothing_at_all() {
         .body(Body::empty())
         .unwrap();
 
-    let (status, _) = send(host, req).await;
+    let (status, _) = send(&modules, host, req).await;
+
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn a_caller_with_a_token_nobody_minted_reads_nothing_at_all() {
+    let modules = installed();
+    let host = StubHost::new().with_setting("acqEnabled", json!(true));
+
+    let (status, _) = get(
+        &modules,
+        host,
+        "a-token-of-its-own-invention",
+        "/_host/setting?key=acqEnabled&kind=bool&default=false",
+    )
+    .await;
 
     assert_eq!(status, StatusCode::UNAUTHORIZED);
 }

--- a/server/crates/kroma-module-supervisor/tests/test_support/mod.rs
+++ b/server/crates/kroma-module-supervisor/tests/test_support/mod.rs
@@ -1,0 +1,63 @@
+#![allow(dead_code)]
+
+use std::sync::Arc;
+
+use kroma_module_host::{SettingReach, SettingReachOf};
+use kroma_module_supervisor::{Supervisor, SupervisorConfig};
+
+/// The token every sidecar shares, which authenticates a caller without naming it.
+pub const FABRIC: &str = "fabric-host-token";
+
+pub const NOTHING_WITHHELD: SettingReachOf = SettingReachOf(|_| SettingReach::Any);
+
+/// A supervisor over a modules directory that removes itself, so a test can put a
+/// manifest where the callback reads declarations from.
+pub struct Modules {
+    pub supervisor: Arc<Supervisor>,
+    dir: kroma_testing::TempDir,
+}
+
+impl Modules {
+    pub fn new(tag: &str) -> Self {
+        let dir = kroma_testing::temp_dir(tag);
+        let supervisor = Supervisor::new(SupervisorConfig {
+            modules_dir: dir.path().to_path_buf(),
+            core_url: "http://127.0.0.1:0".into(),
+            host_token: FABRIC.into(),
+            db_path: dir.path().join("kroma.db"),
+            data_dir: dir.path().to_path_buf(),
+            reserved_ids: Vec::new(),
+            server_version: "0.0.0-test".into(),
+            log_line: None,
+        });
+        Self { supervisor, dir }
+    }
+
+    /// Install `id` with the `settings` block it declares, as JSON, or `None` for a
+    /// manifest predating the field.
+    pub fn declaring(self, id: &str, settings: Option<&str>) -> Self {
+        let dir = self.dir.path().join(id);
+        std::fs::create_dir_all(&dir).unwrap();
+        let settings = settings.map_or(String::new(), |s| format!(r#", "settings": {s}"#));
+        std::fs::write(
+            dir.join("module.json"),
+            format!(
+                r#"{{ "schemaVersion": {}, "id": "{id}", "name": "{id}", "version": "1.0.0"{settings} }}"#,
+                kroma_module_manifest::MODULE_SCHEMA_VERSION,
+            ),
+        )
+        .unwrap();
+        self
+    }
+
+    pub fn token(&self, id: &str) -> String {
+        self.supervisor.module_token(id)
+    }
+
+    pub fn router<S>(&self, reach: SettingReachOf) -> axum::Router<S>
+    where
+        S: kroma_module_host::HostCtx + Clone + Send + Sync + 'static,
+    {
+        kroma_module_supervisor::host_router::<S>(self.supervisor.clone(), reach)
+    }
+}

--- a/server/src/api/it_host_settings.rs
+++ b/server/src/api/it_host_settings.rs
@@ -1,14 +1,32 @@
 //! The `/api/_host/*` settings callbacks against the real wiring: which keys a
-//! sidecar holding the host token reads and writes.
+//! sidecar reads and writes, by what the core declared about the key and what the
+//! calling module declared about itself.
 
 use std::collections::BTreeMap;
 
 use axum::http::StatusCode;
 use serde_json::json;
 
-use crate::api::test_support::{get, send, test_app};
+use crate::api::test_support::{get, send, test_app, TestApp};
 
 const HOST_TOKEN: &str = "test-host-token";
+
+const BRIDGE: &str = "tv.kroma.bridge";
+
+fn bridge_declaring(t: &TestApp, settings: &str) -> String {
+    let dir = t.state.config.data_dir.join("modules").join(BRIDGE);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("module.json"),
+        format!(
+            r#"{{ "schemaVersion": {}, "id": "{BRIDGE}", "name": "Bridge", "version": "1.0.0",
+                  "settings": {settings} }}"#,
+            kroma_module_manifest::MODULE_SCHEMA_VERSION,
+        ),
+    )
+    .unwrap();
+    t.supervisor.module_token(BRIDGE)
+}
 
 #[tokio::test]
 async fn a_stored_operator_credential_never_reaches_a_sidecar() {
@@ -88,6 +106,7 @@ async fn a_sidecar_cannot_put_a_signing_key_of_its_own_choosing_in_place() {
 #[tokio::test]
 async fn the_settings_a_module_runs_on_still_come_back_stored() {
     let t = test_app();
+    let token = bridge_declaring(&t, r#"{ "read": ["vpnWgConfig", "remoteAccessToken"] }"#);
     t.state.settings.set_patch(
         &t.state.db,
         BTreeMap::from([
@@ -100,19 +119,19 @@ async fn the_settings_a_module_runs_on_still_come_back_stored() {
     let (acq_status, acq) = get(
         &t.app,
         "/api/_host/setting?key=acqEnabled&kind=bool&default=false",
-        Some(HOST_TOKEN),
+        Some(&token),
     )
     .await;
     let (wg_status, wg) = get(
         &t.app,
         "/api/_host/setting?key=vpnWgConfig&kind=str&default=",
-        Some(HOST_TOKEN),
+        Some(&token),
     )
     .await;
     let (tunnel_status, tunnel) = get(
         &t.app,
         "/api/_host/setting?key=remoteAccessToken&kind=str&default=",
-        Some(HOST_TOKEN),
+        Some(&token),
     )
     .await;
 
@@ -122,6 +141,39 @@ async fn the_settings_a_module_runs_on_still_come_back_stored() {
     assert_eq!(wg, json!({ "value": "[Interface]" }));
     assert_eq!(tunnel_status, StatusCode::OK);
     assert_eq!(tunnel, json!({ "value": "tunnel-token" }));
+}
+
+#[tokio::test]
+async fn an_operator_credential_reaches_no_module_but_the_one_that_declared_it() {
+    let t = test_app();
+    let token = bridge_declaring(&t, r#"{ "read": ["remoteAccessToken"] }"#);
+    t.state.settings.set_patch(
+        &t.state.db,
+        BTreeMap::from([("vpnWgConfig".to_string(), json!("[Interface]"))]),
+    );
+
+    let (declared_elsewhere, by_bridge) = get(
+        &t.app,
+        "/api/_host/setting?key=vpnWgConfig&kind=str&default=",
+        Some(&token),
+    )
+    .await;
+    let (unnamed, by_fabric) = get(
+        &t.app,
+        "/api/_host/setting?key=vpnWgConfig&kind=str&default=",
+        Some(HOST_TOKEN),
+    )
+    .await;
+
+    assert_eq!(declared_elsewhere, StatusCode::OK);
+    assert_eq!(by_bridge, json!({ "value": "" }));
+    assert_eq!(unnamed, StatusCode::OK);
+    assert_eq!(by_fabric, json!({ "value": "" }));
+    assert_eq!(
+        t.state.settings.get_str("vpnWgConfig", ""),
+        "[Interface]",
+        "the value is stored; it just does not cross the callback"
+    );
 }
 
 #[tokio::test]
@@ -162,12 +214,13 @@ async fn a_sidecar_cannot_write_a_credential_or_retarget_the_registries() {
 #[tokio::test]
 async fn a_sidecar_still_saves_the_settings_it_owns() {
     let t = test_app();
+    let token = bridge_declaring(&t, r#"{ "write": ["vpnWgConfig"] }"#);
 
     let (status, _) = send(
         &t.app,
         "POST",
         "/api/_host/settings",
-        Some(HOST_TOKEN),
+        Some(&token),
         Some(json!({ "patch": { "acqEnabled": true, "vpnWgConfig": "[Interface]" } })),
     )
     .await;
@@ -175,6 +228,28 @@ async fn a_sidecar_still_saves_the_settings_it_owns() {
     assert_eq!(status, StatusCode::NO_CONTENT);
     assert_eq!(t.state.settings.get("acqEnabled"), json!(true));
     assert_eq!(t.state.settings.get("vpnWgConfig"), json!("[Interface]"));
+}
+
+#[tokio::test]
+async fn a_sidecar_cannot_write_a_credential_it_did_not_declare() {
+    let t = test_app();
+    let token = bridge_declaring(&t, r#"{ "read": ["vpnWgConfig"] }"#);
+
+    let (status, _) = send(
+        &t.app,
+        "POST",
+        "/api/_host/settings",
+        Some(&token),
+        Some(json!({ "patch": { "vpnWgConfig": "[Interface] mine" } })),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(
+        t.state.settings.get("vpnWgConfig"),
+        json!(""),
+        "a read declaration is not a write declaration"
+    );
 }
 
 #[tokio::test]

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -231,10 +231,8 @@ pub fn router(
     let api = public
         .merge(content)
         .merge(kroma_module_supervisor::host_router::<SharedState>(
-            supervisor.host_token().to_string(),
-            kroma_module_supervisor::WithheldSettings(
-                crate::services::settings::withheld_from_modules,
-            ),
+            supervisor.clone(),
+            kroma_module_host::SettingReachOf(crate::services::settings::reach_of_setting),
         ))
         // A sidecar registers its scheduled jobs with the core JobManager here, so
         // they appear in admin Tâches like in-core jobs (same host-token guard).

--- a/server/src/api/test_support.rs
+++ b/server/src/api/test_support.rs
@@ -34,6 +34,7 @@ pub struct TestApp {
     pub state: SharedState,
     pub token: String,
     pub user_id: String,
+    pub supervisor: Arc<kroma_module_supervisor::Supervisor>,
     // Owns the temp `data_dir`: dropping the harness removes it. Keep this last
     // so the DB pool and the router let go of the files before the dir goes.
     _data_dir: TempDir,
@@ -135,7 +136,7 @@ fn build_app(tmdb_api_key: Option<&str>, web: &[(&str, &str)]) -> TestApp {
     // No delivery task: a handler test publishes nothing a module would hear, and
     // spawning one would need a runtime the plain `#[test]` cases do not have.
     let subscriptions = std::sync::Arc::new(crate::api::host_events::Subscriptions::default());
-    let app = crate::api::router(state.clone(), supervisor, subscriptions);
+    let app = crate::api::router(state.clone(), supervisor.clone(), subscriptions);
 
     let (user_id, token) = seed_session(&state, "owner@test.dev", "owner", &Permission::all());
     TestApp {
@@ -143,6 +144,7 @@ fn build_app(tmdb_api_key: Option<&str>, web: &[(&str, &str)]) -> TestApp {
         state,
         token,
         user_id,
+        supervisor,
         _data_dir: tmp,
     }
 }


### PR DESCRIPTION
> Stacked on #236 (`fix/settings-reach-is-declared`), which is this PR's base. It
> reshapes the same reach table, so merge that one first and this one retargets to
> `main` on its own.

## What

`vpnWgConfig` and `remoteAccessToken` were readable by every installed module,
because their consumer IS a module and the callback could not tell which module was
asking. A notes module could read the WireGuard config.

Two gates now, both required. The core keeps saying how far a key reaches out of
it, and `sidecar_credential()` becomes the narrow answer rather than a blanket one:
such a key goes to a module that declared it and to no other. The module's half is
a `settings: { read, write }` block in `module.json`, beside `storage` and read the
same way.

### The product decision

**What a module declares, and where.** `settings: { read: [...], write: [...] }` in
`module.json`, over core settings keys. Additive, like `storage`, so it costs no
`MODULE_SCHEMA_VERSION` bump: the field's own doc comment says why, and the zod
schema in `packages/registry` carries it with the same validation `storage.core`
gets. A read declaration is not a write declaration.

**What an installed bundle that declares nothing does.** It keeps every ordinary
preference and reaches neither credential. Absent is not empty, as with `storage`,
so a manifest predating the field is not read as having declared nothing; what does
not wait for it is the enforcement on credentials, deliberately, because a module
that was never shown to an operator as reaching the tunnel config is exactly the one
that should not reach it. The degradation for a module not yet updated fails closed:
an empty `vpnWgConfig` already reads as "no tunnel configured" on both sides, so
downloads gate off rather than leaking outside the tunnel. The three first-party
modules that need these keys declare them here and bump their versions.

**Whether it replaces `sidecar_credential`.** It layers. `sidecar_credential` stays
the core's statement that a key's consumer is a module at all; without it no manifest
declaration could reach the key, so a module still cannot grant itself something the
core keeps. The declaration only narrows.

### Identity, because the issue's premise was not true yet

> the supervisor knows the module id of every callback caller: the host token is
> per-process

It was not: `SupervisorConfig.host_token` is one secret minted at boot and handed to
every sidecar in `KROMA_HOST_TOKEN`. So the supervisor now mints one token per module
process and passes it as `KROMA_MODULE_TOKEN`; the callback resolves the bearer to a
module id and answers for that module.

The fabric token stays exactly as it was, because a module holds it to reach a peer's
`/_port/*`: a token that also *named* its holder would hand one module another's
identity. Identity belongs on the hop where it changes the answer, which is the
module-to-core callback. A caller presenting the fabric token is authenticated but
unnamed, holds no declaration, and so reaches no credential. That is what closes the
hole rather than leaving a bypass: an unnamed caller is refused, not grandfathered.

### A fourth reach, for the log

`SettingReach` carries `Unknown` beside `CoreOnly`. Both are refused; they differ
only in how the refusal reads. Withholding by default (#236) turns every read of a
key the core has never declared into a refusal, and two of those sit on a hot path:
the indexer reads `acqIndexersUseVpn` and `acqFlaresolverrUrl` once per indexer row
per search, and neither is in `defaults()`. Warning about them per search would bury
the refusal that matters. So a module reaching for a key nothing declares is a
`debug` line, and a module reaching for the mail password is a `warn`.

(Those two keys are the bug #236's body reported and neither PR fixes:
`acqIndexersUseVpn` has an admin row in `settings/schema.rs` and no entry in
`defaults()`, so the console's save throws it away, and `acqFlaresolverrUrl` has no
writer at all.)

### `moduleStates`

Handled. It becomes `core_only`. It holds every module's config including the fields
marked `secret`, and a module reads its own out of the point call that carries it
rather than out of that blob. The callback could not have served it anyway, because
it has no JSON kind and `get_str` answers the caller's own default for an object,
which is luck rather than a boundary.

### Preferences

Not scoped by the declaration yet, and that is the one thing the issue asks for that
this does not finish. Scoping them means every manifest listing every preference it
reads, and a missed entry is a silent behaviour change in a module (the naming
templates alone are six dynamic reads). So every first-party manifest lists its full
read and write set anyway, and reaching a key a declaration omits logs one line at
`debug`. Widening enforcement then needs no module changes and already has its
migration signal running.

### The core still names no module

`kroma-module-supervisor` resolves a token to an id it was handed and reads a
declaration out of a manifest. No id table, no module domain in any type or function.
`SettingReach` lives in `kroma-module-host` as `Unknown | CoreOnly | Declared | Any`, which is
mechanism: the core maps its own `public()` / `core_only()` / `sidecar_credential()`
vocabulary onto it and the supervisor only applies the answer.

## Closes

Closes #230

## Checks

- [x] `bun run typecheck`, `bun run test` (10028 passed), `bun run check`,
      `bun run spec:check`
- [x] `cargo clippy --workspace --all-targets` and `cargo test --workspace`; still the
      same 16 pre-existing warning sites, none new
- [x] `bun run modules:check`: manifests validate; the same 6 modules fail clippy on
      `main` for unrelated lints (`dead_code` on a `POINT` const, `result_large_err`)
- [x] One idea: a module's settings reach is what it declared

## Risk

A module that reads `vpnWgConfig` or `remoteAccessToken` and has not declared it gets
its own default instead. For the installed first-party set that is the three modules
updated here; for anything else it is the reach the issue filed. Every refusal is
logged with the module id and the key.

A sidecar built against an older SDK sends the fabric token, is unnamed, and loses
those two keys while keeping everything else. A sidecar built against this one sends
`KROMA_MODULE_TOKEN`; on an older server that variable is absent and it falls back to
the fabric token, so a new bundle on an old host behaves exactly as before.

Peer calls, job runs and event deliveries are untouched: they still authenticate with
the fabric token on both ends.

### Spec

MOD-52 records the declaration, the callback answering within it, and what an
undeclared bundle does. MOD-51 is unchanged (it is about the server's own
credentials, which this does not move). `spec:index` regenerated.
