### PR TITLE
fix(backup): a restore brings back what nothing else can rebuild

### DIFF
--- a/server/crates/kroma-db/src/backup.rs
+++ b/server/crates/kroma-db/src/backup.rs
@@ -27,6 +27,8 @@ mod module_stores;
 mod rows;
 
 #[cfg(test)]
+mod left_out;
+#[cfg(test)]
 mod test_support;
 
 use module_stores::{dump_store, module_stores, restore_modules};
@@ -35,19 +37,6 @@ use rows::{dump_query, restore_rows};
 // On-disk shape version; bump on an incompatible change.
 const VERSION: u32 = 1;
 
-// Tables carried by a portable backup. Everything else (catalogue, embeddings,
-// AI sections, sessions, job run history, and the machine-specific `downloads`
-// torrent state) is regenerated and left out. `settings` carries the VPN /
-// naming / acquisition preferences; `requests` + `wanted` carry the users' media
-// wishlist and its episode ledger. `progress`/`watched`/`my_list` are item-keyed
-// user state that re-links by `item_id` once a re-scan recreates the catalogue
-// with matching ids.
-//
-// A module's own tables are NOT named here any more -- they are not in this
-// database. Each installed module's private store is walked whole (see
-// [`module_stores`]), which is both how the admin's indexer keys and download
-// client passwords still travel and how this list stopped needing to know which
-// modules exist.
 const TABLES: &[&str] = &[
     "users",
     "settings",
@@ -59,6 +48,12 @@ const TABLES: &[&str] = &[
     "progress",
     "watched",
     "my_list",
+    "passkeys",
+    "notification_prefs",
+    "reports",
+    "tmdb_pin",
+    "acq_file_tmdb",
+    "downloaded_subtitles",
 ];
 
 // Settings that name this machine at the statistics collector rather than

--- a/server/crates/kroma-db/src/backup/left_out.rs
+++ b/server/crates/kroma-db/src/backup/left_out.rs
@@ -1,0 +1,87 @@
+use std::collections::BTreeSet;
+
+use super::test_support::{fresh_pool, schema_tables};
+use super::TABLES;
+
+const REBUILT_BY_A_SCAN: &[&str] = &["files", "items", "libraries", "shows"];
+
+const REBUILT_FROM_THE_MEDIA_AND_ITS_PROVIDERS: &[&str] = &[
+    "audio_analysis",
+    "curated_sections",
+    "file_segments",
+    "item_suggestions",
+    "item_vectors",
+    "library_gaps",
+    "markers",
+    "metadata_core",
+    "pipeline_tasks",
+    "season_meta",
+    "translations",
+    "user_taste",
+];
+
+const SIGNED_IN_DEVICES: &[&str] = &["access_tokens", "push_subscriptions", "sessions"];
+
+const SHORT_LIVED: &[&str] = &[
+    "credential_resets",
+    "email_verifications",
+    "job_logs",
+    "job_runs",
+    "notifications",
+    "pin_attempts",
+    "reset_requests",
+    "whisper_jobs",
+];
+
+const THIS_MACHINE_ONLY: &[&str] = &["downloads", "metric_samples"];
+
+const LEFT_OUT: [&[&str]; 5] = [
+    REBUILT_BY_A_SCAN,
+    REBUILT_FROM_THE_MEDIA_AND_ITS_PROVIDERS,
+    SIGNED_IN_DEVICES,
+    SHORT_LIVED,
+    THIS_MACHINE_ONLY,
+];
+
+fn named() -> Vec<&'static str> {
+    TABLES
+        .iter()
+        .chain(LEFT_OUT.iter().flat_map(|group| group.iter()))
+        .copied()
+        .collect()
+}
+
+#[test]
+fn every_table_the_schema_creates_is_backed_up_or_left_out_by_name() {
+    let tables = schema_tables(&fresh_pool("named"));
+    let named = named();
+
+    let unnamed: Vec<&str> = tables
+        .iter()
+        .map(String::as_str)
+        .filter(|t| !named.contains(t))
+        .collect();
+
+    assert_eq!(unnamed, Vec::<&str>::new());
+}
+
+#[test]
+fn every_table_named_here_is_one_the_schema_creates() {
+    let tables = schema_tables(&fresh_pool("stale"));
+
+    let stale: Vec<&str> = named()
+        .into_iter()
+        .filter(|t| !tables.contains(*t))
+        .collect();
+
+    assert_eq!(stale, Vec::<&str>::new());
+}
+
+#[test]
+fn no_table_is_named_twice() {
+    let named = named();
+
+    let unique: BTreeSet<&str> = named.iter().copied().collect();
+
+    assert_eq!(unique.len(), named.len());
+}

--- a/server/crates/kroma-db/src/backup/rows.rs
+++ b/server/crates/kroma-db/src/backup/rows.rs
@@ -22,6 +22,14 @@ pub(super) fn dump_query(conn: &Connection, sql: &str) -> Result<Vec<Map<String,
     Ok(out)
 }
 
