### PR TITLE
fix(modules): one store of Roku strings, and a French box reads French

### DIFF
--- a/modules/README.md
+++ b/modules/README.md
@@ -265,8 +265,39 @@ declarations only, and a `@kromatv/*` import the host does not provide fails the
 build. Anything else a page imports (`zod`, an icon set) is bundled. Import
 components from `@kromatv/ui/kit`; a deeper kit path is folded onto it.
 
+### Strings
+
 Every user-visible string is a key. Ship `locales/{en,fr}.json`; they resolve
 against the module's own catalog first, then the core ones.
+
+The sidecar reads those same files, so a module has one store and not one per
+half. `embedded_locales!()` finds every `locales/<code>.json` at compile time
+and `i18n::engine` resolves them with the engine the core resolves its own
+with, which is what makes a plural and a `{name}` behave the same in a row
+title a backend shapes as on a page:
+
+```rust
+use std::sync::OnceLock;
+
+use kroma_module_sdk::i18n::{self, I18n, Translator};
+
+const CATALOGS: &[(&str, &str)] = kroma_module_sdk::embedded_locales!();
+
+fn strings(locale: &str) -> Translator<'static> {
+    static ENGINE: OnceLock<I18n> = OnceLock::new();
+    ENGINE
+        .get_or_init(|| i18n::engine(CATALOGS).expect("this module's catalogs"))
+        .translator(locale)
+}
+```
+
+`en.json` is the authoritative catalog: a key another locale has no entry for
+falls back to it, and then to the key itself. Resolve for a person with the
+session user's `language`, which is what every other surface reads.
+
+A module whose strings also have to reach something that is not the web
+frontend or the sidecar, a device channel it installs, ships the same JSON
+there rather than restating it in that language.
 
 ## Runtime contract
 

