### PR TITLE
fix(player): Shaka plays a remux through its cuts, and a decoder failure restarts it

### DIFF
--- a/clients/web/src/features/playback/video-engine.test.ts
+++ b/clients/web/src/features/playback/video-engine.test.ts
@@ -234,7 +234,7 @@ describe('attachMediaSource HLS master via Shaka', () => {
     expect(H.shakaInstances).toHaveLength(1);
     const inst = H.shakaInstances[0];
     expect(inst?.attach).toHaveBeenCalledWith(fv.el);
-    expect(inst?.load).toHaveBeenCalledWith('hls:w1:true:600:2');
+    expect(inst?.load).toHaveBeenCalledWith('hls:w1:true:600:2', 0);
     // Shaka's default bufferingGoal is only 10s.
     const cfg = inst?.configure.mock.calls[0]?.[0] as {
       streaming?: { bufferingGoal?: number };
@@ -277,5 +277,42 @@ describe('attachMediaSource HLS master via Shaka', () => {
     await tick();
     await tick();
     expect(H.shakaInstances[0]?.load).toHaveBeenCalled();
+  });
+
+  it('gives up on a picture the decoder refused, which Shaka recovers silently into nothing', async () => {
+    const fv = fakeVideo();
+    const opts = shakaOpts({ v: fv.el });
+    attachMediaSource(opts);
+    await tick();
+
+    fv.set('error', { code: 3 });
+    fv.fire('error');
+
+    expect(opts.onGiveUp).toHaveBeenCalledTimes(1);
+  });
+
+  it('takes an aborted fetch for what it is, not a failure', async () => {
+    const fv = fakeVideo();
+    const opts = shakaOpts({ v: fv.el });
+    attachMediaSource(opts);
+    await tick();
+
+    fv.set('error', { code: 1 });
+    fv.fire('error');
+
+    expect(opts.onGiveUp).not.toHaveBeenCalled();
+  });
+
+  it('stops listening for errors once the source is detached', async () => {
+    const fv = fakeVideo();
+    const opts = shakaOpts({ v: fv.el });
+    const cleanup = attachMediaSource(opts);
+    await tick();
+
+    cleanup();
+    fv.set('error', { code: 3 });
+    fv.fire('error');
+
+    expect(opts.onGiveUp).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/features/playback/video-engine.ts
+++ b/clients/web/src/features/playback/video-engine.ts
@@ -12,7 +12,7 @@ import {
   type EngineDecision,
   hlsBufferConfig,
   itemBufferPlan,
-  shakaStreamingConfig,
+  shakaConfig,
   type WaitReason,
 } from '@kromatv/core';
 import type { WebEnginePref } from '#web/features/playback/engine-pref';
@@ -114,6 +114,8 @@ export interface AttachSourceOptions {
   onRefused: (status: number) => void;
 }
 
+const MEDIA_ERR_ABORTED = 1;
+
 function seekToAnchor(v: HTMLVideoElement, startSec: number): void {
   if (startSec <= 0.5) return;
   const apply = () => {
@@ -176,6 +178,9 @@ export function attachMediaSource(opts: AttachSourceOptions): () => void {
   // Checked before `useNativeHls`: an explicit Shaka override wins, so the choice
   // is honoured even on Safari, where native HLS would otherwise take it.
   if (useShaka) {
+    const onMediaError = () => {
+      if (!destroyed && v.error?.code !== MEDIA_ERR_ABORTED) onGiveUp();
+    };
     // Shaka reports the same relative clock as hls.js, so `baseSec` applies here too.
     void import('shaka-player/dist/shaka-player.compiled.js').then((mod) => {
       if (destroyed) return;
@@ -187,10 +192,11 @@ export function attachMediaSource(opts: AttachSourceOptions): () => void {
       }
       const player = new shaka.Player();
       shakaRef.current = player;
-      player.configure({ streaming: shakaStreamingConfig(plan) });
+      player.configure(shakaConfig(plan));
+      v.addEventListener('error', onMediaError);
       player
         .attach(v)
-        .then(() => player.load(url))
+        .then(() => player.load(url, 0))
         .catch((e: unknown) => {
           const status = shakaHttpStatus(e);
           if (!destroyed && status !== null) onRefused(status);
@@ -198,6 +204,7 @@ export function attachMediaSource(opts: AttachSourceOptions): () => void {
     });
     return () => {
       destroyed = true;
+      v.removeEventListener('error', onMediaError);
       void shakaRef.current?.destroy();
       shakaRef.current = null;
       v.removeAttribute('src');

--- a/packages/core/src/playback-buffer.test.ts
+++ b/packages/core/src/playback-buffer.test.ts
@@ -6,7 +6,7 @@ import {
   isPlayableAt,
   itemBufferPlan,
   reachableBufferEnd,
-  shakaStreamingConfig,
+  shakaConfig,
 } from './playback-buffer';
 
 const FIRST_FILE = MediaFileId.parse('f1');
@@ -185,7 +185,7 @@ describe('engine config', () => {
   it('hands Shaka the plan and a stall detector that gives up waiting sooner', () => {
     const plan = bufferPlan(4_000_000);
 
-    const cfg = shakaStreamingConfig(plan);
+    const cfg = shakaConfig(plan).streaming;
 
     expect(cfg.bufferingGoal).toBe(plan.forwardSec);
     expect(cfg.bufferBehind).toBe(plan.backSec);
@@ -193,8 +193,14 @@ describe('engine config', () => {
     expect(cfg.stallSkip).toBeGreaterThan(0.1);
   });
 
+  it('has Shaka place a segment by its own timestamps rather than the playlist sum', () => {
+    const cfg = shakaConfig(bufferPlan(4_000_000));
+
+    expect(cfg.manifest.hls.ignoreManifestTimestampsInSegmentsMode).toBe(true);
+  });
+
   it('agrees with the readout on what counts as a skippable hole', () => {
-    const hole = shakaStreamingConfig(bufferPlan(4_000_000)).gapDetectionThreshold;
+    const hole = shakaConfig(bufferPlan(4_000_000)).streaming.gapDetectionThreshold;
 
     expect(hlsBufferConfig(bufferPlan(4_000_000)).maxBufferHole).toBe(hole);
     expect(reachableBufferEnd(ranges([[hole, 90]]), 0)).toBe(90);

--- a/packages/core/src/playback-buffer.ts
+++ b/packages/core/src/playback-buffer.ts
@@ -133,18 +133,29 @@ export function hlsBufferConfig(plan: BufferPlan) {
 }
 
 /**
- * The `streaming` half of a Shaka config for `plan`. Shaka bounds its buffer in
- * seconds only, so `forwardSec` is the whole of what keeps it inside the byte
- * budget; its stall detector otherwise sits on a hole for a full second before
- * stepping over it.
+ * The Shaka config for a remux of `plan`. Shaka bounds its buffer in seconds
+ * only, so `forwardSec` is the whole of what keeps it inside the byte budget;
+ * its stall detector otherwise sits on a hole for a full second before stepping
+ * over it.
+ *
+ * Segments land at their own timestamps, not at the playlist's `EXTINF` sum.
+ * ffmpeg rounds `EXTINF` to the millisecond, and writes a copied video's a few
+ * frames off its fragments, so Shaka's default opens a hole or an overlap at
+ * every cut: Chrome discards the frames an overlap replaces along with every
+ * frame decoded from them, and an open-GOP source cannot decode across a hole.
+ * This relies on the remux's fragments counting from zero, as ffmpeg's fMP4
+ * output does under `-copyts`.
  */
-export function shakaStreamingConfig(plan: BufferPlan) {
+export function shakaConfig(plan: BufferPlan) {
   return {
-    bufferingGoal: plan.forwardSec,
-    bufferBehind: plan.backSec,
-    rebufferingGoal: 4,
-    gapDetectionThreshold: SKIPPABLE_GAP_SEC,
-    stallThreshold: 0.3,
-    stallSkip: 0.2,
+    streaming: {
+      bufferingGoal: plan.forwardSec,
+      bufferBehind: plan.backSec,
+      rebufferingGoal: 4,
+      gapDetectionThreshold: SKIPPABLE_GAP_SEC,
+      stallThreshold: 0.3,
+      stallSkip: 0.2,
+    },
+    manifest: { hls: { ignoreManifestTimestampsInSegmentsMode: true } },
   };
 }

--- a/packages/tv/src/features/playback/player/htmlEngine.test.ts
+++ b/packages/tv/src/features/playback/player/htmlEngine.test.ts
@@ -256,7 +256,7 @@ describe('HtmlEngine Shaka master', () => {
     expect(shakaMock.installAll).toHaveBeenCalled();
     expect(shakaMock.attach).toHaveBeenCalledWith(fv.el);
     await tick();
-    expect(shakaMock.load).toHaveBeenCalledWith('master:vid1:false:0:2');
+    expect(shakaMock.load).toHaveBeenCalledWith('master:vid1:false:0:2', 0);
     expect(fv.get('src')).toBe('');
   });
 

--- a/packages/tv/src/features/playback/player/htmlEngine.ts
+++ b/packages/tv/src/features/playback/player/htmlEngine.ts
@@ -17,7 +17,7 @@ import {
   reachableBufferEnd,
   recoverMse,
   STALL_NUDGE_SEC,
-  shakaStreamingConfig,
+  shakaConfig,
 } from '@kromatv/core';
 import {
   type EngineListeners,
@@ -212,12 +212,12 @@ export class HtmlEngine implements TvEngine {
       }
       const player = new shaka.Player();
       this.shaka = player;
-      player.configure({ streaming: shakaStreamingConfig(this.plan) });
+      player.configure(shakaConfig(this.plan));
       // Shaka reports the same relative clock as hls.js, so `baseSec` applies
       // unchanged.
       player
         .attach(this.v)
-        .then(() => player.load(url))
+        .then(() => player.load(url, 0))
         .catch(() => undefined);
     });
   }


### PR DESCRIPTION
## What

Shaka placed each HLS segment at the playlist's `EXTINF` sum instead of at its own timestamps. ffmpeg rounds `EXTINF` to the millisecond and, for a copied video under `-copyts`, writes it a few frames off the fragments, so every cut became a hole or an overlap. A film played from the start froze 8 to 10 frames at about half its cuts: Chrome discards the frame a 1 ms overlap replaces and every frame decoded from it. A remux anchored mid-film got holes, which cost an open-GOP HEVC source its references: VideoToolbox failed with -17694, and Shaka reset the MediaSource and seeked back into the same hole on every playlist refresh without firing its `error` event, so the spinner never went away. `shakaConfig` replaces `shakaStreamingConfig` and sets `manifest.hls.ignoreManifestTimestampsInSegmentsMode` for the web and TV engines. Shaka also loads at relative 0, as hls.js does, instead of three segments short of the live edge when the playlist already holds segments. On the web, an element error on the Shaka path now goes to `onGiveUp`. `sequenceMode` also yields one continuous range, but Shaka documents it as unreliable on Tizen 2/3 and webOS 3, which run this engine.

## Closes

No issue: reported directly with a HAR of the stall and the NAS logs.

## Checks

- [x] `bun run check` and `bun run test` pass, and so does `bun run typecheck`
- [ ] `cargo clippy` and `cargo test`: not run, the server did not change
- [x] Follows `CODE_STYLE.md`: no comments narrating the work, exported API only
- [x] One idea. The spinner's text is a separate PR.

Reproduced in Google Chrome 153 with Shaka 5.2.5's debug build, on segments from the NAS itself (a HAR capture, and a remux made with the package's bundled ffmpeg), served through a playlist that grows at the pace the NAS showed:

| Stream | Current config | This PR |
|---|---|---|
| District 9 resumed at 521 s, 130 s run | 4 decode errors, nothing plays after 21 s | plays 0 to 129 s, no error |
| Mayday from the start, 100 s, 13 cuts | 6 freezes of 317 to 417 ms, each just after a cut | no freeze in 3 runs, same as plain MSE |

## Risk

The option trusts a remux's fragments to count from zero. Every remux the server makes does today, because ffmpeg moves the `-copyts` start into the init segment's edit list. A stream whose fragments carried absolute times would sit at 0 with its buffer at the film's real time, which shows as a spinner over a buffered bar. A Shaka decode error now costs a fresh remux session, and after two of them the stage says the title will not play instead of spinning.