+fn columns(conn: &Connection, table: &str) -> Result<std::collections::HashSet<String>> {
+    let names = conn
+        .prepare("SELECT name FROM pragma_table_info(?1)")?
+        .query_map([table], |r| r.get::<_, String>(0))?
+        .collect::<rusqlite::Result<_>>()?;
+    Ok(names)
+}
+
 // `INSERT OR REPLACE` each row into `table` (replace-by-primary-key). Column
 // names are validated as plain identifiers before interpolation.
 pub(super) fn restore_rows(
@@ -29,9 +37,13 @@ pub(super) fn restore_rows(
     table: &str,
     rows: &[Map<String, Value>],
 ) -> Result<usize> {
+    let known = columns(conn, table)?;
     let mut written = 0;
     for row in rows {
-        let cols: Vec<&String> = row.keys().filter(|c| is_ident(c)).collect();
+        let cols: Vec<&String> = row
+            .keys()
+            .filter(|c| is_ident(c) && known.contains(c.as_str()))
+            .collect();
         if cols.is_empty() {
             continue;
         }
@@ -93,8 +105,48 @@ pub(super) fn is_ident(s: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::backup::import_portable;
     use crate::backup::test_support::*;
+    use crate::backup::{export_portable, import_portable, TABLES};
+
+    #[test]
+    fn a_column_the_target_does_not_have_is_dropped_rather_than_failing_the_restore() {
+        let dst = fresh_pool("unknown-column");
+        let mut doc = empty_doc();
+        doc.tables.insert(
+            "users".into(),
+            vec![Map::from_iter([
+                ("id".to_string(), Value::from("u1")),
+                ("email".to_string(), Value::from("a@b.c")),
+                ("username".to_string(), Value::from("Al")),
+                ("password_hash".to_string(), Value::from("ph")),
+                ("created_at".to_string(), Value::from("t")),
+                ("added_by_a_newer_server".to_string(), Value::from(1)),
+            ])],
+        );
+
+        let summary = import_portable(&dst, &data_dir(&dst), &doc, false).unwrap();
+
+        assert_eq!(summary, vec![("users".to_string(), 1)]);
+    }
+
+    #[test]
+    fn every_table_a_backup_carries_comes_back_through_a_restore() {
+        let src = fresh_pool("every-src");
+        for table in TABLES {
+            seed_a_row_in(&src, table);
+        }
+        let doc = export_portable(&src, &data_dir(&src)).unwrap();
+        let dst = fresh_pool("every-dst");
+
+        import_portable(&dst, &data_dir(&dst), &doc, false).unwrap();
+
+        let empty: Vec<&str> = TABLES
+            .iter()
+            .copied()
+            .filter(|t| count(&dst, t) == 0)
+            .collect();
+        assert_eq!(empty, Vec::<&str>::new());
+    }
 
     #[test]
     fn a_row_whose_columns_are_all_unsafe_identifiers_is_skipped() {

--- a/server/crates/kroma-db/src/backup/test_support.rs
+++ b/server/crates/kroma-db/src/backup/test_support.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use rusqlite::Connection;
 
@@ -57,5 +57,57 @@ pub(super) fn empty_doc() -> BackupDoc {
         tables: BTreeMap::new(),
         assets: BTreeMap::new(),
         modules: BTreeMap::new(),
+    }
+}
+
+pub(super) fn schema_tables(pool: &Pool) -> BTreeSet<String> {
+    let conn = pool.get().unwrap();
+    let names: BTreeSet<String> = conn
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'")
+        .unwrap()
+        .query_map([], |r| r.get(0))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    names
+}
+
+pub(super) fn seed_a_row_in(pool: &Pool, table: &str) {
+    let conn = pool.get().unwrap();
+    let columns: Vec<(String, String)> = conn
+        .prepare("SELECT name, type FROM pragma_table_info(?1)")
+        .unwrap()
+        .query_map([table], |r| Ok((r.get(0)?, r.get(1)?)))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    let names: Vec<String> = columns
+        .iter()
+        .map(|(name, _)| format!("\"{name}\""))
+        .collect();
+    let values: Vec<&str> = columns
+        .iter()
+        .map(|(_, declared)| sample_of(declared))
+        .collect();
+    conn.execute_batch(&format!(
+        "PRAGMA foreign_keys = OFF; \
+         INSERT INTO \"{table}\" ({}) VALUES ({}); \
+         PRAGMA foreign_keys = ON;",
+        names.join(","),
+        values.join(",")
+    ))
+    .unwrap();
+}
+
+fn sample_of(declared: &str) -> &'static str {
+    let declared = declared.to_ascii_uppercase();
+    if declared.contains("INT") {
+        "1"
+    } else if declared.contains("REAL") {
+        "1.5"
+    } else if declared.contains("BLOB") {
+        "x'00'"
+    } else {
+        "'x'"
     }
 }

--- a/server/crates/kroma-engine/src/services/backup/archive.rs
+++ b/server/crates/kroma-engine/src/services/backup/archive.rs
@@ -1,8 +1,9 @@
 //! The backup container: a real ZIP holding `backup.json` (the table dump,
-//! deflate-compressed at max level it's repetitive text that shrinks a lot) and
-//! `assets/<name>` files (user-uploaded avatars, stored as-is since WebP is
-//! already compressed). Also reads the legacy v1 format (raw JSON with avatars
-//! hex-embedded) so old backups still import.
+//! deflate-compressed at max level, since repetitive text shrinks a lot),
+//! `assets/<name>` for user-uploaded avatars (stored as-is, WebP is already
+//! compressed) and `subtitles/<name>` for WebVTT (deflated). Also reads the
+//! legacy v1 format (raw JSON with avatars hex-embedded) so old backups still
+//! import.
 
 use std::io::{Cursor, Read, Write};
 
@@ -12,31 +13,61 @@ use zip::{CompressionMethod, ZipArchive, ZipWriter};
 
 use crate::db::BackupDoc;
 
-/// In-memory backup: the row document plus the asset files it references.
-pub type Assets = Vec<(String, Vec<u8>)>;
+/// The folder a packed file sits in, which is also where a restore puts it back.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Folder {
+    Images,
+    Subtitles,
+}
+
+impl Folder {
+    const ALL: [Self; 2] = [Self::Images, Self::Subtitles];
+
+    fn prefix(self) -> &'static str {
+        match self {
+            Self::Images => "assets/",
+            Self::Subtitles => "subtitles/",
+        }
+    }
+
+    fn compression(self) -> CompressionMethod {
+        match self {
+            Self::Images => CompressionMethod::Stored,
+            Self::Subtitles => CompressionMethod::Deflated,
+        }
+    }
+}
+
+/// One file packed beside the rows.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Asset {
+    pub folder: Folder,
+    pub name: String,
+    pub bytes: Vec<u8>,
+}
+
+/// The files a backup packs beside its rows.
+pub type Assets = Vec<Asset>;
 
 const MANIFEST: &str = "backup.json";
