### PR TITLE
fix(client): a media URL carries the ticket whichever client builds it

### DIFF
--- a/packages/client/src/api/media/artwork.test.ts
+++ b/packages/client/src/api/media/artwork.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
+import { setSessionMediaTicket } from '../../core/session';
 import { recordingClient } from '../../kroma-client.fixture';
 import { artworkScaleValue, artworkWidth, setArtworkScale } from './artwork-scale';
 import { ItemId, ShowId } from './ids';
@@ -8,7 +9,10 @@ const artwork = client.media.artwork;
 const item = ItemId.parse('a b');
 const show = ShowId.parse('s 1');
 
-afterEach(() => setArtworkScale(1));
+afterEach(() => {
+  setArtworkScale(1);
+  setSessionMediaTicket(undefined);
+});
 
 describe('artwork resolution setting', () => {
   it('scales every width a caller asks for', () => {

--- a/packages/client/src/api/media/client.test.ts
+++ b/packages/client/src/api/media/client.test.ts
@@ -1,7 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
+import { setSessionMediaTicket } from '../../core/session';
 import { checkEndpoint, type Endpoint } from '../../endpoints.fixture';
 import { recordingClient } from '../../kroma-client.fixture';
 import { ItemId, LibraryId, ShowId } from './ids';
+
+afterEach(() => setSessionMediaTicket(undefined));
 
 const item = ItemId.parse('i1');
 const spaced = ItemId.parse('i 1');

--- a/packages/client/src/core/session/token.ts
+++ b/packages/client/src/core/session/token.ts
@@ -14,6 +14,20 @@ export function setSessionToken(token: string | undefined): void {
   memorySessionToken = token;
 }
 
+let memoryMediaTicket: string | undefined;
+
+/** The media ticket the last sign-in answered with. Shared like the bearer, so
+ *  a client built after the exchange stamps it on its media URLs too. */
+export function sessionMediaTicket(): string | undefined {
+  return memoryMediaTicket;
+}
+
+/** Set (or clear, with `undefined`) the shared media ticket. The transport's
+ *  `setMediaTicket` calls this; callers do not. */
+export function setSessionMediaTicket(ticket: string | undefined): void {
+  memoryMediaTicket = ticket;
+}
+
 let memorySessionRefresh: (() => Promise<string | undefined>) | undefined;
 
 /** How to mint a fresh session bearer, or undefined when nothing registered one. */

--- a/packages/client/src/kroma-client.test.ts
+++ b/packages/client/src/kroma-client.test.ts
@@ -1,8 +1,47 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ItemId } from './api/media';
-import { sessionToken } from './core/session';
+import { sessionToken, setSessionMediaTicket } from './core/session';
 import { createKromaClient } from './kroma-client';
 import { fakeClient, recordingClient } from './kroma-client.fixture';
+
+describe('the media ticket', () => {
+  const user = {
+    id: 'u1',
+    email: 'a@b.c',
+    username: 'alice',
+    permissions: ['playback'],
+    createdAt: '2026-01-01T00:00:00Z',
+    hasPin: false,
+  };
+  const item = ItemId.parse('i1');
+
+  afterEach(() => setSessionMediaTicket(undefined));
+
+  async function signInElsewhere() {
+    const { client } = recordingClient(() => ({
+      json: { token: 'tok', mediaTicket: 'dev.999.sig', user },
+    }));
+    await client.accounts.exchangeToken('access-token');
+    return client;
+  }
+
+  it('stamps the URLs of a client built after another one signed in', async () => {
+    await signInElsewhere();
+
+    const later = createKromaClient({ baseUrl: 'http://kroma.test' });
+
+    expect(later.media.streamUrl(item)).toBe('http://kroma.test/api/items/i1/stream?t=dev.999.sig');
+  });
+
+  it('leaves every client once one of them clears the session', async () => {
+    const signedIn = await signInElsewhere();
+    const other = createKromaClient({ baseUrl: 'http://kroma.test' });
+
+    signedIn.setAuthToken(undefined);
+
+    expect(other.media.streamUrl(item)).toBe('http://kroma.test/api/items/i1/stream');
+  });
+});
 
 describe('baseUrl normalization', () => {
   it('strips trailing slashes while preserving the scheme separator', () => {

--- a/packages/client/src/kroma-client.ts
+++ b/packages/client/src/kroma-client.ts
@@ -7,7 +7,12 @@ import {
   type TransportConfig,
   withUserAgent,
 } from './core/http';
-import { setSessionRefresh, setSessionToken } from './core/session';
+import {
+  sessionMediaTicket,
+  setSessionMediaTicket,
+  setSessionRefresh,
+  setSessionToken,
+} from './core/session';
 
 /** What the client carries beyond its domains: the bearer, the locale, and the
  * few things a platform needs to reach the server without the transport. */
@@ -58,12 +63,11 @@ export function kromaClientParts(options: KromaClientOptions): {
   const base = options.fetch ?? globalThis.fetch.bind(globalThis);
   let authToken = options.authToken;
   let locale = options.locale;
-  let mediaTicket: string | undefined;
   let refreshHandler: (() => Promise<string | undefined>) | undefined;
 
   const setAuthToken = (token?: string): void => {
     authToken = token;
-    if (!token) mediaTicket = undefined;
+    if (!token) setSessionMediaTicket(undefined);
     setSessionToken(token);
   };
 
@@ -79,10 +83,8 @@ export function kromaClientParts(options: KromaClientOptions): {
     token: () => authToken,
     locale: () => locale,
     refresh: refreshSession,
-    mediaTicket: () => mediaTicket,
-    setMediaTicket: (ticket) => {
-      mediaTicket = ticket;
-    },
+    mediaTicket: sessionMediaTicket,
+    setMediaTicket: setSessionMediaTicket,
   };
   preconnect(baseUrl);
 


### PR DESCRIPTION
## What

#234 kept the media ticket inside each `KromaClient` instance. The web builds a new client on every `kromaClient()` call, so the ticket landed on whichever client ran `/auth/token`, which is the auth provider's or a throwaway one in `exchangeStoredSession`. Every client that later built a stream, HLS, subtitle or storyboard URL had none. Against a #234 server every media request from the web went out without `?t=` and came back 401, and the player sat on a spinner. A 0.1.39 server shows exactly that in the console: `/stream`, `/hls/aac/.../index.m3u8` and `storyboard.img` all 401, none carrying a ticket.

The ticket now lives in the session module next to the bearer, which is shared across clients for the same reason. Clearing the session through any client clears the ticket for all of them, as it already did for the bearer. The TV signs in and builds its URLs through one client, so it was not affected.

## Closes

No issue. It surfaced as 401s on a 0.1.39 server while I was working on the player, and the fix is one small change.

## Checks

- [x] `bun run lint` and `bun run test` pass, or I said below which failed and why
- [ ] `cargo clippy` and `cargo test` pass, if the server changed
- [x] Follows `CODE_STYLE.md`, no comments narrating the work, exported API only
- [x] One idea. If it grew a second, it was split.

Ran `bun run check`, `bun run typecheck` and `bun run test` (943 files, 10062 tests). The server is untouched, so no cargo run. The new test "stamps the URLs of a client built after another one signed in" in `kroma-client.test.ts` fails on main with the ticketless URL and passes here.

## Risk

If this is wrong, web media URLs lose the ticket again and every play fails with a 401, which shows on the first title anyone opens. The other way it could go wrong is one account's ticket riding another account's URLs. Two accounts only meet on a profile switch, and every switch runs an exchange that replaces the ticket, the same as the bearer.
