### PR TITLE
fix(admin): a control the console offers is a value the store will keep

### DIFF
--- a/apps/www/project.inlang/settings.json
+++ b/apps/www/project.inlang/settings.json
@@ -2,9 +2,7 @@
   "$schema": "https://inlang.com/schema/project-settings",
   "baseLocale": "en",
   "locales": ["en", "fr"],
-  "modules": [
-    "https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@latest/dist/index.js"
-  ],
+  "modules": ["https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@latest/dist/index.js"],
   "plugin.inlang.messageFormat": {
     "pathPattern": "./messages/{locale}.json"
   }

--- a/packages/core/src/locales/en/admin.json
+++ b/packages/core/src/locales/en/admin.json
@@ -8,6 +8,8 @@
   "admin.acqEnabledHint": "Without this, only manual downloads (interactive search) work.",
   "admin.acqEngine": "Embedded engine",
   "admin.acqEngineDesc": "The BitTorrent engine built into KROMA (librqbit). Restarted automatically when these settings change.",
+  "admin.acqFlaresolverr": "FlareSolverr address",
+  "admin.acqFlaresolverrHint": "Solves an indexer's Cloudflare challenge through FlareSolverr instead of letting the search fail. Leave empty to use none.",
   "admin.acqForbiddenKeywords": "Forbidden keywords",
   "admin.acqForbiddenKeywordsHint": "Any release containing one of these words is rejected.",
   "admin.acqGeneral": "Automatic acquisition",

--- a/packages/core/src/locales/fr/admin.json
+++ b/packages/core/src/locales/fr/admin.json
@@ -8,6 +8,8 @@
   "admin.acqEnabledHint": "Sans ce réglage, seuls les téléchargements manuels (recherche interactive) fonctionnent.",
   "admin.acqEngine": "Moteur intégré",
   "admin.acqEngineDesc": "Le moteur BitTorrent embarqué dans KROMA (librqbit). Redémarré automatiquement quand ces réglages changent.",
+  "admin.acqFlaresolverr": "Adresse FlareSolverr",
+  "admin.acqFlaresolverrHint": "Résout les protections Cloudflare des indexeurs via FlareSolverr, au lieu de laisser la recherche échouer. Laissez vide pour ne pas en utiliser.",
   "admin.acqForbiddenKeywords": "Mots-clés interdits",
   "admin.acqForbiddenKeywordsHint": "Toute release contenant l'un de ces mots est rejetée.",
   "admin.acqGeneral": "Acquisition automatique",

--- a/server/crates/kroma-engine/src/services/settings/keys.rs
+++ b/server/crates/kroma-engine/src/services/settings/keys.rs
@@ -143,6 +143,8 @@ fn declared() -> Declared {
     // Scheduler timezone offset in minutes from UTC (60 = UTC+1, -300 = UTC-5).
     m.public("jobsUtcOffset", json!(0));
     // Keyword lists are comma-separated, matched as whole tokens against release names.
+    m.public("acqIndexersUseVpn", json!(false));
+    m.public("acqFlaresolverrUrl", json!(""));
     m.public("acqEnabled", json!(false));
     m.public("acqAutoApprove", json!(false));
     m.public("acqDeleteAfterImport", json!(false));

--- a/server/crates/kroma-engine/src/services/settings/schema.rs
+++ b/server/crates/kroma-engine/src/services/settings/schema.rs
@@ -625,6 +625,15 @@ pub fn groups(
                     g("acqIndexersUseVpn"),
                     true,
                 ),
+                row(
+                    "acqFlaresolverrUrl",
+                    t("admin.acqFlaresolverr"),
+                    Some(t("admin.acqFlaresolverrHint")),
+                    "text",
+                    &[],
+                    g("acqFlaresolverrUrl"),
+                    true,
+                ),
             ],
         )],
         _ => Vec::new(),
@@ -734,6 +743,41 @@ mod tests {
 
     fn find_row<'a>(groups: &'a [SettingGroup], key: &str) -> Option<&'a SettingRow> {
         groups.iter().flat_map(|g| &g.rows).find(|r| r.key == key)