-const ASSET_DIR: &str = "assets/";
 // A ZIP's header states an uncompressed size it need not honour, so the bound
 // has to be on what is actually inflated. Well past any real backup, and far
 // short of exhausting the box the import runs on.
 const MAX_INFLATED: u64 = 512 * 1024 * 1024;
 
-/// Serialize a backup to ZIP bytes: `backup.json` + one `assets/<name>` per file.
+/// Serialize a backup to ZIP bytes: `backup.json` plus one entry per file, in its folder.
 pub fn write_zip(doc: &BackupDoc, assets: &Assets) -> Result<Vec<u8>> {
     let mut zw = ZipWriter::new(Cursor::new(Vec::new()));
-    // Max deflate (0–9 on the flate2 backend) for the JSON; avatars are already
-    // compressed (WebP), so storing them avoids wasted CPU for no size win.
     let json_opts = SimpleFileOptions::default()
         .compression_method(CompressionMethod::Deflated)
         .compression_level(Some(9));
-    let asset_opts = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
 
     zw.start_file(MANIFEST, json_opts)?;
     zw.write_all(&serde_json::to_vec_pretty(doc)?)?;
-    for (name, bytes) in assets {
-        zw.start_file(format!("{ASSET_DIR}{name}"), asset_opts)?;
-        zw.write_all(bytes)?;
+    for asset in assets {
+        let opts = SimpleFileOptions::default().compression_method(asset.folder.compression());
+        zw.start_file(format!("{}{}", asset.folder.prefix(), asset.name), opts)?;
+        zw.write_all(&asset.bytes)?;
     }
     Ok(zw.finish()?.into_inner())
 }
@@ -53,11 +84,12 @@ fn read_zip_within(bytes: &[u8], mut budget: u64) -> Result<(BackupDoc, Assets)>
     for i in 0..za.len() {
         let mut entry = za.by_index(i)?;
         let name = entry.name().to_string();
-        let asset = name
-            .strip_prefix(ASSET_DIR)
-            .filter(|a| !a.is_empty())
-            .map(str::to_string);
-        if name != MANIFEST && asset.is_none() {
+        let packed = Folder::ALL.into_iter().find_map(|folder| {
+            name.strip_prefix(folder.prefix())
+                .filter(|n| !n.is_empty())
+                .map(|n| (folder, n.to_string()))
+        });
+        if name != MANIFEST && packed.is_none() {
             continue;
         }
         let mut buf = Vec::new();
@@ -66,8 +98,12 @@ fn read_zip_within(bytes: &[u8], mut budget: u64) -> Result<(BackupDoc, Assets)>
             bail!("backup archive inflates past what an import will read");
         }
         budget -= read;
-        match asset {
-            Some(asset) => assets.push((asset, buf)),
+        match packed {
+            Some((folder, name)) => assets.push(Asset {
+                folder,
+                name,
+                bytes: buf,
+            }),
             None => doc = Some(serde_json::from_slice(&buf).context("parse backup.json")?),
         }
     }
@@ -80,7 +116,13 @@ pub fn read_legacy_json(bytes: &[u8]) -> Result<(BackupDoc, Assets)> {
     let assets = doc
         .assets
         .iter()
-        .filter_map(|(n, h)| Some((n.clone(), hex::decode(h).ok()?)))
+        .filter_map(|(n, h)| {
+            Some(Asset {
+                folder: Folder::Images,
+                name: n.clone(),
+                bytes: hex::decode(h).ok()?,
+            })
+        })
         .collect();
     Ok((doc, assets))
 }
@@ -104,9 +146,20 @@ mod tests {
         }
     }
 
+    fn asset(folder: Folder, name: &str, bytes: &[u8]) -> Asset {
+        Asset {
+            folder,
+            name: name.to_string(),
+            bytes: bytes.to_vec(),
+        }
+    }
+
     #[test]
     fn zip_round_trip_carries_doc_and_assets() {
-        let assets = vec![("ab12.webp".to_string(), b"WEBP".to_vec())];
+        let assets = vec![
+            asset(Folder::Images, "ab12.webp", b"WEBP"),
+            asset(Folder::Subtitles, "cd34.vtt", b"WEBVTT"),
+        ];
         let bytes = write_zip(&doc(), &assets).unwrap();
         assert_eq!(&bytes[..4], b"PK\x03\x04", "is a real zip");
 
@@ -117,7 +170,7 @@ mod tests {
 
     #[test]
     fn an_archive_that_inflates_past_the_budget_is_refused_rather_than_read() {
-        let assets = vec![("big.webp".to_string(), vec![0u8; 64 * 1024])];
+        let assets = vec![asset(Folder::Images, "big.webp", &[0u8; 64 * 1024])];
         let bytes = write_zip(&doc(), &assets).unwrap();
 
         let err = read_zip_within(&bytes, 4096).unwrap_err();
@@ -148,6 +201,6 @@ mod tests {
         d.assets.insert("ab12.webp".into(), hex::encode(b"WEBP"));
         let bytes = serde_json::to_vec(&d).unwrap();
         let (_, got) = read_legacy_json(&bytes).unwrap();
-        assert_eq!(got, vec![("ab12.webp".to_string(), b"WEBP".to_vec())]);
+        assert_eq!(got, vec![asset(Folder::Images, "ab12.webp", b"WEBP")]);
     }
 }

--- a/server/crates/kroma-engine/src/services/backup/assets.rs
+++ b/server/crates/kroma-engine/src/services/backup/assets.rs
@@ -1,0 +1,262 @@
+//! The files a backup packs beside its rows: the avatars users uploaded, and the
+//! subtitles this server generated or downloaded.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use serde_json::{Map, Value};
+
+use crate::db::BackupDoc;
+use crate::infra::image::{images_dir, PUBLIC_PREFIX};
+use crate::services::subtitles::downloaded_dir;
+
+use super::archive::{Asset, Assets, Folder};
+
+const SUBTITLES: &str = "downloaded_subtitles";
+
+/// Every file the rows of `doc` point at. A subtitle row whose file is gone is
+/// removed from `doc`.
+pub fn gather(doc: &mut BackupDoc, data_dir: &Path) -> Assets {
+    let mut files = avatars(doc, data_dir);
+    files.extend(subtitles(doc, data_dir));
+    files
+}
+
+/// Put each file back in its folder, never over one already there.
+pub fn write(data_dir: &Path, files: &Assets) {
+    for file in files.iter().filter(|f| is_safe_name(&f.name)) {
+        let dir = folder_dir(data_dir, file.folder);
+        std::fs::create_dir_all(&dir).ok();
+        let path = dir.join(&file.name);
+        if !path.exists() {
+            let _ = std::fs::write(&path, &file.bytes);
+        }
+    }
+}
+
+/// Point each restored subtitle at this server's copy of its file, wherever the
+/// source kept it. A row that names no file is dropped.
+pub fn rebase_subtitles(doc: &mut BackupDoc, data_dir: &Path) {
+    let dir = downloaded_dir(data_dir);
+    let Some(rows) = doc.tables.get_mut(SUBTITLES) else {
+        return;
+    };
+    rows.retain_mut(|row| {
+        let Some(name) = file_name(row).map(str::to_string) else {
+            return false;
+        };
+        let path = dir.join(name).to_string_lossy().into_owned();
+        row.insert("path".to_string(), Value::from(path));
+        true
+    });
+}
+
+fn avatars(doc: &BackupDoc, data_dir: &Path) -> Assets {
+    let dir = images_dir(data_dir);
+    let mut out = Assets::new();
+    let mut seen = HashSet::new();
+    for user in doc.tables.get("users").into_iter().flatten() {
+        let Some(name) = user
+            .get("avatar_url")
+            .and_then(Value::as_str)
+            .and_then(local_image_name)
+        else {
+            continue;
+        };
+        if seen.insert(name.to_string()) {
+            if let Ok(bytes) = std::fs::read(dir.join(name)) {
+                out.push(Asset {
+                    folder: Folder::Images,
+                    name: name.to_string(),
+                    bytes,
+                });
+            }
+        }
+    }
+    out
+}
+
+fn subtitles(doc: &mut BackupDoc, data_dir: &Path) -> Assets {
+    let dir = downloaded_dir(data_dir);
+    let mut out = Assets::new();
+    let mut packed: HashSet<String> = HashSet::new();
+    let Some(rows) = doc.tables.get_mut(SUBTITLES) else {
+        return out;
+    };
+    rows.retain(|row| {
+        let Some(name) = file_name(row) else {
+            return false;
+        };
+        if packed.contains(name) {
+            return true;
+        }
+        let Ok(bytes) = std::fs::read(dir.join(name)) else {
+            return false;
+        };
+        packed.insert(name.to_string());
+        out.push(Asset {
+            folder: Folder::Subtitles,
+            name: name.to_string(),
+            bytes,
+        });
+        true
+    });
+    out
+}
+
+fn file_name(row: &Map<String, Value>) -> Option<&str> {
+    let path = row.get("path")?.as_str()?;
+    path.rsplit(['/', '\\'])
+        .next()
+        .filter(|name| is_safe_name(name))
+}
+
+fn folder_dir(data_dir: &Path, folder: Folder) -> PathBuf {
+    match folder {
+        Folder::Images => images_dir(data_dir),
+        Folder::Subtitles => downloaded_dir(data_dir),
+    }
+}
+
+fn local_image_name(url: &str) -> Option<&str> {
+    url.strip_prefix(PUBLIC_PREFIX).filter(|n| is_safe_name(n))
+}
+
+fn is_safe_name(name: &str) -> bool {
+    !name.is_empty() && !name.contains('/') && !name.contains('\\') && !name.contains("..")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+    use crate::services::backup::test_support::{fresh, seed_subtitle, seed_user_with_avatar};
+
+    fn restored(paths: &[Option<&str>]) -> BackupDoc {
+        let rows = paths
+            .iter()
+            .map(|path| {
+                let mut row = Map::new();
+                row.insert("id".to_string(), Value::from("s1"));
+                if let Some(path) = path {
+                    row.insert("path".to_string(), Value::from(*path));
+                }
+                row
+            })
+            .collect();
+        BackupDoc {
+            version: 1,
+            exported_at: "t".into(),
+            tables: BTreeMap::from([(SUBTITLES.to_string(), rows)]),
+            assets: BTreeMap::new(),
+            modules: BTreeMap::new(),
+        }
+    }
+
+    fn image(name: &str, bytes: &[u8]) -> Asset {
+        Asset {
+            folder: Folder::Images,
+            name: name.to_string(),
+            bytes: bytes.to_vec(),
+        }
+    }
+
+    #[test]
+    fn a_subtitle_whose_file_is_gone_is_left_out_of_the_backup() {
+        let (pool, dir) = fresh("sub-gone");
+        seed_subtitle(&pool, dir.path(), "s1", b"WEBVTT");
+        std::fs::remove_file(downloaded_dir(dir.path()).join("s1.vtt")).unwrap();
+        let mut doc = crate::db::export_portable(&pool, dir.path()).unwrap();
+
+        let files = gather(&mut doc, dir.path());
+
+        assert!(files.is_empty());
+        assert!(doc.tables[SUBTITLES].is_empty());
+    }
+
+    #[test]
+    fn a_restored_subtitle_points_at_this_servers_copy_from_a_unix_or_a_windows_source() {
+        let mut doc = restored(&[
+            Some("/old/box/subs/downloaded/s1.vtt"),
+            Some(r"C:\kroma\subs\downloaded\s1.vtt"),
+        ]);
+        let here = Path::new("/new/box");
+
+        rebase_subtitles(&mut doc, here);
+
+        let expected = Value::from(
+            downloaded_dir(here)
+                .join("s1.vtt")
+                .to_string_lossy()
+                .into_owned(),
+        );
+        let paths: Vec<&Value> = doc.tables[SUBTITLES]
+            .iter()
+            .map(|row| &row["path"])
+            .collect();
+        assert_eq!(paths, vec![&expected, &expected]);
+    }
+
+    #[test]
+    fn a_restored_subtitle_that_names_no_file_is_dropped() {
+        let mut doc = restored(&[None, Some("/data/subs/downloaded/"), Some("/data/..")]);
+
+        rebase_subtitles(&mut doc, Path::new("/new/box"));
+
+        assert!(doc.tables[SUBTITLES].is_empty());
+    }
+
+    #[test]
+    fn an_asset_naming_a_path_is_never_written_outside_the_cache() {
+        let (_pool, dir) = fresh("assets");
+        let files = vec![
+            image("../escape.webp", b"NOPE"),
+            image("sub/dir.webp", b"NOPE"),
+            image("", b"NOPE"),
+            image("ok.webp", b"YES"),
+        ];
+
+        write(dir.path(), &files);
+
+        assert_eq!(
+            std::fs::read(images_dir(dir.path()).join("ok.webp")).unwrap(),
+            b"YES"
+        );
+        assert!(!images_dir(dir.path())
+            .parent()
+            .unwrap()
+            .join("escape.webp")
+            .exists());
+    }
+
+    #[test]
+    fn an_avatar_that_is_not_a_cached_image_is_not_gathered() {
+        let (pool, dir) = fresh("gather");
+        seed_user_with_avatar(&pool, dir.path());
+        pool.get()
+            .unwrap()
+            .execute(
+                "INSERT INTO users (id,email,username,password_hash,avatar_url,created_at) \
+                 VALUES ('u2','b@b.c','Bo','ph','https://gravatar.example/x.png','t')",
+                [],
+            )
+            .unwrap();
+
+        let mut doc = crate::db::export_portable(&pool, pool.path().parent().unwrap()).unwrap();
+        let files = gather(&mut doc, dir.path());
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].name, "av99.webp");
+
+        pool.get()
+            .unwrap()
+            .execute(
+                "INSERT INTO users (id,email,username,password_hash,avatar_url,created_at) \
+                 VALUES ('u3','c@b.c','Cy','ph','/api/images/av99.webp','t')",
+                [],
+            )
+            .unwrap();
+        let mut doc = crate::db::export_portable(&pool, pool.path().parent().unwrap()).unwrap();
+        assert_eq!(gather(&mut doc, dir.path()).len(), 1);
+    }
+}

--- a/server/crates/kroma-engine/src/services/backup/mod.rs
+++ b/server/crates/kroma-engine/src/services/backup/mod.rs
@@ -1,16 +1,19 @@
-//! Portable backup orchestration: DB rows plus the avatar files they reference,
-//! packed into a ZIP ([`archive`]) with an optional encrypted envelope ([`crypto`]).
+//! Portable backup orchestration: DB rows plus the files they reference
+//! ([`assets`]), packed into a ZIP ([`archive`]) with an optional encrypted
+//! envelope ([`crypto`]).
 
 mod archive;
+mod assets;
 mod crypto;
+
+#[cfg(test)]
+mod test_support;
 
 use std::path::Path;
 
 use anyhow::Result;
-use serde_json::Value;
 
 use crate::db::{self, BackupDoc, Pool};
-use crate::infra::image::{images_dir, PUBLIC_PREFIX};
 
 use archive::Assets;
 
@@ -26,9 +29,9 @@ pub enum ImportError {
 
 /// A non-empty `password` wraps the ZIP in an encrypted envelope; import auto-detects.
 pub fn export(pool: &Pool, data_dir: &Path, password: Option<&str>) -> Result<Vec<u8>> {
-    let doc = db::export_portable(pool, data_dir)?;
-    let assets = gather_assets(&doc, data_dir);
-    let zip = archive::write_zip(&doc, &assets)?;
+    let mut doc = db::export_portable(pool, data_dir)?;
+    let files = assets::gather(&mut doc, data_dir);
+    let zip = archive::write_zip(&doc, &files)?;
     match password.filter(|p| !p.is_empty()) {
         Some(pw) => crypto::seal(&zip, pw),
         None => Ok(zip),
@@ -44,8 +47,9 @@ pub fn import(
     password: Option<&str>,
     reset: bool,
 ) -> std::result::Result<Vec<(String, usize)>, ImportError> {
-    let (doc, assets) = decode(bytes, password)?;
-    write_assets(data_dir, &assets);
+    let (mut doc, files) = decode(bytes, password)?;
+    assets::write(data_dir, &files);
+    assets::rebase_subtitles(&mut doc, data_dir);
     db::import_portable(pool, data_dir, &doc, reset).map_err(ImportError::Db)
 }
 
@@ -75,79 +79,12 @@ fn decode(
     )))
 }
 
-fn gather_assets(doc: &BackupDoc, data_dir: &Path) -> Assets {
-    let dir = images_dir(data_dir);
-    let mut out = Assets::new();
-    let mut seen = std::collections::HashSet::new();
-    for user in doc.tables.get("users").into_iter().flatten() {
-        let Some(name) = user
-            .get("avatar_url")
-            .and_then(Value::as_str)
-            .and_then(local_image_name)
-        else {
-            continue;
-        };
-        if seen.insert(name.to_string()) {
-            if let Ok(bytes) = std::fs::read(dir.join(name)) {
-                out.push((name.to_string(), bytes));
-            }
-        }
-    }
-    out
-}
-
-fn write_assets(data_dir: &Path, assets: &Assets) {
-    let dir = images_dir(data_dir);
-    std::fs::create_dir_all(&dir).ok();
-    for (name, bytes) in assets {
-        if !is_safe_name(name) {
-            continue; // never let a backup write outside the cache dir
-        }
-        let path = dir.join(name);
-        if !path.exists() {
-            let _ = std::fs::write(&path, bytes);
-        }
-    }
-}
-
-fn local_image_name(url: &str) -> Option<&str> {
-    url.strip_prefix(PUBLIC_PREFIX).filter(|n| is_safe_name(n))
-}
-
-fn is_safe_name(name: &str) -> bool {
-    !name.is_empty() && !name.contains('/') && !name.contains('\\') && !name.contains("..")
-}
-
 #[cfg(test)]
 mod tests {
+    use super::test_support::*;
     use super::*;
-    use kroma_testing::TempDir;
-
-    fn fresh(tag: &str) -> (Pool, TempDir) {
-        let data = kroma_testing::temp_dir(&format!("bksvc-{tag}"));
-        std::fs::create_dir_all(images_dir(data.path())).unwrap();
-        let pool = crate::db::init(&data.path().join("kroma.db")).unwrap();
-        (pool, data)
-    }
-
-    fn seed_user_with_avatar(pool: &Pool, data_dir: &Path) {
-        std::fs::write(images_dir(data_dir).join("av99.webp"), b"AVATAR").unwrap();
-        pool.get()
-            .unwrap()
-            .execute(
-                "INSERT INTO users (id,email,username,password_hash,avatar_url,created_at) \
-                 VALUES ('u1','a@b.c','Al','ph','/api/images/av99.webp','t')",
-                [],
-            )
-            .unwrap();
-    }
-
-    fn user_count(pool: &Pool) -> i64 {
-        pool.get()
-            .unwrap()
-            .query_row("SELECT COUNT(*) FROM users", [], |r| r.get(0))
-            .unwrap()
-    }
+    use crate::infra::image::images_dir;
+    use crate::services::subtitles::downloaded_dir;
 
     #[test]
     fn zip_round_trip_restores_rows_and_avatar() {
@@ -166,6 +103,25 @@ mod tests {
             std::fs::read(images_dir(dst_dir.path()).join("av99.webp")).unwrap(),
             b"AVATAR"
         );
+    }
+
+    #[test]
+    fn a_subtitle_comes_back_with_its_file_under_the_new_data_dir() {
+        let (src, src_dir) = fresh("sub-src");
+        seed_subtitle(&src, src_dir.path(), "s1", b"WEBVTT\n\nhello");
+        let bytes = export(&src, src_dir.path(), None).unwrap();
+        let (dst, dst_dir) = fresh("sub-dst");
+
+        import(&dst, dst_dir.path(), &bytes, None, false).unwrap();
+
+        let path = subtitle_path(&dst, "s1").unwrap();
+        assert_eq!(
+            path,
+            downloaded_dir(dst_dir.path())
+                .join("s1.vtt")
+                .to_string_lossy()
+        );
+        assert_eq!(std::fs::read(path).unwrap(), b"WEBVTT\n\nhello");
     }
 
     #[test]
@@ -225,58 +181,6 @@ mod tests {
             import(&dst, dst_dir.path(), &truncated, Some("hunter2"), false),
             Err(ImportError::Invalid(_))
         ));
-    }
-
-    #[test]
-    fn an_asset_naming_a_path_is_never_written_outside_the_cache() {
-        let (_pool, dir) = fresh("assets");
-        let assets: Assets = vec![
-            ("../escape.webp".to_string(), b"NOPE".to_vec()),
-            ("sub/dir.webp".to_string(), b"NOPE".to_vec()),
-            (String::new(), b"NOPE".to_vec()),
-            ("ok.webp".to_string(), b"YES".to_vec()),
-        ];
-        write_assets(dir.path(), &assets);
-
-        assert_eq!(
-            std::fs::read(images_dir(dir.path()).join("ok.webp")).unwrap(),
-            b"YES"
-        );
-        assert!(!images_dir(dir.path())
-            .parent()
-            .unwrap()
-            .join("escape.webp")
-            .exists());
-    }
-
-    #[test]
-    fn an_avatar_that_is_not_a_cached_image_is_not_gathered() {
-        let (pool, dir) = fresh("gather");
-        seed_user_with_avatar(&pool, dir.path());
-        pool.get()
-            .unwrap()
-            .execute(
-                "INSERT INTO users (id,email,username,password_hash,avatar_url,created_at) \
-                 VALUES ('u2','b@b.c','Bo','ph','https://gravatar.example/x.png','t')",
-                [],
-            )
-            .unwrap();
-
-        let doc = crate::db::export_portable(&pool, pool.path().parent().unwrap()).unwrap();
-        let assets = gather_assets(&doc, dir.path());
-        assert_eq!(assets.len(), 1);
-        assert_eq!(assets[0].0, "av99.webp");
-
-        pool.get()
-            .unwrap()
-            .execute(
-                "INSERT INTO users (id,email,username,password_hash,avatar_url,created_at) \
-                 VALUES ('u3','c@b.c','Cy','ph','/api/images/av99.webp','t')",
-                [],
-            )
-            .unwrap();
-        let doc = crate::db::export_portable(&pool, pool.path().parent().unwrap()).unwrap();
-        assert_eq!(gather_assets(&doc, dir.path()).len(), 1);
     }
 
     #[test]