--- a/modules/tv.kroma.acquisition/server/Cargo.lock
+++ b/modules/tv.kroma.acquisition/server/Cargo.lock
@@ -1428,6 +1428,7 @@ dependencies = [
  "kroma-domain",
  "kroma-engine",
  "kroma-http",
+ "kroma-i18n",
  "kroma-module-host",
  "kroma-module-macros",
  "kroma-module-manifest",

--- a/modules/tv.kroma.engine.qbittorrent/server/Cargo.lock
+++ b/modules/tv.kroma.engine.qbittorrent/server/Cargo.lock
@@ -489,6 +489,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kroma-i18n"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
 name = "kroma-module-host"
 version = "0.1.0"
 dependencies = [
@@ -543,6 +550,7 @@ dependencies = [
  "axum",
  "kroma-db",
  "kroma-http",
+ "kroma-i18n",
  "kroma-module-host",
  "kroma-module-macros",
  "kroma-module-manifest",

--- a/modules/tv.kroma.engine.transmission/server/Cargo.lock
+++ b/modules/tv.kroma.engine.transmission/server/Cargo.lock
@@ -489,6 +489,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kroma-i18n"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
 name = "kroma-module-host"
 version = "0.1.0"
 dependencies = [
@@ -543,6 +550,7 @@ dependencies = [
  "axum",
  "kroma-db",
  "kroma-http",
+ "kroma-i18n",
  "kroma-module-host",
  "kroma-module-macros",
  "kroma-module-manifest",

--- a/modules/tv.kroma.indexer/server/Cargo.lock
+++ b/modules/tv.kroma.indexer/server/Cargo.lock
@@ -707,6 +707,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kroma-i18n"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
 name = "kroma-indexer"
 version = "0.1.0"
 dependencies = [
@@ -785,6 +792,7 @@ dependencies = [
  "axum",
  "kroma-db",
  "kroma-http",
+ "kroma-i18n",
  "kroma-module-host",
  "kroma-module-macros",
  "kroma-module-manifest",

--- a/modules/tv.kroma.mdns/server/Cargo.lock
+++ b/modules/tv.kroma.mdns/server/Cargo.lock
@@ -510,6 +510,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kroma-i18n"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
 name = "kroma-mdns"
 version = "0.1.0"
 dependencies = [
@@ -577,6 +584,7 @@ dependencies = [
  "axum",
  "kroma-db",
  "kroma-http",
+ "kroma-i18n",
  "kroma-module-host",
  "kroma-module-macros",
  "kroma-module-manifest",

--- a/modules/tv.kroma.remote/server/Cargo.lock
+++ b/modules/tv.kroma.remote/server/Cargo.lock
@@ -388,6 +388,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kroma-i18n"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
 name = "kroma-module-host"
 version = "0.1.0"
 dependencies = [
@@ -439,6 +446,7 @@ dependencies = [
  "anyhow",
  "axum",
  "kroma-http",
+ "kroma-i18n",
  "kroma-module-host",
  "kroma-module-macros",
  "kroma-module-manifest",

--- a/modules/tv.kroma.roku/README.md
+++ b/modules/tv.kroma.roku/README.md
@@ -6,7 +6,7 @@ The backend (`server/`, `kroma-roku`) finds boxes on the LAN over SSDP, reads wh
 
 A box is at the address its SSDP packet came from, never at the one its reply's `Location` header names, and that address has to be one nothing routes across the internet (RFC1918, loopback, link-local, or the IPv6 equivalents). Anything else is not listed and not installed to, by hand or otherwise: the developer installer is handed the operator's Roku password, so whoever answers gets it.
 
-The channel (`channel/`) pairs itself with Quick Connect, like a television: it shows a code, the viewer approves it from a phone or browser, and the box keeps a device session of its own. `build.rs` zips the tree into the sidecar at compile time, so a `.kmod` carries the channel it installs.
+The channel (`channel/`) pairs itself with Quick Connect, like a television: it shows a code, the viewer approves it from a phone or browser, and the box keeps a device session of its own. `build.rs` zips the tree into the sidecar at compile time, with `locales/` beside it, so a `.kmod` carries the channel it installs and the channel reads the same catalogue the console page and the sidecar do.
 
 The console page (`ui/`) lists the boxes, takes the developer password once, and installs or relaunches the channel on each.
 

--- a/modules/tv.kroma.roku/channel/components/DetailScreen.brs
+++ b/modules/tv.kroma.roku/channel/components/DetailScreen.brs
@@ -14,7 +14,7 @@ end sub
 
 sub onTarget()
     target = m.top.target
-    m.status.text = t("loading")
+    m.status.text = t("roku.channel.loading")
     path = "/api/module/tv.kroma.roku/channel/detail/" + target.kind + "/" + target.id
     m.tasks.push(apiRequest({ path: path, tag: "detail" }, "onDetail"))
 end sub
@@ -22,7 +22,7 @@ end sub
 sub onDetail(event as object)
     reply = event.getData()
     if reply.status <> 200 or reply.json = invalid then
-        m.status.text = t("loadFailed")
+        m.status.text = t("roku.channel.loadFailed")
         return
     end if
     if reply.tag = "episode" then
@@ -43,9 +43,9 @@ end sub
 sub fillActions()
     content = CreateObject("roSGNode", "ContentNode")
     if m.detail.play <> invalid then
-        label = t("play")
+        label = t("roku.channel.play")
         if m.detail.play.resumeMs > 0 then
-            label = t("resumeAt") + " " + formatClock(m.detail.play.resumeMs)
+            label = t("roku.channel.resumeAt") + " " + formatClock(m.detail.play.resumeMs)
         end if
         if m.detail.kind = "show" then label = label + "  ·  " + m.detail.play.title
         content.createChild("ContentNode").title = label

--- a/modules/tv.kroma.roku/channel/components/HomeScreen.brs
+++ b/modules/tv.kroma.roku/channel/components/HomeScreen.brs
@@ -8,14 +8,14 @@ sub init()
 end sub
 
 sub load()
-    m.status.text = t("loading")
+    m.status.text = t("roku.channel.loading")
     m.tasks.push(apiRequest({ path: "/api/module/tv.kroma.roku/channel/home" }, "onHome"))
 end sub
 
 sub onHome(event as object)
     reply = event.getData()
     if reply.status <> 200 or reply.json = invalid or reply.json.rows = invalid then
-        m.status.text = t("loadFailed")
+        m.status.text = t("roku.channel.loadFailed")
         return
     end if
     content = CreateObject("roSGNode", "ContentNode")

--- a/modules/tv.kroma.roku/channel/components/PairScreen.brs
+++ b/modules/tv.kroma.roku/channel/components/PairScreen.brs
@@ -3,8 +3,8 @@ sub init()
     m.hint = m.top.findNode("hint")
     m.timer = m.top.findNode("poll")
     m.timer.observeField("fire", "onPoll")
-    m.top.findNode("title").text = t("pairTitle")
-    m.top.findNode("serverLabel").text = t("pairServer") + ": " + m.global.server
+    m.top.findNode("title").text = t("roku.channel.pairTitle")
+    m.top.findNode("serverLabel").text = t("roku.channel.pairServer") + ": " + m.global.server
     m.tasks = []
     m.secret = ""
     initiate()
@@ -12,7 +12,7 @@ end sub
 
 sub initiate()
     m.secret = ""
-    m.hint.text = t("pairHint")
+    m.hint.text = t("roku.channel.pairHint")
     m.code.text = "····"
     m.tasks.push(apiRequest({ method: "POST", path: "/api/auth/quickconnect/initiate", body: "{}" }, "onInitiated"))
 end sub
@@ -24,7 +24,7 @@ sub onInitiated(event as object)
         m.code.text = reply.json.code
         m.timer.control = "start"
     else
-        m.hint.text = t("pairUnreachable") + " " + m.global.server
+        m.hint.text = t("roku.channel.pairUnreachable") + " " + m.global.server
         m.code.text = ""
     end if
 end sub

--- a/modules/tv.kroma.roku/channel/components/Strings.brs
+++ b/modules/tv.kroma.roku/channel/components/Strings.brs
@@ -1,43 +1,25 @@
 function t(key as string) as string
-    if m.strings = invalid then
-        locale = CreateObject("roDeviceInfo").GetCurrentLocale()
-        if Left(locale, 2) = "fr" then
-            m.strings = frStrings()
-        else
-            m.strings = enStrings()
-        end if
-    end if
+    if m.strings = invalid then m.strings = loadStrings()
     value = m.strings[key]
     if value = invalid then return key
     return value
 end function
 
-function enStrings() as object
-    return {
-        pairTitle: "Pair this Roku",
-        pairHint: "Open KROMA on your phone or in a browser, go to Quick Connect and enter this code.",
-        pairServer: "Server",
-        pairUnreachable: "Cannot reach the server at",
-        loading: "Loading",
-        loadFailed: "Could not load the library.",
-        play: "Play",
-        resumeAt: "Resume at",
-        episodes: "Episodes",
-        signedOut: "Session ended. Pair again."
-    }
+function loadStrings() as object
+    strings = readCatalog("en")
+    locale = LCase(Left(CreateObject("roDeviceInfo").GetCurrentLocale(), 2))
+    if locale = "en" then return strings
+    translated = readCatalog(locale)
+    for each key in translated
+        strings[key] = translated[key]
+    end for
+    return strings
 end function
 
-function frStrings() as object
-    return {
-        pairTitle: "Associer ce Roku",
-        pairHint: "Ouvrez KROMA sur votre téléphone ou dans un navigateur, allez dans Quick Connect et saisissez ce code.",
-        pairServer: "Serveur",
-        pairUnreachable: "Impossible de joindre le serveur à",
-        loading: "Chargement",
-        loadFailed: "Impossible de charger la bibliothèque.",
-        play: "Lire",
-        resumeAt: "Reprendre à",
-        episodes: "Épisodes",
-        signedOut: "Session terminée. Associez à nouveau."
-    }
+function readCatalog(locale as string) as object
+    text = ReadAsciiFile("pkg:/locales/" + locale + ".json")
+    if text = "" then return {}
+    catalog = ParseJson(text)
+    if catalog = invalid then return {}
+    return catalog
 end function

--- a/modules/tv.kroma.roku/locales/en.json
+++ b/modules/tv.kroma.roku/locales/en.json
@@ -29,5 +29,18 @@
   "roku.addressHint": "For a network where the scan hears nothing: the box shows its address under Settings, Network, About. It has to be an address on this network, not a name.",
   "roku.addressPlaceholder": "192.168.1.50",
   "roku.add": "Add this box",
-  "roku.addFailed": "No Roku on this network answered at that address."
+  "roku.addFailed": "No Roku on this network answered at that address.",
+  "roku.channel.continueWatching": "Continue watching",
+  "roku.channel.movies": "Movies",
+  "roku.channel.shows": "Shows",
+  "roku.channel.episodes_one": "{count} episode",
+  "roku.channel.episodes_other": "{count} episodes",
+  "roku.channel.pairTitle": "Pair this Roku",
+  "roku.channel.pairHint": "Open KROMA on your phone or in a browser, go to Quick Connect and enter this code.",
+  "roku.channel.pairServer": "Server",
+  "roku.channel.pairUnreachable": "Cannot reach the server at",
+  "roku.channel.loading": "Loading",
+  "roku.channel.loadFailed": "Could not load the library.",
+  "roku.channel.play": "Play",
+  "roku.channel.resumeAt": "Resume at"
 }

--- a/modules/tv.kroma.roku/locales/fr.json
+++ b/modules/tv.kroma.roku/locales/fr.json
@@ -29,5 +29,18 @@
   "roku.addressHint": "Pour un réseau où la recherche n'entend rien : le boîtier affiche son adresse dans Paramètres, Réseau, À propos. Ce doit être une adresse de ce réseau, pas un nom.",
   "roku.addressPlaceholder": "192.168.1.50",
   "roku.add": "Ajouter ce boîtier",
-  "roku.addFailed": "Aucun Roku de ce réseau n'a répondu à cette adresse."
+  "roku.addFailed": "Aucun Roku de ce réseau n'a répondu à cette adresse.",
+  "roku.channel.continueWatching": "Reprendre",
+  "roku.channel.movies": "Films",
+  "roku.channel.shows": "Séries",
+  "roku.channel.episodes_one": "{count} épisode",
+  "roku.channel.episodes_other": "{count} épisodes",
+  "roku.channel.pairTitle": "Associer ce Roku",
+  "roku.channel.pairHint": "Ouvrez KROMA sur votre téléphone ou dans un navigateur, allez dans Quick Connect et saisissez ce code.",
+  "roku.channel.pairServer": "Serveur",
+  "roku.channel.pairUnreachable": "Impossible de joindre le serveur à",
+  "roku.channel.loading": "Chargement",
+  "roku.channel.loadFailed": "Impossible de charger la bibliothèque.",
+  "roku.channel.play": "Lire",
+  "roku.channel.resumeAt": "Reprendre à"
 }

--- a/modules/tv.kroma.roku/module.json
+++ b/modules/tv.kroma.roku/module.json
@@ -3,7 +3,7 @@
   "schemaVersion": 2,
   "id": "tv.kroma.roku",
   "name": "Roku",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A KROMA channel for Roku boxes: found on the LAN, sideloaded from the console, paired like any television.",
   "engines": {
     "server": ">=0.1.39"

--- a/modules/tv.kroma.roku/server/Cargo.lock
+++ b/modules/tv.kroma.roku/server/Cargo.lock
@@ -567,6 +567,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kroma-i18n"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
 name = "kroma-module-host"
 version = "0.1.0"
 dependencies = [
@@ -621,6 +628,7 @@ dependencies = [
  "axum",
  "kroma-db",
  "kroma-http",
+ "kroma-i18n",
  "kroma-module-host",
  "kroma-module-macros",
  "kroma-module-manifest",

--- a/modules/tv.kroma.roku/server/build.rs
+++ b/modules/tv.kroma.roku/server/build.rs
@@ -1,4 +1,5 @@
-//! Packs `../channel/` (the BrightScript source tree) into the zip a Roku's
+//! Packs `../channel/` (the BrightScript source tree) and `../locales/` (the
+//! module's catalogs, which the channel reads on the box) into the zip a Roku's
 //! developer installer accepts, so the sidecar carries the channel it installs.
 
 use std::fs;
@@ -9,10 +10,11 @@ use zip::write::SimpleFileOptions;
 use zip::{CompressionMethod, ZipWriter};
 
 fn main() {
-    let channel = Path::new(env!("CARGO_MANIFEST_DIR")).join("../channel");
+    let module = Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
     let out = PathBuf::from(std::env::var("OUT_DIR").unwrap()).join("channel.zip");
     let mut entries = Vec::new();
-    collect(&channel, &channel, &mut entries);
+    collect(&module.join("channel"), "", &mut entries);
+    collect(&module.join("locales"), "locales/", &mut entries);
     entries.sort();
 
     let mut zip = ZipWriter::new(fs::File::create(&out).unwrap());
@@ -23,21 +25,19 @@ fn main() {
         println!("cargo:rerun-if-changed={}", path.display());
     }
     zip.finish().unwrap();
-    println!("cargo:rerun-if-changed={}", channel.display());
 }
 
-fn collect(root: &Path, dir: &Path, into: &mut Vec<(String, PathBuf)>) {
+fn collect(dir: &Path, prefix: &str, into: &mut Vec<(String, PathBuf)>) {
+    println!("cargo:rerun-if-changed={}", dir.display());
     for entry in fs::read_dir(dir).unwrap() {
         let path = entry.unwrap().path();
+        let Some(name) = path.file_name().map(|n| n.to_string_lossy().into_owned()) else {
+            continue;
+        };
         if path.is_dir() {
-            collect(root, &path, into);
-        } else if path.file_name().is_some_and(|n| n != ".DS_Store") {
-            let name = path
-                .strip_prefix(root)
-                .unwrap()
-                .to_string_lossy()
-                .replace('\\', "/");
-            into.push((name, path));
+            collect(&path, &format!("{prefix}{name}/"), into);
+        } else if name != ".DS_Store" {
+            into.push((format!("{prefix}{name}"), path));
         }
     }
 }

--- a/modules/tv.kroma.roku/server/src/channel.rs
+++ b/modules/tv.kroma.roku/server/src/channel.rs
@@ -6,6 +6,8 @@
 use serde::Serialize;
 use serde_json::Value;
 
+use kroma_module_sdk::i18n::Translator;
+
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Tile {
@@ -123,129 +125,28 @@ pub fn item_tile(item: &Value, progress: f64) -> Tile {
     }
 }
 
-pub fn show_tile(show: &Value) -> Tile {
+pub fn show_tile(strings: Translator<'_>, show: &Value) -> Tile {
     let id = str(show, "id");
-    let episodes = num(show, "episodeCount").unwrap_or_default();
+    let count = num(show, "episodeCount").unwrap_or_default().to_string();
+    let episodes = strings.t("roku.channel.episodes", &[("count", &count)]);
     Tile {
         poster: format!("/api/shows/{id}/poster"),
         id,
         kind: "show".into(),
         title: str(show, "title"),
-        subtitle: join([&year(show), &format!("{episodes} episodes")]),
+        subtitle: join([&year(show), &episodes]),
         progress: 0.0,
     }
-}
-
-fn hit_tile(hit: &Value) -> Option<Tile> {
-    match str(hit, "type").as_str() {
-        "movie" | "episode" => hit.get("item").map(|i| item_tile(i, 0.0)),
-        "show" => hit.get("show").map(show_tile),
-        _ => None,
-    }
-}
-
-fn fraction(position: Option<i64>, duration: Option<i64>) -> f64 {
-    match (position, duration) {
-        (Some(p), Some(d)) if d > 0 => (p as f64 / d as f64).clamp(0.0, 1.0),
-        _ => 0.0,
-    }
-}
-
-pub fn home_rows(continue_title: &str, continuing: &Value, sections: &Value) -> Vec<Row> {
-    let mut rows = Vec::new();
-    let resume: Vec<Tile> = continuing
-        .as_array()
-        .map(|entries| {
-            entries
-                .iter()
-                .filter_map(|e| {
-                    let progress = fraction(num(e, "positionMs"), num(e, "durationMs"));
-                    e.get("item").map(|i| item_tile(i, progress))
-                })
-                .collect()
-        })
-        .unwrap_or_default();
-    if !resume.is_empty() {
-        rows.push(Row {
-            title: continue_title.to_string(),
-            tiles: resume,
-        });
-    }
-    for section in sections.as_array().into_iter().flatten() {
-        let tiles: Vec<Tile> = section
-            .get("items")
-            .and_then(Value::as_array)
-            .map(|items| items.iter().filter_map(hit_tile).collect())
-            .unwrap_or_default();
-        if !tiles.is_empty() {
-            rows.push(Row {
-                title: str(section, "title"),
-                tiles,
-            });
-        }
-    }
-    rows
-}
-
-const LIBRARY_ROW_CAP: usize = 60;
-
-pub fn library_rows(
-    movies_title: &str,
-    shows_title: &str,
-    movies: &Value,
-    shows: &Value,
-) -> Vec<Row> {
-    let mut rows = Vec::new();
-    let movie_tiles: Vec<Tile> = movies
-        .as_array()
-        .map(|items| {
-            items
-                .iter()
-                .take(LIBRARY_ROW_CAP)
-                .map(|i| item_tile(i, 0.0))
-                .collect()
-        })
-        .unwrap_or_default();
-    if !movie_tiles.is_empty() {
-        rows.push(Row {
-            title: movies_title.to_string(),
-            tiles: movie_tiles,
-        });
-    }
-    let show_tiles: Vec<Tile> = shows
-        .as_array()
-        .map(|items| items.iter().take(LIBRARY_ROW_CAP).map(show_tile).collect())
-        .unwrap_or_default();
-    if !show_tiles.is_empty() {
-        rows.push(Row {
-            title: shows_title.to_string(),
-            tiles: show_tiles,
-        });
-    }
-    rows
 }
 
 #[cfg(test)]
 mod tests {
     use serde_json::json;
 
+    use crate::strings;
+    use crate::test_support::{episode, movie, show};
+
     use super::*;
-
-    fn movie() -> Value {
-        json!({
-            "id": "m1", "kind": "movie", "title": "Dune", "year": 2021,
-            "container": "mov,mp4,m4a,3gp,3g2,mj2",
-            "metadata": { "overview": "Spice.", "backdropUrl": "https://img/dune.jpg" }
-        })
-    }
-
-    fn episode() -> Value {
-        json!({
-            "id": "e3", "kind": "episode", "title": "Chapter 3", "showId": "s1",
-            "showTitle": "Andor", "season": 1, "episode": 3, "episodeTitle": "Reckoning",
-            "container": "matroska,webm"
-        })
-    }
 
     #[test]
     fn a_movie_tile_names_the_title_and_the_year() {
@@ -268,35 +169,27 @@ mod tests {
     }
 
     #[test]
-    fn the_home_starts_with_what_is_in_progress_and_skips_empty_rows() {
-        let continuing =
-            json!([{ "positionMs": 600000, "durationMs": 2400000, "item": episode() }]);
-        let sections = json!([
-            { "title": "Empty", "items": [] },
-            { "title": "Films", "items": [{ "type": "movie", "item": movie() }, { "type": "show", "show": { "id": "s1", "title": "Andor", "year": 2022, "episodeCount": 12 } }] }
-        ]);
+    fn a_show_tile_counts_its_episodes_in_the_language_the_viewer_reads() {
+        let english = show_tile(strings::for_locale("en"), &show());
+        let french = show_tile(strings::for_locale("fr"), &show());
 
-        let rows = home_rows("Reprendre", &continuing, &sections);
-
-        assert_eq!(rows.len(), 2);
-        assert_eq!(rows[0].title, "Reprendre");
-        assert_eq!(rows[0].tiles[0].progress, 0.25);
-        assert_eq!(rows[1].title, "Films");
-        assert_eq!(rows[1].tiles[1].subtitle, "2022 · 12 episodes");
-        assert_eq!(rows[1].tiles[1].poster, "/api/shows/s1/poster");
+        assert_eq!(english.subtitle, "2022 · 12 episodes");
+        assert_eq!(french.subtitle, "2022 · 12 épisodes");
+        assert_eq!(french.poster, "/api/shows/s1/poster");
     }
 
     #[test]
-    fn a_library_with_nothing_curated_still_fills_two_rows() {
-        let movies = json!([movie()]);
-        let shows = json!([{ "id": "s1", "title": "Andor", "episodeCount": 12 }]);
+    fn a_show_with_one_episode_is_not_told_it_has_several() {
+        let one = json!({ "id": "s1", "title": "Andor", "episodeCount": 1 });
 
-        let rows = library_rows("Films", "Séries", &movies, &shows);
-
-        assert_eq!(rows.len(), 2);
-        assert_eq!(rows[0].tiles[0].title, "Dune");
-        assert_eq!(rows[1].tiles[0].subtitle, "12 episodes");
-        assert!(library_rows("Films", "Séries", &Value::Null, &json!([])).is_empty());
+        assert_eq!(
+            show_tile(strings::for_locale("en"), &one).subtitle,
+            "1 episode"
+        );
+        assert_eq!(
+            show_tile(strings::for_locale("fr"), &one).subtitle,
+            "1 épisode"
+        );
     }
 
     #[test]

--- a/modules/tv.kroma.roku/server/src/detail.rs
+++ b/modules/tv.kroma.roku/server/src/detail.rs
@@ -3,6 +3,8 @@
 
 use serde_json::Value;
 
+use kroma_module_sdk::i18n::Translator;
+
 use crate::channel::{
     backdrop, episode_code, item_tile, join, overview, show_tile, str, stream_format, Detail, Play,
 };
@@ -34,9 +36,14 @@ pub fn item_detail(item: &Value, resume_ms: i64) -> Detail {
     }
 }
 
-pub fn show_detail(show_detail: &Value, up_next: &Value, resume_ms: i64) -> Detail {
+pub fn show_detail(
+    strings: Translator<'_>,
+    show_detail: &Value,
+    up_next: &Value,
+    resume_ms: i64,
+) -> Detail {
     let show = show_detail.get("show").cloned().unwrap_or(Value::Null);
-    let tile = show_tile(&show);
+    let tile = show_tile(strings, &show);
     let episodes = show_detail
         .get("seasons")
         .and_then(Value::as_array)
@@ -75,23 +82,10 @@ pub fn show_detail(show_detail: &Value, up_next: &Value, resume_ms: i64) -> Deta
 mod tests {
     use serde_json::json;
 
+    use crate::strings;
+    use crate::test_support::{episode, movie};
+
     use super::*;
-
-    fn movie() -> Value {
-        json!({
-            "id": "m1", "kind": "movie", "title": "Dune", "year": 2021,
-            "container": "mov,mp4,m4a,3gp,3g2,mj2",
-            "metadata": { "overview": "Spice.", "backdropUrl": "https://img/dune.jpg" }
-        })
-    }
-
-    fn episode() -> Value {
-        json!({
-            "id": "e3", "kind": "episode", "title": "Chapter 3", "showId": "s1",
-            "showTitle": "Andor", "season": 1, "episode": 3, "episodeTitle": "Reckoning",
-            "container": "matroska,webm"
-        })
-    }
 
     #[test]
     fn a_movie_detail_plays_itself_from_where_it_was_left() {
@@ -115,9 +109,10 @@ mod tests {
         });
         let up_next = json!({ "item": episode(), "resume": true });
 
-        let detail = show_detail(&show, &up_next, 1000);
+        let detail = show_detail(strings::for_locale("fr"), &show, &up_next, 1000);
 
         assert_eq!(detail.kind, "show");
+        assert_eq!(detail.subtitle, "2022 · 1 épisode");
         assert_eq!(detail.episodes[0].title, "S1 E3 · Reckoning");
         assert_eq!(detail.episodes[0].id, "e3");
         let play = detail.play.unwrap();
@@ -130,7 +125,9 @@ mod tests {
     fn a_show_nothing_was_watched_from_has_no_play_action_yet() {
         let show = json!({ "show": { "id": "s1", "title": "Andor" }, "seasons": [] });
 
-        assert_eq!(show_detail(&show, &Value::Null, 0).play, None);
+        let detail = show_detail(strings::for_locale("en"), &show, &Value::Null, 0);
+
+        assert_eq!(detail.play, None);
     }
 
     #[test]

--- a/modules/tv.kroma.roku/server/src/lib.rs
+++ b/modules/tv.kroma.roku/server/src/lib.rs
@@ -22,7 +22,11 @@ mod ecp;
 mod installer;
 mod lan;
 mod routes;
+pub mod rows;
 pub mod state;
+mod strings;
+#[cfg(test)]
+mod test_support;
 
 pub use state::Roku;
 

--- a/modules/tv.kroma.roku/server/src/routes.rs
+++ b/modules/tv.kroma.roku/server/src/routes.rs
@@ -17,7 +17,7 @@ use kroma_module_sdk::host::{bearer_from_headers, json_error, AuthUser, HostCtx}
 use crate::address::DeviceAddress;
 use crate::core::Core;
 use crate::state::Roku;
-use crate::{channel, detail, lan};
+use crate::{detail, lan, rows, strings};
 
 pub fn routes<S>(roku: Arc<Roku>) -> Router<S>
 where
@@ -144,43 +144,17 @@ fn core_for(headers: &HeaderMap) -> Result<Core, Response> {
         .map_err(|e| json_error(StatusCode::INTERNAL_SERVER_ERROR, &format!("{e:#}")))
 }
 
-struct Labels {
-    continuing: &'static str,
-    movies: &'static str,
-    shows: &'static str,
-}
-
-fn labels(user: &kroma_module_sdk::domain::User) -> Labels {
-    match user.language.as_deref() {
-        Some(l) if l.starts_with("fr") => Labels {
-            continuing: "Reprendre",
-            movies: "Films",
-            shows: "Séries",
-        },
-        _ => Labels {
-            continuing: "Continue watching",
-            movies: "Movies",
-            shows: "Shows",
-        },
-    }
-}
-
 async fn home(AuthUser(user): AuthUser, headers: HeaderMap) -> Result<Response, Response> {
     let core = core_for(&headers)?;
-    let labels = labels(&user);
+    let strings = strings::for_user(&user);
     let (continuing, sections) =
         tokio::join!(core.get_or_null("/continue"), core.get_or_null("/home"));
-    let mut rows = channel::home_rows(labels.continuing, &continuing, &sections);
-    if rows.len() <= 1 {
+    let mut screen = rows::home(strings, &continuing, &sections);
+    if screen.len() <= 1 {
         let (movies, shows) = tokio::join!(core.get_or_null("/movies"), core.get_or_null("/shows"));
-        rows.extend(channel::library_rows(
-            labels.movies,
-            labels.shows,
-            &movies,
-            &shows,
-        ));
+        screen.extend(rows::library(strings, &movies, &shows));
     }
-    Ok(Json(json!({ "rows": rows })).into_response())
+    Ok(Json(json!({ "rows": screen })).into_response())
 }
 
 async fn resume_ms(core: &Core, item_id: &str) -> i64 {
@@ -192,11 +166,12 @@ async fn resume_ms(core: &Core, item_id: &str) -> i64 {
 }
 
 async fn detail(
-    AuthUser(_user): AuthUser,
+    AuthUser(user): AuthUser,
     headers: HeaderMap,
     Path((kind, id)): Path<(String, String)>,
 ) -> Result<Response, Response> {
     let core = core_for(&headers)?;
+    let strings = strings::for_user(&user);
     let not_found = || json_error(StatusCode::NOT_FOUND, "unknown item");
     let detail = if kind == "show" {
         let show = core
@@ -212,7 +187,7 @@ async fn detail(
             Some(item_id) => resume_ms(&core, item_id).await,
             None => 0,
         };
-        detail::show_detail(&show, &up_next, resume)
+        detail::show_detail(strings, &show, &up_next, resume)
     } else {
         let item = core
             .get(&format!("/items/{id}"))
@@ -231,29 +206,14 @@ mod tests {
     use axum::http::Request;
     use tower::ServiceExt;
 
-    use kroma_module_sdk::domain::{LibraryScope, User};
     use kroma_module_sdk::host::testing::StubHost;
+
+    use crate::test_support::user;
 
     use super::*;
 
-    fn operator() -> User {
-        User {
-            id: "u1".into(),
-            email: "ana@kroma.tv".into(),
-            username: "ana".into(),
-            avatar_url: None,
-            language: None,
-            audio_language: None,
-            subtitle_language: None,
-            permissions: Vec::new(),
-            libraries: LibraryScope::All,
-            created_at: "2026-01-01T00:00:00Z".into(),
-            has_pin: false,
-        }
-    }
-
     async fn add_by_hand(ip: &str) -> StatusCode {
-        let host = StubHost::new().with_session("tok", operator());
+        let host = StubHost::new().with_session("tok", user(None));
         let app = routes::<StubHost>(crate::roku_service(std::path::Path::new("/nowhere")))
             .with_state(host);
         let request = Request::post("/roku/add")

--- a/modules/tv.kroma.roku/server/src/rows.rs
+++ b/modules/tv.kroma.roku/server/src/rows.rs
@@ -1,0 +1,149 @@
+//! The first screen a box draws: what is in progress, then whatever the core
+//! curated, then the library itself when nothing was curated at all.
+
+use serde_json::Value;
+
+use kroma_module_sdk::i18n::Translator;
+
+use crate::channel::{item_tile, num, show_tile, str, Row, Tile};
+
+const LIBRARY_ROW_CAP: usize = 60;
+
+pub fn home(strings: Translator<'_>, continuing: &Value, sections: &Value) -> Vec<Row> {
+    let mut rows = Vec::new();
+    let resume: Vec<Tile> = continuing
+        .as_array()
+        .map(|entries| {
+            entries
+                .iter()
+                .filter_map(|e| {
+                    let progress = fraction(num(e, "positionMs"), num(e, "durationMs"));
+                    e.get("item").map(|i| item_tile(i, progress))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    if !resume.is_empty() {
+        rows.push(Row {
+            title: strings.t("roku.channel.continueWatching", &[]),
+            tiles: resume,
+        });
+    }
+    for section in sections.as_array().into_iter().flatten() {
+        let tiles: Vec<Tile> = section
+            .get("items")
+            .and_then(Value::as_array)
+            .map(|items| items.iter().filter_map(|h| hit_tile(strings, h)).collect())
+            .unwrap_or_default();
+        if !tiles.is_empty() {
+            rows.push(Row {
+                title: str(section, "title"),
+                tiles,
+            });
+        }
+    }
+    rows
+}
+
+pub fn library(strings: Translator<'_>, movies: &Value, shows: &Value) -> Vec<Row> {
+    let mut rows = Vec::new();
+    let movie_tiles: Vec<Tile> = movies
+        .as_array()
+        .map(|items| {
+            items
+                .iter()
+                .take(LIBRARY_ROW_CAP)
+                .map(|i| item_tile(i, 0.0))
+                .collect()
+        })
+        .unwrap_or_default();
+    if !movie_tiles.is_empty() {
+        rows.push(Row {
+            title: strings.t("roku.channel.movies", &[]),
+            tiles: movie_tiles,
+        });
+    }
+    let show_tiles: Vec<Tile> = shows
+        .as_array()
+        .map(|items| {
+            items
+                .iter()
+                .take(LIBRARY_ROW_CAP)
+                .map(|s| show_tile(strings, s))
+                .collect()
+        })
+        .unwrap_or_default();
+    if !show_tiles.is_empty() {
+        rows.push(Row {
+            title: strings.t("roku.channel.shows", &[]),
+            tiles: show_tiles,
+        });
+    }
+    rows
+}
+
+fn hit_tile(strings: Translator<'_>, hit: &Value) -> Option<Tile> {
+    match str(hit, "type").as_str() {
+        "movie" | "episode" => hit.get("item").map(|i| item_tile(i, 0.0)),
+        "show" => hit.get("show").map(|s| show_tile(strings, s)),
+        _ => None,
+    }
+}
+
+fn fraction(position: Option<i64>, duration: Option<i64>) -> f64 {
+    match (position, duration) {
+        (Some(p), Some(d)) if d > 0 => (p as f64 / d as f64).clamp(0.0, 1.0),
+        _ => 0.0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use crate::strings;
+    use crate::test_support::{episode, movie, show};
+
+    use super::*;
+
+    #[test]
+    fn the_home_starts_with_what_is_in_progress_and_skips_empty_rows() {
+        let continuing =
+            json!([{ "positionMs": 600000, "durationMs": 2400000, "item": episode() }]);
+        let sections = json!([
+            { "title": "Empty", "items": [] },
+            { "title": "Films", "items": [{ "type": "movie", "item": movie() }, { "type": "show", "show": show() }] }
+        ]);
+
+        let rows = home(strings::for_locale("fr"), &continuing, &sections);
+
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].title, "Reprendre");
+        assert_eq!(rows[0].tiles[0].progress, 0.25);
+        assert_eq!(rows[1].title, "Films");
+        assert_eq!(rows[1].tiles[1].subtitle, "2022 · 12 épisodes");
+        assert_eq!(rows[1].tiles[1].poster, "/api/shows/s1/poster");
+    }
+
+    #[test]
+    fn a_library_with_nothing_curated_still_fills_two_rows() {
+        let movies = json!([movie()]);
+        let shows = json!([show()]);
+
+        let rows = library(strings::for_locale("fr"), &movies, &shows);
+
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].title, "Films");
+        assert_eq!(rows[0].tiles[0].title, "Dune");
+        assert_eq!(rows[1].title, "Séries");
+        assert_eq!(rows[1].tiles[0].subtitle, "2022 · 12 épisodes");
+    }
+
+    #[test]
+    fn a_library_row_the_core_answered_nothing_for_is_not_drawn() {
+        let strings = strings::for_locale("en");
+
+        assert!(library(strings, &Value::Null, &json!([])).is_empty());
+        assert!(home(strings, &Value::Null, &Value::Null).is_empty());
+    }
+}

--- a/modules/tv.kroma.roku/server/src/state.rs
+++ b/modules/tv.kroma.roku/server/src/state.rs
@@ -282,9 +282,10 @@ mod tests {
     }
 
     #[test]
-    fn the_embedded_channel_is_a_zip_holding_a_manifest() {
+    fn the_embedded_channel_is_a_zip_holding_a_manifest_and_the_catalogs_it_reads() {
         assert_eq!(&CHANNEL_ZIP[..2], b"PK");
-        assert!(String::from_utf8_lossy(CHANNEL_ZIP).contains("manifest"));
+        let names = String::from_utf8_lossy(CHANNEL_ZIP);
+        assert!(names.contains("manifest") && names.contains("locales/fr.json"));
     }
 
     #[test]

--- a/modules/tv.kroma.roku/server/src/strings.rs
+++ b/modules/tv.kroma.roku/server/src/strings.rs
@@ -1,0 +1,53 @@
+//! The sidecar's half of the module's catalogs: the strings it sends a box come
+//! from the same `locales/<code>.json` the console page and the channel read.
+
+use std::sync::OnceLock;
+
+use kroma_module_sdk::domain::User;
+use kroma_module_sdk::i18n::{self, I18n, Translator};
+
+const CATALOGS: &[(&str, &str)] = kroma_module_sdk::embedded_locales!();
+
+pub fn for_user(user: &User) -> Translator<'static> {
+    for_locale(user.language.as_deref().unwrap_or(i18n::FALLBACK_LOCALE))
+}
+
+pub fn for_locale(locale: &str) -> Translator<'static> {
+    engine().translator(locale)
+}
+
+fn engine() -> &'static I18n {
+    static ENGINE: OnceLock<I18n> = OnceLock::new();
+    ENGINE.get_or_init(|| i18n::engine(CATALOGS).expect("the Roku module's own catalogs"))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_support;
+
+    use super::*;
+
+    #[test]
+    fn the_catalogs_the_console_page_reads_are_the_ones_the_sidecar_resolves() {
+        let codes: Vec<&str> = CATALOGS.iter().map(|(code, _)| *code).collect();
+
+        assert_eq!(codes, ["en", "fr"]);
+        assert_eq!(for_locale("fr").t("roku.channel.movies", &[]), "Films");
+        assert_eq!(for_locale("en").t("roku.channel.movies", &[]), "Movies");
+    }
+
+    #[test]
+    fn a_locale_no_catalog_answers_falls_back_to_english_rather_than_to_the_key() {
+        assert_eq!(for_locale("de").t("roku.channel.shows", &[]), "Shows");
+        assert_eq!(for_locale("fr_CH").t("roku.channel.shows", &[]), "Séries");
+    }
+
+    #[test]
+    fn an_account_with_no_language_of_its_own_reads_the_fallback() {
+        assert_eq!(
+            for_user(&test_support::user(None)).locale(),
+            i18n::FALLBACK_LOCALE
+        );
+        assert_eq!(for_user(&test_support::user(Some("fr"))).locale(), "fr");
+    }
+}

--- a/modules/tv.kroma.roku/server/src/test_support.rs
+++ b/modules/tv.kroma.roku/server/src/test_support.rs
@@ -1,0 +1,42 @@
+//! The catalog JSON the core answers with, and the account a session resolves
+//! to, as every test here reads them.
+
+use serde_json::{json, Value};
+
+use kroma_module_sdk::domain::{LibraryScope, User};
+
+pub fn movie() -> Value {
+    json!({
+        "id": "m1", "kind": "movie", "title": "Dune", "year": 2021,
+        "container": "mov,mp4,m4a,3gp,3g2,mj2",
+        "metadata": { "overview": "Spice.", "backdropUrl": "https://img/dune.jpg" }
+    })
+}
+
+pub fn episode() -> Value {
+    json!({
+        "id": "e3", "kind": "episode", "title": "Chapter 3", "showId": "s1",
+        "showTitle": "Andor", "season": 1, "episode": 3, "episodeTitle": "Reckoning",
+        "container": "matroska,webm"
+    })
+}
+
+pub fn show() -> Value {
+    json!({ "id": "s1", "title": "Andor", "year": 2022, "episodeCount": 12 })
+}
+
+pub fn user(language: Option<&str>) -> User {
+    User {
+        id: "u1".into(),
+        email: "ana@kroma.tv".into(),
+        username: "ana".into(),
+        avatar_url: None,
+        language: language.map(str::to_string),
+        audio_language: None,
+        subtitle_language: None,
+        permissions: Vec::new(),
+        libraries: LibraryScope::All,
+        created_at: "2026-01-01T00:00:00Z".into(),
+        has_pin: false,
+    }
+}

--- a/modules/tv.kroma.torrents/server/Cargo.lock
+++ b/modules/tv.kroma.torrents/server/Cargo.lock
@@ -1922,6 +1922,7 @@ dependencies = [
  "kroma-domain",
  "kroma-engine",
  "kroma-http",
+ "kroma-i18n",
  "kroma-module-host",
  "kroma-module-macros",
  "kroma-module-manifest",

--- a/modules/tv.kroma.torznab/server/Cargo.lock
+++ b/modules/tv.kroma.torznab/server/Cargo.lock
@@ -388,6 +388,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kroma-i18n"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
 name = "kroma-module-host"
 version = "0.1.0"
 dependencies = [
@@ -439,6 +446,7 @@ dependencies = [
  "anyhow",
  "axum",
  "kroma-http",
+ "kroma-i18n",
  "kroma-module-host",
  "kroma-module-macros",
  "kroma-module-manifest",

--- a/modules/tv.kroma.vector/server/Cargo.lock
+++ b/modules/tv.kroma.vector/server/Cargo.lock
@@ -1190,6 +1190,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kroma-i18n"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
 name = "kroma-module-host"
 version = "0.1.0"
 dependencies = [
@@ -1241,6 +1248,7 @@ dependencies = [
  "anyhow",
  "axum",
  "kroma-http",
+ "kroma-i18n",
  "kroma-module-host",
  "kroma-module-macros",
  "kroma-module-manifest",

--- a/modules/tv.kroma.vpn/server/Cargo.lock
+++ b/modules/tv.kroma.vpn/server/Cargo.lock
@@ -489,6 +489,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kroma-i18n"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
 name = "kroma-module-host"
 version = "0.1.0"
 dependencies = [
@@ -543,6 +550,7 @@ dependencies = [
  "axum",
  "kroma-db",
  "kroma-http",
+ "kroma-i18n",
  "kroma-module-host",
  "kroma-module-macros",
  "kroma-module-manifest",

--- a/modules/tv.kroma.whisper/server/Cargo.lock
+++ b/modules/tv.kroma.whisper/server/Cargo.lock
@@ -1337,6 +1337,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kroma-i18n"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
 name = "kroma-module-host"
 version = "0.1.0"
 dependencies = [
@@ -1392,6 +1399,7 @@ dependencies = [
  "axum",
  "kroma-db",
  "kroma-http",
+ "kroma-i18n",
  "kroma-module-host",
  "kroma-module-macros",
  "kroma-module-manifest",

--- a/packages/ci-tools/src/lanes.ts
+++ b/packages/ci-tools/src/lanes.ts
@@ -55,7 +55,7 @@ export const LANES = {
   sdk: {
     paths: [
       'packages/{cli,client,core,i18n,module-sdk,registry,spatial-nav,ui}/**',
-      'server/crates/{kroma-module-*,kroma-domain,kroma-http,kroma-db,kroma-primitives,kroma-testing}/**',
+      'server/crates/{kroma-module-*,kroma-domain,kroma-http,kroma-i18n,kroma-db,kroma-primitives,kroma-testing}/**',
       'server/Cargo.toml',
       ...INSTALL,
     ],

--- a/packages/ci-tools/src/sdk/vendor-rust.ts
+++ b/packages/ci-tools/src/sdk/vendor-rust.ts
@@ -13,6 +13,7 @@ export const CLOSURE = [
   'kroma-module-wire',
   'kroma-sqlite',
   'kroma-http',
+  'kroma-i18n',
   'kroma-primitives',
   'kroma-testing',
 ] as const;

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1956,6 +1956,7 @@ dependencies = [
  "kroma-domain",
  "kroma-engine",
  "kroma-http",
+ "kroma-i18n",
  "kroma-module-host",
  "kroma-module-macros",
  "kroma-module-manifest",

--- a/server/crates/kroma-module-macros/src/lib.rs
+++ b/server/crates/kroma-module-macros/src/lib.rs
@@ -1,6 +1,7 @@
 //! Proc-macros for KROMA modules. [`embedded_module!`] finds a module's
 //! `module.json` and `icon.<ext>` by convention - the module root is the parent
 //! of the server crate - and expands to the right `EmbeddedModule` constructor.
+//! [`embedded_locales!`] finds its `locales/<code>.json` the same way.
 
 use proc_macro::TokenStream;
 use std::path::{Path, PathBuf};
@@ -49,6 +50,48 @@ fn expansion(manifest_dir: Option<String>) -> String {
     }
 }
 
+/// Builds the catalog list for a module server crate: every
+/// `locales/<code>.json` beside its `module.json`, as `&[(code, json)]` ready
+/// for `kroma_module_sdk::i18n::engine`. Takes no arguments, and a module with
+/// no `locales/` gets an empty slice.
+#[proc_macro]
+pub fn embedded_locales(_input: TokenStream) -> TokenStream {
+    locales_expansion(std::env::var("CARGO_MANIFEST_DIR").ok())
+        .parse()
+        .expect("embedded_locales!(): generated a valid const expression")
+}
+
+fn locales_expansion(manifest_dir: Option<String>) -> String {
+    let Some(manifest_dir) = manifest_dir else {
+        return compile_error("embedded_locales!(): CARGO_MANIFEST_DIR is not set");
+    };
+    let Some(module_root) = Path::new(&manifest_dir).parent() else {
+        return compile_error("embedded_locales!(): the server crate has no parent dir");
+    };
+    let catalogs: Vec<String> = find_catalogs(&module_root.join("locales"))
+        .iter()
+        .map(|(code, path)| format!("({code:?}, include_str!({:?}))", path.to_string_lossy()))
+        .collect();
+    format!("&[{}]", catalogs.join(", "))
+}
+
+fn find_catalogs(dir: &Path) -> Vec<(String, PathBuf)> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut catalogs: Vec<(String, PathBuf)> = entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "json"))
+        .filter_map(|path| {
+            let code = path.file_stem()?.to_string_lossy().into_owned();
+            Some((code, path))
+        })
+        .collect();
+    catalogs.sort();
+    catalogs
+}
+
 fn find_icon(dir: &Path) -> Option<(PathBuf, &'static str)> {
     const CANDIDATES: &[(&str, &str)] = &[
         ("svg", "image/svg+xml"),
@@ -90,10 +133,22 @@ mod tests {
             std::fs::write(self.0.path().join(name), bytes).expect("write");
         }
 
+        fn write_locale(&self, name: &str, bytes: &[u8]) {
+            let dir = self.0.path().join("locales");
+            std::fs::create_dir_all(&dir).expect("locales dir");
+            std::fs::write(dir.join(name), bytes).expect("write");
+        }
+
         fn expand(&self) -> String {
-            expansion(Some(
-                self.0.path().join("server").to_string_lossy().to_string(),
-            ))
+            expansion(Some(self.server_dir()))
+        }
+
+        fn expand_locales(&self) -> String {
+            locales_expansion(Some(self.server_dir()))
+        }
+
+        fn server_dir(&self) -> String {
+            self.0.path().join("server").to_string_lossy().to_string()
         }
     }
 
@@ -131,6 +186,28 @@ mod tests {
         let out = scratch.expand();
         assert!(out.starts_with("EmbeddedModule::iconless("), "{out}");
         assert!(out.contains("module.json"), "{out}");
+    }
+
+    #[test]
+    fn every_catalogue_beside_the_manifest_is_embedded_under_its_locale_code() {
+        let scratch = Scratch::new("locales");
+        scratch.write_locale("fr.json", br#"{"a":"un"}"#);
+        scratch.write_locale("en.json", br#"{"a":"one"}"#);
+        scratch.write_locale("notes.md", b"not a catalogue");
+
+        let out = scratch.expand_locales();
+        assert!(out.starts_with(r#"&[("en", include_str!("#), "{out}");
+        assert!(out.contains(r#"("fr", include_str!("#), "{out}");
+        assert!(!out.contains("notes"), "{out}");
+    }
+
+    #[test]
+    fn a_module_that_ships_no_catalogue_gets_an_empty_list_rather_than_an_error() {
+        let scratch = Scratch::new("no-locales");
+
+        assert_eq!(scratch.expand_locales(), "&[]");
+        assert!(locales_expansion(None).starts_with("compile_error!"));
+        assert!(locales_expansion(Some(String::new())).contains("no parent dir"));
     }
 
     #[test]

--- a/server/crates/kroma-module-sdk/Cargo.toml
+++ b/server/crates/kroma-module-sdk/Cargo.toml
@@ -3,7 +3,7 @@ name = "kroma-module-sdk"
 version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
-description = "The KROMA module SDK: the single crate every server module depends on. Re-exports the manifest layer plus the engine/host/domain/http/db surface, so modules never depend on core crates directly."
+description = "The KROMA module SDK: the single crate every server module depends on. Re-exports the manifest layer plus the engine/host/domain/http/i18n/db surface, so modules never depend on core crates directly."
 license.workspace = true
 
 [dependencies]
@@ -19,9 +19,11 @@ kroma-module-host = { workspace = true }
 kroma-engine = { workspace = true, optional = true }
 kroma-domain = { workspace = true, optional = true }
 kroma-db = { workspace = true, optional = true }
-# What a sidecar links: the wire types, the HTTP client, the SQLite pool.
+# What a sidecar links: the wire types, the HTTP client, the i18n engine its
+# own catalogs resolve against, the SQLite pool.
 kroma-module-wire = { workspace = true }
 kroma-http = { workspace = true }
+kroma-i18n = { workspace = true }
 kroma-sqlite = { workspace = true, optional = true }
 kroma-primitives = { workspace = true }
 # `testing::{TempDir, temp_dir}`, the scratch dir every module test writes in.

--- a/server/crates/kroma-module-sdk/src/lib.rs
+++ b/server/crates/kroma-module-sdk/src/lib.rs
@@ -1,10 +1,11 @@
 //! The KROMA module SDK: the ONE crate a server module depends on.
 //!
 //! A module must not depend on `kroma-engine`, `kroma-db`, `kroma-domain`,
-//! `kroma-sqlite`, `kroma-module-wire` or `kroma-http` directly. This facade re-exports the manifest layer at the crate
-//! root (`EmbeddedModule`, `ModuleManifest`, `Registry`, ...) and mirrors the
-//! host / engine / domain / http / db / primitives surface under submodules, so a
-//! module writes `kroma_module_sdk::engine::state::SharedState` instead of
+//! `kroma-sqlite`, `kroma-module-wire`, `kroma-http` or `kroma-i18n` directly.
+//! This facade re-exports the manifest layer at the crate root
+//! (`EmbeddedModule`, `ModuleManifest`, `Registry`, ...) and mirrors the host /
+//! engine / domain / http / i18n / db / primitives surface under submodules, so
+//! a module writes `kroma_module_sdk::engine::state::SharedState` instead of
 //! reaching into the core crate.
 //!
 //! What is NOT here is any description of what a module is for. A module reaches
@@ -21,6 +22,11 @@ pub use kroma_module_manifest::*;
 /// `module.json` + `icon.<ext>` at compile time. Write
 /// `pub const MODULE: EmbeddedModule = kroma_module_sdk::embedded_module!();`.
 pub use kroma_module_macros::embedded_module;
+
+/// `embedded_locales!()` collects a module's `locales/<code>.json` at compile
+/// time into the `&[(code, json)]` [`i18n::engine`] takes. Write
+/// `const LOCALES: &[(&str, &str)] = kroma_module_sdk::embedded_locales!();`.
+pub use kroma_module_macros::embedded_locales;
 
 /// Host contract: the `ServerModule` trait, `HostCtx`, the point resolvers and
 /// the `service` helper, and the `async_trait` re-export module impls need.
@@ -49,6 +55,72 @@ pub mod domain {
 /// The outbound HTTP client (`Fetch`, `Response`).
 pub mod http {
     pub use kroma_http::*;
+}
+
+/// The catalogs a module ships in `locales/`, resolved by the same engine the
+/// core resolves its own with, so a plural or a `{name}` behaves the same in a
+/// sidecar as it does on a screen.
+pub mod i18n {
+    pub use kroma_i18n::*;
+
+    /// The locale a key falls back to: a module's `en.json` is the
+    /// authoritative catalog, the one every other is a translation of.
+    pub const FALLBACK_LOCALE: &str = "en";
+
+    /// An engine over the catalogs [`crate::embedded_locales!`] found. A module
+    /// that ships no English falls back to its first catalog instead; one that
+    /// ships none at all is an error rather than an engine answering every key
+    /// with itself.
+    pub fn engine(catalogs: &[(&str, &str)]) -> Result<I18n, BuildError> {
+        let fallback = catalogs
+            .iter()
+            .map(|(code, _)| *code)
+            .find(|code| *code == FALLBACK_LOCALE)
+            .or_else(|| catalogs.first().map(|(code, _)| *code))
+            .unwrap_or(FALLBACK_LOCALE);
+        catalogs
+            .iter()
+            .fold(
+                I18n::builder().default_locale(fallback).plural_rule(cldr),
+                |builder, (code, json)| builder.catalog_json(*code, *json),
+            )
+            .build()
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        const EN: &str = r#"{ "items": "{count} items", "items_one": "{count} item" }"#;
+        const FR: &str = r#"{ "items": "{count} objets", "items_one": "{count} objet" }"#;
+        const CATALOGS: &[(&str, &str)] = &[("en", EN), ("fr", FR)];
+
+        #[test]
+        fn a_count_picks_the_variant_the_readers_own_language_declares() {
+            let i18n = engine(CATALOGS).expect("two catalogs");
+
+            assert_eq!(i18n.t("fr", "items", &[("count", "0")]), "0 objet");
+            assert_eq!(i18n.t("en", "items", &[("count", "0")]), "0 items");
+            assert_eq!(i18n.t("fr", "items", &[("count", "2")]), "2 objets");
+        }
+
+        #[test]
+        fn english_leads_whatever_order_the_catalogs_arrived_in() {
+            let reversed: Vec<(&str, &str)> = CATALOGS.iter().rev().copied().collect();
+
+            assert_eq!(engine(&reversed).unwrap().default_locale(), "en");
+            assert_eq!(engine(CATALOGS).unwrap().default_locale(), "en");
+        }
+
+        #[test]
+        fn a_module_with_no_english_resolves_against_the_catalog_it_does_ship() {
+            let only_french = engine(&CATALOGS[1..]).expect("one catalog");
+
+            assert_eq!(only_french.default_locale(), "fr");
+            assert_eq!(only_french.t("en", "items", &[("count", "1")]), "1 objet");
+            assert!(engine(&[]).is_err());
+        }
+    }
 }
 
 /// Direct SQLite access: the pool, the grant and a module's own migrations.


### PR DESCRIPTION
## What

The module kept its user-facing strings in three places and one of them was English in every locale. `channel.rs` built `format!("{episodes} episodes")`, so a French household read `2022 · 12 episodes` on a television. `routes.rs` carried `Reprendre` / `Films` / `Séries` against their English counterparts and picked between them by hand. `Strings.brs` restated nine strings in two languages. Meanwhile `locales/{en,fr}.json` sat beside all three.

**The decision: yes, a sidecar can reach its own `locales/{en,fr}.json`, and now does.** `kroma-i18n` is already generic, its builder takes catalogs from whoever holds them, and one of its own tests says in so many words that a module may hand over a map it built itself. Nothing was missing but the door, so the SDK opens it:

- `embedded_locales!()` (a sibling of `embedded_module!()`) finds every `locales/<code>.json` at compile time and expands to `&[(code, json)]`. Nothing lists the locales, the same way nothing lists the core's.
- `i18n::engine(catalogs)` builds the engine over them with CLDR plurals and `en` as the fallback, which is what the core uses, so a plural and a `{name}` resolve identically in a sidecar and on a screen.
- `kroma-i18n` joins the vendored closure in `packages/ci-tools/src/sdk/vendor-rust.ts`, so a module written outside this repository gets it from `@kromatv/sdk` too. Verified by staging the tarball: `rust/kroma-i18n/` is in it and `kroma-module-sdk` path-depends on it.

With that, the three stores become one:

- The sidecar resolves `roku.channel.*` for the session user's `language`. The episode count is a plural variant (`episodes_one` / `episodes_other`), so it is `1 épisode`, `12 épisodes`, `12 episodes`, and never an English word formatted into a French sentence.
- `build.rs` zips `locales/` beside the channel tree, so `Strings.brs` reads the same two files off `pkg:/` with English as its base and the box's locale layered over it. The BrightScript now holds no strings at all.
- `episodes` and `signedOut` are dropped rather than carried across: no `t()` call drew either of them.

`channel.rs` was at the 300-line limit and is split at the screen it serves: the tile vocabulary and the wire shapes stay, the home and library rows move to `rows.rs` beside `detail.rs`. The `movie()` / `episode()` fixtures that three test modules were each repeating move to `test_support`.

## Closes

Closes #238

## Checks

- [x] `bun run typecheck`, `bun run check`, `bun run test` (10041 passed) and `bun run spec:check` pass.
- [x] `bun run kroma check modules/tv.kroma.roku` clean; module `cargo build`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (53 tests) clean.
- [x] `cd server && cargo clippy --workspace --all-targets` and `cargo test --workspace` clean. The 16 remaining clippy warning sites are pre-existing, in `kroma-db`, `kroma-engine` and `kroma-server`.
- [x] `bun run ci sdk stage` produces a tarball that carries the new vendored crate.
- [x] Follows `CODE_STYLE.md`: no comments narrating the work, exported API only.
- [x] One idea. The `kroma-http` duplication in the same module is #239, in its own PR.

## Risk

Three things are worth a reviewer's eye. The channel now reads its strings at runtime instead of holding them, so a box that somehow gets a zip without `locales/` would draw raw keys rather than English: `state.rs` asserts the embedded zip carries them, which is the only moment that can go wrong. The French copy is the copy that was already in `Strings.brs` and `routes.rs`, moved rather than retranslated, plus `{count} épisode(s)`. And the SDK grew a dependency every sidecar now links, `kroma-i18n`, which is one small crate over `serde_json` and no heavier than the catalogs a module was already shipping to its frontend; every module workspace is relocked in the same commit, the way #149 did when `kroma-http` grew its own.

None of this ran on a real box: there is no Roku on this network, so the BrightScript half is checked by the zip assertion and by reading, not by a sideload. `ReadAsciiFile` + `ParseJson` off `pkg:/locales/` is the one line a reviewer with a box should watch: if it returned nothing the screens would draw raw keys, loudly rather than subtly.

`module.json` goes to 0.1.2. #239 bumps it to the same version from the same base, so whichever lands second wants 0.1.3 on the rebase; nothing else in the two PRs overlaps.
