### PR TITLE
fix(player): the spinner stops writing the wait across the picture

### DIFF
--- a/packages/ui/src/components/organisms/player/parts/stage/stage-overlay.test.tsx
+++ b/packages/ui/src/components/organisms/player/parts/stage/stage-overlay.test.tsx
@@ -37,22 +37,28 @@ describe('the stage while it waits', () => {
     expect(screen.getByRole('progressbar')).toBeTruthy();
   });
 
-  it('names what it waits on once the wait has lasted', () => {
+  it('never writes the wait across the picture, however long it lasts', () => {
     overlay({ waiting: true, reason: 'buffering' });
-    pass(250);
+
+    pass(10_000);
+
     expect(screen.queryByText('Buffering…')).toBeNull();
-
-    pass(2500);
-
-    expect(screen.getByText('Buffering…')).toBeTruthy();
   });
 
-  it('says plain loading where the engine cannot tell why', () => {
+  it('names the wait to assistive tech', () => {
+    overlay({ waiting: true, reason: 'buffering' });
+
+    pass(250);
+
+    expect(screen.getByLabelText('Buffering…')).toBeTruthy();
+  });
+
+  it('calls it plain loading where the engine cannot tell why', () => {
     overlay({ waiting: true });
 
-    pass(3000);
+    pass(250);
 
-    expect(screen.getByText('Loading…')).toBeTruthy();
+    expect(screen.getByLabelText('Loading…')).toBeTruthy();
   });
 
   it('puts the failure up instead of a spinner', () => {

--- a/packages/ui/src/components/organisms/player/parts/stage/stage-overlay.tsx
+++ b/packages/ui/src/components/organisms/player/parts/stage/stage-overlay.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Box } from '#ui/components/atoms/box';
 import { Spinner } from '#ui/components/atoms/spinner';
-import { Text } from '#ui/components/atoms/text';
 import { EmptyState } from '#ui/components/molecules/empty-state';
 import { styles } from '#ui/core';
 import { backdropBlur } from '#ui/lib/css';
@@ -14,38 +13,29 @@ interface StageOverlayProps {
   /** The line under {@link error}, where there is something to do about it. */
   hint?: string | null;
   waiting?: boolean;
-  /** Worded under the spinner once a wait has lasted; plain loading without it. */
+  /** What the spinner tells assistive tech it waits on; plain loading without it. */
   reason?: 'loading' | 'buffering';
 }
 
-type WaitStage = 'hidden' | 'spinning' | 'named';
-
 const SPIN_AFTER_MS = 200;
-const NAME_AFTER_MS = 2500;
 const DISC = 88;
-const LABEL_GAP = 16;
 
-function useWaitStage(waiting: boolean): WaitStage {
-  const [stage, setStage] = useState<WaitStage>('hidden');
+function useSpinnerShown(waiting: boolean): boolean {
+  const [shown, setShown] = useState(false);
   useEffect(() => {
-    setStage('hidden');
+    setShown(false);
     if (!waiting) return;
-    const spin = setTimeout(() => setStage('spinning'), SPIN_AFTER_MS);
-    const name = setTimeout(() => setStage('named'), NAME_AFTER_MS);
-    return () => {
-      clearTimeout(spin);
-      clearTimeout(name);
-    };
+    const spin = setTimeout(() => setShown(true), SPIN_AFTER_MS);
+    return () => clearTimeout(spin);
   }, [waiting]);
-  return stage;
+  return shown;
 }
 
 /** What covers the picture while there is none: the failure across the stage,
- *  or the spinner, which says what it waits on once the wait has lasted.
- *  Nothing when the film is playing. */
+ *  or the spinner. Nothing when the film is playing. */
 function StageOverlay({ error, hint, waiting = false, reason }: Readonly<StageOverlayProps>) {
   const t = useT();
-  const stage = useWaitStage(waiting && !error);
+  const shown = useSpinnerShown(waiting && !error);
   if (error) {
     return (
       <Box fill z={4} center px={64}>
@@ -56,30 +46,21 @@ function StageOverlay({ error, hint, waiting = false, reason }: Readonly<StageOv
       </Box>
     );
   }
-  if (stage === 'hidden') return null;
-  const label = t(reason === 'buffering' ? 'player.buffering' : 'player.loading');
+  if (!shown) return null;
   return (
     <Box fill z={4} center>
       <Box w={DISC} h={DISC} radius="circle" bg="black/50" center style={s.frost}>
-        <Spinner size={48} thickness={4} label={label} />
+        <Spinner
+          size={48}
+          thickness={4}
+          label={t(reason === 'buffering' ? 'player.buffering' : 'player.loading')}
+        />
       </Box>
-      {stage === 'named' ? (
-        <Box absolute left={0} right={0} top="50%" align="center" style={s.below}>
-          <Box radius="pill" bg="black/50" px={14} py={6} style={s.frost}>
-            <Text variant="meta" color="white/90">
-              {label}
-            </Text>
-          </Box>
-        </Box>
-      ) : null}
     </Box>
   );
 }
 
-const s = styles({
-  frost: backdropBlur(8),
-  below: { marginTop: DISC / 2 + LABEL_GAP },
-});
+const s = styles({ frost: backdropBlur(8) });
 
 export type { StageOverlayProps };
 export { StageOverlay };


### PR DESCRIPTION
## What

After 2.5 s the stage overlay wrote "Loading…" or "Buffering…" in a pill under the spinner (#243). The disc and the pill are black at half opacity, so over a black frame both vanish and what is left is a bare arc with a word floating under it. The spinner keeps the word as its accessible label and draws nothing else.

## Closes

No issue: raised directly after #243 reached the NAS.

## Checks

- [x] `bun run check` and `bun run test` pass, and so does `bun run typecheck`
- [ ] `cargo clippy` and `cargo test`: not run, the server did not change
- [x] Follows `CODE_STYLE.md`: no comments narrating the work, exported API only
- [x] One idea

## Risk

A sighted viewer no longer reads why the picture waits; a screen reader still hears it. If the label went missing too, `stage-overlay.test.tsx` would fail on `getByLabelText`.