--- a/server/crates/kroma-engine/src/services/backup/test_support.rs
+++ b/server/crates/kroma-engine/src/services/backup/test_support.rs
@@ -1,0 +1,66 @@
+use std::path::Path;
+
+use kroma_testing::TempDir;
+
+use crate::db::Pool;
+use crate::infra::image::images_dir;
+use crate::services::subtitles::downloaded_dir;
+
+pub(super) fn fresh(tag: &str) -> (Pool, TempDir) {
+    let data = kroma_testing::temp_dir(&format!("bksvc-{tag}"));
+    std::fs::create_dir_all(images_dir(data.path())).unwrap();
+    let pool = crate::db::init(&data.path().join("kroma.db")).unwrap();
+    (pool, data)
+}
+
+pub(super) fn seed_user_with_avatar(pool: &Pool, data_dir: &Path) {
+    std::fs::write(images_dir(data_dir).join("av99.webp"), b"AVATAR").unwrap();
+    pool.get()
+        .unwrap()
+        .execute(
+            "INSERT INTO users (id,email,username,password_hash,avatar_url,created_at) \
+             VALUES ('u1','a@b.c','Al','ph','/api/images/av99.webp','t')",
+            [],
+        )
+        .unwrap();
+}
+
+pub(super) fn seed_subtitle(pool: &Pool, data_dir: &Path, id: &str, vtt: &[u8]) {
+    let dir = downloaded_dir(data_dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(format!("{id}.vtt"));
+    std::fs::write(&path, vtt).unwrap();
+    let path = path.to_string_lossy().into_owned();
+    let conn = pool.get().unwrap();
+    conn.execute_batch(
+        "INSERT OR IGNORE INTO libraries (id,name,kind,path,added_at) \
+         VALUES ('lib','L','movies','/x','t'); \
+         INSERT OR IGNORE INTO items (id,kind,title,container,library,added_at) \
+         VALUES ('it1','movie','Film','mkv','lib','t');",
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO downloaded_subtitles (id,item_id,label,provider,path,created_at) \
+         VALUES (?1,'it1','English','whisper',?2,'t')",
+        [id, path.as_str()],
+    )
+    .unwrap();
+}
+
+pub(super) fn user_count(pool: &Pool) -> i64 {
+    pool.get()
+        .unwrap()
+        .query_row("SELECT COUNT(*) FROM users", [], |r| r.get(0))
+        .unwrap()
+}
+
+pub(super) fn subtitle_path(pool: &Pool, id: &str) -> Option<String> {
+    pool.get()
+        .unwrap()
+        .query_row(
+            "SELECT path FROM downloaded_subtitles WHERE id = ?1",
+            [id],
+            |r| r.get(0),
+        )
+        .ok()
+}

--- a/server/crates/kroma-engine/src/services/jobs/registry.rs
+++ b/server/crates/kroma-engine/src/services/jobs/registry.rs
@@ -89,6 +89,30 @@ impl JobManager {
         }
     }
 