+    }
+
+    /// Every view the admin console can ask for. A view missing here is a view
+    /// this file's guarantees are never checked against.
+    const VIEWS: &[&str] = &[
+        "general",
+        "network",
+        "transcoder",
+        "acquisition",
+        "vpn",
+    ];
+
+    #[test]
+    fn every_row_the_console_offers_is_a_key_the_store_will_keep() {
+        let pool = test_pool();
+        let s = Settings::load(&pool);
+        let known = super::super::keys::defaults();
+
+        let orphans: Vec<String> = VIEWS
+            .iter()
+            .flat_map(|view| groups(view, &s, &test_config(), "en"))
+            .flat_map(|g| g.rows)
+            // `value` displays what the server was started with and `action` is a
+            // button: neither is a control a person can change, so neither belongs
+            // in the store.
+            .filter(|r| r.kind != "action" && r.kind != "value")
+            .map(|r| r.key)
+            .filter(|key| !known.contains_key(key))
+            .collect();
+
+        assert!(
+            orphans.is_empty(),
+            "the console offers a control whose value set_patch throws away, \
+             so the save reports success and changes nothing: {orphans:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

The VPN page offers **"Route indexer searches through the VPN"**. An operator turns it on, the
save returns 200, and the value is discarded: `set_patch` writes only what `defaults()`
declares, and `acqIndexersUseVpn` was never declared.

So `tv.kroma.indexer` read `false` every time. Indexer traffic has never once gone through the
tunnel, behind a switch that reports success. Anyone debugging that has no reason to suspect
the setting they just saved.

`acqFlaresolverrUrl` is the same fault from the other end. The indexer reads it in `session_key`
and again when it builds a `Session`, and its manifest declares it under `settings.read`, but
**nothing offered a way to set it**. No admin row at all, so FlareSolverr could not be configured
even in principle.

Both are declared now, and FlareSolverr gets the control it never had, beside the VPN toggle its
session key already pairs it with.

### The guard, rather than two fixes

A test asserts that every row the console offers, across every view, is a key `defaults()`
declares.

It distinguishes a **control** from a **readout**, which is the whole subtlety: `value` rows
display what the server was started with (`version`, `port`, `publicAddress`, `transcodeDir`)
and `action` rows are buttons. None of those belong in the store, and a naive check flags all
four as false positives. Only the two `toggle`/`text` rows were real.

Proven to be the guard and not a tautology by removing one declaration:

```
the console offers a control whose value set_patch throws away, so the save reports
success and changes nothing: ["acqIndexersUseVpn"]
```

## Closes

Closes #241.

**The issue was half right and half wrong, in opposite directions**, and the corrections matter:

- `acqFlaresolverrUrl` does not merely lack a writer. It had **no admin control at all**.
- Neither key is dead. The issue's DoD offered "if nothing reads it, it is dead and should go",
  but **both are read by a shipped module that declares them**. This is a live feature stuck on
  its default, not a leftover to delete.

## Checks

- [x] `bun run typecheck` 44/44
- [x] `bun run check`
- [x] `bun run test` 10041 passed, 2 skipped
- [x] `cargo test --workspace` 2571 passed
- [x] One idea

## Risk

`acqIndexersUseVpn` starts working the moment this lands, on any server where an operator
already turned it on and believed it. That is the point, but it is a behaviour change on
upgrade: indexer searches begin routing through the tunnel, and the hint already warns that a
downed VPN then fails searches rather than leaking. Anyone who toggled it experimentally, saw no
effect and moved on will now get the effect.

The new FlareSolverr row is inert until set: empty means none, which is what the indexer already
does with the value it could never receive.

The test walks a hardcoded list of views (`general`, `network`, `transcoder`, `acquisition`,
`vpn`). A view added later without being added there is unchecked. I could not find a way to
enumerate them from `groups()`, which matches on `&str` and returns empty for anything unknown.
