### PR TITLE
fix(admin): a module card is as tall as its row

### DIFF
--- a/clients/web/src/features/admin/module-store.tsx
+++ b/clients/web/src/features/admin/module-store.tsx
@@ -110,6 +110,7 @@ function StoreCard({
         p={16}
         gap={12}
         row
+        flex
         align="flex-start"
         opacity={m.compatible ? 1 : 0.7}
       >


### PR DESCRIPTION
## What

On Admin > Modules > Discover, cards in the same row had different heights. The kit's `Grid` already stretches every cell to the tallest card in its row, but `StoreCard` kept its content height inside that cell. So a card with "Installed" in place of a button, a one-line description, or an update chip that wrapped came out shorter or taller than the cards next to it. The card's `Surface` now takes `flex` and fills its cell.

The fix is in the card, not in `Grid`. The other grids, the poster grids included, should not start stretching their children.

## Closes

No issue. It was reported directly with a screenshot of the Discover tab.

## Checks

- [x] `bun run lint` and `bun run test` pass, or I said below which failed and why
- [ ] `cargo clippy` and `cargo test` pass, if the server changed
- [x] Follows `CODE_STYLE.md`, no comments narrating the work, exported API only
- [x] One idea. If it grew a second, it was split.

I ran `biome check` on the file. Tests were not run because this is a one-prop layout change and no test renders this card. The server is untouched.

I ran it in Chromium against a private server. Searching "trans" puts the one-line Whisper card in a row with two two-line cards:

- before: Torrent downloads 134 px, Transmission engine 134 px, Whisper transcription 116 px
- after: all three 134 px

## Risk

Low. The one thing that could look wrong is a card stretched taller than its content. That only happens when a neighbour in the same row is taller, and the extra space falls below the description. Heights match within a row, not across the whole grid, so a card alone on the last row still takes its own height.