+    /// Re-read every override from the database. A job whose row is gone goes
+    /// back on its default schedule.
+    pub fn reload_schedules(&self, pool: &db::Pool) {
+        let remote: std::collections::HashMap<&str, Option<String>> = self
+            .remote
+            .read()
+            .unwrap()
+            .iter()
+            .map(|(key, job)| (*key, job.schedule.clone()))
+            .collect();
+        for (job, st) in self.schedules.write().unwrap().iter_mut() {
+            let schedule = match self.jobs.get(job) {
+                Some(b) => b.schedule.map(str::to_string),
+                None => remote.get(job.as_str()).cloned().flatten(),
+            };
+            *st = ScheduleState {
+                schedule,
+                enabled: true,
+                customized: false,
+            };
+        }
+        self.load_schedules(pool);
+    }
+
     /// Persists the override. `schedule = Some(None)` clears it (manual-only).
     pub fn update_schedule(
         &self,
@@ -136,6 +160,58 @@ mod tests {
     use super::*;
     use crate::services::jobs::test_support::{test_pool, TEST_BUILTIN};
     use crate::services::jobs::{JobContext, RemoteRun};
+
+    #[test]
+    fn reloading_puts_a_job_whose_override_is_gone_back_on_its_default() {
+        let pool = test_pool();
+        let mut m = JobManager::new();
+        m.register(&TEST_BUILTIN);
+        m.update_schedule(&pool, JobKey("test.job"), None, Some(false))
+            .unwrap();
+        pool.get()
+            .unwrap()
+            .execute("DELETE FROM job_schedules", [])
+            .unwrap();
+
+        m.reload_schedules(&pool);
+
+        assert_eq!(
+            m.jobs_for_trigger(Trigger::LibraryChange),
+            vec![JobKey("test.job")]
+        );
+    }
+
+    #[test]
+    fn reloading_puts_a_module_job_back_on_the_schedule_it_registered_with() {
+        let pool = test_pool();
+        let m = JobManager::new();
+        let run: RemoteRun = Arc::new(|_ctx: &JobContext| Ok(()));
+        m.register_remote(
+            "mod.job",
+            Category::Maintenance,
+            Some("0 4 * * *".into()),
+            run,
+        );
+        m.update_schedule(
+            &pool,
+            JobKey("mod.job"),
+            Some(Some("0 5 * * *".into())),
+            None,
+        )
+        .unwrap();
+        pool.get()
+            .unwrap()
+            .execute("DELETE FROM job_schedules", [])
+            .unwrap();
+
+        m.reload_schedules(&pool);
+
+        let schedules = m.schedules.read().unwrap();
+        assert_eq!(
+            schedules[&JobKey("mod.job")].schedule.as_deref(),
+            Some("0 4 * * *")
+        );
+    }
 
     #[test]
     fn register_remote_is_resolvable() {

--- a/server/crates/kroma-engine/src/services/subtitles/mod.rs
+++ b/server/crates/kroma-engine/src/services/subtitles/mod.rs
@@ -151,7 +151,7 @@ pub fn generate(
 
     let provider = spec.mode.provider();
     let id = stable_id(item_id, provider, &spec.target_lang);
-    let dir = data_dir.join("subs").join("downloaded");
+    let dir = downloaded_dir(data_dir);
     std::fs::create_dir_all(&dir)
         .map_err(|e| format!("could not create the subtitle cache dir: {e}"))?;
     let path = dir.join(format!("{id}.vtt"));
@@ -171,6 +171,11 @@ pub fn generate(
     db::insert_downloaded_sub(pool, &sub)
         .map_err(|e| format!("could not record the subtitle in the database: {e}"))?;
     Ok(sub)
+}
+
+/// Where the WebVTT of a generated or downloaded subtitle is kept.
+pub fn downloaded_dir(data_dir: &Path) -> std::path::PathBuf {
+    data_dir.join("subs").join("downloaded")
 }
 
 // Deterministic, so re-generating the same language replaces rather than duplicates.

--- a/server/src/api/admin/backup.rs
+++ b/server/src/api/admin/backup.rs
@@ -146,6 +146,7 @@ pub async fn import_backup(
     // the rescan shares the single-flight guard with /api/scan and watch-triggered
     // runs, instead of racing a second walk + sync on the same DB.
     state.settings.reload(&state.db);
+    state.jobs.reload_schedules(&state.db);
     state.events.publish(ServerEvent::SettingsUpdated);
     let rescan_started = !matches!(
         state.jobs.trigger(

--- a/server/src/api/it_backup.rs
+++ b/server/src/api/it_backup.rs
@@ -1,0 +1,44 @@
+use axum::body::Body;
+use axum::extract::ConnectInfo;
+use axum::http::{Request, StatusCode};
+use axum::Router;
+use tower::ServiceExt;
+
+use crate::api::test_support::test_app;
+use crate::db;
+use crate::services::jobs::JobKey;
+
+async fn import(app: &Router, token: &str, backup: Vec<u8>) -> StatusCode {
+    let mut req = Request::builder()
+        .method("POST")
+        .uri("/api/admin/backup/import")
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::from(backup))
+        .unwrap();
+    req.extensions_mut()
+        .insert(ConnectInfo(std::net::SocketAddr::from((
+            [127, 0, 0, 1],
+            40000,
+        ))));
+    app.clone().oneshot(req).await.unwrap().status()
+}
+
+#[tokio::test]
+async fn a_cron_override_in_a_backup_is_in_force_as_soon_as_it_is_restored() {
+    let source = test_app();
+    db::upsert_job_schedule(&source.state.db, "cache.cleanup", Some("0 6 * * *"), true).unwrap();
+    let backup =
+        crate::services::backup::export(&source.state.db, &source.state.config.data_dir, None)
+            .unwrap();
+    let target = test_app();
+
+    let status = import(&target.app, &target.token, backup).await;
+
+    let job = target
+        .state
+        .jobs
+        .detail(&target.state, JobKey("cache.cleanup"))
+        .unwrap();
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(job.info.schedule.as_deref(), Some("0 6 * * *"));
+}

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -63,6 +63,8 @@ mod it_auth;
 #[cfg(test)]
 mod it_auth_faults;
 #[cfg(test)]
+mod it_backup;
+#[cfg(test)]
 mod it_cast;
 #[cfg(test)]
 mod it_content;


### PR DESCRIPTION
## What

The export named ten tables by hand, and nothing asked whoever added an eleventh which side it belonged on. A restore dropped the match corrections in `tmdb_pin`, every passkey, `notification_prefs`, the `reports` queue, the TMDB ids in `acq_file_tmdb`, and every downloaded or transcribed subtitle. Those six tables now travel. Every table the schema creates must be named once, in `TABLES` or in a group in `backup/left_out.rs` whose name says why it stays behind, and a test fails on a table that is in neither. A second test seeds a row in every table `TABLES` names and checks each one comes back.

A subtitle row holds its file's path on the source, so the `.vtt` files go into the archive under `subtitles/` and the import points each row at the target's own copy. A row whose file is gone stays out of the export.

The import route also reloads cron overrides instead of leaving them for the next boot, and a job whose override the restore removed goes back to its default. `restore_rows` skips a column the target lacks, so a backup from a newer server restores instead of failing with a 500.

On my dev database the dropped tables held 9 match corrections and 10 notification preference rows.

## Closes

No issue. It came out of an audit of what a restore loses.

## Checks

- [ ] `bun run lint` and `bun run test` pass, or I said below which failed and why
- [x] `cargo clippy` and `cargo test` pass, if the server changed
- [x] Follows `CODE_STYLE.md`: no comments narrating the work, exported API only
- [x] One idea. If it grew a second, it was split.

No TypeScript changed, so I did not run the bun checks. `cargo test --workspace` in `server/`: 2596 passed, 0 failed. `cargo clippy --workspace --all-targets`, the way `bun run ci rust clippy` runs it: exit 0, and none of its 22 warnings is in a file this PR touches. No module workspace changed, so I did not run those.

## Risk

- With Reset on, the target now also empties these six tables, even when the file predates them. A reset restore from an old backup clears passkeys and match corrections that the file cannot put back.
- A passkey only signs in on a server reached under the same domain as the source. Elsewhere it sits unused and the password still works.
- An older server ignores the new tables and the `subtitles/` entries, as before. The format only grew, so `VERSION` stays 1.

Not fixed here: a module that is not installed on the target still loses its rows with only a log line, so the operator has to install it and import the same file again. A restored `instanceId` still waits for a restart.
